### PR TITLE
Fix arrays of RC elements: constructor form, codegen dispatch, and field tracer

### DIFF
--- a/issues/borrowed-arg-invalidated-by-aliased-container-mutation.md
+++ b/issues/borrowed-arg-invalidated-by-aliased-container-mutation.md
@@ -463,7 +463,7 @@ statement-skipping bug: "has a value" ≠ "is compile-time inlined".
 **Rules probed and found SOUND:** nested projection chains (`h.inner.b`),
 and a projection whose ROOT is the caller's own parameter rather than a local.
 
-**The regression test is BLOCKED and tracked separately.** The only shape
+**The regression test WAS blocked; it is now checked in.** The only shape
 that discriminates is a fixed-size `Array` field: its element reads are
 inline, non-owning, and carry an `UnknownValue`. `ArrayList` reads go through
 the Index trait and yield an OWNING temp, so they were already safe at `+0`
@@ -471,7 +471,8 @@ and a test built on them passes with or without the fix — worthless as a
 regression guard. But `Array(Box(i32), N)(...)` emits invalid C in BOTH
 compilers (pre-existing, verified with these changes stashed), so the test
 cannot be checked in yet. Filed as
-`issues/array-of-rc-constructor-emits-invalid-c.md`, which carries the
-reproducer and an instruction to add this test when that codegen bug is
-fixed. The fixes here are verified by hand (101 → 42) and by the full gate
-battery.
+`issues/fixed/array-of-rc-constructor-emits-invalid-c.md` (fixed 2026-08-08; three defects, see that doc), which carried the
+reproducer. That bug is now fixed and the test — "an INDEXED borrowed
+argument is protected like a field projection" — is checked into
+`tests/rc.test.yo`, passing under both compilers. The fixes here are
+additionally verified by hand (101 → 42) and by the full gate battery.

--- a/issues/fixed/array-of-rc-constructor-emits-invalid-c.md
+++ b/issues/fixed/array-of-rc-constructor-emits-invalid-c.md
@@ -1,6 +1,6 @@
 # `Array(Box(i32), N)(...)` constructor emits invalid C
 
