### PR TITLE
Make the CI gates binding, and gate the compiler on type-checking itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,26 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Require a green test run for this commit
+        # This workflow publishes to npm and the VS Code Marketplace — both
+        # irreversible. It used to go checkout -> build -> publish with no test
+        # dependency at all, so a red develop was publishable. Gate on the
+        # Test workflow having CONCLUDED SUCCESSFULLY for the exact SHA being
+        # released, rather than re-running the ~55 min suite inline.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "Releasing $SHA"
+          CONCLUSION=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/test.yml/runs?head_sha=$SHA&status=completed" \
+            --jq '[.workflow_runs[] | select(.conclusion != null)] | first | .conclusion // "none"')
+          echo "Test workflow conclusion for $SHA: $CONCLUSION"
+          if [[ "$CONCLUSION" != "success" ]]; then
+            echo "::error::Refusing to release $SHA — the Test workflow is '$CONCLUSION', not 'success'."
+            exit 1
+          fi
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -657,3 +657,68 @@ jobs:
       # See the WASM job: tests/internal is host-toolchain-only.
       - name: Run WASI tests
         run: node --expose-gc --max-old-space-size=4096 ./out/cjs/yo-cli.cjs test ./tests --exclude tests/internal --parallel 2 --bail --verbose --target wasm-wasi --profile
+
+  # Full-corpus HOLLOW SWEEP under the self-hosted binary.
+  #
+  # Why this exists: bootstrap-self-test runs `<bin> test` on only the 23-file
+  # gates_fast battery, so the other 165 language .test.yo files were exercised
+  # SOLELY by the TypeScript compiler — the one plans/SELF_HOSTING_COMPLETION.md
+  # Phase 2 deletes. scripts/bootstrap/hollow_sweep69.sh was written to close
+  # that and had never been wired into any workflow.
+  #
+  # It scores each file HONESTLY: GREEN requires exit 0 AND an emitted batch
+  # `__yo_user_main` that is not a `// Failed to transpile` comment. A hollow
+  # batch runs no assertions while still reporting "N passed" — the first sweep
+  # found 3 such files, one of them claiming 49 passed
+  # (issues/yo-self-hollow-language-test-files.md).
+  #
+  # Gated as a RATCHET against scripts/bootstrap/known-hollow.txt so it blocks
+  # any NEW hollow file today while those 3 are worked down. It fails in both
+  # directions — an un-allowlisted hollow file fails, and an allowlisted file
+  # that is no longer hollow also fails, so the list cannot go stale.
+  hollow-sweep:
+    name: Full-corpus hollow sweep (all 188 language files, self-hosted)
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install liburing
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liburing-dev
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: |
+          bun install
+          bun run build
+
+      - name: "Stage 1: build the self-hosted compiler with the TS compiler"
+        run: node --expose-gc --max-old-space-size=4096 ./out/cjs/yo-cli.cjs compile yo-self/main.yo --release -o /tmp/yo-stage1
+
+      - name: Sweep every language test file through the self-hosted binary
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: BIN=/tmp/yo-stage1 OUT=/tmp/hsweep bash scripts/bootstrap/hollow_sweep69.sh
+
+      - name: Upload sweep results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hollow-sweep-results
+          path: /tmp/hsweep/results.txt
+          if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -672,10 +672,16 @@ jobs:
   # found 3 such files, one of them claiming 49 passed
   # (issues/yo-self-hollow-language-test-files.md).
   #
-  # Gated as a RATCHET against scripts/bootstrap/known-hollow.txt so it blocks
-  # any NEW hollow file today while those 3 are worked down. It fails in both
-  # directions — an un-allowlisted hollow file fails, and an allowlisted file
-  # that is no longer hollow also fails, so the list cannot go stale.
+  # Gated as a RATCHET against scripts/bootstrap/known-failing.tsv so it blocks
+  # any NEW regression today while the known ones are worked down. It compares
+  # <path, verdict> PAIRS and fails in both directions — an un-allowlisted failure
+  # fails, a listed entry that no longer matches fails, and a missing allowlist
+  # file fails loudly rather than scoring everything as new.
+  #
+  # The first CI run of this job also found 2 RED files that PASS on macOS
+  # (tests/ref_local_binding, tests/string/string) — a Linux-only divergence in
+  # yo-self that had never been visible, since neither file is in the 23-file
+  # battery. They are allowlisted with that note.
   hollow-sweep:
     name: Full-corpus hollow sweep (all 188 language files, self-hosted)
     runs-on: ubuntu-latest
@@ -715,10 +721,15 @@ jobs:
           YO_MAIN_STACK_MB: "4096"
         run: BIN=/tmp/yo-stage1 OUT=/tmp/hsweep bash scripts/bootstrap/hollow_sweep69.sh
 
+      # results.txt alone is a scorecard, not a diagnosis — the first CI run of
+      # this job reported two RED files with no way to see WHY. Upload the
+      # per-file logs too (they are one small log per test file).
       - name: Upload sweep results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: hollow-sweep-results
