### PR TITLE
RC aliasing Stage 0: dup projection arguments to borrowing parameters (both compilers)

### DIFF
--- a/issues/borrowed-arg-invalidated-by-aliased-container-mutation.md
+++ b/issues/borrowed-arg-invalidated-by-aliased-container-mutation.md
@@ -96,6 +96,137 @@ Staged plan (each stage sound on its own):
 Benchmarks that decide whether Stage 1 must land together with Stage 0: stage-1
 self-compile wall time (~6 min baseline) and the fast suite (~5.5 min baseline).
 
+### Stage 0 implementation notes (surveyed 2026-08-07, pre-branch)
+
+- **Site:** `src/evaluator/calls/helper.ts` `evaluateArgs` — the
+  `parameter.isOwningTheRcValue && !parameter.isCompileTimeOnly` block
+  (~line 411) handles own-params (move-or-dup + consume). Stage 0 adds the
+  BORROWING-branch sibling: when the parameter is NOT owning and the argument
+  is an RC-typed **projection** (place chain rooted at a runtime variable —
+  reuse the "place" predicate from the match-place dup elision,
+  plans/PERF_BORROW_ELISION.md §1, NOT a plain local atom), insert
+  `setExprAsNeedsToCallDup(evaluatedArgExpr, context)` plus the
+  statement-temp drop (the same post-call arg-temp drop machinery codegen
+  already flushes) — and do NOT consume.
+- **Cancellation exemption:** the dup/drop pair optimizer
+  (`searchRecursively` / `optimizeDupDropPairs` in
+  `src/evaluator/exprs/begin.ts`) must skip these dups (a cancelled pair is a
+  move — it would reopen the hole). Precedent: the `io.async` capture skip.
+  Add a marker on the dup expr (or its ExprInfo) rather than a positional
+  heuristic.
+- **yo-self twin:** `yo-self/evaluator/calls/helper.yo` arg loop (the Step-5b
+  region patched for `is_parameter` in f017aaf23) + its
+  `_optimize_dup_drop_pairs` in `evaluator/exprs/begin.yo`. Gate with the
+  emit-diff discipline (per-function dup/drop counts before/after — fewer
+  dups than intended = new cancellation = potential UAF).
+- **Test:** the fixme reproducer becomes assertable once Stage 0 defines the
+  semantics — check in a test asserting the borrowed projection still reads
+  the PRE-mutation value after the callee mutates the container through the
+  aliased root (plus an rc() balance check around the call).
+- **Benchmarks to run before/after:** stage-1 self-compile wall time and the
+  fast suite; if the added dup traffic is material, Stage 1 (mutation
+  summaries in `src/evaluator/effects/`) lands in the same arc.
+
+### Stage 0 landing log (2026-08-07, feat/rc-aliasing-stage0)
+
+Core landed in both compilers (TS expr.ts
+`setExprAsNeedsToCallDupForBorrowedProjection` + helper.ts borrow branch;
+yo-self utils.yo twin + helper.yo Step 4c). Reproducer flipped from
+`borrowed: 101` (recycled allocation) to `borrowed: 42`; emit shows the
++1/-1 pair on normal and early-return paths; Guard Malloc clean.
+
+**Codegen invariant the new dups exposed** — several arg-rendering sites
+emitted a deferred dup WITHOUT first declaring the argument's eval temp the
+dup names (`___dup(<temp>)` → undeclared C identifier, raw projection read
+lost). Pre-Stage-0 this was latent: deferred dups only reached those sites
+on shapes that always materialized. Sites fixed (each: materialize the arg
+temp, then dup):
+
+1. `and-or.ts` / `and_or.yo` — the short-circuit conditional-temp collector
+   missed dup-result temps (they live in the ExprInfo side-channel, not the
+   syntactic tree): block-level drop for an if-scoped, conditionally-run
+   dup. Surfaced by `a && f(w.b)` (tests/regex, cli/arg_parser).
+2. `recur.ts` / `recur.yo` — the recur arg path replaced argCode with the
+   dup result without ever materializing the source temp. Surfaced by
+   `recur(K, V, h._left, key)` (std/imm/sorted_map, tests/imm_threading).
+   The recur.yo twin also gained the whole dup/drop arg handling (was a
+   documented Phase-4 gap).
+3. `other-fn-call.ts` — the closure/state-machine capture exclusions
+   skipped the temp declaration while the dup still emitted. Surfaced by
+   `self._buf` in an async loop (tests/sys/bufio). A dup targeting the
+   arg's own temp now forces the declaration.
+
+Suite progress under Stage 0: bailed at 974 → 1080 → 1376 files, one new
+site per round; the fourth full run passed 2671/0.
+
+### yo-self arm status (2026-08-07, evening)
+
+- Twins landed: dup marker (utils.yo — SYNTHESIZED, no nested eval; see
+  issues/yo-self-dup-eval-inside-macro-generated-body-corrupts-module-eval.md),
+  Step 4c in BOTH call paths (helper.yo + function.yo's inline FuncVal
+  loop, gated `!checking_phase` + `!callee_is_extern` via the Func meta),
+  shared predicate `arg_is_rc_projection_place` (utils.yo), and_or.yo
+  collector + branch-drop undeclared gate, recur.yo full dup/drop arg
+  handling, drop_dup.yo declare-assign for synthesized dup results.
+- Green: tok_i minimal (derive+impl), fixme repro (`borrowed: 42`),
+  tests/rc.test.yo 22/22 under the self-hosted binary (/tmp/s1_rc0h);
+  battery 0 failures / corpus 155 / std 153; stage-2 self-emit rc=0
+  hollow=0 AND clang-clean; stage-3 emits.
+- **OPEN BLOCKER — FIXPOINT_BROKEN (P=rc2): stage-3 diverges with
+  RECYCLED-STRING garbage** (`switch (().tag)`, `(Some).data`,
+  `enum_yo_id_3343` where variable_name strings belong) — the STAGE-2
+  BINARY has a String UAF, i.e. the stage-1 (TS-emitted) C over-drops a
+  variable_name String somewhere. First divergence: rc2_stage2.c line
+  ~28694, fn `yo_id_817405` (an `args.len()==1 && tok.value == "import"`
+  helper — Option-String projection dup shape). Global emit-diff:
+  s1_ue.c (pre-S0) 12,260 dups / 298,042 drops → s1_rc0h.c 15,761 /
+  319,583 (+3.5k dups, +21.5k drops — plausibly consistent with
+  early-return duplication, so counts alone don't convict).
+- **Fast deterministic repro for the UAF:**
+  `DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib /tmp/rc2_s2 compile
+<scratchpad>/tok_e.yo --release --emit-c --skip-c-compiler -o /tmp/x`
+  → rc=139 in seconds (tok_e = the tiny ref-struct+derive file).
+- **Crash chain (lldb):** `yo_id_4627` (Option(String) clone, faults
+  reading the freed object at x21+0x40) ← called from `yo_id_729516`
+  (recursive, signature `(value_code : String, value_type : TypeValue*,
+context)` = codegen/exprs/drop_dup.yo `generate_dup_code_for_value`,
+  def at rc2_stage2.c:13039) ← yo_id_740424 ← yo_id_816465 ←
+  yo_id_817065 ← yo_id_736607 ← yo_id_736875 ← yo_id_737129 ←
+  yo_id_817295 ← yo_id_818391 ← main. So the FREED object is state read
+  by codegen's dup-for-value walk (a TypeValue's field/variant Strings,
+  or an ExprInfo-held object) — over-dropped earlier in the stage-2
+  binary's run. The import-helper (`yo_id_817405`) emission delta was
+  checked pre-vs-post Stage 0 and is BALANCED — the divergence garbage
+  there is a downstream symptom, not the site.
+- Emission-diff note: pre-Stage-0 `/tmp/ue_stage2.c` vs Stage-0
+  `/tmp/rc2_stage2.c` — same-function diffs are the tool (function
+  bodies differ only by the Stage-0 pairs; ids shift by file).
+- **RESOLVED (same day): FIXPOINT HOLDS.** Two-part fix after
+  malloc_history named the exact sites:
+  1. The scope-end reliance was structurally unsound in yo-self — an
+     unconsumed owning temp's drop gets emitted by the multi-exit cleanup
+     machinery (match-arm exits + escape paths + scope end) on
+     NON-exclusive paths. Redesign: the marker CONSUMES the synthesized
+     dup temp and returns an explicit `___drop(<dup temp>)`, threaded
+     through the previously-dormant TS-mirror channel
+     `CheckParamResult.s0_drop` → `FuncCallResult.deferred_drop_expressions`
+     → the call node's ExprInfo (4 consumer sites in function.yo; the 3
+     `try_to_call_type_with_arguments` sites are construction results with
+     no drop field and stay unwired) → codegen's post-call flush.
+  2. recur.yo's node-drop flush ran BEFORE the call emission (TS-mirrored
+     position, previously vacuous) — with Stage-0 drops now on recur
+     nodes, it freed the argument the recursion was about to consume
+     (gmalloc-traced: clone at +5276, freed at +5320, consumed at +5340
+     in dup-for-value). The flush moved to AFTER the result-temp emission.
+- Final validation: tok_i + repro + rc.test.yo 22/22 under the
+  self-hosted binary; battery 0 failures / corpus 155 / std 153;
+  stage-2 emit + clang clean; **stage-2 ≡ stage-3 (FIXPOINT_HOLDS)**;
+  Guard Malloc clean on the repros and a self-hosted compile probe.
+- Known accepted gaps (leak-direction, never corruption): unit-result
+  `recur` calls do not flush their Stage-0 drops (no post-call emission
+  point); macro-generated bodies' emissions carry the dups per each
+  compiler's own evaluator decisions.
+
 Sequencing: lands AFTER the 2026-08-06 CI-gating change (leak fix + branch-dup
 classification) is green in CI, as its own change.
 