-**Status:** OPEN. Pre-existing (reproduced with the aliasing Stage-0 audit
+**Status:** FIXED 2026-08-08 (both compilers). Pre-existing (reproduced with the aliasing Stage-0 audit
 changes stashed), affects **both** compilers. Found 2026-08-08 while trying
 to build a regression test for the Stage-0 indexed-borrow hole.
 
@@ -62,3 +62,33 @@ fixed, because it must run under both compilers in the gate battery.
 
 **When fixing this, add that test** — the reproducer above plus a callee that
 replaces/reassigns the array element in a loop while a borrow of it is live.
+
+## Resolution (2026-08-08)
+
+Three distinct defects, all reached from the one reproducer:
+
+1. **`Array(T, N)(...)` claimed to be a compile-time constant with runtime
+   elements.** The constructor path manufactured `UnknownValue` placeholders
+   and stamped the array as comptime regardless, so codegen routed it to the
+   constant emitter — which has no case for an Unknown and emitted an EMPTY
+   initializer slot. The array-LITERAL path already guarded with
+   `every(val => !!val)`, which is exactly why literals worked. Fixed by
+   mirroring that guard: an `UnknownValue` means "type known, value not" — a
+   runtime element — and does not count as a compile-time value.
+2. **No codegen dispatch for the runtime constructor shape.** The literal
+   reaches `generateAnonymousArray` via its `array` head; the constructor has
+   no such head. Now routed by SHAPE (array-typed call + runtime args + no
+   comptime value), so both forms share one head-agnostic emitter.
+3. **The generated RC tracer subscripted the array WRAPPER.** `Array(T, N)`
+   is `Array_..._N { T data[N]; }`, not a bare C array, so
+   `sizeof(obj->a)/sizeof(obj->a[0])` and `obj->a[i]` were invalid for any
+   ref struct with an `Array(Box(T), N)` field. Both now go through `.data`.
+
+Same root confusion as the Stage-0 marker hole in PR #79: an `UnknownValue`
+(runtime) read as a compile-time value. Three separate bugs from that one
+conflation — worth watching wherever `$.value` is tested for truthiness.
+
+**The blocked test is now checked in**, along with an array-of-RC test
+asserting the constructor and literal forms agree (values AND element `rc`)
+and that a fully compile-time array still folds. `tests/rc.test.yo` 33/33
+under both compilers.

--- a/src/codegen/exprs/generation.ts
+++ b/src/codegen/exprs/generation.ts
@@ -36,6 +36,7 @@ import {
 import { generateOpAnd, generateOpOr } from "./and-or";
 import { generateAnonymousArray, generateYoArrayFill } from "./array-fns";
 import { isArrayType } from "../../types/guards";
+import { isTypeValue } from "../../value";
 import { generateAssignment } from "./assignment";
 import { generateAsyncBlock, generateIoAsyncSyncCall } from "./async";
 import { emitAsyncFutureEscape } from "./async-completion";
@@ -107,6 +108,18 @@ import { generateSizeOf } from "./sizeof";
 import { generateAnonymousTuple } from "./tuple-fn";
 import { generateTypeId } from "./typeid";
 import { generateWhileLoop } from "./while";
+
+/**
+ * True when this call's CALLEE is an array TYPE (`Array(T, N)(...)`), as
+ * opposed to an ordinary function that merely RETURNS an array.
+ */
+function exprFuncIsArrayTypeValue(expr: FnCallExpr): boolean {
+  const funcValue = expr.func.$?.value;
+  if (!funcValue || !isTypeValue(funcValue)) {
+    return false;
+  }
+  return isArrayType(funcValue.value);
+}
 
 let indexTraitTempCounter = 0;
 
@@ -934,7 +947,13 @@ function generateFuncCall(
   else if (
     isArrayType(expr.$?.type) &&
     expr.$?.runtimeArgExprsInOrder &&
-    !expr.$?.value
+    !expr.$?.value &&
+    // The CALLEE must be the array TYPE itself. Matching on the result type
+    // alone was far too broad: any ordinary function returning an array
+    // (`md5(data) -> Array(u8, 16)`) also has an array type and runtime args,
+    // and got emitted as an array literal of its own arguments instead of
+    // being called.
+    exprFuncIsArrayTypeValue(expr)
   ) {
     const result = generateAnonymousArray(expr, indent, context);
     if (result !== undefined) {

--- a/src/codegen/exprs/generation.ts
+++ b/src/codegen/exprs/generation.ts
@@ -35,6 +35,7 @@ import {
 } from "../utils";
 import { generateOpAnd, generateOpOr } from "./and-or";
 import { generateAnonymousArray, generateYoArrayFill } from "./array-fns";
+import { isArrayType } from "../../types/guards";
 import { generateAssignment } from "./assignment";
 import { generateAsyncBlock, generateIoAsyncSyncCall } from "./async";
 import { emitAsyncFutureEscape } from "./async-completion";
@@ -917,6 +918,24 @@ function generateFuncCall(
   }
   // (anonymous) array value
   else if (exprIsFunctionCallOf(expr, BuiltinKeywords.array)) {
+    const result = generateAnonymousArray(expr, indent, context);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  // `Array(T, N)(a, b)` with RUNTIME elements. The array-literal form
+  // `[a, b,]` reaches the emitter above through its `array` head; the type-
+  // constructor form has no such head, so route it by SHAPE instead: an
+  // array-typed call carrying runtime argument expressions and no
+  // compile-time value. `generateAnonymousArray` is head-agnostic — it works
+  // off `runtimeArgExprsInOrder`, the array type and the temp — so both forms
+  // share one emitter. A fully compile-time array still carries a value and
+  // is emitted as a constant by the branch below.
+  else if (
+    isArrayType(expr.$?.type) &&
+    expr.$?.runtimeArgExprsInOrder &&
+    !expr.$?.value
+  ) {
     const result = generateAnonymousArray(expr, indent, context);
     if (result !== undefined) {
       return result;

--- a/src/codegen/functions/generation.ts
+++ b/src/codegen/functions/generation.ts
@@ -2875,14 +2875,19 @@ export function emitTraverseValue(
     }
 
     if (isArrayType(type)) {
-      // Fixed-size inline array `Array(T, N)` — emitted as a C array, so the
-      // element count is `sizeof(arr)/sizeof(arr[0])`. Visit each element.
-      const elemCount = `(sizeof(${access}) / sizeof(${access}[0]))`;
+      // Fixed-size inline array `Array(T, N)` — emitted NOT as a bare C array
+      // but as a STRUCT WRAPPER (`Array_..._N { T data[N]; }`), so both the
+      // element count and the element access must go through `.data`.
+      // Subscripting the wrapper directly produced "subscripted value is not
+      // an array, pointer, or vector" for any ref struct with an
+      // `Array(Box(T), N)` field — i.e. the first time such a field needed a
+      // generated tracer.
+      const elemCount = `(sizeof(${access}.data) / sizeof(${access}.data[0]))`;
       emitter.emitLine(
         `  for (size_t __yo_ti = 0; __yo_ti < ${elemCount}; __yo_ti++) {`
       );
       emitTraverseValue(
-        `${access}[__yo_ti]`,
+        `${access}.data[__yo_ti]`,
         type.childType,
         context,
         visited,

--- a/src/evaluator/calls/array-type.ts
+++ b/src/evaluator/calls/array-type.ts
@@ -1,6 +1,7 @@
 import type { Environment } from "../../env";
 import { formatErrorMessage } from "../../error";
 import {
+  attachTempVariableToExpr,
   type Expr,
   type FnCallExpr,
   setExprAsNeedsToCallDup,
@@ -13,7 +14,6 @@ import { typeToString } from "../../types/utils";
 import {
   createArrayValue,
   createComptimeIntValue,
-  createUnknownValue,
   isNumberValue,
   isUnknownValue,
   type Value,
@@ -72,6 +72,8 @@ export function tryToImplementArrayByArrayType({
 
   // Evaluate each argument and check type compatibility
   const elements: Value[] = [];
+  const runtimeArgExprsInOrder: Expr[] = [];
+  let allElementsAreComptime = true;
   let env = callerEnv;
 
   // Keep track of the expected element type, which may need updating for nested arrays
@@ -133,17 +135,40 @@ export function tryToImplementArrayByArrayType({
       });
     }
 
-    // Store the value if available (for compile-time arrays)
-    if (evaluatedArg.$.value !== undefined) {
+    // Record the element for codegen either way; whether the ARRAY as a whole
+    // is a compile-time constant is decided below.
+    runtimeArgExprsInOrder.push(evaluatedArg);
+
+    // Store the value if available (for compile-time arrays). An
+    // `UnknownValue` does NOT count: it means "type known, value not" — a
+    // RUNTIME element — so an array containing one is not a constant.
+    if (
+      evaluatedArg.$.value !== undefined &&
+      !isUnknownValue(evaluatedArg.$.value)
+    ) {
       elements.push(evaluatedArg.$.value);
     } else {
-      // For runtime arrays, we'll create unknown values as placeholders
-      elements.push(createUnknownValue(expectedElementType, { env, context }));
+      allElementsAreComptime = false;
     }
   }
 
-  // Create the array value
-  const arrayValue = createArrayValue(finalArrayType, elements);
+  // Only a fully compile-time array gets a compile-time value. Stamping one
+  // with manufactured `UnknownValue` placeholders (as this used to) told
+  // codegen "emit this as a constant", and its comptime emitter has no case
+  // for an Unknown — it produced
+  //   .data = { /* skip generating: <comptime Box(i32)> */, ... }
+  // i.e. an EMPTY initializer slot, so any array of RC/reference elements
+  // failed to compile with "expected expression". The array-LITERAL path
+  // (values/array.ts) already guarded this way, which is why `[a, b,]` worked
+  // while `Array(T, N)(a, b)` did not.
+  //
+  // Leaving the value undefined routes the expression to the same runtime
+  // emitter the literal form uses (`generateAnonymousArray`), which builds
+  // the struct from `runtimeArgExprsInOrder` and honours the per-element
+  // deferred dups already attached above.
+  const arrayValue = allElementsAreComptime
+    ? createArrayValue(finalArrayType, elements)
+    : undefined;
 
   // Set the result
   expr.$ = {
@@ -151,7 +176,14 @@ export function tryToImplementArrayByArrayType({
     value: arrayValue,
     type: finalArrayType,
     pathCollection: [],
+    runtimeArgExprsInOrder,
   };
+
+  if (!arrayValue) {
+    // Runtime construction needs a temp to materialize into, exactly as the
+    // array-literal path does.
+    attachTempVariableToExpr(expr, true);
+  }
 
   return expr;
 }

--- a/src/tests/fixme.yo
+++ b/src/tests/fixme.yo
@@ -1,25 +1,24 @@
 pragma(Pragma.AllowUnsafe);
 open(import("std/libc/stdio"));
-{ ArrayList } :: import("std/collections/array_list");
 
-H :: ref(struct(a : Array(Box(i32), 2)));
-
-mk :: (fn() -> H)(
-  H(a : Array(Box(i32), 2)(box(i32(42)), box(i32(7))))
-);
-
-poke :: (fn(h : H, borrowed : Box(i32)) -> i32)({
-  (i : i32) = i32(0);
-  while(runtime(i < i32(2)), {
-    h.a(0) = box(i32(100) + i);
-    i = (i + i32(1));
-  });
-  borrowed.*
-});
+S :: struct(x : Box(i32), y : Box(i32));
+E :: enum(None, Some(b : Box(i32)));
+BoxPair :: struct(a : Box(i32), b : Box(i32));
+RS :: ref(struct(t : BoxPair, s : S, e : E));
 
 main :: (fn() -> unit)({
-  h := mk();
-  unsafe(printf("A = %d (want 42)\n", poke(h, h.a(0))));
+  // tuple of RC
+  t := (box(i32(1)), box(i32(2)),);
+  unsafe(printf("tuple  %d %d\n", t.0.*, t.1.*));
+  // struct of RC
+  s := S(x : box(i32(3)), y : box(i32(4)));
+  unsafe(printf("struct %d %d\n", s.x.*, s.y.*));
+  // enum payload of RC
+  e := E.Some(b : box(i32(5)));
+  unsafe(printf("enum   %d\n", match(e,.Some(b) => b.*,.None => i32(0))));
+  // ref struct holding all three -> exercises the generated tracer
+  r := RS(t : BoxPair(a : box(i32(6)), b : box(i32(7))), s : S(x : box(i32(8)), y : box(i32(9))), e : E.Some(b : box(i32(10))));
+  unsafe(printf("nested %d %d %d\n", r.t.a.*, r.s.x.*, match(r.e,.Some(b) => b.*,.None => i32(0))));
 });
 
 export(main);

--- a/tests/rc.test.yo
+++ b/tests/rc.test.yo
@@ -691,6 +691,55 @@ stage1_honest :: (fn(w : AliasWrap, borrowed : Box(i32), seed : i32) -> i32)({
   t := stage1_poke(w, seed);
   borrowed.* + (t - t)
 });
+// Regression (issues/fixed/array-of-rc-constructor-emits-invalid-c.md): the
+// `Array(T, N)(...)` CONSTRUCTOR used to manufacture UnknownValue placeholders
+// for runtime elements and then stamp the array as a compile-time constant, so
+// codegen emitted `.data = { /* skip generating */, ... }` — an empty
+// initializer slot — and every array of RC elements failed to compile. The
+// array-LITERAL form already guarded correctly, so the two must agree.
+test("arrays of RC elements build at runtime, constructor and literal alike", {
+  b1 := box(i32(42));
+  lit := [b1, box(i32(7)),];
+  assert(lit(0).* == i32(42), "literal element 0");
+  assert(lit(1).* == i32(7), "literal element 1");
+  b2 := box(i32(42));
+  ctor := Array(Box(i32), 2)(b2, box(i32(7)));
+  assert(ctor(0).* == i32(42), "constructor element 0");
+  assert(ctor(1).* == i32(7), "constructor element 1");
+  // The two forms must not diverge in ownership either.
+  assert(rc(b1) == rc(b2), "constructor and literal agree on element rc");
+  // A fully compile-time array still folds to a constant.
+  c :: Array(i32, 3)(1, 2, 3);
+  assert(c(2) == 3, "comptime array still folds");
+});
+// Aliasing STAGE 0 SOUNDNESS — the rules deciding WHICH arguments get
+// protected at all. Stage 1 can only elide a dup Stage 0 created, so a shape
+// Stage 0 declines to mark is unprotected whatever Stage 1 concludes.
+//
+// The borrowed argument here is an INDEX read, not a field access. The
+// projection predicate used to require a 2-arg dot, and the marker used to
+// skip any argument carrying a `$.value` — but a runtime element read carries
+// an `UnknownValue`, a value OBJECT meaning "type known, value not". Between
+// them every indexed borrow went unprotected: this read 101 (the recycled
+// allocation) instead of 42. A fixed-size Array is the shape that
+// discriminates — ArrayList index reads go through the Index trait and yield
+// an OWNING temp, so they were already safe at +0.
+Stage0Arr :: ref(struct(a : Array(Box(i32), 2)));
+stage0_poke_index :: (fn(h : Stage0Arr, borrowed : Box(i32)) -> i32)({
+  (i : i32) = i32(0);
+  while(runtime(i < i32(2)), {
+    h.a(0) = box(i32(100) + i);
+    i = (i + i32(1));
+  });
+  borrowed.*
+});
+test("an INDEXED borrowed argument is protected like a field projection", {
+  h := Stage0Arr(a : Array(Box(i32), 2)(box(i32(42)), box(i32(7))));
+  assert(
+    stage0_poke_index(h, h.a(0)) == i32(42),
+    "an element read is a place into container storage too"
+  );
+});
 // Aliasing Stage 1 SOUNDNESS — one probe per "this callee is read-only"
 // decision rule in the mutation-summary walk. Each callee below invalidates
 // the borrowed projection through a DIFFERENT mechanism; every one must be

--- a/yo-self/codegen/exprs/generation.yo
+++ b/yo-self/codegen/exprs/generation.yo
@@ -645,7 +645,21 @@ generate_func_call :: (fn(expr : AstExpr, indent : String, context : FunctionGen
   // is head-agnostic, so both forms share one emitter. A fully compile-time
   // array keeps its value and is emitted as a constant elsewhere. Mirrors the
   // same dispatch in src/codegen/exprs/generation.ts.
-  if((!(ast_expr_is_atom(expr))) && (is_array_type(ei.ty) && (ei.runtime_arg_exprs_in_order.is_some() && ei.value.is_none())), {
+  // The CALLEE must be the array TYPE itself. Matching on the result type
+  // alone was far too broad: any ordinary function RETURNING an array
+  // (`md5(data) -> Array(u8, 16)`) also has an array type and runtime args,
+  // and got emitted as an array literal of its own arguments instead of being
+  // called.
+  arr_ctor_callee := match(
+    expr,
+    .FnCall(_, __ac_f, _, _, _) => match(
+      context.base.get_expr_info(__ac_f),
+      .Some(__ac_fi) => match(__ac_fi.value,.Some(__ac_v) => match(__ac_v,.TypeVal(__ac_t) => is_array_type(__ac_t), _ => false),.None => false),
+      .None => false
+    ),
+    .Atom(_, _) => false
+  );
+  if(arr_ctor_callee && (is_array_type(ei.ty) && (ei.runtime_arg_exprs_in_order.is_some() && ei.value.is_none())), {
     match(generate_anonymous_array(expr, indent.clone(), context),.Some(r) => return(r),.None => ());
   });
   if(ast_expr_is_fn_call_of(expr, BF_RECUR, Option(usize).None), return(generate_recur(expr, indent.clone(), context)));

--- a/yo-self/codegen/exprs/generation.yo
+++ b/yo-self/codegen/exprs/generation.yo
@@ -101,7 +101,7 @@ open(import("std/string"));
 } :: import("../../expr.yo");
 { has_any_control_flow, ExprInfo, lookup_macro_expansion } :: import("../../expr_info.yo");
 { is_func_val, is_unknown_val, is_struct_val, is_enum_val, EvalValue } :: import("../../value.yo");
-{ is_unit_type, is_primitive_type, is_pointer_type } :: import("../../types/guards.yo");
+{ is_unit_type, is_primitive_type, is_pointer_type, is_array_type } :: import("../../types/guards.yo");
 { FunctionGenerationContext } :: import("../functions/context.yo");
 { set_generate_expr_fn, _call_generate_expr } :: import("./_expr.yo");
 { is_builtin_yo_inline_function } :: import("../constants.yo");
@@ -638,6 +638,16 @@ generate_func_call :: (fn(expr : AstExpr, indent : String, context : FunctionGen
   if(ast_expr_is_fn_call_of(expr, BF_ADDRESS_OF, Option(usize).Some(usize(1))), return(generate_address_of(expr, indent.clone(), context)));
   if(ast_expr_is_fn_call_of(expr, BK_TUPLE, Option(usize).None), return(generate_anonymous_tuple(expr, indent.clone(), context)));
   if(ast_expr_is_fn_call_of(expr, BK_ARRAY_VAL, Option(usize).None), match(generate_anonymous_array(expr, indent.clone(), context),.Some(r) => return(r),.None => ()));
+  // `Array(T, N)(a, b)` with RUNTIME elements. The array-literal form reaches
+  // the emitter above through its `array` head; the type-constructor form has
+  // no such head, so route it by SHAPE: an array-typed call carrying runtime
+  // argument expressions and no compile-time value. `generate_anonymous_array`
+  // is head-agnostic, so both forms share one emitter. A fully compile-time
+  // array keeps its value and is emitted as a constant elsewhere. Mirrors the
+  // same dispatch in src/codegen/exprs/generation.ts.
+  if((!(ast_expr_is_atom(expr))) && (is_array_type(ei.ty) && (ei.runtime_arg_exprs_in_order.is_some() && ei.value.is_none())), {
+    match(generate_anonymous_array(expr, indent.clone(), context),.Some(r) => return(r),.None => ());
+  });
   if(ast_expr_is_fn_call_of(expr, BF_RECUR, Option(usize).None), return(generate_recur(expr, indent.clone(), context)));
   if(ast_expr_is_fn_call_of(expr, BF_RUNTIME, Option(usize).Some(usize(1))), return(match(expr,.FnCall(_, _, a, _, _) => match(a.get(usize(0)),.Some(inner) => _call_generate_expr(inner, indent.clone(), context),.None => String.from("")),.Atom(_, _) => String.from(""))));
   if(ast_expr_is_fn_call_of(expr, BF_SIZEOF, Option(usize).Some(usize(1))), return(generate_sizeof(expr, indent.clone(), context)));

--- a/yo-self/codegen/functions/constructors.yo
+++ b/yo-self/codegen/functions/constructors.yo
@@ -290,13 +290,18 @@ _traverse_value :: (fn(access : String, ty : TypeValue, context : FunctionGenera
       },
       _ => ()
     ),
-    // Fixed inline array Array(T, N) — emitted as a C array, so the element count
-    // is sizeof(arr)/sizeof(arr[0]). Visit each element.
+    // Fixed inline array Array(T, N) — emitted NOT as a bare C array but as a
+    // STRUCT WRAPPER (`Array_..._N { T data[N]; }`), so both the element count
+    // and the element access must go through `.data`. Subscripting the wrapper
+    // directly produced "subscripted value is not an array, pointer, or
+    // vector" for any ref struct with an `Array(Box(T), N)` field — the first
+    // shape that ever needed a generated tracer. Mirrors the same fix in
+    // src/codegen/functions/generation.ts.
     is_array_type(ty) => match(
       ty,
       .Array({ element }) => {
-        em.emit_string_line(`  for (size_t __yo_ti = 0; __yo_ti < (sizeof(${access}) / sizeof(${access}[0])); __yo_ti++) {`);
-        recur(`${access}[__yo_ti]`, element, context);
+        em.emit_string_line(`  for (size_t __yo_ti = 0; __yo_ti < (sizeof(${access}.data) / sizeof(${access}.data[0])); __yo_ti++) {`);
+        recur(`${access}.data[__yo_ti]`, element, context);
         em.emit_string_line(`  }`);
       },
       _ => ()

--- a/yo-self/evaluator/calls/array_type.yo
+++ b/yo-self/evaluator/calls/array_type.yo
@@ -25,8 +25,11 @@ open(import("std/string"));
 { type_to_string } :: import("../../types/string.yo");
 { are_types_compatible } :: import("../../types/compatibility.yo");
 { EvalContext, ExpectedTypeCtx } :: import("../context.yo");
-{ EvalValue, create_unknown_val } :: import("../../value.yo");
-{ set_expr_as_needs_to_call_dup } :: import("../utils.yo");
+{ EvalValue, is_unknown_val } :: import("../../value.yo");
+{
+  set_expr_as_needs_to_call_dup,
+  attach_temp_variable_to_expr
+} :: import("../utils.yo");
 { evaluate_expression } :: import("../exprs/expr.yo");
 { format_error_message } :: import("../../error.yo");
 { Exception } :: import("std/error");
@@ -102,6 +105,8 @@ try_to_implement_array_by_array_type :: (
   });
   // Evaluate each argument and collect elements.
   elements := ArrayList(EvalValue).new();
+  runtime_arg_exprs := ArrayList(AstExpr).new();
+  (all_elements_are_comptime : bool) = true;
   (env : Environment) = caller_env;
   (expected_element_type : TypeValue) = elem_type;
   (i : usize) = usize(0);
@@ -157,14 +162,21 @@ try_to_implement_array_by_array_type :: (
         )
       );
     });
-    // Store value (compile-time) or unknown placeholder (runtime).
+    // Record the element for codegen either way; whether the ARRAY as a whole
+    // is a compile-time constant is decided after the loop.
+    runtime_arg_exprs.push(evaluated_arg);
+    // An `UnknownVal` does NOT count as a compile-time value: it means "type
+    // known, value not" — a RUNTIME element — so an array containing one is
+    // not a constant.
     match(
       arg_info.value,
-      .Some(v) => {
+      .Some(v) => if(is_unknown_val(v), {
+        all_elements_are_comptime = false;
+      }, {
         elements.push(v);
-      },
+      }),
       .None => {
-        elements.push(create_unknown_val(arg_info.ty));
+        all_elements_are_comptime = false;
       }
     );
     i = (i + usize(1));
@@ -173,8 +185,25 @@ try_to_implement_array_by_array_type :: (
   // Re-use array_type but with refined element type (may have been updated from first element).
   final_array_type := TypeValue.Array(expected_element_type, eff_len, String.from(""));
   out_info := new_expr_info(env, final_array_type);
-  out_info.value =.Some(EvalValue.ArrayVal(elements));
+  // Only a FULLY compile-time array gets a compile-time value. Stamping one
+  // with manufactured `UnknownVal` placeholders (as this used to) told codegen
+  // "emit this as a constant", and the comptime emitter has no case for an
+  // Unknown — it produced `.data = { /* skip generating value */, ... }`, an
+  // EMPTY initializer slot, so any array of RC/reference elements failed to
+  // compile with "expected expression". The array-LITERAL path
+  // (values/array.yo) already guarded exactly this way, which is why
+  // `[a, b,]` worked while `Array(T, N)(a, b)` did not. Mirrors the same fix
+  // in src/evaluator/calls/array-type.ts.
+  if(all_elements_are_comptime, {
+    out_info.value =.Some(EvalValue.ArrayVal(elements));
+  });
+  out_info.runtime_arg_exprs_in_order = Option(ArrayList(AstExpr)).Some(runtime_arg_exprs);
   expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_info);
+  if(!(all_elements_are_comptime), {
+    // Runtime construction needs a temp to materialize into, exactly as the
+    // array-literal path does.
+    attach_temp_variable_to_expr(expr, true, ctx);
+  });
   expr
 });
 export(try_to_implement_array_by_array_type);


### PR DESCRIPTION
## Summary

Arrays of RC/reference elements were **uncompilable**. `Array(Box(i32), 2)(box(i32(42)), box(i32(7)))` emitted invalid C in both compilers. Three distinct defects, all reached from that one reproducer — and all sharing a root confusion with the Stage-0 marker hole fixed in #79.

This also **unblocks the Stage-0 indexed-borrow regression test** that #79 had to land without, which was the motivation for picking this up.

## The three defects

**1. `Array(T, N)(...)` claimed to be a compile-time constant even with runtime elements.** The constructor path *manufactured* `UnknownValue` placeholders for runtime elements and then stamped the array as a comptime value anyway. Codegen dutifully routed it to the constant emitter, which has no case for an Unknown:

```c
.data = { /* skip generating: <comptime Box(i32)> */, /* skip generating: ... */ }
```

An empty initializer slot → `error: expected expression`.

The array-**literal** path (`values/array.ts`) already guarded with `every(val => !!val)` — which is precisely why `[a, b,]` worked while `Array(T, N)(a, b)` did not. Both compilers had the identical bug, down to the identical placeholder comment. Fixed by mirroring the literal path: an `UnknownValue` means *"type known, value not"* — a runtime element — and does not count as a compile-time value.

**2. Codegen had no dispatch for the runtime constructor shape.** The literal form reaches `generateAnonymousArray` through its `array` head; the type-constructor form has no such head. Now routed by **shape** instead — an array-typed call carrying runtime args and no compile-time value — so both forms share one emitter rather than duplicating logic. `generateAnonymousArray` turned out to be entirely head-agnostic and already handles the per-element deferred dups the constructor path attaches.

**3. The generated RC tracer subscripted the array *wrapper*.** `Array(T, N)` is emitted as `Array_…_N { T data[N]; }`, not a bare C array, so `sizeof(obj->a)/sizeof(obj->a[0])` and `obj->a[i]` produced *"subscripted value is not an array, pointer, or vector"* for any ref struct with an `Array(Box(T), N)` field — the first shape that ever needed such a tracer. Both the count and the access now go through `.data`. (Caught by the self-hosted test run after I'd ported only defects 1 and 2.)

## Root cause worth remembering

All three trace back to the same conflation as #79's Stage-0 hole: **an `UnknownValue` (meaning *runtime*, type known) being read as a compile-time value**. Per AGENTS.md, `$.value == undefined` means runtime while `UnknownValue` means "type known, value not" — so a bare truthiness test on `$.value` is wrong. That's now four bugs from this one distinction, which makes it worth watching wherever `$.value` is tested.

## Tests

Two, both previously impossible to write:

- **arrays of RC elements build at runtime, constructor and literal alike** — asserts the two forms agree on values *and* on element `rc` (they must not diverge in ownership), and that a fully compile-time array still folds to a constant.
- **an INDEXED borrowed argument is protected like a field projection** — the Stage-0 regression test #79 documented as blocked. A fixed-size `Array` field is the only shape that discriminates: `ArrayList` index reads go through the Index trait and yield an *owning* temp, so they were already safe at `+0` and a test built on them passes with or without the fix.

`issues/array-of-rc-constructor-emits-invalid-c.md` moves to `issues/fixed/` with the full resolution; the aliasing issue doc is updated to note the test is no longer blocked.

## Validation

| Gate | Result |
| --- | --- |
| `tests/rc.test.yo` | **33/33 under BOTH compilers** (2 new) |
| Reproducer | constructor and literal now agree exactly (values + element rc); comptime array still folds |
| Guard Malloc | clean |
| Self-hosted battery (hollow detection) | 0 failures, hollow=0 |
| Differential corpus | **155 PASS / 0 DIFF** |
| `check ./std` | 153/153 |
| Stage-2 → clang → stage-3 | **FIXPOINT HOLDS**, hollow=0 |
| TS fast suite | see checks |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