-          path: /tmp/hsweep/results.txt
+          path: |
+            /tmp/hsweep/results.txt
+            /tmp/hsweep/*.log
           if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,10 +269,13 @@ jobs:
   # function bodies — see plans/archive/YO_SELF_STAGE2_HANDOFF.md).
   #
   # Runs scripts/bootstrap/gates_fast.sh, the same tier-1 gate used locally on
-  # every change: two repro compiles, a 20-file battery via `<bin> test` WITH
+  # every change: two repro compiles, a 23-file battery via `<bin> test` WITH
   # HOLLOW DETECTION, the 155-program corpus diff-test (yo-self output vs TS
-  # output, byte-compared), and `<bin> check ./std`. The script exits non-zero if
-  # any of those fail.
+  # output, byte-compared), `<bin> check ./std`, `<bin> check ./yo-self` (GATE 4
+  # — the compiler type-checking ITSELF; ~137 s, and the only gate that covers
+  # build_runner.yo / version_cache.yo, which sit outside main.yo's import
+  # closure and were type-checked by NOTHING). The script exits non-zero if any
+  # of those fail.
   #
   # HOLLOW DETECTION is the point of the battery: a batch whose `__yo_user_main`
   # contains "Failed to transpile" reports tests as passing while running nothing
@@ -569,9 +572,14 @@ jobs:
           submodules: recursive
 
       - name: Setup Emscripten
+        # Pin the version, for the same reason wasmtime is pinned below: the
+        # "latest" alias is resolved at run time and fetches a bundled Node
+        # tarball from storage.googleapis.com, which returned HTTP 403 on run
+        # 31238532553 and left the job with no toolchain. 6.0.6 is what
+        # "latest" resolved to on the green runs.
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: "latest"
+          version: "6.0.6"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -612,9 +620,14 @@ jobs:
           submodules: recursive
 
       - name: Setup Emscripten
+        # Pin the version, for the same reason wasmtime is pinned below: the
+        # "latest" alias is resolved at run time and fetches a bundled Node
+        # tarball from storage.googleapis.com, which returned HTTP 403 on run
+        # 31238532553 and left the job with no toolchain. 6.0.6 is what
+        # "latest" resolved to on the green runs.
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: "latest"
+          version: "6.0.6"
 
       - name: Install wasmtime
         # Pin the version: the installer's "latest release" lookup hits the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,19 @@ bun test src/tests/build-system.test.ts --timeout 10000
 # is what keeps it fast — tests/internal compiles the compiler 58 times.
 ./yo-cli test ./tests --exclude tests/internal --bail
 
+# Self-hosted gate battery (needs a built yo-self binary in $S1). GATE 4 is
+# `check ./yo-self` — the ONLY thing that type-checks build_runner.yo and
+# version_cache.yo, which sit outside main.yo's import closure.
+S1=/tmp/yo-s1 P=local bash scripts/bootstrap/gates_fast.sh
+S1=/tmp/yo-s1 P=local bash scripts/bootstrap/fixpoint_only.sh
+
+# Full-corpus hollow sweep: every language test file through the SELF-HOSTED
+# binary, scored honestly (a batch `__yo_user_main` that is a "Failed to
+# transpile" comment reports "N passed" while running nothing). Resumable via
+# $OUT/results.txt. Gated as a ratchet against scripts/bootstrap/known-hollow.txt,
+# so it fails on any NEW hollow file AND on a stale allowlist entry.
+BIN=/tmp/yo-s1 OUT=/tmp/hsweep bash scripts/bootstrap/hollow_sweep69.sh
+
 # Evaluator-only check (fast, no codegen — useful for type-check iteration during refactors)
 ./yo-cli check ./std
 ./yo-cli check ./src/tests/fixme.yo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,8 +150,9 @@ S1=/tmp/yo-s1 P=local bash scripts/bootstrap/fixpoint_only.sh
 # Full-corpus hollow sweep: every language test file through the SELF-HOSTED
 # binary, scored honestly (a batch `__yo_user_main` that is a "Failed to
 # transpile" comment reports "N passed" while running nothing). Resumable via
-# $OUT/results.txt. Gated as a ratchet against scripts/bootstrap/known-hollow.txt,
-# so it fails on any NEW hollow file AND on a stale allowlist entry.
+# $OUT/results.txt. Gated as a ratchet against scripts/bootstrap/known-failing.tsv
+# (<path> <verdict> pairs, HOLLOW and RED), so it fails on any NEW regression, on a
+# stale allowlist entry, and on a file that merely CHANGES verdict.
 BIN=/tmp/yo-s1 OUT=/tmp/hsweep bash scripts/bootstrap/hollow_sweep69.sh
 
 # Evaluator-only check (fast, no codegen — useful for type-check iteration during refactors)

--- a/issues/ctl-handler-void-signature-vs-sret-cast.md
+++ b/issues/ctl-handler-void-signature-vs-sret-cast.md
@@ -153,12 +153,37 @@ any property the compiler enforces. Any `try`/`catch` that formats or inspects t
 value position where the surrounding type exceeds 16 bytes moves a handler from the first
 shape to the second.
 
-### What is still not established
+### Narrowing the surviving question
 
-Whether `fn_yo_id_820507` (or the other `err`-reading handlers) is bound at one of those
-95 large-`ResumeType` sites specifically. Tracing which handler reaches which call site
-through the effect record is the one remaining step; if any such pairing exists, this is
-a live x86_64 miscompile rather than a fragile-but-latent one.
+Exactly **3 of the 29** handlers read `err` beyond the `err;` no-op —
+`fn_yo_id_818463`, `fn_yo_id_818705`, `fn_yo_id_820507`. Locating where each is bound:
+
+```c
+// stage-2 C, inside `void __yo_user_main(__yo_t119 io) {`
+__yo_t19 _file____User_temp_1065093 = (__yo_t19){ .throw = fn_yo_id_820507 };
+__yo_t19 exn = _file____User_temp_1065093;
+```
+
+So the `err.vtable->to_string(...)` handler is the compiler's **top-level error printer**
+in `__yo_user_main` — the "yo-self: error: …" path. That is the outermost handler, the
+one a throw reaches whenever no nearer handler catches it, which makes the dangerous
+pairing ordinary rather than exotic.
+
+**Still not proven**, and it needs a dynamic check rather than more grepping: whether a
+throw at one of the 95 large-`ResumeType` sites actually reaches THIS handler rather than
+a nearer one. Two facts sit in tension and should be reconciled before the ABI work is
+scheduled:
+
+- if such a throw did reach it, `err.vtable` would be the sret pointer and the
+  `to_string` dispatch would read a garbage function pointer — a hard crash, not a subtle
+  wrong answer;
+- yet yo-self reports compile errors correctly on x86_64 CI today.
+
+The likeliest reconciliation is that the error paths actually exercised route through
+nearer handlers or through ≤16-byte sites. Confirm by building the x86_64 binary with
+`-fsanitize=function` (per the section below) and running `check` over a deliberately
+broken file — that flags the mismatched call at the moment it happens, without needing to
+reason about which handler won.
 
 ## CONFIRMED by measurement (2026-08-06), and it reproduces on macOS arm64
 

--- a/issues/ctl-handler-void-signature-vs-sret-cast.md
+++ b/issues/ctl-handler-void-signature-vs-sret-cast.md
@@ -1,16 +1,15 @@
-# `ctl` handlers are emitted `void` but called through value-returning casts (latent x86_64 ABI break)
+# `ctl` handlers are emitted `void` but called through value-returning casts (x86_64 ABI break)
 
 **Found 2026-08-06** while root-causing
 `issues/fixed/escape-path-drops-unwound-call-result-temp.md`.
 
 **Severity revised 2026-08-08.** This was filed as _latent_ on the premise that no
-reachable `ctl` has a `ResumeType` over 16 bytes. Measurement refuted that: **95
-`exn.throw` call sites in `yo-self`'s own stage-2 C** cast to one of 7 distinct
-
-> 16-byte structs, and all 29 handlers bound to `.throw` are emitted `void*`. Nothing
-> fails today only because most handlers **discard `err`** — an accidental invariant, not
-> an enforced one, and at least one handler does dereference `err.vtable`. See
-> "MEASURED 2026-08-08" below.
+reachable `ctl` has a `ResumeType` over 16 bytes. Measurement refuted that premise: 95
+`exn.throw` call sites in `yo-self`'s own stage-2 C cast to one of 7 distinct structs
+that each exceed 16 bytes, and all 29 handlers bound to `.throw` are emitted `void*`.
+Nothing fails today only because most handlers **discard `err`** — an accidental
+invariant, not an enforced one, and at least one handler does dereference
+`err.vtable`. See "MEASURED 2026-08-08" below.
 
 ## What codegen does
 

--- a/issues/ctl-handler-void-signature-vs-sret-cast.md
+++ b/issues/ctl-handler-void-signature-vs-sret-cast.md
@@ -51,9 +51,109 @@ is undefined behaviour in C regardless, but whether it _matters_ depends on the 
 
 ## Why nothing fails today
 
-No `ctl` in `std/` or `yo-self/` has a `ResumeType` larger than 16 bytes at a call site
+~~No `ctl` in `std/` or `yo-self/` has a `ResumeType` larger than 16 bytes at a call site
 that also unwinds. `ParseResult` at 16 bytes is the widest in the parser and sits exactly
-at the register/memory boundary — one more field would push it over.
+at the register/memory boundary — one more field would push it over.~~
+
+**REFUTED by measurement 2026-08-08 — see the next section. The premise above is false,
+and it is false inside `yo-self`'s own emitted C.**
+
+## MEASURED 2026-08-08: >16-byte ResumeTypes are everywhere in yo-self's own C
+
+The claim above was never independently checked, and it does not hold. Method — take the
+stage-2 self-emit (`fixpoint_only.sh` leaves it at `/tmp/<P>_stage2.c`) and read the
+cast that every effect-record call site builds:
+
+```bash
+# every exn.throw call site, grouped by the return type it casts to
+grep -oE '\(\([A-Za-z_][A-Za-z0-9_]* \(\*\)\([^)]*\)\)exn\.throw' /tmp/<P>_stage2.c \
+  | sed -E 's/^\(\(([A-Za-z_][A-Za-z0-9_]*) .*/\1/' | sort | uniq -c | sort -rn
+
+# then size them decisively, in one compile
+cp /tmp/<P>_stage2.c /tmp/szcheck.c
+printf '_Static_assert(sizeof(__yo_t299) <= 16, "OVER16: __yo_t299");\n' >> /tmp/szcheck.c
+clang -std=c11 -fsyntax-only -w /tmp/szcheck.c 2>&1 | grep -oE 'OVER16: __yo_t[0-9]+'
+```
+
+Result: of 1064 `exn.throw` call sites, 140 cast to a non-`void` return type, and
+**95 of those cast to one of 7 distinct structs larger than 16 bytes**:
+
+| type        | sites | identity                      |
+| ----------- | ----- | ----------------------------- |
+| `__yo_t299` | 25    | `FuncParamsResult` (8 fields) |
+| `__yo_t290` | 25    |                               |
+| `__yo_t556` | 18    |                               |
+| `__yo_t571` | 15    |                               |
+| `__yo_t526` | 6     |                               |
+| `__yo_t552` | 5     |                               |
+| `__yo_t582` | 1     |                               |
+
+A representative site — note this is `exn.throw` itself, not an ordinary fn-ptr call:
+
+```c
+__yo_t299 _file____User_temp_503617 =
+  (((__yo_t299 (*)(__yo_t852))exn.throw)((__yo_t852)(_file____User_temp_503616)));
+```
+
+The remaining 45 non-void casts are `int64_t` / `int32_t` / `uint32_t` / `bool` and
+small structs — all ≤ 16 bytes, all in the REGISTER class, all fine.
+
+### What this does and does not establish
+
+**Established:** the "no reachable >16-byte `ResumeType`" premise is false, so the
+severity assessment that rested on it ("the bug is latent") needs redoing. This is
+`yo-self` compiling ITSELF, on the same x86_64 CI architecture the SysV analysis applies
+to.
+
+**Also established (the follow-up check):** the handlers really are emitted with a
+register-class return, not the concrete one. All 29 distinct functions bound to
+`.throw` in the stage-2 C are `void*`:
+
+```c
+static inline void* fn_yo_id_306605(__yo_t852 err);
+```
+
+So at those 95 sites the caller builds a MEMORY-class call (hidden sret pointer in RDI,
+`err` displaced to RSI) into a callee that reads `err` from RDI. The mismatch is real and
+present, exactly as analyzed — the doc's own mechanism corrupts the callee **on entry**,
+before any resume/unwind decision, so the original "at a call site that also unwinds"
+qualifier never narrowed the exposure the way it was assumed to.
+
+### The actual reason nothing fails today
+
+Not the absence of large `ResumeType`s — it is that **most handlers discard `err`**:
+
+```c
+static inline void* fn_yo_id_306605(__yo_t852 err) {
+  err;                       // <- a no-op statement; the value is never read
+  __yo_effect_escaped = 1;
+  { ... memcpy(__yo_unwind_value, &_unw_val, sizeof(__yo_t206)); }
+  return (void*){0};
+}
+```
+
+A garbage `err` is harmless if nobody reads it. **But not all handlers discard it** — this
+one dereferences the dyn vtable, which is precisely the predicted crash:
+
+```c
+static inline void* fn_yo_id_820507(__yo_t852 err) {
+  ...
+  __yo_t0 _tmp = (err).vtable->to_string((err).data);   // <- bogus vtable if err is the sret ptr
+```
+
+So today's green suite rests on an **accidental invariant** — "the handlers that happen to
+be bound at >16-byte call sites happen to be the ones that ignore their argument" — not on
+any property the compiler enforces. Any `try`/`catch` that formats or inspects the error in
+value position where the surrounding type exceeds 16 bytes moves a handler from the first
+shape to the second.
+
+### What is still not established
+
+Whether `fn_yo_id_820507` (or the other `err`-reading handlers) is bound at one of the 95
+
+> 16-byte sites specifically. Tracing which handler reaches which call site through the
+> effect record is the one remaining step; if any pairing exists, this is a live miscompile
+> on x86_64 rather than a fragile-but-latent one.
 
 ## CONFIRMED by measurement (2026-08-06), and it reproduces on macOS arm64
 
@@ -128,6 +228,14 @@ these — then enable `-fsanitize=function` as the guard (only after, or the
 suite fails wholesale). The WASM history means validation needs the wasm32
 CI arms, not just native.
 
-Recommendation: implement as a dedicated PR after PR 76 merges — the bug is
+Recommendation: implement as a dedicated PR after PR 76 merges — ~~the bug is
 latent (no reachable `ctl` has a >16-byte `ResumeType` at an unwinding call
-site), and this is ABI surgery across every effects call path.
+site), and~~ this is ABI surgery across every effects call path.
+
+**Updated 2026-08-08:** the latency argument above is withdrawn — 95 `exn.throw` call
+sites in `yo-self`'s own stage-2 C cast to >16-byte return types (see the measured
+section). Before budgeting the ABI surgery, do the one remaining cheap check: confirm
+whether the handlers bound at those sites are emitted `void`. If they are, this stops
+being latent and should be sequenced ahead of `plans/SELF_HOSTING_COMPLETION.md` P1 —
+it is exactly the class of thing that gets far more expensive to adjudicate once the
+TypeScript reference compiler is retired in P2.

--- a/issues/ctl-handler-void-signature-vs-sret-cast.md
+++ b/issues/ctl-handler-void-signature-vs-sret-cast.md
@@ -1,9 +1,16 @@
 # `ctl` handlers are emitted `void` but called through value-returning casts (latent x86_64 ABI break)
 
 **Found 2026-08-06** while root-causing
-`issues/fixed/escape-path-drops-unwound-call-result-temp.md`. **Latent** — not
-reachable from the current corpus, so nothing is failing today. Filed because the
-mechanism is a real ABI violation and the next `ctl` with a wide `ResumeType` will hit it.
+`issues/fixed/escape-path-drops-unwound-call-result-temp.md`.
+
+**Severity revised 2026-08-08.** This was filed as _latent_ on the premise that no
+reachable `ctl` has a `ResumeType` over 16 bytes. Measurement refuted that: **95
+`exn.throw` call sites in `yo-self`'s own stage-2 C** cast to one of 7 distinct
+
+> 16-byte structs, and all 29 handlers bound to `.throw` are emitted `void*`. Nothing
+> fails today only because most handlers **discard `err`** — an accidental invariant, not
+> an enforced one, and at least one handler does dereference `err.vtable`. See
+> "MEASURED 2026-08-08" below.
 
 ## What codegen does
 
@@ -149,11 +156,10 @@ shape to the second.
 
 ### What is still not established
 
-Whether `fn_yo_id_820507` (or the other `err`-reading handlers) is bound at one of the 95
-
-> 16-byte sites specifically. Tracing which handler reaches which call site through the
-> effect record is the one remaining step; if any pairing exists, this is a live miscompile
-> on x86_64 rather than a fragile-but-latent one.
+Whether `fn_yo_id_820507` (or the other `err`-reading handlers) is bound at one of those
+95 large-`ResumeType` sites specifically. Tracing which handler reaches which call site
+through the effect record is the one remaining step; if any such pairing exists, this is
+a live x86_64 miscompile rather than a fragile-but-latent one.
 
 ## CONFIRMED by measurement (2026-08-06), and it reproduces on macOS arm64
 

--- a/issues/repros/rc-depth-cap-skips-deep-teardown.yo
+++ b/issues/repros/rc-depth-cap-skips-deep-teardown.yo
@@ -1,0 +1,54 @@
+{ println } :: import("std/fmt");
+
+// Reproducer for issues/yo-self-rc-depth-cap-skips-deep-teardown.md
+//
+// yo-self's `_type_contains_rc_inner` (yo-self/types/utils.yo) returns FALSE at
+// `depth > 8`. TS's `typeContainsRcType` (src/types/utils.ts) has no depth cap —
+// it guards recursion with an identity `checkedTypes` set instead.
+//
+// A ref struct with a Dispose impl makes teardown OBSERVABLE without ever
+// reading a freed value: if the enclosing struct's drop is emitted, "disposed"
+// prints; if the depth cap suppressed it, nothing prints and the object leaked.
+//
+// L0 puts Tracked at depth 10 (past the cap); L2 puts it at depth 8 (inside the
+// cap) as the control that must behave identically in both compilers.
+//
+// EXPECTED (TS):      disposed=42 and disposed=7
+// ACTUAL (yo-self):   disposed=7 only — the depth-10 object is never disposed.
+Tracked :: ref(struct(v : i32));
+impl(
+  Tracked,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      println(`disposed=${self.v}`);
+    })
+  )
+);
+
+L9 :: struct(t : Tracked);
+L8 :: struct(v : L9);
+L7 :: struct(v : L8);
+L6 :: struct(v : L7);
+L5 :: struct(v : L6);
+L4 :: struct(v : L5);
+L3 :: struct(v : L4);
+L2 :: struct(v : L3);
+L1 :: struct(v : L2);
+L0 :: struct(v : L1);
+
+main :: (fn() -> unit)({
+  println(`-- enter deep scope --`);
+  {
+    deep := L0(v : L1(v : L2(v : L3(v : L4(v : L5(v : L6(v : L7(v : L8(v : L9(t : Tracked(v : 42)))))))))));
+    println(`deep built = ${deep.v.v.v.v.v.v.v.v.v.t.v}`);
+  };
+  println(`-- left deep scope --`);
+  println(`-- enter control scope --`);
+  {
+    ctl := L2(v : L3(v : L4(v : L5(v : L6(v : L7(v : L8(v : L9(t : Tracked(v : 7)))))))));
+    println(`ctl built = ${ctl.v.v.v.v.v.v.v.t.v}`);
+  };
+  println(`-- left control scope --`);
+});
+
+export(main);

--- a/issues/yo-self-formatter-diverges-from-ts.md
+++ b/issues/yo-self-formatter-diverges-from-ts.md
@@ -1,0 +1,102 @@
+# yo-self's formatter diverges from the TS reference on ~315 files
+
+**Found 2026-08-08** by the first-ever `fmt` differential between the two
+compilers. **One bug fixed here; the rest is open and owned by P1.**
+
+## How to reproduce
+
+The tree is kept formatted by the TS formatter (CI runs
+`node ./out/cjs/yo-cli.cjs fmt --check ./std ./tests ./yo-self` and it is green),
+so pointing the self-hosted formatter at the same trees surfaces every
+disagreement:
+
+```bash
+# Leftover test-batch artifacts are gitignored but NOT excluded from fmt, and
+# are never formatted — they fail BOTH formatters and mask the real signal.
+find tests \( -name ".yo_selftest_batch_*" -o -name ".yo_test_batch_*" \) -delete
+YO_MAIN_STACK_MB=4096 <bin> fmt --check ./std ./tests ./yo-self
+```
+
+To see an individual divergence without dirtying the tree, copy the file to
+`/tmp`, format the copy, and `diff` against the original.
+
+## Fixed here: a line-leading `.` was written before the indent
+
+Every match arm whose pattern started a line came out with the dot ahead of the
+indentation:
+
+```rust
+// TS (correct)          // yo-self (before this fix)
+    .Some(v) => ...      .    Some(v) => ...
+```
+
+`src/formatter.ts` routes **every** emit through one helper, so the indent can
+never be skipped:
+
+```ts
+  const write = (text: string): void => {
+    if (text.length === 0) return;
+    writeIndentIfNeeded();     // emits the pending indent, clears atLineStart
+    result += text;
+  };
+  case TokenType.Dot: { trimTrailingHorizontalWhitespace(); write("."); break; }
+```
+
+`yo-self/formatter.yo` has no `write` helper — it **inlines** that block at each
+of its call sites, and the `TokenKind.Dot` arm was the one site that got
+neither half: a bare `result.push_str(".")`, so the dot went out first and
+`at_line_start` stayed set, leaving the _next_ token to write the indent after
+it. Fixed by mirroring TS at that site (`_trim_trailing_h_ws`, already present
+at `formatter.yo:186`, then the inlined write-indent block, then the dot).
+
+Effect: the `fmt --check` divergence count drops **417 → 315 files**.
+
+## Still open: two dominant rule classes
+
+Harvested by formatting 60 of the diverging files into `/tmp` and classifying
+every changed line pair (`<` = TS, `>` = yo-self):
+
+| count | class                      | example                                                                                                               |
+| ----- | -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| 560   | space added before `)`     | TS `(==) : (fn(...))` vs self `(== ) : (fn(...))`; TS `(fn(fd : int, cmd : int, ...) -> int)` vs self `... ) -> int)` |
+| 310   | space added before `.`     | TS `match(l.get(i),.Some(__e) => __e,...)` vs self `match(l.get(i), .Some(__e) => ...)`                               |
+| 337   | line-breaking, not spacing | see the caveat below                                                                                                  |
+
+## Caveat that shapes the fix — TS's formatter is not canonical
+
+The naive framing ("the self-hosted formatter must agree the tree is formatted")
+is **not** a clean differential, and the third row above is why. On a minimal
+input the two disagree about line structure, not spacing:
+
+```rust
+// input
+  match(x, .Some(v) => v, .None => 0)
+// TS      — keeps one line, and writes `, .Some` WITH a space
+  match(x, .Some(v) => v, .None => 0)
+// yo-self — breaks across lines
+  match(x,
+  .Some(v) => v,
+  .None => 0)
+```
+
+Note TS produces `, .Some` here while _preserving_ `,.Some` where it already
+appears in the repo. So the TS formatter **preserves existing line structure**
+rather than canonicalizing it, and a raw `fmt --check` disagreement mixes real
+spacing bugs with benign line-breaking differences. Any gate must account for
+that — comparing `fmt` output of an already-TS-formatted file is fine, but
+treating every "would format" as a bug is not.
+
+## Why this was never caught
+
+CI has only ever run `fmt --check` through the **TypeScript** CLI
+(`.github/workflows/test.yml:83`). The self-hosted `fmt` is at flag parity and
+its output had never been compared to the reference. This matters for
+`plans/SELF_HOSTING_COMPLETION.md` **P2**: once `src/` is retired the
+self-hosted formatter becomes canonical, `fmt --check` becomes self-referential,
+and the first `yo fmt` would silently restyle hundreds of files with no gate
+able to notice.
+
+**A `fmt` differential gate is therefore P1 work, and must land with the fix**
+— `scripts/bootstrap/gates_fast.sh` carries a note where it would go. It was
+deliberately not wired in now: a permanently-red gate trains everyone to ignore
+CI, which is the same failure this pass was fixing elsewhere.

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -34,10 +34,10 @@ evidence that anything ran.
 ## Why this was invisible
 
 CI runs `<bin> test` on only the **23-file** `gates_fast.sh` battery; the other
-**165 language files are exercised solely by the TypeScript compiler**. All
+**165 language files were exercised solely by the TypeScript compiler**. All
 three hollow files are outside the battery. `hollow_sweep69.sh` was written
-precisely to close this and is wired into no workflow
-(`grep -rn hollow_sweep .github/` returns nothing).
+precisely to close this and had been wired into no workflow at all
+(`grep -rn hollow_sweep .github/` returned nothing) — see the ratchet below.
 
 This matters for `plans/SELF_HOSTING_COMPLETION.md` **P2**: after `src/` is
 retired, the self-hosted binary's "N passed" becomes the only signal there is.

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -74,10 +74,23 @@ declarations interacting with batch generation. Reduce by **deleting arms from
 the real file** (keeping the `test(...)` wrapper and the module preamble) rather
 than by writing a new small file.
 
-## Suggested next step
+## Gated as a ratchet (done)
 
-Wire the sweep into CI as a **ratchet** rather than waiting on all three fixes:
-fail on any hollow file not in a checked-in allowlist, and also fail when a
-listed file stops being hollow (so the list cannot go stale). That banks the
-165-file differential immediately — no _new_ hollow file can land — while the
-three known ones are worked down. The sweep is resumable via `$OUT/results.txt`.
+The sweep now runs in CI as the `hollow-sweep` job, scored against
+`scripts/bootstrap/known-hollow.txt`. It fails in **both** directions: a hollow
+file that is not allowlisted fails (so no _new_ hollow file can land), and an
+allowlisted file that is no longer hollow also fails (so the list cannot go
+stale). `ALLOWLIST=/dev/null` demands a fully-clean sweep. The sweep is
+resumable via `$OUT/results.txt`.
+
+That banks the 165-file differential immediately, while these three are worked
+down. **Fixing one means deleting its line from the allowlist** — the gate will
+tell you to.
+
+## Remaining work
+
+Root-cause and fix the three, then empty the allowlist. Start with
+`safe_code_structural_gates.test.yo`: it is the smallest (115 lines, a single
+`test(...)`, the rest module-level `comptime_expect_error(...)`), so it has the
+fewest confounders — and per the section above, reduce it by deleting arms from
+the real file, not by writing a new one.

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -1,0 +1,83 @@
+# 3 of 188 language test files are HOLLOW under the self-hosted compiler
+
+**Found 2026-08-08** by the first full-corpus hollow sweep. These files exit 0
+and report passing tests while **running no assertions at all**.
+
+## The census (first ever)
+
+`scripts/bootstrap/hollow_sweep69.sh` runs every `tests/**/*.test.yo` except
+`tests/internal` through `<bin> test` and scores each file honestly: GREEN
+requires exit 0 **and** an emitted batch `__yo_user_main` that is not a
+`// Failed to transpile` comment.
+
+```
+BIN=<self-hosted binary> OUT=/tmp/hsweep bash scripts/bootstrap/hollow_sweep69.sh
+awk '{print $2}' /tmp/hsweep/results.txt | sort | uniq -c
+```
+
+| verdict | count |
+| ------- | ----- |
+| GREEN   | 185   |
+| HOLLOW  | **3** |
+| RED     | 0     |
+
+```
+tests/index.test.yo                      HOLLOW rc=0 hollow=1 markers=1  49 passed
+tests/safe_code_structural_gates.test.yo HOLLOW rc=0 hollow=1 markers=1   1 passed
+tests/variadic_comptime.test.yo          HOLLOW rc=0 hollow=1 markers=1  10 passed
+```
+
+Note the pass counts. `tests/index.test.yo` reports **49 passed** while
+executing nothing — a bare "N passed" from the self-hosted runner is not
+evidence that anything ran.
+
+## Why this was invisible
+
+CI runs `<bin> test` on only the **23-file** `gates_fast.sh` battery; the other
+**165 language files are exercised solely by the TypeScript compiler**. All
+three hollow files are outside the battery. `hollow_sweep69.sh` was written
+precisely to close this and is wired into no workflow
+(`grep -rn hollow_sweep .github/` returns nothing).
+
+This matters for `plans/SELF_HOSTING_COMPLETION.md` **P2**: after `src/` is
+retired, the self-hosted binary's "N passed" becomes the only signal there is.
+
+## Shape of the failure
+
+In all three the **entire** test-dispatch `match` degrades to a comment, so the
+whole file's body is skipped in one go:
+
+```c
+  // Failed to transpile match(((__yo_batch_env.env).get)(("YO_TEST_INDEX".to_string)()),
+  //   .Some(__yo_test_idx) => cond((__yo_test_idx == ("0".to_string)()) => begin(...
+```
+
+Candidate constructs per file (each file's arms are dominated by one theme):
+
+- `index.test.yo` — Index-trait reads, array/string slicing, `ComptimeList`
+- `safe_code_structural_gates.test.yo` — `inout` params; 115 lines with a single
+  `test(...)`, the rest module-level `comptime_expect_error(...)` negative cases
+- `variadic_comptime.test.yo` — variadic comptime functions
+
+## Do not extract a minimal `main` — it false-passes
+
+Both obvious reductions were tried and **both compile cleanly** under the
+self-hosted compiler, proving nothing:
+
+1. `swap(x, y)` with `inout(a) : i32` params in a plain `main` — clean.
+2. The same body kept inside a `test(...)` wrapper in a fresh one-test file —
+   also clean, `0` markers in the batch `__yo_user_main`.
+
+So the trigger is not `inout` alone, nor the batch wrapper alone. It needs the
+surrounding file — most likely the module-level `comptime_expect_error(...)`
+declarations interacting with batch generation. Reduce by **deleting arms from
+the real file** (keeping the `test(...)` wrapper and the module preamble) rather
+than by writing a new small file.
+
+## Suggested next step
+
+Wire the sweep into CI as a **ratchet** rather than waiting on all three fixes:
+fail on any hollow file not in a checked-in allowlist, and also fail when a
+listed file stops being hollow (so the list cannot go stale). That banks the
+165-file differential immediately — no _new_ hollow file can land — while the
+three known ones are worked down. The sweep is resumable via `$OUT/results.txt`.

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -102,10 +102,57 @@ Neither file is in the 23-file `gates_fast` battery, so neither had ever been ru
 under the self-hosted compiler on Linux before this sweep existed — which is exactly
 the blind spot the sweep was written to close.
 
-Diagnosis is not yet possible from macOS: the failures do not reproduce locally. The
-CI job now uploads the per-file sweep logs alongside `results.txt`, so the next run
-carries the actual error text. **Start there** rather than trying to reproduce on
-macOS.
+### Root causes (from the uploaded sweep logs — they are two different bugs)
+
+**`tests/string/string.test.yo` — clang's bracket-nesting limit.**
+
+```
+tests/string/.yo_selftest_batch_1.bin.c:44334:23:
+  fatal error: bracket nesting level exceeded maximum of 256
+yo-self: error: compile: C compiler failed (exit 256)
+```
+
+Not an RC or semantics bug — the self-hosted compiler emits **more deeply nested C
+than the reference does** for this file, and trips clang's default
+`-fbracket-depth=256`. The TS compiler builds the same test fine on the same runner,
+so the emitted nesting genuinely differs between the two. Two candidate fixes, and
+the choice matters: pass `-fbracket-depth=<N>` in the C-compiler invocation (papers
+over it, and the flag is clang/gcc-specific), or find why yo-self nests deeper and
+flatten it (addresses the divergence). Prefer diagnosing the divergence first — a
+gratuitously deeper emit is itself a signal.
+
+**`tests/ref_local_binding.test.yo` — an RC lifetime failure.**
+
+```
+✗ "binding the handle keeps an object alive"
+```
+
+The test is a handle-aliasing case:
+
+```rust
+a := Holder(s : String.from("kept"), n : i32(0));
+b := a;
+a = Holder(s : String.from("other"), n : i32(1));
+assert(b.s == "kept", "b's handle keeps the original object alive");
+```
+
+so `b` must keep the first `Holder` alive after `a` is reassigned. This is the
+premature-drop / use-after-free shape, in the RC area — treat it as the higher
+severity of the two.
+
+**Do not assume it is an allocator-masked UAF.** That is the obvious hypothesis
+("passes on macOS, fails on Linux" usually means freed memory still holds the old
+bytes on macOS), and it was tested and **did not reproduce**:
+
+```bash
+MallocScribble=1 MallocPreScribble=1 <bin> test tests/ref_local_binding.test.yo --parallel 1
+# -> 2 passed
+```
+
+So something other than allocator behaviour differs. Next candidates: platform-
+specific codegen paths, or a divergence between the macOS- and Linux-built
+self-hosted binaries themselves. Start from the CI artifact, not from local
+bisection.
 
 ## Gated as a ratchet (done)
 

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -74,23 +74,57 @@ declarations interacting with batch generation. Reduce by **deleting arms from
 the real file** (keeping the `test(...)` wrapper and the module preamble) rather
 than by writing a new small file.
 
+## Plus 2 RED files — and they are LINUX-ONLY (found in CI, 2026-08-08)
+
+The census above was taken on macOS arm64. The first CI run of the sweep (Linux
+x86_64) reproduced the same 3 HOLLOW exactly, and found **two more files that fail
+outright there while passing on macOS**:
+
+```
+tests/ref_local_binding.test.yo  RED rc=1 hollow=0 markers=0  1 passed
+tests/string/string.test.yo      RED rc=1 hollow=0 markers=0  none
+```
+
+- `ref_local_binding` exits 1 _after_ reporting "1 passed" — a later test fails.
+- `string/string` exits 1 with no summary at all — it dies before running anything.
+
+Both pass under the TS compiler on Linux (the `test (ubuntu-latest)` job is green),
+so this is a **platform-specific divergence in `yo-self` itself**, not a broken test.
+Neither file is in the 23-file `gates_fast` battery, so neither had ever been run
+under the self-hosted compiler on Linux before this sweep existed — which is exactly
+the blind spot the sweep was written to close.
+
+Diagnosis is not yet possible from macOS: the failures do not reproduce locally. The
+CI job now uploads the per-file sweep logs alongside `results.txt`, so the next run
+carries the actual error text. **Start there** rather than trying to reproduce on
+macOS.
+
 ## Gated as a ratchet (done)
 
-The sweep now runs in CI as the `hollow-sweep` job, scored against
-`scripts/bootstrap/known-hollow.txt`. It fails in **both** directions: a hollow
-file that is not allowlisted fails (so no _new_ hollow file can land), and an
-allowlisted file that is no longer hollow also fails (so the list cannot go
-stale). `ALLOWLIST=/dev/null` demands a fully-clean sweep. The sweep is
-resumable via `$OUT/results.txt`.
+The sweep runs in CI as the `hollow-sweep` job, scored against
+`scripts/bootstrap/known-failing.tsv` — `<path> <verdict>` pairs covering both
+HOLLOW and RED. It compares **pairs, not bare paths**, so a file that changes
+verdict (HOLLOW → RED or back) is caught rather than silently tolerated, and it
+fails in both directions: an unlisted failure fails (no _new_ regression can
+land), and a listed entry that no longer matches also fails (the list cannot go
+stale). A missing allowlist file fails loudly too. `ALLOWLIST=/dev/null` demands a
+fully-clean sweep. The sweep is resumable via `$OUT/results.txt`.
 
-That banks the 165-file differential immediately, while these three are worked
-down. **Fixing one means deleting its line from the allowlist** — the gate will
-tell you to.
+That banks the 165-file differential immediately, while these five are worked down.
+**Fixing one means deleting its line** — the gate will tell you to.
+
+> **Do not rename the allowlist to `.txt`.** `.gitignore` carries a blanket `*.txt`
+> rule, which silently kept the first version of this file out of the repo — so the
+> gate's first CI run scored every known file as a new regression. The script now
+> fails explicitly when the allowlist is missing rather than treating it as empty.
 
 ## Remaining work
 
-Root-cause and fix the three, then empty the allowlist. Start with
-`safe_code_structural_gates.test.yo`: it is the smallest (115 lines, a single
-`test(...)`, the rest module-level `comptime_expect_error(...)`), so it has the
-fewest confounders — and per the section above, reduce it by deleting arms from
-the real file, not by writing a new one.
+Root-cause and fix the five, then empty the allowlist.
+
+- **The 3 HOLLOW**: start with `safe_code_structural_gates.test.yo` — smallest (115
+  lines, a single `test(...)`, the rest module-level `comptime_expect_error(...)`),
+  so the fewest confounders. Per the section above, reduce it by deleting arms from
+  the real file, not by writing a new one.
+- **The 2 RED**: read the per-file logs from the `hollow-sweep-results` CI artifact
+  first — they do not reproduce on macOS, so local bisection will not work.

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -1,7 +1,15 @@
-# 3 of 188 language test files are HOLLOW under the self-hosted compiler
+# 5 of 188 language test files fail under the self-hosted compiler (3 HOLLOW, 2 Linux-only RED)
 
-**Found 2026-08-08** by the first full-corpus hollow sweep. These files exit 0
-and report passing tests while **running no assertions at all**.
+**Found 2026-08-08** by the first full-corpus hollow sweep. Three exit 0 and report
+passing tests while **running no assertions at all**; two more fail outright on
+Linux while passing on macOS.
+
+| platform            | GREEN | HOLLOW | RED   |
+| ------------------- | ----- | ------ | ----- |
+| macOS arm64 (local) | 185   | 3      | 0     |
+| Linux x86_64 (CI)   | 183   | 3      | **2** |
+
+The 3 HOLLOW are identical on both. The 2 RED are Linux-only — see that section.
 
 ## The census (first ever)
 

--- a/issues/yo-self-rc-depth-cap-skips-deep-teardown.md
+++ b/issues/yo-self-rc-depth-cap-skips-deep-teardown.md
@@ -1,0 +1,133 @@
+# yo-self's RC depth cap silently skips teardown for deeply nested values
+
+**Found 2026-08-08.** Confirmed with a minimal reproducer and a differential
+run against the TS compiler. **Leak direction, not corruption.**
+
+## Symptom
+
+An object nested more than 8 aggregate levels deep is **never torn down** by the
+self-hosted compiler. Its `dispose` does not run and its refcount is never
+decremented. The same object nested 8 levels deep is torn down correctly.
+
+Reproducer: [`issues/repros/rc-depth-cap-skips-deep-teardown.yo`](repros/rc-depth-cap-skips-deep-teardown.yo)
+
+```
+                       depth 8 (control)   depth 10 (past cap)
+  TS (src/)            disposed=7          disposed=42
+  yo-self              disposed=7          (nothing — leaked)
+```
+
+Both compilers print the same values and exit 0. The divergence is invisible to
+any stdout+exit-code differential; only the missing `disposed=` line reveals it.
+
+## Root cause
+
+`_type_contains_rc_inner` in `yo-self/types/utils.yo` caps its recursion by
+**depth**:
+
+```rust
+    // Depth limit — conservative: return false at max depth
+    (depth > u32(8)) => false,
+```
+
+TS's `typeContainsRcType` (`src/types/utils.ts:130-175`) has **no depth cap**.
+It guards recursion with an identity visited-set:
+
+```ts
+if (checkedTypes.includes(type)) {
+  return false;
+} else {
+  checkedTypes.push(type);
+}
+```
+
+The port's own comment explains the substitution — a depth cap was chosen
+"instead of a checkedTypes set" because yo-self's `TypeValue` is **value-typed**
+and cannot do TS's reference-identity `includes` cheaply. That is a real
+representational difference, so this was a considered trade, not an oversight.
+But the two guards are not equivalent: TS's terminates only on an actual
+**cycle**, while yo-self's also terminates on ordinary **non-recursive nesting**,
+and answers `false` — "contains no RC" — when it does.
+
+### Why it leaks rather than corrupts
+
+The predicate is consulted at two different starting points for the same value:
+
+- the **dup** decision inspects the argument type — `Tracked` at depth 0, which
+  `is_rc_type` accepts immediately, so the dup **is** emitted;
+- the **drop** decision inspects the variable's type — `L0`, from which
+  `Tracked` sits at depth 10, so the cap answers `false` and the drop is
+  **not** emitted.
+
+Dup without drop is a leak. Had both consulted the predicate at the same depth
+they would both have answered `false` and the result would have been
+self-consistent (no dup, no drop) — which is why this survived every gate.
+
+## Why no existing gate catches it
+
+`type_contains_rc_type` has **139 references** in `yo-self` and gates the whole
+RC dup/drop policy (`env.yo` `get_variables_needing_drop`, the closure-capture
+ownership checks, both dup markers, `types/union.yo`). Despite that reach:
+
+- the **stage-2/stage-3 fixpoint** proves the compiler is self-_consistent_, and
+  a uniformly-missing drop is perfectly self-consistent;
+- **`check ./std`** only type-checks — it never runs teardown;
+- the **155-program corpus differential** compares stdout and exit code, and a
+  leak changes neither;
+- no test in the repo nests aggregates deeper than the cap.
+
+## The same pattern is next door — and it is enormously hot
+
+`_type_is_control_bound_inner` in the same file carries an identical
+`(depth > u32(8)) => false` cap with the same rationale comment. Marker counts
+per workload (each marker print = one walk that recursed 9+ levels and gave up):
+
+| workload                         | `__DBG_RC_DEPTH8_FIRED` | `__DBG_CTL_DEPTH8_FIRED` |
+| -------------------------------- | ----------------------- | ------------------------ |
+| `check ./std` (153/153 pass)     | 0                       | 117                      |
+| `check ./yo-self` (238/238 pass) | 0                       | 1,864,783                |
+| self-emit of `yo-self/main.yo`   | 0                       | **181,325,397**          |
+
+**181 million cap hits in a single self-compile.** Almost certainly the guard
+doing its intended job on genuinely self-referential types — but that is exactly
+where the two guards differ in COST, not just in answer: TS terminates the
+moment it revisits a type, while yo-self re-walks nine levels **every time**.
+For a cyclic type both return `false`, so this is not a correctness difference
+— it is potentially a large, entirely unmeasured slice of self-compile time,
+and it is invisible in a profile as "type walking" rather than as a cap.
+
+So the visited-set fix below is a **correctness fix for the RC predicate and a
+performance lever for the control-bound one**. Size the perf prize by measuring
+before/after on a self-emit; do not assume it.
+
+(The RC marker never fired in any real workload — only in the synthetic
+reproducer — so the leak's blast radius on today's code is small. The bug is
+real and reachable, but nothing in `std/`, `yo-self/`, or the corpus nests
+deeply enough to hit it.)
+
+## Suggested fix
+
+Do not raise the cap — that moves the threshold without removing the class.
+Cycles can only arise through **self-referential named struct/enum shells**
+(`resolve_enum_shell` / `resolve_struct_shell` at the head of the walk), not
+through ordinary nesting. So track visited **shell identities** and drop the
+depth cap entirely: recursion still terminates on genuine recursive types, while
+non-recursive nesting is walked to any depth, matching TS.
+
+Apply the same treatment to `_type_is_control_bound_inner`.
+
+## Probe method (reusable)
+
+Replacing the cap's `false` with a marker print localizes it in one build:
+
+```rust
+    (depth > u32(8)) => {
+      eprintln(`__DBG_RC_DEPTH8_FIRED`);
+      false
+    },
+```
+
+then grep the marker across `check ./std`, `check ./yo-self`, a full self-emit,
+and any candidate reproducer. Note `eprintln` is already in scope in that file
+via an open import — adding `{ eprintln } :: import("std/fmt")` fails with
+"variable shadowing is not allowed".

--- a/plans/SELF_HOSTING_COMPLETION.md
+++ b/plans/SELF_HOSTING_COMPLETION.md
@@ -58,6 +58,25 @@ Also in scope:
   `--test-name-pattern`, `--keep-generated-files`, `--exclude`, …). The
   self-hosted test runner currently ignores `--parallel` ("v1 runs
   sequentially") — implement it or document it as accepted divergence.
+- **`fmt` parity + its differential gate.** The self-hosted formatter disagrees
+  with the reference on ~315 files
+  ([`issues/yo-self-formatter-diverges-from-ts.md`](../issues/yo-self-formatter-diverges-from-ts.md)),
+  down from 417 after one bug fix. Two rule classes remain (a space before `)`,
+  a space before `.`). This is P1-critical rather than cosmetic: at P2 the
+  self-hosted formatter becomes canonical and `fmt --check` becomes
+  self-referential, so the first `yo fmt` would silently restyle hundreds of
+  files with no gate able to notice. The gate must land WITH the fix —
+  `scripts/bootstrap/gates_fast.sh` carries a note where it goes. Mind the
+  caveat recorded there: the TS formatter preserves existing line structure
+  rather than canonicalizing it, so a raw "would format" count conflates real
+  spacing bugs with line-breaking differences.
+- **The 3 hollow language test files**
+  ([`issues/yo-self-hollow-language-test-files.md`](../issues/yo-self-hollow-language-test-files.md)).
+  The first full-corpus sweep scored 185 GREEN / 3 HOLLOW — files that report
+  passes (one claims 49) while running no assertions. CI now runs the sweep as a
+  ratchet against `scripts/bootstrap/known-hollow.txt`, so no NEW hollow file can
+  land; these three still need root-causing. Reduce by deleting arms from the
+  real file — both obvious minimal extractions compile cleanly and prove nothing.
 - Leftover from the port: activate `types/flowability.yo` (setter/caller
   wiring — list in `REMAINING_EVALUATOR_PORTS.md`).
 

--- a/plans/SELF_HOSTING_COMPLETION.md
+++ b/plans/SELF_HOSTING_COMPLETION.md
@@ -73,10 +73,15 @@ Also in scope:
 - **The 3 hollow language test files**
   ([`issues/yo-self-hollow-language-test-files.md`](../issues/yo-self-hollow-language-test-files.md)).
   The first full-corpus sweep scored 185 GREEN / 3 HOLLOW — files that report
-  passes (one claims 49) while running no assertions. CI now runs the sweep as a
-  ratchet against `scripts/bootstrap/known-hollow.txt`, so no NEW hollow file can
-  land; these three still need root-causing. Reduce by deleting arms from the
+  passes (one claims 49) while running no assertions. Its first CI run added **2 RED
+  files that pass on macOS but fail on Linux** (`ref_local_binding`,
+  `string/string`) — a platform divergence in `yo-self` that was invisible because
+  neither file is in the 23-file battery. CI now runs the sweep as a ratchet against
+  `scripts/bootstrap/known-failing.tsv`, so no NEW regression can land; all five
+  still need root-causing. For the HOLLOW ones, reduce by deleting arms from the
   real file — both obvious minimal extractions compile cleanly and prove nothing.
+  For the RED ones, start from the `hollow-sweep-results` CI artifact; they do not
+  reproduce on macOS.
 - Leftover from the port: activate `types/flowability.yo` (setter/caller
   wiring — list in `REMAINING_EVALUATOR_PORTS.md`).
 

--- a/scripts/bootstrap/gates_fast.sh
+++ b/scripts/bootstrap/gates_fast.sh
@@ -98,5 +98,29 @@ if [ "$std_rc" != "0" ]; then
   dump_log "/tmp/${P}_std.log"
 fi
 
+echo "=== T1 GATE 4: check ./yo-self ==="
+# The compiler type-checking ITSELF. GATE 3 only covers ./std, which left two
+# ported-but-unwired libraries (build_runner.yo, version_cache.yo — ~1600 lines)
+# type-checked by nothing at all: they are outside main.yo's import closure, so
+# the stage-2/stage-3 compiles never touch them either. This is also the
+# workload that exposed the -O0 stack-exhaustion class (AGENTS.md), hence the
+# explicit stack bump.
+YO_MAIN_STACK_MB=4096 "$S1" check ./yo-self &> "/tmp/${P}_yoself.log"
+yoself_rc=$?
+echo "YOSELF_RC=$yoself_rc  $(tail -1 "/tmp/${P}_yoself.log")"
+if [ "$yoself_rc" != "0" ]; then
+  fail "check ./yo-self rc=$yoself_rc"
+  dump_log "/tmp/${P}_yoself.log"
+fi
+
+# NOTE: a `fmt` differential is deliberately NOT a gate yet. Running
+# `<bin> fmt --check ./std ./tests ./yo-self` today reports 315 files (down from
+# 417 once the line-leading-dot bug was fixed), so wiring it in would land a
+# permanently-red gate. The remaining divergence is tracked in
+# issues/yo-self-formatter-diverges-from-ts.md, which also records why the naive
+# framing is not a clean differential: the TS formatter PRESERVES existing line
+# structure rather than canonicalizing it, so "would format" mixes real spacing
+# bugs with line-breaking differences. Add the gate with the fix, per P1.
+
 echo "=== T1_DONE (${P}) failures=${fails} ==="
 [ "$fails" = "0" ] || exit 1

--- a/scripts/bootstrap/hollow_sweep69.sh
+++ b/scripts/bootstrap/hollow_sweep69.sh
@@ -54,36 +54,40 @@ echo "SWEEP_DONE" >> "$RESULTS"
 #   * an allowlisted file that is no longer hollow -> fail (delete its line)
 # Set ALLOWLIST=/dev/null to demand a fully-clean sweep.
 # ---------------------------------------------------------------------------
-ALLOWLIST="${ALLOWLIST:-$(dirname "$0")/known-hollow.txt}"
+ALLOWLIST="${ALLOWLIST:-$(dirname "$0")/known-failing.tsv}"
 
-known=$(grep -vE '^\s*(#|$)' "$ALLOWLIST" 2>/dev/null | sort -u)
-actual_hollow=$(awk '$2 == "HOLLOW" {print $1}' "$RESULTS" | sort -u)
-actual_red=$(awk '$2 == "RED" {print $1}' "$RESULTS" | sort -u)
+if [ ! -f "$ALLOWLIST" ] && [ "$ALLOWLIST" != "/dev/null" ]; then
+  # Guard against the failure that shipped the first version of this gate: the
+  # allowlist lived at known-hollow.TXT and `.gitignore`'s blanket `*.txt` rule
+  # silently kept it out of the repo, so CI scored every known file as new.
+  echo "FAIL: allowlist '$ALLOWLIST' does not exist (is it gitignored?)"
+  exit 1
+fi
+
+# Compare "<path>\t<verdict>" PAIRS, not bare paths, so a file that changes from
+# HOLLOW to RED (or back) is caught rather than silently tolerated.
+known=$(grep -vE '^\s*(#|$)' "$ALLOWLIST" 2>/dev/null | awk 'NF>=2 {print $1"\t"$2}' | sort -u)
+actual=$(awk '$2 == "HOLLOW" || $2 == "RED" {print $1"\t"$2}' "$RESULTS" | sort -u)
 
 echo
 echo "=== hollow sweep scorecard ==="
 awk 'NF > 1 {print $2}' "$RESULTS" | sort | uniq -c
-echo "allowlisted known-hollow: $(echo "$known" | grep -c . )"
+echo "allowlisted known-failing: $(echo "$known" | grep -c .)"
 
 gate_fails=0
 
-new_hollow=$(comm -23 <(echo "$actual_hollow") <(echo "$known"))
-if [ -n "$new_hollow" ]; then
-  echo "FAIL: hollow file(s) not in $ALLOWLIST — a test file reports passes while running nothing:"
-  echo "$new_hollow" | sed 's/^/  /'
+regressions=$(comm -23 <(echo "$actual") <(echo "$known"))
+if [ -n "$regressions" ]; then
+  echo "FAIL: failing file(s) not in $ALLOWLIST — a NEW regression under the self-hosted compiler."
+  echo "      (HOLLOW = reports passes while running nothing; RED = non-zero exit/timeout)"
+  echo "$regressions" | sed 's/^/  /'
   gate_fails=1
 fi
 
-fixed=$(comm -13 <(echo "$actual_hollow") <(echo "$known"))
-if [ -n "$fixed" ]; then
-  echo "FAIL: allowlisted file(s) are no longer hollow — delete their lines from $ALLOWLIST:"
-  echo "$fixed" | sed 's/^/  /'
-  gate_fails=1
-fi
-
-if [ -n "$actual_red" ]; then
-  echo "FAIL: RED file(s) (non-zero exit or timeout):"
-  echo "$actual_red" | sed 's/^/  /'
+stale=$(comm -13 <(echo "$actual") <(echo "$known"))
+if [ -n "$stale" ]; then
+  echo "FAIL: allowlisted entr(ies) no longer match — delete or update these lines in $ALLOWLIST:"
+  echo "$stale" | sed 's/^/  /'
   gate_fails=1
 fi
 

--- a/scripts/bootstrap/hollow_sweep69.sh
+++ b/scripts/bootstrap/hollow_sweep69.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# hollow_sweep69.sh — full 183-file sweep that scores a test file HONESTLY:
+# hollow_sweep69.sh — full 188-file sweep that scores a test file HONESTLY:
 # a file counts as GREEN only if it exits 0 AND its emitted batch `main` is not
 # a `// Failed to transpile` comment. See issues/retired/yo-self-hollow-test-batch-main.md
 # (a hollow main runs no assertions, so the harness reports every test as passed).
@@ -45,3 +45,49 @@ for t in $(find tests -path tests/internal -prune -o -name '*.test.yo' -print | 
   echo "$t $verdict rc=$rc hollow=$hollow markers=$markers ${summary:-none}" >> "$RESULTS"
 done
 echo "SWEEP_DONE" >> "$RESULTS"
+
+# ---------------------------------------------------------------------------
+# Gate. Scores the sweep against a checked-in allowlist of KNOWN-hollow files so
+# this can gate CI today (blocking any NEW hollow file) while the known ones are
+# worked down. Fails in BOTH directions so the allowlist cannot go stale:
+#   * a hollow/RED file that is NOT allowlisted  -> fail (a regression)
+#   * an allowlisted file that is no longer hollow -> fail (delete its line)
+# Set ALLOWLIST=/dev/null to demand a fully-clean sweep.
+# ---------------------------------------------------------------------------
+ALLOWLIST="${ALLOWLIST:-$(dirname "$0")/known-hollow.txt}"
+
+known=$(grep -vE '^\s*(#|$)' "$ALLOWLIST" 2>/dev/null | sort -u)
+actual_hollow=$(awk '$2 == "HOLLOW" {print $1}' "$RESULTS" | sort -u)
+actual_red=$(awk '$2 == "RED" {print $1}' "$RESULTS" | sort -u)
+
+echo
+echo "=== hollow sweep scorecard ==="
+awk 'NF > 1 {print $2}' "$RESULTS" | sort | uniq -c
+echo "allowlisted known-hollow: $(echo "$known" | grep -c . )"
+
+gate_fails=0
+
+new_hollow=$(comm -23 <(echo "$actual_hollow") <(echo "$known"))
+if [ -n "$new_hollow" ]; then
+  echo "FAIL: hollow file(s) not in $ALLOWLIST — a test file reports passes while running nothing:"
+  echo "$new_hollow" | sed 's/^/  /'
+  gate_fails=1
+fi
+
+fixed=$(comm -13 <(echo "$actual_hollow") <(echo "$known"))
+if [ -n "$fixed" ]; then
+  echo "FAIL: allowlisted file(s) are no longer hollow — delete their lines from $ALLOWLIST:"
+  echo "$fixed" | sed 's/^/  /'
+  gate_fails=1
+fi
+
+if [ -n "$actual_red" ]; then
+  echo "FAIL: RED file(s) (non-zero exit or timeout):"
+  echo "$actual_red" | sed 's/^/  /'
+  gate_fails=1
+fi
+
+if [ "$gate_fails" = "0" ]; then
+  echo "SWEEP_GATE_OK"
+fi
+exit "$gate_fails"

--- a/scripts/bootstrap/known-failing.tsv
+++ b/scripts/bootstrap/known-failing.tsv
@@ -1,0 +1,34 @@
+# Language test files that do NOT pass cleanly under the self-hosted compiler.
+# Format: <path> <verdict>, whitespace-separated. Blank lines and `#` ignored.
+#
+# NOTE the `.tsv` extension: `.gitignore` has a blanket `*.txt` rule, which
+# silently swallowed the first version of this file so CI ran with NO allowlist
+# at all. Do not rename this to `.txt`.
+#
+# Verdicts (see scripts/bootstrap/hollow_sweep69.sh):
+#   HOLLOW  exit 0 and "N passed", but the emitted batch `__yo_user_main` is a
+#           `// Failed to transpile` comment — so no assertion actually ran.
+#   RED     non-zero exit or timeout.
+#
+# This is an ALLOWLIST OF KNOWN DEBT, not a permanent exemption. It exists so the
+# full-corpus sweep can gate CI TODAY — blocking any NEW failure — while these are
+# worked down. See issues/yo-self-hollow-language-test-files.md.
+#
+# The gate fails in BOTH directions: a failing file missing from this list fails,
+# and a listed file that now passes (or changed verdict) ALSO fails, so the list
+# cannot go stale. Fixing one means deleting its line.
+
+# --- HOLLOW: report passes while running nothing (found 2026-08-08) ---
+tests/index.test.yo	HOLLOW
+tests/safe_code_structural_gates.test.yo	HOLLOW
+tests/variadic_comptime.test.yo	HOLLOW
+
+# --- RED: fail outright under the self-hosted compiler ON LINUX ONLY ---
+# Both PASS under the self-hosted binary on macOS arm64 and pass under the TS
+# compiler everywhere, so this is a platform-specific divergence in yo-self.
+# Neither file is in the 23-file gates_fast battery, so neither had ever been
+# run under the self-hosted compiler on Linux before this sweep existed.
+#   ref_local_binding: rc=1 after reporting "1 passed" -> a later test fails
+#   string/string:     rc=1 with no summary at all     -> dies before running
+tests/ref_local_binding.test.yo	RED
+tests/string/string.test.yo	RED

--- a/scripts/diff-test.sh
+++ b/scripts/diff-test.sh
@@ -16,13 +16,14 @@
 #   PASS       both compiled+ran and behavior matched
 #   DIFF       both compiled+ran but stdout / exit-code / test-summary differ
 #   SELF-FAIL  the self-hosted compiler failed to compile/run (TS succeeded)
-#              — this is the expected baseline state until the port progresses
+#              — fails the harness; pass --allow-self-fail for a mid-port sweep
 #   TS-FAIL    the TS reference compiler failed (flags a broken test/baseline)
 #   BOTH-FAIL  both compilers failed (e.g. the circular_error_{a,b} baseline)
 #
 # Usage:
 #   scripts/diff-test.sh <path> [--parallel N] [--cc clang|gcc|zig]
 #                               [--release] [--filter SUBSTR] [-v]
+#                               [--allow-self-fail]
 #
 # Env:
 #   YO_SELF_BIN        path to the self-hosted binary (default /tmp/yo-self-bin)
@@ -43,6 +44,7 @@ RELEASE=""
 FILTER=""
 VERBOSE=0
 TARGET=""
+ALLOW_SELF_FAIL=0   # 1 = tolerate SELF-FAIL/BOTH-FAIL (mid-port sweeps only)
 RUN_TIMEOUT=120     # seconds per compiled-program run
 
 usage() { sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
@@ -54,6 +56,7 @@ while [[ $# -gt 0 ]]; do
     --release)  RELEASE="--release"; shift ;;
     --filter)   FILTER="$2"; shift 2 ;;
     -v|--verbose) VERBOSE=1; shift ;;
+    --allow-self-fail) ALLOW_SELF_FAIL=1; shift ;;
     -h|--help)  usage 0 ;;
     -*)         echo "unknown flag: $1" >&2; usage 2 ;;
     *)          TARGET="$1"; shift ;;
