### PR TITLE
Replace shell:true with cmd.exe /c to avoid DEP0190 warning

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1,4 +1,3 @@
-import { spawnSync, type SpawnSyncOptions } from "child_process";
 import * as fs from "fs";
 import path from "path";
 import {
@@ -6,12 +5,10 @@ import {
   getCompilerInfo,
   getSanitizerFlags,
   isLiburingAvailable,
+  spawnCompiler,
 } from "../compiler-utils";
 import { ModuleManager } from "../module-manager";
 
-// On Windows, .bat/.cmd scripts require shell:true for spawnSync to find them.
-const spawnShellOption: SpawnSyncOptions =
-  process.platform === "win32" ? { shell: true } : {};
 import {
   type TargetInfo,
   clangTriple,
@@ -282,9 +279,8 @@ export class CodeGenerator {
           console.log(
             `Compiling to object: ${compiler} ${compileToObjArgs.join(" ")}`
           );
-          const objResult = spawnSync(compiler, compileToObjArgs, {
+          const objResult = spawnCompiler(compiler, compileToObjArgs, {
             stdio: "inherit",
-            ...spawnShellOption,
           });
           if (objResult.error || objResult.status !== 0) {
             console.error(`Object compilation failed`);
@@ -305,9 +301,8 @@ export class CodeGenerator {
             : [...archiver.argsPrefix, "rcs", archiveFile, objectFile];
 
           console.log(`Creating archive: ${arTool} ${arArgs.join(" ")}`);
-          const arResult = spawnSync(arTool, arArgs, {
+          const arResult = spawnCompiler(arTool, arArgs, {
             stdio: "inherit",
-            ...spawnShellOption,
           });
           if (arResult.error || arResult.status !== 0) {
             console.error(`Archive creation failed`);
@@ -594,9 +589,8 @@ export class CodeGenerator {
 
         console.log(`Compiling with: ${compiler} ${compileArgs.join(" ")}`);
 
-        const result = spawnSync(compiler, compileArgs, {
+        const result = spawnCompiler(compiler, compileArgs, {
           stdio: "inherit",
-          ...spawnShellOption,
         });
 
         if (result.error) {

--- a/src/compiler-utils.ts
+++ b/src/compiler-utils.ts
@@ -1,4 +1,9 @@
-import { execSync } from "child_process";
+import {
+  execSync,
+  spawnSync,
+  type SpawnSyncOptions,
+  type SpawnSyncReturns,
+} from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -248,4 +253,24 @@ export function getMacOSLsanSuppressions(): string {
     return "";
   }
   return "leak:libobjc\nleak:libdyld\nleak:libxpc\nleak:libsystem_malloc\nleak:dyld";
+}
+
+/**
+ * Spawn a compiler process, handling Windows .bat/.cmd wrappers.
+ *
+ * On Windows, tools like `emcc` are .bat scripts that Node's `spawnSync`
+ * cannot find without `shell: true`. Using `shell: true` with an args array
+ * triggers DEP0190. Instead we invoke `cmd.exe /c <tool> ...args` which
+ * resolves .bat files and keeps args properly separated.
+ */
+export function spawnCompiler(
+  command: string,
+  args: readonly string[],
+  options?: SpawnSyncOptions
+): SpawnSyncReturns<string | Buffer> {
+  if (process.platform === "win32") {
+    const comspec = process.env.COMSPEC || "cmd.exe";
+    return spawnSync(comspec, ["/c", command, ...args], options ?? {});
+  }
+  return spawnSync(command, args, options ?? {});
 }

--- a/src/test-runner.ts
+++ b/src/test-runner.ts
@@ -1,11 +1,7 @@
-import { spawn, spawnSync, type SpawnSyncOptions } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-
-// On Windows, .bat/.cmd scripts require shell:true for spawnSync to find them.
-const spawnShellOption: SpawnSyncOptions =
-  process.platform === "win32" ? { shell: true } : {};
 import {
   buildAsanRunEnvironment,
   findClangAsanDllPath,
@@ -13,6 +9,7 @@ import {
   getMacOSLsanSuppressions,
   getSanitizerFlags,
   isLiburingAvailable,
+  spawnCompiler,
 } from "./compiler-utils";
 import { clearEnvContainingPrelude } from "./env";
 import { YoError } from "./error";
@@ -533,10 +530,9 @@ function runSingleTest(
     }
 
     const cCompileStart = Date.now();
-    const compileResult = spawnSync(cCompiler, compileArgs, {
+    const compileResult = spawnCompiler(cCompiler, compileArgs, {
       stdio: "pipe",
       encoding: "utf-8",
-      ...spawnShellOption,
     });
     const cCompileEnd = Date.now();
 


### PR DESCRIPTION
Node.js v22+ deprecates passing args array with shell:true (DEP0190).

Use cmd.exe /c on Windows instead, via shared spawnCompiler() helper.