### PR TITLE
Add -fno-exceptions flag for emcc to fix Emscripten 4.0.23+ compatibility

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -582,6 +582,11 @@ export class CodeGenerator {
         if (isEmcc) {
           compileArgs.splice(-2, 0, "-sEMULATE_FUNCTION_POINTER_CASTS=1");
 
+          // Yo generates C11, not C++ — disable C++ exception handling to avoid
+          // linker errors on Emscripten 4.0.23+ where the JS symbols library
+          // references __cxa_increment_exception_refcount.
+          compileArgs.splice(-2, 0, "-fno-exceptions");
+
           if (isTargetStandaloneWasi(targetInfo)) {
             // Standalone WASI: produce a .wasm file without JS glue
             compileArgs.splice(-2, 0, "-sSTANDALONE_WASM");

--- a/src/test-runner.ts
+++ b/src/test-runner.ts
@@ -520,6 +520,7 @@ function compileBatchedBinary(
 
     if (isEmcc) {
       compileArgs.splice(-2, 0, "-sEMULATE_FUNCTION_POINTER_CASTS=1");
+      compileArgs.splice(-2, 0, "-fno-exceptions");
       if (isWasi) {
         compileArgs.splice(-2, 0, "-sSTANDALONE_WASM");
       } else {


### PR DESCRIPTION
Emscripten 4.0.23 changed how C++ exception symbols are handled in libemscripten_js_symbols.so, causing wasm-ld to fail with:
  undefined symbol: __cxa_increment_exception_refcount

Since Yo generates C11 (not C++), C++ exception handling is unnecessary. Adding -fno-exceptions prevents the linker from referencing these symbols, fixing builds with newer Emscripten while remaining compatible with older versions (tested with 4.0.12 and 4.0.23).