### PR TITLE
fix(ci): build after version bump so yo --version is correct

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
     - name: Install dependencies
       run: |
         bun install
-        npm install -g @vscode/vsce
-        bun run build
 
     - name: Bump version in root package.json
       id: version
@@ -57,6 +55,9 @@ jobs:
       run: |
         cd vscode-extension
         npm version ${{ inputs.bump }} --no-git-tag-version
+
+    - name: Build
+      run: bun run build
 
     - name: Get last commit message
       id: last_commit
@@ -83,6 +84,7 @@ jobs:
       run: |
         cd vscode-extension
         bun install
+        npm install -g @vscode/vsce
         bun run build
         bun package
 


### PR DESCRIPTION
yo-cli.ts imports package.json version at build time. Previously bun run build ran before npm version bump, so the published package had the old version baked in. Moved build step after both version bumps.