### PR TITLE
Fix comptime while loop unrolling and match branch elimination

### DIFF
--- a/src/codegen/exprs/match.ts
+++ b/src/codegen/exprs/match.ts
@@ -255,6 +255,9 @@ export function generateMatchExpression(
         exprIsFunctionCall(caseExpr) &&
         exprIsFunctionCallOf(caseExpr, "=>", 2)
       ) {
+        // Skip non-executed cases (comptime branch elimination)
+        if (!caseExpr.args[0]?.$?.caseExecuted) continue;
+
         const caseValue = caseExpr.args[0]!; // .None, .Some(ptr)
         const caseBody = caseExpr.args[1]!;
 
@@ -396,6 +399,9 @@ export function generateMatchExpression(
         exprIsFunctionCall(caseExpr) &&
         exprIsFunctionCallOf(caseExpr, "=>", 2)
       ) {
+        // Skip non-executed cases (comptime branch elimination)
+        if (!caseExpr.args[0]?.$?.caseExecuted) continue;
+
         // This is a case => value pair
         const caseValue = caseExpr.args[0];
         const caseBody = caseExpr.args[1];
@@ -486,6 +492,9 @@ export function generateMatchExpression(
       exprIsFunctionCall(caseExpr) &&
       exprIsFunctionCallOf(caseExpr, "=>", 2)
     ) {
+      // Skip non-executed cases (comptime branch elimination)
+      if (!caseExpr.args[0]?.$?.caseExecuted) continue;
+
       // This is a case => value pair
       const caseValue = caseExpr.args[0];
       let caseBody = caseExpr.args[1];
@@ -1056,6 +1065,9 @@ function generatePrimitiveMatchExpression(
       exprIsFunctionCall(caseExpr) &&
       exprIsFunctionCallOf(caseExpr, "=>", 2)
     ) {
+      // Skip non-executed cases (comptime branch elimination)
+      if (!caseExpr.args[0]?.$?.caseExecuted) continue;
+
       const caseValue = caseExpr.args[0];
       const caseBody = caseExpr.args[1];
 

--- a/src/codegen/exprs/while.ts
+++ b/src/codegen/exprs/while.ts
@@ -154,12 +154,23 @@ function generateLoopBody(
  * Generate C code for while loop expression
  * Supports both while(condition, body) and while(condition, step, body) forms
  * The 3-argument form is transpiled to a C for loop, 2-argument form to a C while loop
+ *
+ * When the evaluator has unrolled the loop (comptime condition with runtime body),
+ * the unrolled bodies are emitted sequentially without a loop.
  */
 export function generateWhileLoop(
   expr: FnCallExpr,
   indent: string,
   context: CodeGenContext
 ): string {
+  // Handle comptime-unrolled loops: emit bodies sequentially, no C loop
+  if (expr.$?.comptimeUnrolledBodies) {
+    for (const body of expr.$.comptimeUnrolledBodies) {
+      generateLoopBody(body, indent, context);
+    }
+    return "";
+  }
+
   const args = expr.args;
 
   if (args.length === 2) {

--- a/src/evaluator/exprs/while.ts
+++ b/src/evaluator/exprs/while.ts
@@ -1,6 +1,7 @@
 import type { Environment } from "../../env";
 import { formatErrorMessage } from "../../error";
 import {
+  cloneExpr,
   type Expr,
   exprToString,
   type FnCallExpr,
@@ -230,13 +231,100 @@ export function evaluateWhile({
     }
 
     // If the condition is compile-time true AND the body has runtime values,
-    // we should stop compile-time evaluation to avoid infinite loops
+    // try to unroll the loop by re-evaluating the condition with the updated env.
+    // If the condition eventually becomes false, we can unroll completely.
+    // Otherwise, fall back to a runtime loop.
     if (
       isBooleanValue(conditionValue) &&
       conditionValue.value === true &&
       bodyHasRuntimeValue
     ) {
-      // The loop will run at runtime, but we can't evaluate it at compile-time
+      // Re-evaluate the condition with the updated env to check if it will terminate
+      const checkCondClone = cloneExpr(conditionExpr);
+      const checkCondResult = evaluateBeginExpression({
+        expr: checkCondClone,
+        env,
+        context: { ...context },
+        variablesToAdd: [],
+      });
+      const nextCondValue = checkCondResult.$?.value;
+
+      if (isBooleanValue(nextCondValue)) {
+        // Condition is still comptime-known — we can try to unroll
+        const MAX_UNROLL_ITERATIONS = 10000;
+        const unrolledBodies: Expr[] = [bodyExpr]; // First iteration already evaluated
+
+        let currentEnv = env;
+        let condStillTrue = nextCondValue.value;
+
+        for (
+          let iter = 1;
+          condStillTrue && iter < MAX_UNROLL_ITERATIONS;
+          iter++
+        ) {
+          // Clone and evaluate the body for this iteration
+          const clonedBody = cloneExpr(bodyExpr);
+          const evalBody = evaluateBeginExpression({
+            expr: clonedBody,
+            env: currentEnv,
+            context: {
+              ...context,
+              isEvaluatingLoopBody: { kind: "while", env: currentEnv },
+            },
+            variablesToAdd: [],
+          });
+          if (!evalBody.$) break;
+
+          unrolledBodies.push(clonedBody);
+          currentEnv = evalBody.$.env;
+
+          // Execute step if provided (3-argument form)
+          if (stepExpr) {
+            const clonedStep = cloneExpr(stepExpr);
+            const evalStep = evaluateExpression({
+              expr: clonedStep,
+              env: currentEnv,
+              context: { ...context },
+            });
+            if (!evalStep.$) break;
+            currentEnv = evalStep.$.env;
+          }
+
+          // Re-evaluate the condition with the updated env
+          const condClone = cloneExpr(conditionExpr);
+          const condResult = evaluateBeginExpression({
+            expr: condClone,
+            env: currentEnv,
+            context: { ...context },
+            variablesToAdd: [],
+          });
+          const condVal = condResult.$?.value;
+
+          if (isBooleanValue(condVal) && condVal.value === false) {
+            condStillTrue = false;
+          } else if (isBooleanValue(condVal) && condVal.value === true) {
+            condStillTrue = true;
+          } else {
+            // Condition became runtime — can't unroll further, fall back
+            break;
+          }
+        }
+
+        if (!condStillTrue) {
+          // Loop terminates — store unrolled bodies
+          expr.$ = {
+            env: currentEnv,
+            pathCollection: [],
+            type: VUnit.type,
+            value: undefined,
+            comptimeUnrolledBodies: unrolledBodies,
+          };
+          return expr;
+        }
+      }
+
+      // Unrolling failed (condition stayed true, became runtime, or hit max iterations)
+      // Fall back to runtime loop
       expr.$ = {
         env: env,
         pathCollection: [],

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -412,6 +412,16 @@ export interface EvaluatedExprData {
    * cond/match branch arrows (which are not function boundaries).
    */
   isAnonymousFunctionDefinition?: boolean;
+
+  /**
+   * For while loops with comptime-known terminating conditions and runtime bodies,
+   * this contains the unrolled body expressions (one per iteration).
+   * Used by codegen to emit the bodies sequentially instead of generating a C loop.
+   *
+   * Example: `i :: 0; while (i < 3), { printf("%d\n", i32(i)); i = (i + 1); };`
+   * produces 3 unrolled body expressions, each with `i` bound to 0, 1, 2 respectively.
+   */
+  comptimeUnrolledBodies?: Expr[];
 }
 
 export type AtomExpr = {

--- a/src/tests/fixme.yo
+++ b/src/tests/fixme.yo
@@ -1,15 +1,10 @@
-{ yield } :: import "std/async";
+open import "std/libc/stdio";
 
 main :: (fn(using(io : IO)) -> unit)({
-  task := io.async((using(io : IO)) => {
-    a := i32(10);
-    io.await(yield());
-    b := (a + i32(5));
-    io.await(yield());
-    c := i32(20);
-    io.await(yield());
-    return (b + c);
-  });
-  r := io.await(task);
+  i :: 0;
+  while (i < 3), {
+    printf("%d\n", i32(i));
+    i = (i + 1);
+  };
 });
 export main;

--- a/tests/basic.test.yo
+++ b/tests/basic.test.yo
@@ -2428,3 +2428,98 @@ test "Test 'comptime_fn' function call and function overloading", {
   val2 :: op2.comptime_unwrap();
   comptime_assert(val2 == 55);
 };
+
+test "Test comptime while loop unrolling with runtime body", {
+  // 2-arg form: comptime counter with runtime accumulator
+  {
+    sum := 0;
+    i :: 0;
+    while (i < 5), {
+      sum = (sum + i32(i));
+      i = (i + 1);
+    };
+    assert((sum == 10), "2-arg unrolled sum should be 10");
+  };
+
+  // 3-arg form: comptime counter with step expression and runtime accumulator
+  {
+    sum := 0;
+    i :: 0;
+    while (i < 5), i = (i + 1), {
+      sum = (sum + i32(i));
+    };
+    assert((sum == 10), "3-arg unrolled sum should be 10");
+  };
+
+  // comptime condition initially false: body should not execute
+  {
+    sum := 0;
+    i :: 10;
+    while (i < 5), {
+      sum = (sum + i32(i));
+      i = (i + 1);
+    };
+    assert((sum == 0), "initially false condition should produce 0");
+  };
+
+  // single iteration unroll
+  {
+    sum := 0;
+    i :: 0;
+    while (i < 1), {
+      sum = (sum + i32(i));
+      i = (i + 1);
+    };
+    assert((sum == 0), "single iteration should produce 0");
+  };
+
+  // comptime unrolled while with multiple runtime side effects per iteration
+  {
+    a := 0;
+    b := 0;
+    i :: 0;
+    while (i < 3), {
+      a = (a + i32(i));
+      b = (b + i32((i * i)));
+      i = (i + 1);
+    };
+    assert((a == 3), "a should be 0+1+2 = 3");
+    assert((b == 5), "b should be 0+1+4 = 5");
+  };
+};
+
+test "Test comptime match branch elimination", {
+  // primitive match with comptime scrutinee — only matching branch should be emitted
+  {
+    x :: 2;
+    result := match(x,
+      1 => i32(10),
+      2 => i32(20),
+      3 => i32(30),
+      _ => i32(0)
+    );
+    assert((result == 20), "match on comptime 2 should yield 20");
+  };
+
+  // comptime scrutinee matching first branch
+  {
+    x :: 1;
+    result := match(x,
+      1 => i32(100),
+      2 => i32(200),
+      _ => i32(0)
+    );
+    assert((result == 100), "match on comptime 1 should yield 100");
+  };
+
+  // comptime scrutinee matching wildcard
+  {
+    x :: 99;
+    result := match(x,
+      1 => i32(10),
+      2 => i32(20),
+      _ => i32(999)
+    );
+    assert((result == 999), "match on comptime 99 should yield wildcard 999");
+  };
+};


### PR DESCRIPTION
When a while loop has a comptime-known condition and runtime body, the evaluator now unrolls the loop by re-evaluating the condition after each iteration. If the condition eventually becomes false, the unrolled bodies are stored and codegen emits them sequentially instead of a C loop.

Also fix match codegen crashing when the scrutinee is comptime-known: skip non-executed branches (caseExecuted check) in all 4 match codegen paths (nullable pointer, simple enum, complex enum, primitive).