--- a/issues/yo-self-dup-eval-inside-macro-generated-body-corrupts-module-eval.md
+++ b/issues/yo-self-dup-eval-inside-macro-generated-body-corrupts-module-eval.md
@@ -1,0 +1,80 @@
+# yo-self: evaluating a fresh `___dup` expr inside a macro-generated body's def-time eval corrupts the enclosing module evaluation
+
+**Status:** SIDESTEPPED for Stage 0 (fix direction 2 below implemented —
+the marker now SYNTHESIZES the dup instead of evaluating it, and the
+deferred-dup emitter declare-assigns a synthesized dup's result temp via
+the get_variable_type_string choke-point). The underlying evaluator
+fragility — a nested `evaluate_expression_raw` inside a derive-generated
+body's def-time eval corrupting the module evaluation — REMAINS OPEN and
+unowned by any current caller: the own-param marker
+(`set_expr_as_needs_to_call_dup`) still evaluates, but never fires inside
+derive-generated bodies today. Root-cause before adding any new nested
+eval to arg-processing paths. (An `auto-generated://` token skip was
+tried first and does NOT work: derive-generated bodies carry quote-
+template tokens from the macro's defining file, not auto-generated
+ones.)
+
+## Symptom
+
+With aliasing Stage 0's borrow-projection marker active in yo-self,
+compiling this shape under the self-hosted binary fails:
+
+```rust
+Tok :: ref(struct(value : String));
+derive(Tok, Eq(Tok));
+impl(Tok, Clone(clone : (fn(inout(self) : Self) -> Self)(self)));
+// error: Variable "Tok" not found   ← at the impl's `Tok` argument
+```
+
+The original presentation was the stage-2 self-emit failing on
+`yo-self/token.yo` (`derive(Token, Eq(Token))` followed by
+`impl(Token, Clone(...))`) — FIXPOINT_BROKEN with STAGE2_RC=1.
+
+## Bisection (all on the tok_i minimal repro, one stage-1 build per step)
+
+- Marker neutered before the dup evaluation → PASSES.
+- Dup evaluation only (post-steps skipped) → FAILS.
+- Dup evaluation under a local logging exception → **no throw observed**,
+  still fails.
+- The env-replacement step (`ei.env = dup_ei.env`) was removed first on the
+  statement-flow-leak theory — necessary hygiene (yo-self threads env
+  through statement infos where TS's dup env is same-stack) but NOT the
+  vector.
+
+So: a **successful** `evaluate_expression_raw(___dup(temp), ei.env, ...)`
+run from inside the def-time evaluation of a derive-generated `==` body
+(String projections `lhs.value == rhs.value` trigger the Stage-0 marker
+there) corrupts state that the module evaluation still depends on — the
+next module statement's type lookup misses a binding that exists. No
+error is thrown or swallowed (`YO_DEBUG_SWALLOW` silent, swallow-pattern
+diff between failing/passing variants empty).
+
+Candidate mechanisms (unproven): the `(temp.___dup)()` method-dispatch
+route specializing `String.___dup` mid-derive and touching shared
+ctx/registry state the expansion machinery still holds; or the recorded
+snapshot env's frame list being mutated by the nested eval in a way the
+module statement flow observes. The own-param marker
+(`set_expr_as_needs_to_call_dup`) does the same nested eval but never
+fires inside derive-generated bodies (no own-params there), so this was
+latent until Stage 0.
+
+## Workaround (landed with Stage 0)
+
+`set_expr_as_needs_to_call_dup_for_borrowed_projection` skips call sites
+whose token `module_path` starts with `auto-generated://` (the same
+discipline as the M3 early-return-drop walk). Parity gap vs TS: yo-self
+emissions of macro-generated bodies do not carry Stage-0 projection dups
+(each compiler's emission is self-consistent; the corpus diff-test judges
+run behavior).
+
+## Real fix directions
+
+1. Root-cause the shared-state mutation: instrument what the \_\_\_dup
+   method-dispatch specialization touches (ctx fields, registries,
+   g_frame_indexes) during a derive body's def-time eval.
+2. Or make the marker synthesize the dup WITHOUT a nested
+   `evaluate_expression_raw` (build the evaluated form directly — the dup
+   of a known temp needs no general evaluation).
+3. Relates to plans/backlog/YO_SELF_ENV_SHARING.md (def-time body envs
+   COPY what TS SHARES) — the structural fix likely falls out of that
+   work.

--- a/src/codegen/exprs/and-or.ts
+++ b/src/codegen/exprs/and-or.ts
@@ -57,6 +57,20 @@ function collectCreatedVarNamesFromExpr(expr: Expr, result: Set<string>): void {
     if (expr.$?.variableName) {
       result.add(expr.$.variableName);
     }
+    // Deferred `___dup` results are temps too — they are DECLARED next to the
+    // expression they balance (inside this conditional branch), but they live
+    // in the ExprInfo side-channel, not the syntactic tree. Without this, an
+    // aliasing-Stage-0 borrow dup on a projection argument inside a
+    // short-circuit RHS (`a && f(w.b)`) left its scope-end drop at the outer
+    // block level: an undeclared identifier in C (the declaration is inside
+    // the `if`), and an unconditional drop for a conditionally-run dup.
+    if (expr.$?.deferredDupExpressions) {
+      for (const dupExpr of expr.$.deferredDupExpressions) {
+        if (dupExpr.$?.variableName) {
+          result.add(dupExpr.$.variableName);
+        }
+      }
+    }
 
     // For nested &&/||, only collect from the first (unconditional) arg.
     // Subsequent args are inside conditional branches and their drops are

--- a/src/codegen/exprs/other-fn-call.ts
+++ b/src/codegen/exprs/other-fn-call.ts
@@ -587,11 +587,41 @@ export function generateOtherFunctionCall(
           // Track whether we emitted a temp variable declaration
           let emittedTempVarDeclaration = false;
 
+          // A deferred `___dup` that targets THIS argument's own eval temp
+          // forces the temp declaration even for closure/state-machine
+          // captured accesses: the dup names the temp
+          // (`___dup(<temp>)`), so skipping the declaration emits an
+          // undeclared C identifier and loses the raw read (aliasing
+          // Stage 0 projection dups on `self._buf` inside an async loop
+          // surfaced the SM case). The capture exclusions below exist to
+          // avoid REDUNDANT copies of already-addressable storage — a
+          // dup-carrying arg needs the materialization regardless.
+          let argDupForcesTempDeclaration = false;
+          if (
+            arg.$?.variableName &&
+            arg.$?.deferredDupExpressions &&
+            arg.$.deferredDupExpressions.length > 0
+          ) {
+            const argTempCName = getVariableNameForCodegen(
+              arg.$.variableName,
+              arg.$.env
+            );
+            argDupForcesTempDeclaration = arg.$.deferredDupExpressions.some(
+              (e) => {
+                const target = getDeferredDupTargetAtomName(e);
+                return (
+                  !!target &&
+                  getVariableNameForCodegen(target, e.$?.env) === argTempCName
+                );
+              }
+            );
+          }
+
           if (
             argCode &&
             argCode !== arg.$.variableName &&
-            !isClosureCapturedVariable &&
-            !isStateMachineCapturedVariable &&
+            ((!isClosureCapturedVariable && !isStateMachineCapturedVariable) ||
+              argDupForcesTempDeclaration) &&
             !isComptimeOnlyArg &&
             !isRefArg &&
             !paramIsRef

--- a/src/codegen/exprs/recur.ts
+++ b/src/codegen/exprs/recur.ts
@@ -6,6 +6,7 @@ import {
   type CodeGenContext,
   getTypeString,
   getVariableNameForCodegen,
+  getVariableTypeString,
 } from "../utils";
 import {
   generateDeferredDropExpressions,
@@ -56,6 +57,37 @@ export function generateRecur(
           arg.$?.deferredDupExpressions &&
           arg.$.deferredDupExpressions.length > 0
         ) {
+          // Materialize the argument into its eval temp BEFORE the dup: the
+          // dup names that temp (`___dup(<temp>)`), so without the
+          // declaration the emitted C references an undeclared identifier
+          // AND the raw projection read is lost (argCode is discarded below
+          // in favor of the dup result). Mirrors other-fn-call.ts's arg-temp
+          // declaration; surfaced by aliasing-Stage-0 projection dups on
+          // recur args (`recur(K, V, h._left, key)` in
+          // std/imm/sorted_map.yo _node_contains).
+          if (arg.$.variableName) {
+            const sanitizedArgTemp = getVariableNameForCodegen(
+              arg.$.variableName,
+              arg.$.env
+            );
+            if (argCode !== sanitizedArgTemp) {
+              if (!functionContext.declaredTempVars) {
+                functionContext.declaredTempVars = new Set();
+              }
+              if (!functionContext.declaredTempVars.has(sanitizedArgTemp)) {
+                functionContext.declaredTempVars.add(sanitizedArgTemp);
+                const effectiveType = arg.$.convertedRuntimeType || arg.$.type;
+                const varTypeAndName = getVariableTypeString(
+                  effectiveType,
+                  arg.$.variableName,
+                  context
+                );
+                context.emitter.emitLine(
+                  `${indent}${varTypeAndName} = ${argCode};`
+                );
+              }
+            }
+          }
           generateDeferredDupExpressions(arg, indent, functionContext);
           // Use the dup result variable instead of the original
           const dupExpr = arg.$.deferredDupExpressions[0]!;

--- a/src/evaluator/calls/helper.ts
+++ b/src/evaluator/calls/helper.ts
@@ -32,6 +32,7 @@ import {
   requireExprNotConsumed,
   setExprAsConsumed,
   setExprAsNeedsToCallDup,
+  setExprAsNeedsToCallDupForBorrowedProjection,
 } from "../../expr";
 import { evaluatedBodyContainsEscape } from "../../expr-traversal";
 import type {
@@ -227,6 +228,43 @@ function generateDeferredDropExpressions({
       deferredDropExpressions.length > 0 ? deferredDropExpressions : undefined,
     env: finalEnv,
   };
+}
+
+/**
+ * Aliasing Stage 0 predicate: a bare field-access chain (`w.b`, `a.b.c`)
+ * rooted at a RUNTIME variable — a PROJECTION place. A bare atom is NOT a
+ * projection (the caller's own binding keeps a plain local alive for the
+ * call, so it stays +0). A method call (`x.f()`) is not a 2-arg dot call —
+ * its `func` is the dot — and produces an owned temp anyway. Mirrors
+ * match.ts `exprIsPlaceExpression` minus the atom case (kept local: match.ts
+ * importing from this module makes the reverse import a cycle).
+ */
+function exprIsRcProjectionPlace(
+  expr: Expr | undefined,
+  env: Environment
+): boolean {
+  if (
+    !expr ||
+    !exprIsFunctionCall(expr) ||
+    !exprIsFunctionCallOf(expr, ".", 2) ||
+    !exprIsAtom(expr.args[1]!)
+  ) {
+    return false;
+  }
+  let root: Expr = expr.args[0]!;
+  while (
+    exprIsFunctionCall(root) &&
+    exprIsFunctionCallOf(root, ".", 2) &&
+    exprIsAtom(root.args[1]!)
+  ) {
+    root = root.args[0]!;
+  }
+  if (!exprIsAtom(root)) {
+    return false;
+  }
+  const rootVars = getVariablesFromEnv(env, root.token.value);
+  const rootVar = rootVars.length ? rootVars[rootVars.length - 1] : undefined;
+  return rootVar !== undefined && !rootVar.isCompileTimeOnly;
 }
 
 export function checkIfFunctionParameterMatchesArgument({
@@ -447,6 +485,33 @@ export function checkIfFunctionParameterMatchesArgument({
             callerEnv,
             true // NOTE: Allow to consume again here is necessary.
           );
+        }
+      } else if (
+        !parameter.isOwningTheRcValue &&
+        !parameter.isCompileTimeOnly &&
+        !parameter.isRef &&
+        // EXTERN/builtin callees run no Yo code — nothing inside them can
+        // reassign an aliased Yo container field, so their borrows cannot
+        // dangle and the +1 would be pure overhead on the hottest
+        // primitives (`__yo_ptr_eq`, libc shims). Also dodges the inline-
+        // builtin emitters, which render args inline (no temp to dup).
+        !functionType.externName &&
+        exprIsRcProjectionPlace(argExpr, callerEnv)
+      ) {
+        // Aliasing Stage 0
+        // (issues/borrowed-arg-invalidated-by-aliased-container-mutation.md):
+        // an RC-typed field PROJECTION passed to a borrowing parameter hands
+        // the callee a view into storage it may reassign through an aliased
+        // handle (`f(w, w.b)` reassigning `w.b` in a loop frees the old value
+        // mid-call — the borrowed parameter dangles). Materialize a caller-
+        // owned +1 for the call; the caller's normal scope-end drop releases
+        // it. Plain locals stay +0 (the caller's binding keeps them alive),
+        // owned temps stay +0 (alive to scope end already — the marker
+        // no-ops), and `inout` (ref) parameters are place writes, not RC
+        // handles.
+        setExprAsNeedsToCallDupForBorrowedProjection(evaluatedArgExpr, context);
+        if (evaluatedArgExpr.$?.env) {
+          callerEnv = evaluatedArgExpr.$.env;
         }
       }
     }

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -2444,6 +2444,85 @@ export function setExprAsConsumed(
 }
 
 /**
+ * Aliasing Stage 0 (issues/borrowed-arg-invalidated-by-aliased-container-mutation.md):
+ * dup an RC-typed PROJECTION argument passed to a BORROWING parameter, keeping
+ * the +1 in the CALLER.
+ *
+ * A field projection (`w.b`) evaluates to a non-owning temp — a view into
+ * storage the callee may reassign through an aliased handle (`f(w, w.b)`
+ * reassigning `w.b` in a loop frees the old value mid-call: the borrowed
+ * parameter dangles). The dup materializes an owned +1 for the call; unlike
+ * `setExprAsNeedsToCallDup` (the own-param path), the dup RESULT temp is left
+ * OWNING and UNCONSUMED so the caller's normal scope-end drop releases it,
+ * and the SOURCE binding is not consumed (a borrow stays usable).
+ *
+ * No-ops when the argument's temp already OWNS its value (an owned temp is
+ * kept alive to scope end regardless — no aliasing hole) or when the value is
+ * compile-time (inlined, no RC traffic).
+ */
+export function setExprAsNeedsToCallDupForBorrowedProjection(
+  expr: Expr,
+  context: EvaluatorContext
+): void {
+  if (!expr.$ || !expr.$.variableName) {
+    return;
+  }
+  if (expr.$.value) {
+    return;
+  }
+  if (!typeContainsRcType(expr.$.type)) {
+    return;
+  }
+  const variableName = expr.$.variableName;
+  const variables = getVariablesFromEnv(expr.$.env, variableName);
+  const variable = variables.length
+    ? variables[variables.length - 1]
+    : undefined;
+  if (!variable || variable.isOwningTheRcValue) {
+    return;
+  }
+  const dupCallExpr = generateExprFromCode(
+    `${BuiltinFunctions.___dup[0]!}(${variableName})`
+  );
+  const evaluatedDupCallExpr = evaluateExpression({
+    expr: dupCallExpr,
+    env: expr.$.env,
+    context: { ...context, expectedType: undefined },
+  }) as FnCallExpr;
+  // Stamp the USE SITE's source token (same rationale as
+  // setExprAsNeedsToCallDup below: the optimizer needs the real source
+  // position, not the generated token).
+  (
+    evaluatedDupCallExpr as FnCallExpr & { __useSiteToken?: Token }
+  ).__useSiteToken = expr.token;
+  // evaluateDup marks its result temp NON-owning (the own-param contract —
+  // the callee drops the transferred +1). Here the CALLER keeps the +1, so
+  // flip the result temp back to OWNING: the enclosing scope's normal
+  // scope-end drop is the balancing -1. (The dup/drop pair optimizer cannot
+  // cancel this pair into a move: the dup targets the SOURCE temp, the drop
+  // targets the dup RESULT temp — different variables.)
+  const dupResultTempName = evaluatedDupCallExpr.$?.variableName;
+  if (dupResultTempName) {
+    const dupResultVars = getVariablesFromEnv(
+      evaluatedDupCallExpr.$!.env,
+      dupResultTempName
+    );
+    if (dupResultVars.length) {
+      const dupResultVar = dupResultVars[dupResultVars.length - 1]!;
+      if (!dupResultVar.isOwningTheRcValue) {
+        evaluatedDupCallExpr.$!.env = updateExistingVariable(
+          evaluatedDupCallExpr.$!.env,
+          dupResultVar,
+          { ...dupResultVar, isOwningTheRcValue: true }
+        );
+      }
+    }
+  }
+  expr.$.deferredDupExpressions = [evaluatedDupCallExpr];
+  expr.$.env = evaluatedDupCallExpr.$!.env;
+}
+
+/**
  * @param expr
  * @param context
  * @returns

--- a/src/tests/fixme.yo
+++ b/src/tests/fixme.yo
@@ -1,15 +1,19 @@
 open(import("std/fmt"));
-{ ArrayList } :: import("std/collections/array_list");
-g_seen := ArrayList(ArrayList(i32)).new();
-mk :: (fn() -> ArrayList(i32))({
-  l := ArrayList(i32).new();
-  g_seen.push(l);
-  l
+open(import("std/string"));
+
+Wrap :: ref(struct(b : Box(i32)));
+
+poke_loop :: (fn(w : Wrap, borrowed : Box(i32)) -> unit)({
+  (i : i32) = i32(0);
+  while(runtime(i < i32(2)), {
+    w.b = box(i32(100) + i);
+    i = (i + i32(1));
+  });
+  println(`borrowed: ${borrowed.*}`);
 });
-discard_stmt_body :: (fn() -> unit)(___ := mk());
+
 main :: (fn() -> unit)({
-  discard_stmt_body();
-  survivor := match(g_seen.get(usize(0)),.Some(l) => l,.None => ArrayList(i32).new());
-  println(`rc=${rc(survivor)}`);
+  w := Wrap(b : box(i32(42)));
+  poke_loop(w, w.b);
 });
 export(main);

--- a/tests/rc.test.yo
+++ b/tests/rc.test.yo
@@ -606,3 +606,29 @@ test("Bare discard-statement fn body compiles and drops the discarded value", {
     "discarded value must be dropped (rc 3, not 4)"
   );
 });
+// Regression (issues/borrowed-arg-invalidated-by-aliased-container-mutation.md,
+// aliasing Stage 0): an RC-typed field PROJECTION passed to a BORROWING
+// parameter gets a caller-owned +1 for the call. Without it, `poke(w, w.b)`
+// reassigning `w.b` in a LOOP freed the old box mid-call (the loop cannot
+// defer the old-value drop across iterations) — the borrowed parameter then
+// read a RECYCLED allocation (printed 101, the newest box, instead of 42).
+AliasWrap :: ref(struct(b : Box(i32)));
+alias_poke_loop :: (fn(w : AliasWrap, borrowed : Box(i32)) -> unit)({
+  (i : i32) = i32(0);
+  while(runtime(i < i32(2)), {
+    w.b = box(i32(100) + i);
+    i = (i + i32(1));
+  });
+  assert(borrowed.* == i32(42), "borrowed projection reads the pre-mutation value");
+});
+test("borrowed projection argument survives aliased container mutation", {
+  w := AliasWrap(b : box(i32(42)));
+  b0 := w.b;
+  assert(rc(b0) == 2, "w.b + b0 before the call");
+  alias_poke_loop(w, w.b);
+  // After the call: the callee's reassignment dropped w.b's handle on the
+  // 42-box; b0 plus the Stage-0 dup temp (released at THIS scope's end)
+  // remain. rc 3 = the dup leaked twice; rc 1 = it was double-dropped.
+  assert(rc(b0) == 2, "exactly one Stage-0 +1 outstanding until scope end");
+  assert(b0.* == i32(42), "original box intact after the aliased mutation");
+});

--- a/yo-self/codegen/exprs/and_or.yo
+++ b/yo-self/codegen/exprs/and_or.yo
@@ -15,10 +15,11 @@ open(import("std/string"));
 { HashSet } :: import("std/collections/hash_set");
 { AstExpr, ast_expr_is_fn_call_of, BK_OP_AND, BK_OP_OR } :: import("../../expr.yo");
 { EvalValue } :: import("../../value.yo");
-{ random_id } :: import("../../utils.yo");
+{ random_id, is_temp_variable_name } :: import("../../utils.yo");
 { FunctionGenerationContext } :: import("../functions/context.yo");
 { _call_generate_expr } :: import("./_expr.yo");
-{ get_deferred_drop_target_atom_name } :: import("../utils/index.yo");
+{ get_deferred_drop_target_atom_name, sanitize_for_c_identifier } :: import("../utils/index.yo");
+{ _looks_like_minted_temp } :: import("./begin.yo");
 /// `base` followed by `n` levels of two-space indent.
 _indent_n :: (fn(base : String, n : usize) -> String)({
   out := base.clone();
@@ -79,13 +80,49 @@ _collect_created_var_names_from_expr :: (fn(expr : AstExpr, result : HashSet(Str
     .FnCall(_, func, args, _, _) => {
       match(
         context.base.get_expr_info(expr),
-        .Some(ei) => match(
-          ei.variable_name,
-          .Some(vn) => {
-            _a := result.add(vn.clone());
-          },
-          .None => ()
-        ),
+        .Some(ei) => {
+          match(
+            ei.variable_name,
+            .Some(vn) => {
+              _a := result.add(vn.clone());
+            },
+            .None => ()
+          );
+          // Deferred `___dup` results are temps too — declared next to the
+          // expression they balance (inside this conditional branch) but
+          // living in the ExprInfo side-channel, not the syntactic tree.
+          // Without this, an aliasing-Stage-0 borrow dup on a projection
+          // argument inside a short-circuit RHS (`a && f(w.b)`) left its
+          // scope-end drop at the outer block level — an undeclared C
+          // identifier and an unconditional drop for a conditionally-run
+          // dup. Mirrors TS and-or.ts collectCreatedVarNamesFromExpr.
+          match(
+            ei.deferred_dup_expressions,
+            .Some(dups) => {
+              nd := dups.len();
+              (di : usize) = usize(0);
+              while(di < nd, {
+                match(
+                  dups.get(di),
+                  .Some(de) => match(
+                    context.base.get_expr_info(de),
+                    .Some(dei) => match(
+                      dei.variable_name,
+                      .Some(dvn) => {
+                        _b := result.add(dvn.clone());
+                      },
+                      .None => ()
+                    ),
+                    .None => ()
+                  ),
+                  .None => ()
+                );
+                di = (di + usize(1));
+              });
+            },
+            .None => ()
+          );
+        },
         .None => ()
       );
       is_nested := (ast_expr_is_fn_call_of(expr, BK_OP_AND, Option(usize).None) || ast_expr_is_fn_call_of(expr, BK_OP_OR, Option(usize).None));
@@ -131,13 +168,23 @@ _emit_drops_for_conditional_branch :: (fn(var_names : HashSet(String), indent : 
           .Some(drop_expr) => match(
             get_deferred_drop_target_atom_name(drop_expr),
             .Some(target) => if(var_names.contains(target.clone()), {
-              drop_code := _call_generate_expr(drop_expr, indent.clone(), context);
-              if(drop_code.len() > usize(0), {
-                line := indent.clone();
-                line.push_string(drop_code);
-                line.push_str(";");
-                em := context.base.emitter;
-                em.emit_string_line(line);
+              // Skip a drop whose target TEMP was never emitted as a C
+              // declaration (e.g. an aliasing-Stage-0 dup RESULT temp whose
+              // dup was itself gate-skipped) — same undeclared-temp gate as
+              // generate_deferred_drop_expressions. A never-declared temp
+              // holds no +1 to release; emitting the drop is an undeclared-
+              // identifier C error (the rc1 stage-2 clang break).
+              sc_target_cn := sanitize_for_c_identifier(target.clone(), false);
+              sc_undeclared := ((is_temp_variable_name(String.from(""), sc_target_cn.clone()) || _looks_like_minted_temp(sc_target_cn.clone())) && (!(context.base.declared_c_var_names.contains(sc_target_cn))));
+              if(!(sc_undeclared), {
+                drop_code := _call_generate_expr(drop_expr, indent.clone(), context);
+                if(drop_code.len() > usize(0), {
+                  line := indent.clone();
+                  line.push_string(drop_code);
+                  line.push_str(";");
+                  em := context.base.emitter;
+                  em.emit_string_line(line);
+                });
               });
               match(
                 context.short_circuit_handled_drop_var_names,

--- a/yo-self/codegen/exprs/drop_dup.yo
+++ b/yo-self/codegen/exprs/drop_dup.yo
@@ -888,7 +888,34 @@ generate_deferred_dup_expressions :: (fn(expr : AstExpr, indent : String, contex
               if(!(dup_undeclared_temp), {
                 code := _call_generate_expr(dup_expr, indent.clone(), context);
                 if(code.len() > usize(0), {
+                  // A SYNTHESIZED dup (aliasing Stage 0's borrow marker —
+                  // no nested evaluation, so no other_fn_call temp
+                  // materialization) renders as a bare inline-incr
+                  // expression while its RESULT temp name is what call
+                  // sites pass. Declare-assign the result temp via the
+                  // get_variable_type_string choke-point; evaluated dups
+                  // already render AS their temp name and skip this.
+                  dup_result_decl := match(
+                    context.base.get_expr_info(dup_expr),
+                    .Some(ddei) => match(
+                      ddei.variable_name,
+                      .Some(ddvn) => {
+                        ddtn := get_variable_name_for_codegen(ddvn.clone(), Option(Environment).Some(ddei.env));
+                        if((!(ddtn == code)) && (!(context.base.declared_c_var_names.contains(ddtn.clone()))), Option(String).Some(get_variable_type_string(ddei.ty, ddvn, context.base)), Option(String).None)
+                      },
+                      .None => Option(String).None
+                    ),
+                    .None => Option(String).None
+                  );
                   line := indent.clone();
+                  match(
+                    dup_result_decl,
+                    .Some(dr_decl) => {
+                      line.push_string(dr_decl);
+                      line.push_str(" = ");
+                    },
+                    .None => ()
+                  );
                   line.push_string(code);
                   line.push_str(";");
                   em.emit_string_line(line);

--- a/yo-self/codegen/exprs/recur.yo
+++ b/yo-self/codegen/exprs/recur.yo
@@ -1,17 +1,17 @@
 //! `recur(...)` self-call emitter — mirrors `src/codegen/exprs/recur.ts`.
 //!
 //! DEFERRED (documented divergences, none reached by the no-RC/no-effect
-//! corpus): the `(*name)`→`name` ref-argument strip (yo-self Variable has no
-//! is_ref flag); deferred dup/drop emission for moved RC arguments (Phase 4);
-//! evidence-parameter forwarding for `using()`/effects (Phase 3/5).
+//! corpus): evidence-parameter forwarding for `using()`/effects (Phase 3/5).
 open(import("std/string"));
 { HashSet } :: import("std/collections/hash_set");
-{ AstExpr } :: import("../../expr.yo");
+{ AstExpr, ast_expr_is_fn_call } :: import("../../expr.yo");
 { FunctionGenerationContext } :: import("../functions/context.yo");
 { _call_generate_expr } :: import("./_expr.yo");
-{ get_variable_name_for_codegen, get_type_string } :: import("../utils/index.yo");
+{ get_variable_name_for_codegen, get_type_string, get_variable_type_string } :: import("../utils/index.yo");
 { Environment, get_variables_from_env } :: import("../../env.yo");
 { is_unit_type } :: import("../../types/guards.yo");
+{ expr_info_converted_runtime_type } :: import("../../expr_info.yo");
+{ generate_deferred_dup_expressions, generate_deferred_drop_expressions } :: import("./drop_dup.yo");
 /// Emit a recursive self-call `<currentFunctionName>(<args>)`. If the recur
 /// has a result variable name, emit it into a named temp first (so enclosing
 /// scope drops don't run before the call). Mirrors `generateRecur`.
@@ -54,6 +54,78 @@ generate_recur :: (fn(expr : AstExpr, indent : String, context : FunctionGenerat
               ),
               .None => ()
             );
+            // Deferred `___dup` on a recur argument (aliasing Stage 0
+            // projection dups): materialize the argument into its eval temp
+            // FIRST — the dup names that temp, and without the declaration
+            // the emitted C references an undeclared identifier while the
+            // raw projection read is lost (arg_code is replaced by the dup
+            // result below). get_variable_type_string is the
+            // declared_c_var_names choke-point, so the dup emitter's
+            // undeclared-temp gate sees the declaration. Mirrors TS
+            // recur.ts (`recur(K, V, h._left, key)` in
+            // std/imm/sorted_map.yo _node_contains surfaced this).
+            match(
+              context.base.get_expr_info(arg),
+              .Some(aei2) => match(
+                aei2.deferred_dup_expressions,
+                .Some(dups) => if(dups.len() > usize(0), {
+                  match(
+                    aei2.variable_name,
+                    .Some(avn) => {
+                      sanitized_arg_temp := get_variable_name_for_codegen(avn.clone(), Option(Environment).Some(aei2.env));
+                      if(!(arg_code == sanitized_arg_temp), {
+                        already_arg := match(context.declared_temp_vars,.Some(s) => s.contains(sanitized_arg_temp.clone()),.None => false);
+                        if(!(already_arg), {
+                          match(
+                            context.declared_temp_vars,
+                            .Some(s) => {
+                              _aa := s.add(sanitized_arg_temp.clone());
+                            },
+                            .None => {
+                              ns0 := HashSet(String).new();
+                              _aa := ns0.add(sanitized_arg_temp.clone());
+                              context.declared_temp_vars = Option(HashSet(String)).Some(ns0);
+                            }
+                          );
+                          eff_ty := match(expr_info_converted_runtime_type(aei2),.Some(ct) => ct,.None => aei2.ty);
+                          dline := indent.clone();
+                          dline.push_string(get_variable_type_string(eff_ty, avn.clone(), context.base));
+                          dline.push_str(" = ");
+                          dline.push_string(arg_code.clone());
+                          dline.push_str(";");
+                          dem := context.base.emitter;
+                          dem.emit_string_line(dline);
+                        });
+                      });
+                    },
+                    .None => ()
+                  );
+                  generate_deferred_dup_expressions(arg, indent.clone(), context);
+                  // Pass the dup RESULT temp instead of the original.
+                  match(
+                    dups.get(usize(0)),
+                    .Some(de) => if(
+                      ast_expr_is_fn_call(de),
+                      match(
+                        context.base.get_expr_info(de),
+                        .Some(dei) => match(
+                          dei.variable_name,
+                          .Some(dvn) => {
+                            arg_code = get_variable_name_for_codegen(dvn.clone(), Option(Environment).Some(dei.env));
+                          },
+                          .None => ()
+                        ),
+                        .None => ()
+                      ),
+                      ()
+                    ),
+                    .None => ()
+                  );
+                }),
+                .None => ()
+              ),
+              .None => ()
+            );
             args_list.push_string(arg_code);
           },
           .None => ()
@@ -92,6 +164,14 @@ generate_recur :: (fn(expr : AstExpr, indent : String, context : FunctionGenerat
             line.push_str(";");
             em := context.base.emitter;
             em.emit_string_line(line);
+            // Deferred drops on the recur node — flushed AFTER the call is
+            // emitted (aliasing Stage 0 attaches the balancing drop of a
+            // projection-arg dup here; flushing BEFORE the call freed the
+            // argument the recursion was about to consume — the stage-2
+            // dup-for-value UAF, gmalloc-traced: clone at +5276, freed at
+            // +5320, consumed at +5340). Expression-level flush: skip
+            // param-targeted drops (drop_dup.yo _drop_target_is_parameter).
+            generate_deferred_drop_expressions(expr, indent.clone(), context, true);
           });
           return(temp_var_name);
         }),

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -72,7 +72,7 @@ open(import("std/fmt"));
 { Token, TokenKind, string_is_operator } :: import("../../token.yo");
 { EvalValue, FuncValData, type_of_eval_value, is_type_val, is_unknown_val, is_func_val, create_runtime_unknown_val_with_name } :: import("../../value.yo");
 { random_id } :: import("../../utils.yo");
-{ attach_temp_variable_to_expr, set_expr_as_consumed, set_expr_as_needs_to_call_dup, parse_raw_int } :: import("../utils.yo");
+{ attach_temp_variable_to_expr, set_expr_as_consumed, set_expr_as_needs_to_call_dup, set_expr_as_needs_to_call_dup_for_borrowed_projection, arg_is_rc_projection_place, parse_raw_int } :: import("../utils.yo");
 {
   EvalContext,
   ExpectedTypeCtx,
@@ -2697,6 +2697,7 @@ evaluate_function_call :: (
       // (comptime scalars are unaffected — they never hit is_runtime_ctor).
       if(op_result_is_runtime, {
         out_op.runtime_arg_exprs_in_order = Option(ArrayList(AstExpr)).Some(call_result_op.runtime_arg_exprs_in_order);
+        out_op.deferred_drop_expressions = call_result_op.deferred_drop_expressions;
       });
       expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_op);
       // RUNTIME operator on a non-primitive type (e.g. derived `==`/`<` on an
@@ -3922,6 +3923,9 @@ Fix: wrap the call:
           ),
           .None => ArrayList(bool).new()
         );
+        // Aliasing Stage 0: drops synthesized for projection args in THIS
+        // call's inline arg loop; merged into the call's ExprInfo below.
+        fv_s0_drops := ArrayList(AstExpr).new();
         fv_param_is_owning := match(
           callee_info_opt,
           .Some(ci) => match(
@@ -4480,6 +4484,33 @@ Fix: wrap the call:
                     });
                   });
                 }
+              );
+            });
+            // Step 4c: Aliasing Stage 0 (twin of helper.yo's Step 4c — this
+            // inline FuncVal arg loop BYPASSES
+            // try_to_call_function_with_arguments, so the projection dup must
+            // land here too or plain calls to module fns keep the hole). An
+            // RC-typed field PROJECTION passed to a BORROWING parameter gets
+            // a caller-owned +1 for the call; extern/builtin callees run no
+            // Yo code and are skipped.
+            fv_p_is_ref := match(fv_param_is_ref.get(ai),.Some(r) => r,.None => false);
+            fv_callee_is_extern := match(
+              callee_info_opt,
+              .Some(fv_ci_ext) => match(
+                fv_ci_ext.ty,
+                .Func({ meta : __fmext }) => __fmext.*.extern_name.is_some(),
+                _ => false
+              ),
+              .None => false
+            );
+            fv_s0_gates := ((((!(fv_p_owning)) && !(fv_p_is_ct)) && ((!(fv_p_is_ref)) && !(fv_callee_is_extern))) && !(ctx.is_in_function_call_checking_phase));
+            if(fv_s0_gates && arg_is_rc_projection_place(arg_expr_eff, env), {
+              match(
+                set_expr_as_needs_to_call_dup_for_borrowed_projection(evaled_arg, ctx, exn),
+                .Some(fv_s0d) => {
+                  fv_s0_drops.push(fv_s0d);
+                },
+                .None => ()
               );
             });
           };
@@ -5459,6 +5490,9 @@ Fix: wrap the call:
         out.value = body_info.value;
         // Runtime arg exprs for codegen (the call's C-argument materialization).
         out.runtime_arg_exprs_in_order = Option(ArrayList(AstExpr)).Some(runtime_arg_exprs);
+        if(fv_s0_drops.len() > usize(0), {
+          out.deferred_drop_expressions = Option(ArrayList(AstExpr)).Some(fv_s0_drops);
+        });
         // control_flow is intentionally NOT propagated (Return is consumed here).
         expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out);
         // Temp variable for the (non-unit) call result (mirrors TS
@@ -5623,6 +5657,7 @@ Fix: wrap the call:
         out_rt := new_expr_info(call_result_rt.caller_env, ret_type_rt);
         out_rt.value = Option(EvalValue).Some(_call_result_unknown(ret_type_rt, env));
         out_rt.runtime_arg_exprs_in_order = Option(ArrayList(AstExpr)).Some(call_result_rt.runtime_arg_exprs_in_order);
+        out_rt.deferred_drop_expressions = call_result_rt.deferred_drop_expressions;
         expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_rt);
         // Same temp attachment as the method + valueless-callee arms (TS
         // function.ts:2263 attaches for EVERY runtime call). Without it, an
@@ -5965,6 +6000,7 @@ Fix: wrap the call:
           out_m := new_expr_info(call_result_m.caller_env, m_out_ty);
           out_m.value = m_result_val;
           out_m.runtime_arg_exprs_in_order = Option(ArrayList(AstExpr)).Some(call_result_m.runtime_arg_exprs_in_order);
+          out_m.deferred_drop_expressions = call_result_m.deferred_drop_expressions;
           expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_m);
           // Attach the call-result temp (TS function.ts:2263 does this for
           // EVERY runtime call, methods included). Without it a method call's
@@ -6106,6 +6142,7 @@ Fix: wrap the call:
           out_none := new_expr_info(call_result_none.caller_env, ret_type_none);
           out_none.value = Option(EvalValue).Some(_call_result_unknown(ret_type_none, callee_env));
           out_none.runtime_arg_exprs_in_order = Option(ArrayList(AstExpr)).Some(call_result_none.runtime_arg_exprs_in_order);
+          out_none.deferred_drop_expressions = call_result_none.deferred_drop_expressions;
           expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_none);
           // Same temp attachment as the method arm (TS function.ts:2263).
           attach_temp_variable_to_expr(expr, true, ctx);

--- a/yo-self/evaluator/calls/helper.yo
+++ b/yo-self/evaluator/calls/helper.yo
@@ -51,7 +51,7 @@ open(import("std/fmt"));
 } :: import("../../env.yo");
 // dup-on-store / move for owned fn-call args (TS helper.ts:411-451). utils.yo
 // imports nothing from calls/, so this is acyclic.
-{ set_expr_as_consumed, set_expr_as_needs_to_call_dup, are_values_equal, require_expr_not_consumed } :: import("../utils.yo");
+{ set_expr_as_consumed, set_expr_as_needs_to_call_dup, set_expr_as_needs_to_call_dup_for_borrowed_projection, arg_is_rc_projection_place, are_values_equal, require_expr_not_consumed } :: import("../utils.yo");
 { TypeValue, FuncMeta } :: import("../../types/definitions.yo");
 { Token } :: import("../../token.yo");
 { HashMap } :: import("std/collections/hash_map");
@@ -440,7 +440,12 @@ CheckParamResult :: ref(
     caller_env : Environment,
     arg_value : Option(EvalValue),
     arg_type : TypeValue,
-    resolved_param_type : TypeValue
+    resolved_param_type : TypeValue,
+    /// Aliasing Stage 0: the synthesized `___drop(<dup temp>)` balancing this
+    /// argument's projection dup — the CALLER attaches it to the call node's
+    /// deferred drops (single post-call emission; scope-end machinery emits
+    /// on non-exclusive exits, see the marker's note in utils.yo).
+    s0_drop : Option(AstExpr)
   )
 );
 // ---------------------------------------------------------------------------
@@ -628,7 +633,11 @@ check_if_function_parameter_matches_argument :: (
     /// The parameter's `= <value>` ASSIGNED value, or `.None`. Appended last
     /// with a default so existing call sites need no change. See the Step-5b
     /// guard below (TS helper.ts:481-497).
-    (param_assigned_value : Option(EvalValue)) ?= Option(EvalValue).None
+    (param_assigned_value : Option(EvalValue)) ?= Option(EvalValue).None,
+    /// Aliasing Stage 0: true when the CALLEE is extern/builtin (no Yo code
+    /// runs inside — its borrows cannot dangle), so Step 4c skips the
+    /// projection dup. Mirrors TS helper.ts `!functionType.externName`.
+    (callee_is_extern : bool) ?= false
   ) -> CheckParamResult
 )({
   // Step 1: Strip "label: value" colon-label wrapper from arg if present,
@@ -832,6 +841,20 @@ check_if_function_parameter_matches_argument :: (
         });
       }
     );
+  });
+  // Step 4c: Aliasing Stage 0 (mirrors TS helper.ts's borrow-projection
+  // branch; issues/borrowed-arg-invalidated-by-aliased-container-mutation.md).
+  // An RC-typed field PROJECTION passed to a BORROWING parameter hands the
+  // callee a view into storage it may reassign through an aliased handle
+  // (`f(w, w.b)` reassigning `w.b` in a loop frees the old value mid-call —
+  // the borrowed parameter dangles). Materialize a caller-owned +1 for the
+  // call; the caller's scope-end drop releases it. Plain locals and owned
+  // temps stay +0 (the marker no-ops on owning temps), `inout` (ref) params
+  // are place writes, and — like Step 4b — trial calls in the CHECKING PHASE
+  // must not mutate the real caller env.
+  (s0_drop_captured : Option(AstExpr)) = Option(AstExpr).None;
+  if(((((!(param_is_owning)) && !(is_ct_only)) && ((!(param_is_ref)) && !(ctx.is_in_function_call_checking_phase))) && !(callee_is_extern)) && arg_is_rc_projection_place(actual_arg, caller_env_r), {
+    s0_drop_captured = set_expr_as_needs_to_call_dup_for_borrowed_projection(evaled_arg, ctx, exn);
   });
   // Step 5: Comptime check — runtime arg cannot fill a comptime parameter.
   //
@@ -1101,7 +1124,8 @@ ${ast_expr_to_string(actual_arg)}`
     caller_env : caller_env_r,
     arg_value : arg_value,
     arg_type : arg_type,
-    resolved_param_type : final_pt
+    resolved_param_type : final_pt,
+    s0_drop : s0_drop_captured
   )
 });
 // ---------------------------------------------------------------------------
@@ -4501,6 +4525,10 @@ try_to_call_function_with_arguments :: (
       il := __fm8.*.implicit_labels;
       ispr := __fm8.*.implicit_spreads;
       fn_has_variadic := __fm8.*.has_variadic;
+      // Aliasing Stage 0: extern/builtin callees run no Yo code, so their
+      // borrows cannot dangle — Step 4c skips the projection dup for them
+      // (mirrors TS helper.ts `!functionType.externName`).
+      callee_is_extern := __fm8.*.extern_name.is_some();
       ispr;
       wt;
       // ----------------------------------------------------------------
@@ -5540,6 +5568,10 @@ try_to_call_function_with_arguments :: (
       );
       io_async_param_direct := (is_io_async_call(expr) && !(io_async_has_ret_constraint));
       (pi : usize) = usize(0);
+      // Aliasing Stage 0: per-call `___drop(<dup temp>)`s from the params
+      // (CheckParamResult.s0_drop) — attached to the call node via
+      // FuncCallResult.deferred_drop_expressions (post-call flush).
+      s0_call_drops := ArrayList(AstExpr).new();
       while(pi < n_params, {
         plabel := match(pl.get(pi),.Some(l) => l,.None => String.from(""));
         ptype := match(pt.get(pi),.Some(t) => t,.None => t_unit());
@@ -5656,7 +5688,15 @@ try_to_call_function_with_arguments :: (
           ctx,
           rt_args,
           exn,
-          match(call_param_assigned.get(pi),.Some(a) => a,.None => Option(EvalValue).None)
+          match(call_param_assigned.get(pi),.Some(a) => a,.None => Option(EvalValue).None),
+          callee_is_extern
+        );
+        match(
+          pr.s0_drop,
+          .Some(s0d) => {
+            s0_call_drops.push(s0d);
+          },
+          .None => ()
         );
         callee_env_m = pr.callee_env;
         caller_env_m = pr.caller_env;
@@ -6498,7 +6538,7 @@ try_to_call_function_with_arguments :: (
         ),
         runtime_arg_exprs_in_order : rt_args,
         specialized_function_value : spec_func_val,
-        deferred_drop_expressions : Option(ArrayList(AstExpr)).None
+        deferred_drop_expressions : if(s0_call_drops.len() > usize(0), Option(ArrayList(AstExpr)).Some(s0_call_drops), Option(ArrayList(AstExpr)).None)
       )
     },
     _ => {

--- a/yo-self/evaluator/utils.yo
+++ b/yo-self/evaluator/utils.yo
@@ -52,9 +52,12 @@ open(import("std/string"));
   ast_expr_token,
   ast_expr_id,
   ast_expr_is_atom,
+  ast_expr_is_fn_call_of,
   ast_expr_to_string,
   make_err_expr,
-  BF_DUP
+  BF_DUP,
+  BF_DROP,
+  BF_DOT
 } :: import("../expr.yo");
 {
   ExprInfo,
@@ -63,7 +66,8 @@ open(import("std/string"));
   expr_info_origin_type,
   expr_info_set_origin_type,
   get_arm_init_range,
-  get_branch_init_record
+  get_branch_init_record,
+  new_expr_info
 } :: import("../expr_info.yo");
 {
   Environment,
@@ -770,6 +774,188 @@ set_expr_as_needs_to_call_dup :: (
       );
     }
   );
+});
+/// Aliasing Stage 0 (issues/borrowed-arg-invalidated-by-aliased-container-mutation.md):
+/// dup an RC-typed PROJECTION argument passed to a BORROWING parameter,
+/// keeping the +1 in the CALLER. Mirrors TS
+/// `setExprAsNeedsToCallDupForBorrowedProjection` (expr.ts).
+///
+/// Unlike `set_expr_as_needs_to_call_dup` above (the own-param path, whose
+/// dup RESULT temp is consumed because the callee drops the transferred +1),
+/// the dup result here is left OWNING and UNCONSUMED so the caller's normal
+/// scope-end drop is the balancing -1, and the SOURCE binding is never
+/// consumed (a borrow stays usable). No-ops when the argument's temp already
+/// OWNS its value (alive to scope end regardless — no aliasing hole) or when
+/// the value is a codegen-inlinable comptime constant (no RC traffic).
+set_expr_as_needs_to_call_dup_for_borrowed_projection :: (
+  fn(
+    rhs : AstExpr,
+    ctx : EvalContext,
+    exn : Exception
+  ) -> Option(AstExpr)
+)({
+  var_name_opt := match(
+    expr_info_table_get(ctx.expr_info_table, ast_expr_id(rhs)),
+    .Some(info) => info.variable_name,
+    .None => Option(String).None
+  );
+  (s0_result : Option(AstExpr)) = Option(AstExpr).None;
+  match(
+    var_name_opt,
+    .None => (),
+    .Some(variable_name) => {
+      ei := match(
+        expr_info_table_get(ctx.expr_info_table, ast_expr_id(rhs)),
+        .Some(info) => info,
+        .None => new_expr_info_placeholder_for_unreachable_(rhs)
+      );
+      // Same concrete-value inlinability gate as set_expr_as_needs_to_call_dup:
+      // only a value codegen actually INLINES has no C variable to dup.
+      has_concrete_value := match(
+        ei.value,
+        .Some(cv) => (!(is_unknown_val(cv)) && !(type_contains_rc_type(ei.ty))),
+        .None => false
+      );
+      if(has_concrete_value, {
+        return(Option(AstExpr).None);
+      });
+      if(!(type_contains_rc_type(ei.ty)), {
+        return(Option(AstExpr).None);
+      });
+      match(
+        find_variable_in_env(ei.env, variable_name),
+        .None => (),
+        .Some(v) => {
+          if(v.is_owning_the_rc_value, {
+            return(Option(AstExpr).None);
+          });
+          // SYNTHESIZE the evaluated dup form instead of evaluating it.
+          // Evaluating a fresh `___dup(...)` expression from INSIDE a
+          // derive/quote-generated body's def-time eval corrupts the
+          // enclosing module evaluation through shared state (no throw —
+          // bisected in issues/yo-self-dup-eval-inside-macro-generated-body-
+          // corrupts-module-eval.md). A dup of a KNOWN temp needs no general
+          // evaluation: mint the result temp OWNING in the rhs env (its
+          // scope-end drop is the balancing -1; the pair optimizer cannot
+          // cancel dup-of-SOURCE against drop-of-RESULT), and stamp the dup
+          // node + its arg atom with the ExprInfo codegen's deferred-dup
+          // emitter reads (dei.variable_name / target atom env). Deliberate
+          // mechanism divergence from TS (which evaluates the dup): the
+          // nested eval is unsound in yo-self's def-time contexts.
+          dup_expr := generate_expr_from_code(`${BF_DUP}(${variable_name})`, exn);
+          dup_temp := generate_new_temp_variable_name(ei.env.module_path);
+          reg_var := add_variable_to_begin_block_frame(
+            ei.env,
+            dup_temp.clone(),
+            ei.ty,
+            Option(EvalValue).None,
+            false,
+            true,
+            ast_expr_token(rhs)
+          );
+          // CONSUME the dup temp immediately: the balancing -1 is the
+          // EXPLICIT `___drop` returned below, attached by the caller to the
+          // CALL node's deferred drops (single post-call emission). Leaving
+          // the temp unconsumed-owning let yo-self's multi-exit cleanup
+          // machinery (match-arm exits + escape paths + scope end) emit its
+          // drop on NON-exclusive paths — the stage-2 binary over-released
+          // context.base and corrupted the whole emit (FIXPOINT_BROKEN,
+          // recycled-name garbage; gmalloc-traced to dup-for-value's enum
+          // arm).
+          match(
+            reg_var,
+            .Some(rv) => {
+              rv.consumed_at_token = Option(Box(Token)).Some(box(ast_expr_token(rhs)));
+            },
+            .None => ()
+          );
+          dup_info := new_expr_info(ei.env, ei.ty);
+          dup_info.variable_name = Option(String).Some(dup_temp.clone());
+          expr_info_table_set(ctx.expr_info_table, ast_expr_id(dup_expr), dup_info);
+          match(
+            dup_expr,
+            .FnCall(_, _, dd_args, _, _) => match(
+              dd_args.get(usize(0)),
+              .Some(dd_atom) => {
+                dd_atom_info := new_expr_info(ei.env, ei.ty);
+                dd_atom_info.variable_name = Option(String).Some(variable_name.clone());
+                expr_info_table_set(ctx.expr_info_table, ast_expr_id(dd_atom), dd_atom_info);
+              },
+              .None => ()
+            ),
+            .Atom(_, _) => ()
+          );
+          g_dup_use_site_tokens.set(ast_expr_id(dup_expr), ast_expr_token(rhs));
+          dup_list := ArrayList(AstExpr).new();
+          dup_list.push(dup_expr);
+          ei.deferred_dup_expressions = Option(ArrayList(AstExpr)).Some(dup_list);
+          // Synthesize the balancing `___drop(dup_temp)` for the CALLER to
+          // attach to the call node's deferred drops.
+          s0_drop_expr := generate_expr_from_code(`${BF_DROP}(${dup_temp})`, exn);
+          s0_drop_info := new_expr_info(ei.env, ei.ty);
+          expr_info_table_set(ctx.expr_info_table, ast_expr_id(s0_drop_expr), s0_drop_info);
+          match(
+            s0_drop_expr,
+            .FnCall(_, _, sd_args, _, _) => match(
+              sd_args.get(usize(0)),
+              .Some(sd_atom) => {
+                sd_atom_info := new_expr_info(ei.env, ei.ty);
+                sd_atom_info.variable_name = Option(String).Some(dup_temp.clone());
+                expr_info_table_set(ctx.expr_info_table, ast_expr_id(sd_atom), sd_atom_info);
+              },
+              .None => ()
+            ),
+            .Atom(_, _) => ()
+          );
+          s0_result = Option(AstExpr).Some(s0_drop_expr);
+          // NOTE: deliberately NOT propagating the dup eval's env onto the
+          // rhs ExprInfo (unlike set_expr_as_needs_to_call_dup above). The
+          // dup temp was added IN PLACE to ei.env's current frame, so the
+          // rhs env already resolves it — and REPLACING ei.env here leaked a
+          // def-time BODY env into the enclosing statement flow: yo-self
+          // threads env through statement infos, so a module-level derive's
+          // generated-body eval replaced the MODULE env mid-module
+          // ("Variable Tok not found" on the impl FOLLOWING derive(Eq) of a
+          // String-field ref struct — the tok_i minimal repro).
+        }
+      );
+    }
+  );
+  s0_result
+});
+/// Aliasing Stage 0 predicate: a bare field-access chain (`w.b`, `a.b.c`)
+/// rooted at a RUNTIME variable — a PROJECTION place. A bare atom is NOT a
+/// projection (the caller's binding keeps a plain local alive for the call,
+/// +0). A method call (`x.f()`) is not a 2-arg dot call — its `func` is the
+/// dot — and produces an owned temp anyway. Mirrors TS helper.ts
+/// `exprIsRcProjectionPlace`.
+arg_is_rc_projection_place :: (fn(e : AstExpr, env : Environment) -> bool)({
+  if(!(ast_expr_is_fn_call_of(e, BF_DOT, Option(usize).Some(usize(2)))), {
+    return(false);
+  });
+  e_args := match(e,.FnCall(_, _, __aipp_a, _, _) => __aipp_a,.Atom(_, _) => ArrayList(AstExpr).new());
+  e_a1 := match(e_args.get(usize(1)),.Some(x) => x,.None => return(false));
+  if(!(ast_expr_is_atom(e_a1)), {
+    return(false);
+  });
+  (root : AstExpr) = match(e_args.get(usize(0)),.Some(x) => x,.None => return(false));
+  while(ast_expr_is_fn_call_of(root, BF_DOT, Option(usize).Some(usize(2))), {
+    r_args := match(root,.FnCall(_, _, __aipp_ra, _, _) => __aipp_ra,.Atom(_, _) => ArrayList(AstExpr).new());
+    r_a1 := match(r_args.get(usize(1)),.Some(x) => x,.None => return(false));
+    if(!(ast_expr_is_atom(r_a1)), {
+      return(false);
+    });
+    root = match(r_args.get(usize(0)),.Some(x) => x,.None => return(false));
+  });
+  if(!(ast_expr_is_atom(root)), {
+    return(false);
+  });
+  vars := get_variables_from_env(env, ast_expr_token(root).value);
+  if(vars.len() == usize(0), {
+    return(false);
+  });
+  v := match(vars.get(vars.len() - usize(1)),.Some(x) => x,.None => return(false));
+  !(v.is_compile_time_only)
 });
 // ---------------------------------------------------------------------------
 // doc_comment_lookup_key_from_token
@@ -1651,7 +1837,7 @@ export(
 );
 export(throw_expr_is_implicit_variable_error);
 export(require_expr_not_consumed);
-export(set_expr_as_needs_to_call_dup);
+export(set_expr_as_needs_to_call_dup, set_expr_as_needs_to_call_dup_for_borrowed_projection, arg_is_rc_projection_place);
 export(get_dup_use_site_token);
 export(attach_temp_variable_to_expr);
 export(doc_comment_lookup_key_from_token);


### PR DESCRIPTION
## Summary

Closes the compile-time RC model's **borrowed-argument aliasing hole** with the staged plan's Stage 0 (`issues/borrowed-arg-invalidated-by-aliased-container-mutation.md`, decision 2026-08-06: Lobster-style, staged): an RC-typed field **projection** passed to a **borrowing** parameter now gets a caller-owned `+1` for the call, in **both compilers**.

Before: `poke(w, w.b)` where the callee reassigns `w.b` in a loop freed the old box mid-call — the borrowed parameter read a recycled allocation (deterministically printed the wrong value; an arbitrary UAF under a hostile heap). After: the borrowed projection reads the pre-mutation value; the `+1` is released exactly once.

**Scope guards:** plain locals stay `+0` (the caller's binding keeps them alive), owned temps stay `+0` (alive to scope end already), `inout`/comptime params excluded, and **extern/builtin callees excluded** (no Yo code runs inside them — no aliased reassignment is possible, and they're the hottest primitives).

## Implementation

- **TS**: `setExprAsNeedsToCallDupForBorrowedProjection` (expr.ts) + the borrowing branch and `exprIsRcProjectionPlace` predicate in `evaluateArgs` (helper.ts). The dup result temp is flipped back to owning so the normal scope-end drop balances it.
- **yo-self**: the marker **synthesizes** the dup instead of evaluating it (a nested `evaluate_expression_raw` inside a derive-generated body's def-time eval corrupts the module evaluation — bisected, documented in `issues/yo-self-dup-eval-inside-macro-generated-body-corrupts-module-eval.md`), **consumes** the temp, and returns an explicit `___drop` threaded through the previously-dormant `CheckParamResult`/`FuncCallResult.deferred_drop_expressions` channel to the call node's post-call flush (yo-self's multi-exit cleanup machinery emits unconsumed-owning-temp drops on non-exclusive paths — scope-end reliance was unsound there). Step 4c lands in both call paths (helper.yo + function.yo's inline FuncVal loop).

## Latent codegen bugs the new dups surfaced (fixed in the same PR)

The invariant "a deferred dup on an argument requires the argument's eval temp to be declared before the dup emits" was violated at several arg-rendering sites (latent — deferred dups previously only reached shapes that always materialized):

1. `and-or.ts` / `and_or.yo` — the short-circuit conditional-temp collector missed dup temps (ExprInfo side-channel), leaving a block-level drop for an if-scoped dup; the yo-self branch-drop emitter also gained the undeclared-temp gate.
2. `recur.ts` / `recur.yo` — the recur arg path replaced argCode with the dup result without materializing the source temp; recur.yo also gained the full dup/drop arg handling (was a documented gap) and its node-drop flush moved **after** the call emission (flushing before freed the argument the recursion was about to consume — the stage-2 fixpoint UAF, Guard-Malloc-traced to the exact instruction offsets).
3. `other-fn-call.ts` — closure/state-machine capture exclusions skipped the temp declaration while the dup still emitted; a dup targeting the arg's own temp now forces the declaration.
4. `drop_dup.yo` — synthesized dup results are declare-assigned via the `get_variable_type_string` choke-point.

## Validation

| Gate | Result |
| --- | --- |
| Aliasing repro (both compilers) | `borrowed: 42` (was `101`/recycled), Guard Malloc clean |
| New regression test `tests/rc.test.yo` ("borrowed projection argument survives aliased container mutation", rc-balance asserts) | 22/22 both compilers; red-before verified on the base commit |
| TS fast suite (`./tests` minus internal) | **2671 passed / 0 failed** |
| Self-hosted battery (23 files, hollow detection) | 0 failures |
| Differential corpus (tests/codegen-bootstrap) | **155 PASS / 0 DIFF** |
| `yo-self-bin check ./std` | 153/153 |
| Stage-2 self-emit → clang → stage-3 | clean, **FIXPOINT HOLDS (stage-2 ≡ stage-3)** |
| Guard Malloc (repros + self-hosted compile probe) | clean |
| Perf (`check ./std` ×3, self-hosted, pre→post) | min user 45.3 s → 55.7 s (**+23%**) — the cost of the unconditional Stage-0 dups; Stage 1 (read-only callee summaries) is the designed claw-back and is the next scheduled arc |

## Follow-ups (tracked)

- **Stage 1** (per-specialization mutation summaries, `src/evaluator/effects/`): restores `+0` borrows for read-only callees; decision on urgency informed by the perf row above.
- The yo-self nested-eval fragility in derive contexts (own issue doc) — root-cause before any new nested eval in arg-processing paths.
- Accepted leak-direction gaps: unit-result `recur` calls don't flush Stage-0 drops; details in the issue doc's landing log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
