### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: develop
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,9 +35,9 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -100,13 +100,10 @@ jobs:
           registryUrl: https://marketplace.visualstudio.com
 
       - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
-          release_name: Release v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
           body: |
             ${{ inputs.bump == 'minor' && 'Minor' || 'Patch' }} release v${{ steps.version.outputs.version }}
 
@@ -114,16 +111,7 @@ jobs:
             ${{ steps.last_commit.outputs.message }}
           draft: false
           prerelease: false
-
-      - name: Upload VSIX to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.create_vsix.outputs.vsixPath}}
-          asset_name: ${{ steps.create_vsix.outputs.vsixPath}}
-          asset_content_type: application/vsix
+          files: ${{ steps.create_vsix.outputs.vsixPath }}
 
       - name: Generate documentation website
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -48,7 +48,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -108,7 +108,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -154,7 +154,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ test_*
 
 tmp*
 yo-out*
+site*

--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -75,6 +75,42 @@ function escapeHtml(s: string): string {
  * - `https://shd101wyy.github.io/Yo/` → `std/index.html` (relative, same site)
  * - `#anchor` links → kept as-is
  */
+/**
+ * Generate a GitHub-compatible slug from heading text.
+ * - Strip HTML tags
+ * - Lowercase
+ * - Replace spaces with hyphens
+ * - Remove non-alphanumeric characters (except hyphens)
+ */
+function slugify(text: string): string {
+  return text
+    .replace(/<[^>]+>/g, "") // strip HTML tags
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Add `id` attributes to heading elements so that #anchor links work.
+ * Handles duplicate slugs by appending `-1`, `-2`, etc.
+ */
+function injectHeadingIds(html: string): string {
+  const slugCounts = new Map<string, number>();
+  return html.replace(
+    /<(h[1-6])>([\s\S]*?)<\/\1>/gi,
+    (_match: string, tag: string, content: string) => {
+      let slug = slugify(content);
+      const count = slugCounts.get(slug) ?? 0;
+      slugCounts.set(slug, count + 1);
+      if (count > 0) slug = `${slug}-${count}`;
+      return `<${tag} id="${slug}">${content}</${tag}>`;
+    }
+  );
+}
+
 function rewriteReadmeLinks(html: string): string {
   // Rewrite the generated docs link to relative std/ path (same site)
   html = html.replace(
@@ -383,6 +419,7 @@ async function main(): Promise<void> {
   });
 
   let readmeHtml = md.render(readmeSrc);
+  readmeHtml = injectHeadingIds(readmeHtml);
   readmeHtml = rewriteReadmeLinks(readmeHtml);
 
   const css = generateHomepageCSS();

--- a/src/doc/builder.ts
+++ b/src/doc/builder.ts
@@ -134,24 +134,28 @@ function functionParamsToDocParams(
 }
 
 function forallParamsToDocParams(
-  params: FunctionType["forallParameters"]
+  params: FunctionType["forallParameters"],
+  docLookup?: DocLookup
 ): DocParam[] {
   return params.map((p) => ({
     name: p.label,
     type: typeToString(p.type),
     isComptime: true,
     isImplicit: false,
+    doc: docLookup?.get(p.label),
   }));
 }
 
 function implicitParamsToDocParams(
-  params: FunctionType["implicitParameters"]
+  params: FunctionType["implicitParameters"],
+  docLookup?: DocLookup
 ): DocParam[] {
   return params.map((p) => ({
     name: p.label,
     type: typeToString(p.type),
     isComptime: true,
     isImplicit: true,
+    doc: docLookup?.get(p.label),
   }));
 }
 
@@ -178,11 +182,11 @@ function buildDocFunction(
     returnType: typeToString(funcType.return.type),
     typeParams:
       funcType.forallParameters.length > 0
-        ? forallParamsToDocParams(funcType.forallParameters)
+        ? forallParamsToDocParams(funcType.forallParameters, docLookup)
         : undefined,
     effects:
       funcType.implicitParameters.length > 0
-        ? implicitParamsToDocParams(funcType.implicitParameters)
+        ? implicitParamsToDocParams(funcType.implicitParameters, docLookup)
         : undefined,
     isMethod,
     selfType,

--- a/src/doc/extractor.test.ts
+++ b/src/doc/extractor.test.ts
@@ -624,4 +624,30 @@ describe("extractInlineDocs", () => {
     expect(docs.size).toBe(1);
     expect(docs.get("x")).toBe("The **bold** value.\n\nExample: `x = 42`");
   });
+
+  it("extracts docs for optional fields with ?= syntax", () => {
+    const docs = inlineDocsFromSource(`Config :: struct(
+      /// Step name.
+      name : comptime_string,
+      /// Compilation target triple.
+      (target : comptime_string) ?= "host",
+      /// Optimization level.
+      (optimize : i32) ?= 0
+    );`);
+
+    expect(docs.size).toBe(3);
+    expect(docs.get("name")).toBe("Step name.");
+    expect(docs.get("target")).toBe("Compilation target triple.");
+    expect(docs.get("optimize")).toBe("Optimization level.");
+  });
+
+  it("extracts top-level doc for ?= field via extractDocComments", () => {
+    const source = `/// Target doc.\n(target : i32) ?= 0;\n`;
+    const tokens = tokenize(source, "test.yo");
+    const result = extractDocComments(tokens);
+
+    expect(result.declarations.length).toBe(1);
+    expect(result.declarations[0]!.declarationName).toBe("target");
+    expect(result.declarations[0]!.comment.content).toBe("Target doc.");
+  });
 });

--- a/src/doc/extractor.ts
+++ b/src/doc/extractor.ts
@@ -322,6 +322,12 @@ function findNextDeclarationName(
     if (token.type === TokenType.Identifier) {
       return { name: token.value, position: token.position };
     }
+    // Skip opening parens so we can reach identifiers inside
+    // `(name : Type) ?= default` optional-field syntax
+    if (token.type === TokenType.LParen) {
+      i++;
+      continue;
+    }
     // If we hit something that's not an identifier (e.g., a keyword, operator),
     // the doc comment doesn't have a clear declaration target
     return { name: "", position: null };
@@ -418,6 +424,12 @@ function findNextIdentifier(
     }
     if (token.type === TokenType.Identifier) {
       return token.value;
+    }
+    // Skip opening parens so we can reach identifiers inside
+    // `(name : Type) ?= default` optional-field syntax
+    if (token.type === TokenType.LParen) {
+      i++;
+      continue;
     }
     // Hit a non-identifier, non-whitespace token — stop
     return "";

--- a/src/doc/render-html.ts
+++ b/src/doc/render-html.ts
@@ -81,6 +81,58 @@ function moduleGroup(name: string): string {
   return idx >= 0 ? name.slice(0, idx) : "";
 }
 
+// ── Symbol link resolution ────────────────────────────────────────────
+
+/** Map from symbol name → relative URL (from module/ directory) */
+type SymbolLinks = Map<string, string>;
+
+/** Build a lookup map from every documented symbol to its URL. */
+function buildSymbolLinks(model: DocModel): SymbolLinks {
+  const links: SymbolLinks = new Map();
+  for (const mod of model.modules) {
+    const fname = moduleToFilename(mod.name);
+    for (const t of mod.types) {
+      links.set(t.name, `${fname}.html#type-${t.name}`);
+    }
+    for (const tr of mod.traits) {
+      links.set(tr.name, `${fname}.html#trait-${tr.name}`);
+    }
+    for (const fn of mod.functions) {
+      links.set(fn.name, `${fname}.html#fn-${fn.name}`);
+    }
+    for (const c of mod.constants) {
+      links.set(c.name, `${fname}.html#const-${c.name}`);
+    }
+  }
+  return links;
+}
+
+/**
+ * Replace known PascalCase symbol names in a type string with clickable links.
+ * Handles types like `Option(T)`, `HashMap(K, V)`, `Result(T, E)`, etc.
+ */
+function linkifyType(
+  typeStr: string,
+  symbolLinks: SymbolLinks,
+  currentModuleFilename?: string
+): string {
+  const escaped = escapeHtml(typeStr);
+  // Match PascalCase identifiers (start with uppercase letter)
+  return escaped.replace(/\b([A-Z][a-zA-Z0-9_]*)\b/g, (match) => {
+    const href = symbolLinks.get(match);
+    if (!href) return match;
+    // Optimize same-page links to just anchors
+    if (
+      currentModuleFilename &&
+      href.startsWith(`${currentModuleFilename}.html#`)
+    ) {
+      const anchor = href.slice(href.indexOf("#"));
+      return `<a class="type-link" href="${anchor}">${match}</a>`;
+    }
+    return `<a class="type-link" href="${href}">${match}</a>`;
+  });
+}
+
 // ── CSS styles ───────────────────────────────────────────────────────
 
 function generateCSS(): string {
@@ -460,6 +512,15 @@ pre code {
   font-size: 13px;
   color: var(--accent);
   white-space: nowrap;
+}
+
+.type-link {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--accent);
+}
+.type-link:hover {
+  border-bottom-style: solid;
 }
 
 /* Methods section */
@@ -1085,7 +1146,9 @@ function renderSections(
 function renderParamsTable(
   md: MarkdownRenderer,
   params: DocParam[],
-  label: string = "Parameters"
+  label: string = "Parameters",
+  links?: SymbolLinks,
+  currentModFile?: string
 ): string {
   if (params.length === 0) return "";
 
@@ -1101,7 +1164,10 @@ function renderParamsTable(
     const docCell = hasDoc
       ? `<td>${p.doc ? renderMarkdown(md, p.doc) : ""}</td>`
       : "";
-    html += `\n<tr><td><code>${escapeHtml(p.name)}</code></td><td class="type-col">${escapeHtml(p.type)}</td><td>${notes.join(", ")}</td>${docCell}</tr>`;
+    const typeHtml = links
+      ? linkifyType(p.type, links, currentModFile)
+      : escapeHtml(p.type);
+    html += `\n<tr><td><code>${escapeHtml(p.name)}</code></td><td class="type-col">${typeHtml}</td><td>${notes.join(", ")}</td>${docCell}</tr>`;
   }
   html += `\n</tbody></table>`;
   return html;
@@ -1109,13 +1175,21 @@ function renderParamsTable(
 
 // ── Fields table rendering ───────────────────────────────────────────
 
-function renderFieldsTable(md: MarkdownRenderer, fields: DocField[]): string {
+function renderFieldsTable(
+  md: MarkdownRenderer,
+  fields: DocField[],
+  links?: SymbolLinks,
+  currentModFile?: string
+): string {
   if (fields.length === 0) return "";
 
   let html = `<h4>Fields</h4>\n<table class="fields-table">\n<thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>\n<tbody>`;
   for (const f of fields) {
     const docText = f.doc ? renderMarkdown(md, f.doc) : "";
-    html += `\n<tr><td><code>${escapeHtml(f.name)}</code></td><td class="type-col">${escapeHtml(f.type)}</td><td>${docText}</td></tr>`;
+    const typeHtml = links
+      ? linkifyType(f.type, links, currentModFile)
+      : escapeHtml(f.type);
+    html += `\n<tr><td><code>${escapeHtml(f.name)}</code></td><td class="type-col">${typeHtml}</td><td>${docText}</td></tr>`;
   }
   html += `\n</tbody></table>`;
   return html;
@@ -1125,7 +1199,9 @@ function renderFieldsTable(md: MarkdownRenderer, fields: DocField[]): string {
 
 function renderVariantsTable(
   md: MarkdownRenderer,
-  variants: DocVariant[]
+  variants: DocVariant[],
+  links?: SymbolLinks,
+  currentModFile?: string
 ): string {
   if (variants.length === 0) return "";
 
@@ -1133,7 +1209,12 @@ function renderVariantsTable(
   for (const v of variants) {
     const fieldsStr = v.fields
       ? v.fields
-          .map((f) => `${escapeHtml(f.name)}: ${escapeHtml(f.type)}`)
+          .map((f) => {
+            const typeHtml = links
+              ? linkifyType(f.type, links, currentModFile)
+              : escapeHtml(f.type);
+            return `${escapeHtml(f.name)}: ${typeHtml}`;
+          })
           .join(", ")
       : "";
     const docText = v.doc ? renderMarkdown(md, v.doc) : "";
@@ -1147,14 +1228,21 @@ function renderVariantsTable(
 
 function renderAssociatedTypes(
   md: MarkdownRenderer,
-  types: DocAssociatedType[] | undefined
+  types: DocAssociatedType[] | undefined,
+  links?: SymbolLinks,
+  currentModFile?: string
 ): string {
   if (!types || types.length === 0) return "";
 
   let html = `<h4>Associated Types</h4>\n<table class="fields-table">\n<thead><tr><th>Name</th><th>Constraint</th><th>Description</th></tr></thead>\n<tbody>`;
   for (const t of types) {
     const docText = t.doc ? renderMarkdown(md, t.doc) : "";
-    html += `\n<tr><td><code>${escapeHtml(t.name)}</code></td><td class="type-col">${t.constraint ? escapeHtml(t.constraint) : ""}</td><td>${docText}</td></tr>`;
+    const constraintHtml = t.constraint
+      ? links
+        ? linkifyType(t.constraint, links, currentModFile)
+        : escapeHtml(t.constraint)
+      : "";
+    html += `\n<tr><td><code>${escapeHtml(t.name)}</code></td><td class="type-col">${constraintHtml}</td><td>${docText}</td></tr>`;
   }
   html += `\n</tbody></table>`;
   return html;
@@ -1165,7 +1253,9 @@ function renderAssociatedTypes(
 function renderMethods(
   md: MarkdownRenderer,
   methods: DocFunction[],
-  parentName: string
+  parentName: string,
+  links?: SymbolLinks,
+  currentModFile?: string
 ): string {
   if (methods.length === 0) return "";
 
@@ -1177,9 +1267,18 @@ function renderMethods(
     html += renderDeprecatedBanner(md, m.deprecated);
     html += renderDoc(md, m.doc);
     if (m.parameters.length > 0) {
-      html += renderParamsTable(md, m.parameters);
+      html += renderParamsTable(
+        md,
+        m.parameters,
+        "Parameters",
+        links,
+        currentModFile
+      );
     }
-    html += `\n<p>Returns: <code>${escapeHtml(m.returnType)}</code></p>`;
+    const retHtml = links
+      ? linkifyType(m.returnType, links, currentModFile)
+      : escapeHtml(m.returnType);
+    html += `\n<p>Returns: <code>${retHtml}</code></p>`;
     html += renderSections(md, m);
     html += `\n</div></div>`;
   }
@@ -1188,12 +1287,25 @@ function renderMethods(
 
 // ── Trait impls rendering ────────────────────────────────────────────
 
-function renderTraitImpls(impls: string[]): string {
+function renderTraitImpls(
+  impls: string[],
+  links?: SymbolLinks,
+  currentModFile?: string
+): string {
   if (impls.length === 0) return "";
 
   let html = `<h4>Trait Implementations</h4>\n<div class="trait-impl-list">`;
   for (const name of impls) {
-    html += `\n<span class="trait-impl-badge">${escapeHtml(name)}</span>`;
+    const href = links?.get(name);
+    if (href) {
+      const resolvedHref =
+        currentModFile && href.startsWith(`${currentModFile}.html#`)
+          ? href.slice(href.indexOf("#"))
+          : href;
+      html += `\n<a class="trait-impl-badge" href="${resolvedHref}">${escapeHtml(name)}</a>`;
+    } else {
+      html += `\n<span class="trait-impl-badge">${escapeHtml(name)}</span>`;
+    }
   }
   html += `\n</div>`;
   return html;
@@ -1201,7 +1313,12 @@ function renderTraitImpls(impls: string[]): string {
 
 // ── Function rendering ───────────────────────────────────────────────
 
-function renderFunction(md: MarkdownRenderer, fn: DocFunction): string {
+function renderFunction(
+  md: MarkdownRenderer,
+  fn: DocFunction,
+  links?: SymbolLinks,
+  currentModFile?: string
+): string {
   let html = `<div class="item-card${fn.deprecated ? " deprecated" : ""}" id="fn-${escapeHtml(fn.name)}">
 <div class="item-header">
   <a class="item-name" href="#fn-${escapeHtml(fn.name)}">${escapeHtml(fn.name)}</a>
@@ -1213,16 +1330,31 @@ function renderFunction(md: MarkdownRenderer, fn: DocFunction): string {
   html += renderDoc(md, fn.doc);
 
   if (fn.typeParams && fn.typeParams.length > 0) {
-    html += renderParamsTable(md, fn.typeParams, "Type Parameters");
+    html += renderParamsTable(
+      md,
+      fn.typeParams,
+      "Type Parameters",
+      links,
+      currentModFile
+    );
   }
   if (fn.parameters.length > 0) {
-    html += renderParamsTable(md, fn.parameters);
+    html += renderParamsTable(
+      md,
+      fn.parameters,
+      "Parameters",
+      links,
+      currentModFile
+    );
   }
   if (fn.effects && fn.effects.length > 0) {
-    html += renderParamsTable(md, fn.effects, "Effects");
+    html += renderParamsTable(md, fn.effects, "Effects", links, currentModFile);
   }
 
-  html += `\n<p>Returns: <code>${escapeHtml(fn.returnType)}</code></p>`;
+  const retHtml = links
+    ? linkifyType(fn.returnType, links, currentModFile)
+    : escapeHtml(fn.returnType);
+  html += `\n<p>Returns: <code>${retHtml}</code></p>`;
   html += renderSections(md, fn);
   html += `\n</div></div>`;
   return html;
@@ -1230,7 +1362,12 @@ function renderFunction(md: MarkdownRenderer, fn: DocFunction): string {
 
 // ── Type rendering ───────────────────────────────────────────────────
 
-function renderType(md: MarkdownRenderer, t: DocType): string {
+function renderType(
+  md: MarkdownRenderer,
+  t: DocType,
+  links?: SymbolLinks,
+  currentModFile?: string
+): string {
   let html = `<div class="item-card${t.deprecated ? " deprecated" : ""}" id="type-${escapeHtml(t.name)}">
 <div class="item-header">
   <a class="item-name" href="#type-${escapeHtml(t.name)}">${escapeHtml(t.name)}</a>
@@ -1242,16 +1379,22 @@ function renderType(md: MarkdownRenderer, t: DocType): string {
   html += renderDoc(md, t.doc);
 
   if (t.typeParams && t.typeParams.length > 0) {
-    html += renderParamsTable(md, t.typeParams, "Type Parameters");
+    html += renderParamsTable(
+      md,
+      t.typeParams,
+      "Type Parameters",
+      links,
+      currentModFile
+    );
   }
   if (t.fields && t.fields.length > 0) {
-    html += renderFieldsTable(md, t.fields);
+    html += renderFieldsTable(md, t.fields, links, currentModFile);
   }
   if (t.variants && t.variants.length > 0) {
-    html += renderVariantsTable(md, t.variants);
+    html += renderVariantsTable(md, t.variants, links, currentModFile);
   }
-  html += renderTraitImpls(t.traitImpls);
-  html += renderMethods(md, t.methods, t.name);
+  html += renderTraitImpls(t.traitImpls, links, currentModFile);
+  html += renderMethods(md, t.methods, t.name, links, currentModFile);
   if (t.examples) {
     html += `\n<div class="doc-section"><h5>Examples</h5><div class="doc-section-content">${renderMarkdown(md, t.examples)}</div></div>`;
   }
@@ -1262,7 +1405,12 @@ function renderType(md: MarkdownRenderer, t: DocType): string {
 
 // ── Trait rendering ──────────────────────────────────────────────────
 
-function renderTrait(md: MarkdownRenderer, tr: DocTrait): string {
+function renderTrait(
+  md: MarkdownRenderer,
+  tr: DocTrait,
+  links?: SymbolLinks,
+  currentModFile?: string
+): string {
   let html = `<div class="item-card${tr.deprecated ? " deprecated" : ""}" id="trait-${escapeHtml(tr.name)}">
 <div class="item-header">
   <a class="item-name" href="#trait-${escapeHtml(tr.name)}">${escapeHtml(tr.name)}</a>
@@ -1274,10 +1422,16 @@ function renderTrait(md: MarkdownRenderer, tr: DocTrait): string {
   html += renderDoc(md, tr.doc);
 
   if (tr.typeParams && tr.typeParams.length > 0) {
-    html += renderParamsTable(md, tr.typeParams, "Type Parameters");
+    html += renderParamsTable(
+      md,
+      tr.typeParams,
+      "Type Parameters",
+      links,
+      currentModFile
+    );
   }
-  html += renderAssociatedTypes(md, tr.associatedTypes);
-  html += renderMethods(md, tr.methods, tr.name);
+  html += renderAssociatedTypes(md, tr.associatedTypes, links, currentModFile);
+  html += renderMethods(md, tr.methods, tr.name, links, currentModFile);
   if (tr.examples) {
     html += `\n<div class="doc-section"><h5>Examples</h5><div class="doc-section-content">${renderMarkdown(md, tr.examples)}</div></div>`;
   }
@@ -1285,7 +1439,16 @@ function renderTrait(md: MarkdownRenderer, tr: DocTrait): string {
   if (tr.implementors.length > 0) {
     html += `\n<h4>Implementors</h4>\n<div class="trait-impl-list">`;
     for (const name of tr.implementors) {
-      html += `\n<span class="trait-impl-badge">${escapeHtml(name)}</span>`;
+      const href = links?.get(name);
+      if (href) {
+        const resolvedHref =
+          currentModFile && href.startsWith(`${currentModFile}.html#`)
+            ? href.slice(href.indexOf("#"))
+            : href;
+        html += `\n<a class="trait-impl-badge" href="${resolvedHref}">${escapeHtml(name)}</a>`;
+      } else {
+        html += `\n<span class="trait-impl-badge">${escapeHtml(name)}</span>`;
+      }
     }
     html += `\n</div>`;
   }
@@ -1296,12 +1459,20 @@ function renderTrait(md: MarkdownRenderer, tr: DocTrait): string {
 
 // ── Constant rendering ───────────────────────────────────────────────
 
-function renderConstant(md: MarkdownRenderer, c: DocConstant): string {
+function renderConstant(
+  md: MarkdownRenderer,
+  c: DocConstant,
+  links?: SymbolLinks,
+  currentModFile?: string
+): string {
+  const typeHtml = links
+    ? linkifyType(c.type, links, currentModFile)
+    : escapeHtml(c.type);
   let html = `<div class="item-card${c.deprecated ? " deprecated" : ""}" id="const-${escapeHtml(c.name)}">
 <div class="item-header">
   <a class="item-name" href="#const-${escapeHtml(c.name)}">${escapeHtml(c.name)}</a>
   <span class="item-kind">constant</span>
-  <span class="item-sig">${escapeHtml(c.type)}</span>
+  <span class="item-sig">${typeHtml}</span>
 </div>
 <div class="item-body">`;
   html += renderDeprecatedBanner(md, c.deprecated);
@@ -1391,7 +1562,12 @@ function renderModuleCard(md: MarkdownRenderer, mod: DocModule): string {
 
 // ── Module page ──────────────────────────────────────────────────────
 
-function renderModuleContent(md: MarkdownRenderer, mod: DocModule): string {
+function renderModuleContent(
+  md: MarkdownRenderer,
+  mod: DocModule,
+  links?: SymbolLinks
+): string {
+  const currentModFile = moduleToFilename(mod.name);
   let html = `<div class="breadcrumb"><a href="../index.html">Home</a> &rsaquo; ${escapeHtml(mod.name)}</div>`;
   html += `<h1>Module <code>${escapeHtml(mod.name)}</code></h1>`;
   html += `<div class="module-path">${escapeHtml(mod.path)}</div>`;
@@ -1401,7 +1577,7 @@ function renderModuleContent(md: MarkdownRenderer, mod: DocModule): string {
   if (mod.types.length > 0) {
     html += `<h2>Types</h2>\n<div class="item-list">`;
     for (const t of mod.types) {
-      html += renderType(md, t);
+      html += renderType(md, t, links, currentModFile);
     }
     html += `\n</div>`;
   }
@@ -1410,7 +1586,7 @@ function renderModuleContent(md: MarkdownRenderer, mod: DocModule): string {
   if (mod.traits.length > 0) {
     html += `<h2>Traits / Modules</h2>\n<div class="item-list">`;
     for (const tr of mod.traits) {
-      html += renderTrait(md, tr);
+      html += renderTrait(md, tr, links, currentModFile);
     }
     html += `\n</div>`;
   }
@@ -1419,7 +1595,7 @@ function renderModuleContent(md: MarkdownRenderer, mod: DocModule): string {
   if (mod.functions.length > 0) {
     html += `<h2>Functions</h2>\n<div class="item-list">`;
     for (const fn of mod.functions) {
-      html += renderFunction(md, fn);
+      html += renderFunction(md, fn, links, currentModFile);
     }
     html += `\n</div>`;
   }
@@ -1428,7 +1604,7 @@ function renderModuleContent(md: MarkdownRenderer, mod: DocModule): string {
   if (mod.constants.length > 0) {
     html += `<h2>Constants</h2>\n<div class="item-list">`;
     for (const c of mod.constants) {
-      html += renderConstant(md, c);
+      html += renderConstant(md, c, links, currentModFile);
     }
     html += `\n</div>`;
   }
@@ -1461,6 +1637,7 @@ export async function renderDocSite(options: RenderHtmlOptions): Promise<void> {
   const cssText = generateCSS();
   const jsText = generateSearchJS();
   const searchIdx = buildSearchIndex(model);
+  const symbolLinks = buildSymbolLinks(model);
 
   // Ensure output directories exist
   fs.mkdirSync(outputDir, { recursive: true });
@@ -1487,7 +1664,7 @@ export async function renderDocSite(options: RenderHtmlOptions): Promise<void> {
       .replace(/href="module\//g, 'href="')
       .replace('href="index.html"', 'href="../index.html"');
 
-    const modContent = renderModuleContent(md, mod);
+    const modContent = renderModuleContent(md, mod, symbolLinks);
     const modSearchIdx = searchIdx.map((e) => ({
       ...e,
       href: e.href.startsWith("module/") ? e.href.slice(7) : `../${e.href}`,
@@ -1514,6 +1691,8 @@ export async function renderDocSite(options: RenderHtmlOptions): Promise<void> {
 export {
   escapeHtml,
   buildSearchIndex,
+  buildSymbolLinks,
+  linkifyType,
   firstSentence,
   generateCSS,
   generateSearchJS,

--- a/src/doc/render-html.ts
+++ b/src/doc/render-html.ts
@@ -785,7 +785,7 @@ function generateHighlightJS(): string {
     // Extract strings and comments first (they take priority)
     var protected_ = [];
     var placeholder = function(match, cls) {
-      var id = '\\x00' + protected_.length + '\\x00';
+      var id = '\\x00_' + protected_.length + '_\\x00';
       protected_.push('<span class="' + cls + '">' + esc(match) + '</span>');
       return id;
     };
@@ -804,7 +804,7 @@ function generateHighlightJS(): string {
     src = src.replace(NUMBERS, '<span class="hljs-number">$1</span>');
     // Restore protected tokens
     for (var i = 0; i < protected_.length; i++) {
-      src = src.replace('\\x00' + i + '\\x00', protected_[i]);
+      src = src.replace('\\x00_' + i + '_\\x00', protected_[i]);
     }
     return src;
   }

--- a/src/doc/render-html.ts
+++ b/src/doc/render-html.ts
@@ -477,6 +477,20 @@ pre code {
   font-size: 14px;
 }
 
+.method-header code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+.decl-signature code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
 .method-body {
   padding: 12px 16px;
 }
@@ -796,6 +810,10 @@ function generateHighlightJS(): string {
   }
 
   document.querySelectorAll('pre > code[class*="language-"]').forEach(function(el) {
+    el.innerHTML = highlight(el.textContent || '');
+  });
+
+  document.querySelectorAll('.method-header code, .decl-signature').forEach(function(el) {
     el.innerHTML = highlight(el.textContent || '');
   });
 })();

--- a/src/doc/render-html.ts
+++ b/src/doc/render-html.ts
@@ -317,15 +317,17 @@ h4 { font-size: 15px; font-weight: 600; margin: 16px 0 6px; }
   color: var(--text-secondary);
 }
 
-.doc-content code {
+code {
   font-family: var(--font-mono);
   font-size: 0.9em;
   background: var(--bg-code);
   padding: 2px 5px;
   border-radius: 3px;
+  border: 1px solid var(--border-light);
+  color: var(--text);
 }
 
-.doc-content pre {
+pre {
   background: var(--bg-code-block);
   color: var(--text-code);
   padding: 16px;
@@ -336,11 +338,27 @@ h4 { font-size: 15px; font-weight: 600; margin: 16px 0 6px; }
   line-height: 1.5;
 }
 
-.doc-content pre code {
+pre code {
   background: none;
   padding: 0;
+  border: none;
   color: inherit;
+  font-size: inherit;
 }
+
+/* Syntax highlighting — One Dark inspired */
+.hljs-keyword { color: #c678dd; }
+.hljs-type { color: #e5c07b; }
+.hljs-string { color: #98c379; }
+.hljs-number { color: #d19a66; }
+.hljs-comment { color: #5c6370; font-style: italic; }
+.hljs-function { color: #61afef; }
+.hljs-operator { color: #56b6c2; }
+.hljs-punctuation { color: #abb2bf; }
+.hljs-property { color: #e06c75; }
+.hljs-constant { color: #d19a66; }
+.hljs-builtin { color: #e5c07b; }
+.hljs-attr { color: #d19a66; }
 
 /* Item cards */
 .item-list { margin: 12px 0; }
@@ -729,6 +747,61 @@ function generateSearchJS(): string {
 `.trim();
 }
 
+// ── Syntax highlighting JS ───────────────────────────────────────────
+
+function generateHighlightJS(): string {
+  return `
+(function() {
+  var KEYWORDS = /\\b(fn|struct|enum|union|module|trait|impl|object|newtype|open|import|export|return|escape|recur|match|cond|if|while|for|break|continue|test|assert|comptime|runtime|comptime_assert|comptime_expect_error|forall|using|given|where|defer|dyn|pub|let|const|type|true|false|else|in|as|self|Self)\\b/g;
+  var TYPES = /\\b(i8|i16|i32|i64|u8|u16|u32|u64|f32|f64|bool|char|rune|str|usize|isize|unit|void|Type|comptime_string|comptime_int|comptime_float)\\b/g;
+  var BUILTINS = /\\b(Option|Result|Box|box|String|Future|IO|Impl|Slice|Array|Pointer|Fn|HashMap|ArrayList|BTreeMap|Deque|LinkedList|HashSet|BTreeSet|Rc|Arc|Mutex|Channel|WaitGroup|Thread|JoinHandle|Range)\\b/g;
+  var STRINGS = /(\`(?:[^\`\\\\]|\\\\.)*\`|"(?:[^"\\\\]|\\\\.)*")/g;
+  var NUMBERS = /\\b(0x[0-9a-fA-F_]+|0b[01_]+|0o[0-7_]+|[0-9][0-9_]*\\.?[0-9_]*(?:[eE][+-]?[0-9_]+)?)\\b/g;
+  var LINE_COMMENTS = /(\\/\\/(?!\\/)[^\\n]*)/g;
+  var DOC_COMMENTS = /(\\/\\/\\/[^\\n]*|\\/\\/![^\\n]*)/g;
+  var BLOCK_COMMENTS = /(\\/\\*[\\s\\S]*?\\*\\/)/g;
+  var OPERATORS = /([=!<>&|+\\-*\\/%^~]+|::|\\.\\.|=>|\\?=|:=)/g;
+  var PROPERTIES = /\\.([a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=\\(|\\b)/g;
+
+  function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+  function highlight(code) {
+    var tokens = [];
+    var src = code;
+    // Extract strings and comments first (they take priority)
+    var protected_ = [];
+    var placeholder = function(match, cls) {
+      var id = '\\x00' + protected_.length + '\\x00';
+      protected_.push('<span class="' + cls + '">' + esc(match) + '</span>');
+      return id;
+    };
+    // Block comments first
+    src = src.replace(BLOCK_COMMENTS, function(m) { return placeholder(m, 'hljs-comment'); });
+    // Doc comments before line comments
+    src = src.replace(DOC_COMMENTS, function(m) { return placeholder(m, 'hljs-comment'); });
+    src = src.replace(LINE_COMMENTS, function(m) { return placeholder(m, 'hljs-comment'); });
+    // Strings (template and double-quoted)
+    src = src.replace(STRINGS, function(m) { return placeholder(m, 'hljs-string'); });
+    // Now highlight the rest
+    src = esc(src);
+    src = src.replace(KEYWORDS, '<span class="hljs-keyword">$1</span>');
+    src = src.replace(TYPES, '<span class="hljs-type">$1</span>');
+    src = src.replace(BUILTINS, '<span class="hljs-builtin">$1</span>');
+    src = src.replace(NUMBERS, '<span class="hljs-number">$1</span>');
+    // Restore protected tokens
+    for (var i = 0; i < protected_.length; i++) {
+      src = src.replace('\\x00' + i + '\\x00', protected_[i]);
+    }
+    return src;
+  }
+
+  document.querySelectorAll('pre > code[class*="language-"]').forEach(function(el) {
+    el.innerHTML = highlight(el.textContent || '');
+  });
+})();
+`.trim();
+}
+
 // ── Search index builder ─────────────────────────────────────────────
 
 interface SearchEntry {
@@ -841,6 +914,7 @@ ${content}
 <button id="back-to-top" class="back-to-top" aria-label="Back to top">&uarr;</button>
 <script>window.__SEARCH_INDEX = ${JSON.stringify(searchIndex)};</script>
 <script>${jsText}</script>
+<script>${generateHighlightJS()}</script>
 </body>
 </html>`;
 }
@@ -1425,6 +1499,7 @@ export {
   firstSentence,
   generateCSS,
   generateSearchJS,
+  generateHighlightJS,
   moduleToFilename,
   moduleDisplayName,
   moduleGroup,

--- a/src/tests/fixme.yo
+++ b/src/tests/fixme.yo
@@ -1,7 +1,18 @@
-open import "std/fmt";
+Point :: struct(
+  /// This is the x coordinate of the point.
+  (x : i32) ?= 0,
+
+  /// This is the y coordinate of the point.
+  (y : i32) ?= 1
+);
 
 main :: (fn() -> unit) {
-  x := "hi\"there";
-  println(x);
+  p1 := Point();
+  assert(p1.x == 0);
+  assert(p1.y == 1);
+
+  (p2 : Point) = {};
+  assert(p2.x == 0);
+  assert(p2.y == 1);
 };
 export main;

--- a/src/tests/fixme.yo
+++ b/src/tests/fixme.yo
@@ -1,6 +1,7 @@
+open import "std/fmt";
+
 main :: (fn() -> unit) {
-  x := 12;
-  y := unsafe.cast(x, f32);
-  assert(y == 12.0);
+  x := "hi\"there";
+  println(x);
 };
 export main;

--- a/std/build.yo
+++ b/std/build.yo
@@ -18,17 +18,17 @@
 
 /// Optimization level for compiled artifacts.
 Optimize :: enum(
-  /// No optimizations, full debug info.
-  /// Compiler Flags: -O0 -g
+  /// No optimizations, full debug info.  
+  /// Compiler Flags: `-O0 -g`
   Debug,
-  /// Optimized with safety checks.
-  /// Compiler Flags: -O2 -g
+  /// Optimized with safety checks.  
+  /// Compiler Flags: `-O2 -g`
   ReleaseSafe,
-  /// Maximum speed optimizations.
-  /// Compiler Flags: -O3
+  /// Maximum speed optimizations.  
+  /// Compiler Flags: `-O3`
   ReleaseFast,
-  /// Optimize for binary size.
-  /// Compiler Flags -O2
+  /// Optimize for binary size.  
+  /// Compiler Flags `-O2`
   ReleaseSmall
 );
 export Optimize;

--- a/std/build.yo
+++ b/std/build.yo
@@ -19,12 +19,16 @@
 /// Optimization level for compiled artifacts.
 Optimize :: enum(
   /// No optimizations, full debug info.
+  /// Compiler Flags: -O0 -g
   Debug,
   /// Optimized with safety checks.
+  /// Compiler Flags: -O2 -g
   ReleaseSafe,
   /// Maximum speed optimizations.
+  /// Compiler Flags: -O3
   ReleaseFast,
   /// Optimize for binary size.
+  /// Compiler Flags -O2
   ReleaseSmall
 );
 export Optimize;

--- a/std/encoding/base64.yo
+++ b/std/encoding/base64.yo
@@ -1,10 +1,13 @@
 //! Base64 encoding and decoding (RFC 4648) with standard and URL-safe variants.
 //!
-//! Example:
-//!   { base64_encode, base64_decode } :: import "std/encoding/base64";
+//! # Example
 //!
-//!   s := base64_encode(data);
-//!   b := base64_decode(s.to_str()).unwrap();
+//! ```rust
+//! { base64_encode, base64_decode } :: import "std/encoding/base64";
+//!
+//! s := base64_encode(data);
+//! b := base64_decode(s.to_str()).unwrap();
+//! ```
 
 open import "../string";
 { ArrayList } :: import "../collections/array_list";

--- a/std/encoding/hex.yo
+++ b/std/encoding/hex.yo
@@ -2,11 +2,14 @@
 //!
 //! Converts between raw bytes (`ArrayList(u8)`) and hex strings.
 //!
-//! Example:
-//!   { hex_encode, hex_decode } :: import "std/encoding/hex";
+//! # Example
 //!
-//!   s := hex_encode(data);         // "deadbeef"
-//!   b := hex_decode("deadbeef");
+//! ```rust
+//! { hex_encode, hex_decode } :: import "std/encoding/hex";
+//!
+//! s := hex_encode(data);         // "deadbeef"
+//! b := hex_decode("deadbeef");
+//! ```
 
 open import "../string";
 { ArrayList } :: import "../collections/array_list";

--- a/std/encoding/html.yo
+++ b/std/encoding/html.yo
@@ -3,11 +3,14 @@
 //! Decodes named (&amp;), decimal (&#38;), and hex (&#x26;) HTML character references.
 //! Uses Legacy mode — entities without trailing semicolon are also decoded.
 //!
-//! Example:
-//!   { decode_html } :: import "std/encoding/html";
+//! # Example
 //!
-//!   result := decode_html(`&amp; &lt; &#38; &#x26;`);
-//!   assert((result == `& < & &`), "decoded entities");
+//! ```rust
+//! { decode_html } :: import "std/encoding/html";
+//!
+//! result := decode_html(`&amp; &lt; &#38; &#x26;`);
+//! assert((result == `& < & &`), "decoded entities");
+//! ```
 
 open import "../string";
 { HashMap } :: import "../collections/hash_map";

--- a/std/encoding/json.yo
+++ b/std/encoding/json.yo
@@ -2,13 +2,16 @@
 //!
 //! Provides a dynamically-typed JSON value tree.
 //!
-//! Example:
-//!   { json_parse, json_stringify, JsonValue } :: import "std/encoding/json";
-//!   { Exception } :: import "std/error";
+//! # Example
 //!
-//!   given(exn) := Exception(throw : ((err) -> { escape (); }));
-//!   v := json_parse(`{"x": 1}`);
-//!   println(json_stringify(v));
+//! ```rust
+//! { json_parse, json_stringify, JsonValue } :: import "std/encoding/json";
+//! { Exception } :: import "std/error";
+//!
+//! given(exn) := Exception(throw : ((err) -> { escape (); }));
+//! v := json_parse(`{"x": 1}`);
+//! println(json_stringify(v));
+//! ```
 
 open import "../string";
 { ArrayList } :: import "../collections/array_list";

--- a/std/encoding/punycode.yo
+++ b/std/encoding/punycode.yo
@@ -2,13 +2,16 @@
 //!
 //! Provides punycode encoding/decoding and IDN hostname conversion.
 //!
-//! Example:
-//!   { punycode_decode, punycode_encode, to_unicode, to_ascii } :: import "std/encoding/punycode";
+//! # Example
 //!
-//!   encoded := punycode_encode(`München`);
-//!   decoded := punycode_decode(encoded);
-//!   ascii_domain := to_ascii(`münchen.de`);  // "xn--mnchen-3ya.de"
-//!   unicode_domain := to_unicode(ascii_domain);  // "münchen.de"
+//! ```rust
+//! { punycode_decode, punycode_encode, to_unicode, to_ascii } :: import "std/encoding/punycode";
+//!
+//! encoded := punycode_encode(`München`);
+//! decoded := punycode_decode(encoded);
+//! ascii_domain := to_ascii(`münchen.de`);  // "xn--mnchen-3ya.de"
+//! unicode_domain := to_unicode(ascii_domain);  // "münchen.de"
+//! ```
 
 open import "../string";
 { ArrayList } :: import "../collections/array_list";

--- a/std/encoding/toml.yo
+++ b/std/encoding/toml.yo
@@ -3,10 +3,13 @@
 //! Parses a subset of TOML into a `TomlValue` tree.
 //! Supports: strings, integers, booleans, table sections, comments.
 //!
-//! Example:
-//!   { toml_parse, TomlValue } :: import "std/encoding/toml";
-//!   // Or via the encoding index:
-//!   { toml_parse, TomlValue } :: import "std/encoding";
+//! # Example
+//!
+//! ```rust
+//! { toml_parse, TomlValue } :: import "std/encoding/toml";
+//! // Or via the encoding index:
+//! { toml_parse, TomlValue } :: import "std/encoding";
+//! ```
 
 open import "../string";
 { ArrayList } :: import "../collections/array_list";

--- a/std/encoding/utf16.yo
+++ b/std/encoding/utf16.yo
@@ -2,11 +2,14 @@
 //!
 //! Converts between Yo's UTF-8 `str` and UTF-16 code units (`ArrayList(u16)`).
 //!
-//! Example:
-//!   { utf8_to_utf16, utf16_to_utf8 } :: import "std/encoding/utf16";
+//! # Example
 //!
-//!   words := utf8_to_utf16("hello");
-//!   s := utf16_to_utf8(words);
+//! ```rust
+//! { utf8_to_utf16, utf16_to_utf8 } :: import "std/encoding/utf16";
+//!
+//! words := utf8_to_utf16("hello");
+//! s := utf16_to_utf8(words);
+//! ```
 
 open import "../string";
 { ArrayList } :: import "../collections/array_list";

--- a/std/fs/dir.yo
+++ b/std/fs/dir.yo
@@ -2,24 +2,24 @@
 //!
 //! Wraps low-level `std/sys/dir` with typed APIs using the `Exception` effect.
 //!
-//! Example:
+//! # Example
 //!
-//!   ```yo
-//!   { create_dir, remove_dir, read_dir } :: import "std/fs/dir";
-//!   { Path } :: import "std/path";
+//! ```rust
+//! { create_dir, remove_dir, read_dir } :: import "std/fs/dir";
+//! { Path } :: import "std/path";
 //!
-//!   main :: (fn(using(io : IO)) -> unit)({
-//!     given(exn) : Exception = {
-//!       throw : (fn(forall(T : Type), error: AnyError) -> T)(
-//!         { println(error.to_string()); exit(i32(1)); }
-//!       )
-//!     };
+//! main :: (fn(using(io : IO)) -> unit)({
+//!   given(exn) : Exception = {
+//!     throw : (fn(forall(T : Type), error: AnyError) -> T)(
+//!       { println(error.to_string()); exit(i32(1)); }
+//!     )
+//!   };
 //!
-//!     io.await(create_dir(Path.new(`/tmp/yo_test`)));
-//!     entries := io.await(read_dir(Path.new(`/tmp/yo_test`)));
-//!     io.await(remove_dir(Path.new(`/tmp/yo_test`)));
-//!   });
-//!   ```
+//!   io.await(create_dir(Path.new(`/tmp/yo_test`)));
+//!   entries := io.await(read_dir(Path.new(`/tmp/yo_test`)));
+//!   io.await(remove_dir(Path.new(`/tmp/yo_test`)));
+//! });
+//! ```
 
 { GlobalAllocator } :: import "../allocator";
 { malloc, free } :: GlobalAllocator;

--- a/std/fs/dir.yo
+++ b/std/fs/dir.yo
@@ -3,6 +3,8 @@
 //! Wraps low-level `std/sys/dir` with typed APIs using the `Exception` effect.
 //!
 //! Example:
+//!
+//!   ```yo
 //!   { create_dir, remove_dir, read_dir } :: import "std/fs/dir";
 //!   { Path } :: import "std/path";
 //!
@@ -17,6 +19,7 @@
 //!     entries := io.await(read_dir(Path.new(`/tmp/yo_test`)));
 //!     io.await(remove_dir(Path.new(`/tmp/yo_test`)));
 //!   });
+//!   ```
 
 { GlobalAllocator } :: import "../allocator";
 { malloc, free } :: GlobalAllocator;

--- a/std/fs/file.yo
+++ b/std/fs/file.yo
@@ -3,26 +3,29 @@
 //! Wraps a file descriptor with typed async I/O operations.
 //! Uses the `Exception` effect for error handling.
 //!
-//! Example:
-//!   { File, read_string, write_file, OpenMode } :: import "std/fs/file";
+//! # Example
 //!
-//!   main :: (fn(using(io : IO)) -> unit)({
-//!     given(exn) := Exception(
-//!       throw : (fn(forall(T : Type), error: AnyError) -> T)(
-//!         { println(error); panic("Exception found."); }
-//!       )
-//!     );
+//! ```rust
+//! { File, read_string, write_file, OpenMode } :: import "std/fs/file";
 //!
-//!     // Write a file
-//!     io.await(write_file(Path.new(`test.txt`), `hello world`));
+//! main :: (fn(using(io : IO)) -> unit)({
+//!   given(exn) := Exception(
+//!     throw : (fn(forall(T : Type), error: AnyError) -> T)(
+//!       { println(error); panic("Exception found."); }
+//!     )
+//!   );
 //!
-//!     // Read it back
-//!     content := io.await(read_string(Path.new(`test.txt`)));
-//!     println(content);
+//!   // Write a file
+//!   io.await(write_file(Path.new(`test.txt`), `hello world`));
 //!
-//!     // Open with OpenMode
-//!     f := io.await(File.open(Path.new(`test.txt`), .Read));
-//!   });
+//!   // Read it back
+//!   content := io.await(read_string(Path.new(`test.txt`)));
+//!   println(content);
+//!
+//!   // Open with OpenMode
+//!   f := io.await(File.open(Path.new(`test.txt`), .Read));
+//! });
+//! ```
 
 { GlobalAllocator } :: import "../allocator";
 { malloc, free } :: GlobalAllocator;

--- a/std/http/client.yo
+++ b/std/http/client.yo
@@ -245,9 +245,12 @@ _read_http_response :: (fn(stream: TcpStream, using(io : IO, exn : Exception)) -
 
 /// Perform an HTTP request with custom options.
 ///
-/// Example:
-///   opts := FetchOptions.new().with_method(.POST).with_body(`{"key": "value"}`);
-///   resp := io.await(fetch_with(`http://example.com/api`, opts, using(io)));
+/// # Example
+///
+/// ```rust
+/// opts := FetchOptions.new().with_method(.POST).with_body(`{"key": "value"}`);
+/// resp := io.await(fetch_with(`http://example.com/api`, opts, using(io)));
+/// ```
 fetch_with :: (fn(url_str: String, opts: FetchOptions, using(io : IO)) ->
   Impl(Future(HttpResponse, IO, Exception))
 )(
@@ -359,9 +362,12 @@ export fetch_with;
 /// Perform an HTTP GET request to the given URL string.
 /// Returns the `HttpResponse` on success.
 ///
-/// Example:
-///   resp := io.await(fetch(`http://example.com`, using(io)));
-///   cond(resp.is_ok() => println(resp.body), true => println(`Error`));
+/// # Example
+///
+/// ```rust
+/// resp := io.await(fetch(`http://example.com`, using(io)));
+/// cond(resp.is_ok() => println(resp.body), true => println(`Error`));
+/// ```
 fetch :: (fn(url_str: String, using(io : IO)) ->
   Impl(Future(HttpResponse, IO, Exception))
 )(


### PR DESCRIPTION
- actions/checkout v3 → v4
- actions/setup-node v3 → v4
- Replace deprecated actions/create-release@v1 and actions/upload-release-asset@v1 with softprops/action-gh-release@v2

Fixes the 'set-output command is deprecated' warnings.