@@ -199,7 +202,18 @@ echo "────────────────────────�
 printf 'PASS %d  DIFF %d  SELF-FAIL %d  TS-FAIL %d  BOTH-FAIL %d  (total %d)\n' \
   "${COUNT[PASS]}" "${COUNT[DIFF]}" "${COUNT[SELF-FAIL]}" "${COUNT[TS-FAIL]}" "${COUNT[BOTH-FAIL]}" "$total"
 
-# Exit non-zero if anything diverged in a way the port must fix (DIFF/TS-FAIL).
-# SELF-FAIL/BOTH-FAIL are expected during the port and do not fail the harness.
-if [[ ${COUNT[DIFF]} -gt 0 || ${COUNT[TS-FAIL]} -gt 0 ]]; then exit 1; fi
+# Exit non-zero on any verdict that means the self-hosted compiler is wrong or
+# broken. SELF-FAIL/BOTH-FAIL used to be tolerated here ("expected during the
+# port") — that stopped being true when the bootstrap completed, and the silent
+# exit-0 meant any caller other than gates_fast.sh (which greps the scorecard
+# line for `SELF-FAIL 0`) would go GREEN over a compiler that cannot compile the
+# corpus at all. Pass --allow-self-fail to restore the old behavior for a
+# genuine mid-port sweep.
+FAILED=$(( ${COUNT[DIFF]} + ${COUNT[TS-FAIL]} ))
+if [[ $ALLOW_SELF_FAIL -eq 0 ]]; then
+  FAILED=$(( FAILED + ${COUNT[SELF-FAIL]} + ${COUNT[BOTH-FAIL]} ))
+elif [[ ${COUNT[SELF-FAIL]} -gt 0 || ${COUNT[BOTH-FAIL]} -gt 0 ]]; then
+  echo "note: --allow-self-fail tolerated ${COUNT[SELF-FAIL]} SELF-FAIL + ${COUNT[BOTH-FAIL]} BOTH-FAIL"
+fi
+if [[ $FAILED -gt 0 ]]; then exit 1; fi
 exit 0

--- a/yo-self/formatter.yo
+++ b/yo-self/formatter.yo
@@ -2170,6 +2170,23 @@ format_yo_source :: (
                     );
                   },
                   (token.kind == TokenKind.Dot) => {
+                    // Mirrors formatter.ts:381-385 — `trimTrailingHorizontalWhitespace(); write(".")`.
+                    // TS routes EVERY emit through `write()`, which calls
+                    // `writeIndentIfNeeded()` first; yo-self inlines that helper at each
+                    // site and this one was missed, so a line-leading dot was pushed
+                    // BEFORE the pending indent and left `at_line_start` set. The next
+                    // token then wrote the indent after it, formatting every match arm as
+                    // `.    Some(v) =>` instead of `    .Some(v) =>`.
+                    result = _trim_trailing_h_ws(result);
+                    if(at_line_start, {
+                      (sp : usize) = usize(0);
+                      count := (indent_level * INDENT_SIZE);
+                      while(sp < count, {
+                        result.push_str(" ");
+                        sp = (sp + usize(1));
+                      });
+                      at_line_start = false;
+                    });
                     result.push_str(".");
                   },
                   (token.kind == TokenKind.Operator) => {


### PR DESCRIPTION
## Summary

Every plan's success criterion is "gates green." I audited what that phrase actually enforced before starting `plans/SELF_HOSTING_COMPLETION.md`, and it enforced considerably less than assumed — in four places, each verified by hand.

## The four holes

**1. `scripts/diff-test.sh` exited 0 when the self-hosted compiler outright FAILED.** Its exit gate tested only `DIFF` and `TS-FAIL`, with a comment that `SELF-FAIL`/`BOTH-FAIL` were *"expected during the port"* — true once, false since the bootstrap completed. Only `gates_fast.sh`'s **external** `grep -qE 'SELF-FAIL 0'` on the scorecard line was catching them, so any other caller — including the per-subcommand CLI harness P1 needs — would have inherited a green exit over a compiler that cannot compile the corpus at all.

Now fails on all four bad verdicts, with `--allow-self-fail` for a genuine mid-port sweep. **Verified red-first**: same input, `exit=1` without the flag, `exit=0` with it.

**2. `release.yml` published to npm and the VS Code Marketplace with no test dependency.** checkout `develop` → bump → build → `npm publish`, no `needs:`, no test invocation anywhere in the file. A red `develop` was publishable, and publishing is the only irreversible action in the repo. It now requires the Test workflow to have **concluded successfully for the exact SHA** being released — via the Actions API, rather than re-running the ~55 min suite inline. Query validated both ways: a green SHA reports `success`; an unknown SHA reports `none`, which blocks.

**3. emsdk was pinned to `"latest"`** in both wasm jobs while wasmtime, twelve lines below, is pinned *with a written rate-limit rationale*. That unpinned lookup produced the window's one genuine infra failure (HTTP 403 fetching a bundled Node tarball, run 31238532553). Pinned to `6.0.6` — what `"latest"` resolves to on the green runs.

**4. Nothing type-checked the compiler itself.** New `gates_fast.sh` **GATE 4: `check ./yo-self`**. GATE 3 covered only `./std`, which left `build_runner.yo` (952 lines) and `version_cache.yo` (640 lines) type-checked by **nothing at all** — they sit outside `main.yo`'s import closure, so the stage-1/2/3 compiles never touch them either, and `tests/internal` has no file for either. This is also the workload that exposed the `-O0` stack-exhaustion class, hence the stack bump. Costs 137 s; passes 238/238.

## A real formatter bug, found by the first `fmt` differential

CI has only ever run `fmt --check` through the **TypeScript** CLI, so the self-hosted formatter's output had never been compared to the reference. Pointing it at the (TS-formatted) tree immediately surfaced: yo-self wrote a line-leading `.` **before** the pending indent, formatting every match arm as `.    Some(v) =>` instead of `    .Some(v) =>`.

`src/formatter.ts` routes every emit through a `write()` helper that calls `writeIndentIfNeeded()` first. `yo-self/formatter.yo` has no such helper — it **inlines** that block at each of 13 call sites, and the `TokenKind.Dot` arm got neither half. So the dot went out first and `at_line_start` stayed set, leaving the *next* token to write the indent after it. Mirroring TS at that one site drops the divergence **417 → 315 files**.

## What I deliberately did NOT do

**The `fmt` differential is not wired in as a gate.** 315 files still diverge (two rules: a space before `)`, a space before `.`), and the framing itself needs care — the TS formatter **preserves existing line structure** rather than canonicalizing it (it writes `, .Some` on fresh input while leaving `,.Some` alone where it already exists), so "would format" mixes real spacing bugs with benign line-breaking differences. A permanently-red gate trains everyone to ignore CI, which is the exact failure this PR fixes elsewhere. Tracked in `issues/yo-self-formatter-diverges-from-ts.md` with the classification and method; `gates_fast.sh` carries a note where the gate goes. It lands with the fix, in P1.

## Also filed (probed, sized, not started)

`issues/yo-self-rc-depth-cap-skips-deep-teardown.md` — yo-self's `_type_contains_rc_inner` returns `false` at `depth > 8` where TS's `typeContainsRcType` uses an unbounded identity visited-set. An object nested more than 8 aggregate levels deep is **never torn down**: with the included reproducer, TS prints `disposed=42`, yo-self prints nothing. It leaks rather than corrupts because the dup decision inspects the argument type (depth 0 → RC → dup emitted) while the drop decision inspects the variable type (depth 10 → cap → drop omitted).

Blast radius on today's code is **nil** — the marker fired 0 times across `check ./std`, `check ./yo-self`, and a full self-emit; only the synthetic reproducer triggers it. But the twin cap in `_type_is_control_bound_inner` fired **181,325,397 times in one self-emit**, which is a *performance* lever rather than a correctness one: TS stops the moment it revisits a type, yo-self re-walks nine levels every time. Both sized; neither started, because the fix (visited set keyed on struct/enum shell ids — `.Struct` carries an `id`) belongs in its own change with a before/after measurement.

## Validation

| Gate | Result |
| --- | --- |
| `gates_fast.sh` | **0 failures** |
| Differential corpus | 155 PASS / **0 DIFF** / 0 SELF-FAIL |
| `check ./std` | 153/153 |
| `check ./yo-self` (new GATE 4) | **238/238**, 137 s |
| Stage-2 → clang → stage-3 | **FIXPOINT HOLDS**, hollow=0 |
| `diff-test.sh` exit contract | red-first verified (1 without flag / 0 with) |
| Release-gate query | validated green-SHA and unknown-SHA |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — the full language corpus is now gated too

`bootstrap-self-test` runs `<bin> test` on only the **23-file** battery, so the other **165 language `.test.yo` files were exercised solely by the TypeScript compiler** — the one P2 deletes. `hollow_sweep69.sh` exists precisely to close that and was wired into **no workflow at all**.

The first full-corpus sweep: **185 GREEN / 3 HOLLOW / 0 RED**. A HOLLOW file exits 0 and reports passing tests while its emitted batch `__yo_user_main` is a `// Failed to transpile` comment — no assertion runs:

```
tests/index.test.yo                       49 passed   <- running nothing
tests/safe_code_structural_gates.test.yo   1 passed
tests/variadic_comptime.test.yo           10 passed
```

`tests/index.test.yo` claims **49 passed** while executing nothing. A bare "N passed" from the self-hosted runner is not evidence that anything ran.

**Gated as a ratchet, not blocked on the three fixes.** New `hollow-sweep` CI job scores the sweep against `scripts/bootstrap/known-hollow.txt` and fails in **both** directions: a hollow file that isn't allowlisted fails (no *new* hollow file can land), and an allowlisted file that is no longer hollow also fails (so the list can't go stale — fixing one means deleting its line). `ALLOWLIST=/dev/null` demands a clean sweep.

Red-first verified all three ways:

| allowlist | result |
| --- | --- |
| `/dev/null` | `rc=1`, names the 3 hollow files |
| real list + one healthy file | `rc=1`, names the stale entry |
| real list | `rc=0`, `SWEEP_GATE_OK` |

One finding in `issues/yo-self-hollow-language-test-files.md` worth reading before anyone reduces these: **both obvious minimal extractions compile cleanly** — `inout` params in a plain `main`, and the same body inside a fresh one-test `test(...)` wrapper. The trigger needs the surrounding file, so reduce by deleting arms from the real file, not by writing a small one.

`plans/SELF_HOSTING_COMPLETION.md` now carries the fmt-parity and hollow-file debt as explicit P1 scope, and AGENTS.md documents both gate commands.
