### PR TITLE
Fix the two RED files from the hollow sweep: test batching, and a dup/drop cancellation on the wrong alias

### DIFF
--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -99,10 +99,14 @@ tests/string/string.test.yo      RED rc=1 hollow=0 markers=0  none
 - `string/string` exits 1 with no summary at all — it dies before running anything.
 
 Both pass under the TS compiler on Linux (the `test (ubuntu-latest)` job is green),
-so this is a **platform-specific divergence in `yo-self` itself**, not a broken test.
-Neither file is in the 23-file `gates_fast` battery, so neither had ever been run
-under the self-hosted compiler on Linux before this sweep existed — which is exactly
-the blind spot the sweep was written to close.
+so both are divergences in `yo-self` itself, not broken tests. Neither file is in
+the 23-file `gates_fast` battery, so neither had ever been run under the
+self-hosted compiler on Linux before this sweep existed — exactly the blind spot
+the sweep was written to close.
+
+**Neither turned out to be genuinely platform-specific.** Linux merely exposed
+both: one through a stricter clang default, the other through a stricter
+allocator. Both reproduce and are fixable from macOS once you know that.
 
 ### Root causes (from the uploaded sweep logs — they are two different bugs)
 
@@ -116,12 +120,22 @@ yo-self: error: compile: C compiler failed (exit 256)
 
 Not an RC or semantics bug — the self-hosted compiler emits **more deeply nested C
 than the reference does** for this file, and trips clang's default
-`-fbracket-depth=256`. The TS compiler builds the same test fine on the same runner,
-so the emitted nesting genuinely differs between the two. Two candidate fixes, and
-the choice matters: pass `-fbracket-depth=<N>` in the C-compiler invocation (papers
-over it, and the flag is clang/gcc-specific), or find why yo-self nests deeper and
-flatten it (addresses the divergence). Prefer diagnosing the divergence first — a
-gratuitously deeper emit is itself a signal.
+`-fbracket-depth=256`.
+
+**RESOLVED — it was a missing port, and the deeper nesting was the symptom.**
+yo-self compiled every test in a file as ONE batch, and the generated `cond`
+dispatch nests one brace level per test: 252 tests → 261 levels. TS was already
+batching at `DEFAULT_TEST_BATCH_SIZE = 100` (`src/test-runner.ts:54`), so its emit
+for the same file peaks at 105 across 3 batches.
+
+It is also not platform-specific: local clang 21.1.7 just defaults to a higher
+bracket depth than CI's. `clang -fbracket-depth=256 -fsyntax-only <batch>.c`
+reproduces it exactly on macOS, which is what made it debuggable.
+
+The tempting fix — passing `-fbracket-depth=<N>` — was rejected: it papers over a
+real divergence and the flag is clang/gcc-specific. Porting the batching addresses
+the cause. After the fix: 3 batches at depth 109/109/61, 252/252 passing, every
+batch clean under an explicit `-fbracket-depth=256`.
 
 **`tests/ref_local_binding.test.yo` — an RC lifetime failure.**
 
@@ -138,9 +152,8 @@ a = Holder(s : String.from("other"), n : i32(1));
 assert(b.s == "kept", "b's handle keeps the original object alive");
 ```
 
-so `b` must keep the first `Holder` alive after `a` is reassigned. This is the
-premature-drop / use-after-free shape, in the RC area — treat it as the higher
-severity of the two.
+so `b` must keep the first `Holder` alive after `a` is reassigned. This was the
+higher-severity of the two — an RC lifetime defect rather than a build failure.
 
 **RESOLVED.** It _was_ allocator-dependent, but not in the way the obvious
 hypothesis predicted, which is why `MallocScribble` came back negative:
@@ -177,7 +190,8 @@ land), and a listed entry that no longer matches also fails (the list cannot go
 stale). A missing allowlist file fails loudly too. `ALLOWLIST=/dev/null` demands a
 fully-clean sweep. The sweep is resumable via `$OUT/results.txt`.
 
-That banks the 165-file differential immediately, while these five are worked down.
+That banks the 165-file differential immediately, while the remaining three are
+worked down.
 **Fixing one means deleting its line** — the gate will tell you to.
 
 > **Do not rename the allowlist to `.txt`.** `.gitignore` carries a blanket `*.txt`

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -1,15 +1,17 @@
-# 5 of 188 language test files fail under the self-hosted compiler (3 HOLLOW, 2 Linux-only RED)
+# 3 of 188 language test files are HOLLOW under the self-hosted compiler
 
-**Found 2026-08-08** by the first full-corpus hollow sweep. Three exit 0 and report
-passing tests while **running no assertions at all**; two more fail outright on
-Linux while passing on macOS.
+**Found 2026-08-08** by the first full-corpus hollow sweep. They exit 0 and report
+passing tests while **running no assertions at all**.
 
-| platform            | GREEN | HOLLOW | RED   |
-| ------------------- | ----- | ------ | ----- |
-| macOS arm64 (local) | 185   | 3      | 0     |
-| Linux x86_64 (CI)   | 183   | 3      | **2** |
+| platform            | GREEN | HOLLOW | RED              |
+| ------------------- | ----- | ------ | ---------------- |
+| macOS arm64 (local) | 185   | 3      | 0                |
+| Linux x86_64 (CI)   | 183   | 3      | 2 → **0, fixed** |
 
-The 3 HOLLOW are identical on both. The 2 RED are Linux-only — see that section.
+> **The 2 RED files are FIXED** (see "Plus 2 RED files" below for the diagnosis).
+> Neither was actually platform-specific — Linux merely exposed both. They are no
+> longer in `scripts/bootstrap/known-failing.tsv`. **The 3 HOLLOW remain open**
+> and are what this issue now tracks.
 
 ## The census (first ever)
 
@@ -82,7 +84,7 @@ declarations interacting with batch generation. Reduce by **deleting arms from
 the real file** (keeping the `test(...)` wrapper and the module preamble) rather
 than by writing a new small file.
 
-## Plus 2 RED files — and they are LINUX-ONLY (found in CI, 2026-08-08)
+## Plus 2 RED files — FIXED 2026-08-08 (found in CI the same day)
 
 The census above was taken on macOS arm64. The first CI run of the sweep (Linux
 x86_64) reproduced the same 3 HOLLOW exactly, and found **two more files that fail
@@ -140,19 +142,29 @@ so `b` must keep the first `Holder` alive after `a` is reassigned. This is the
 premature-drop / use-after-free shape, in the RC area — treat it as the higher
 severity of the two.
 
-**Do not assume it is an allocator-masked UAF.** That is the obvious hypothesis
-("passes on macOS, fails on Linux" usually means freed memory still holds the old
-bytes on macOS), and it was tested and **did not reproduce**:
+**RESOLVED.** It _was_ allocator-dependent, but not in the way the obvious
+hypothesis predicted, which is why `MallocScribble` came back negative:
 
 ```bash
 MallocScribble=1 MallocPreScribble=1 <bin> test tests/ref_local_binding.test.yo --parallel 1
-# -> 2 passed
+# -> 2 passed   (scribble fills FREED memory; it does not detect a DOUBLE free)
 ```
 
-So something other than allocator behaviour differs. Next candidates: platform-
-specific codegen paths, or a divergence between the macOS- and Linux-built
-self-hosted binaries themselves. Start from the CI artifact, not from local
-bisection.
+The actual defect is a **double free**, not a stale read: `b := a` left two
+`__yo_decr_rc` calls on one `rc=1` object because the dup/drop pair optimizer
+cancelled the drop of the wrong variable in the alias chain (it walked the frame
+forwards where TS walks it reversed). glibc's allocator detects the second free
+and aborts; macOS malloc tolerates it. Scribble was the wrong instrument —
+it perturbs freed _contents_, and nothing here ever read freed contents.
+
+Fixed in `yo-self/evaluator/exprs/begin.yo` (reverse the walk **and** port TS's
+`dupCalls.length = 0`; either half alone still double-drops). Regression coverage
+is in `tests/rc.test.yo` — it counts disposals via a module-level counter so it
+fails on every platform, not only where the allocator happens to notice.
+
+**Lesson worth keeping:** "passes on macOS, fails on Linux" has at least two
+distinct causes — a stale read of freed memory (scribble finds it) and a double
+free (scribble does not). A negative scribble result rules out only the first.
 
 ## Gated as a ratchet (done)
 
@@ -175,11 +187,17 @@ That banks the 165-file differential immediately, while these five are worked do
 
 ## Remaining work
 
-Root-cause and fix the five, then empty the allowlist.
+The 2 RED are fixed and de-allowlisted. **Three HOLLOW files remain**; fixing them
+empties `scripts/bootstrap/known-failing.tsv` and the gate then demands a fully
+clean sweep on its own.
 
-- **The 3 HOLLOW**: start with `safe_code_structural_gates.test.yo` — smallest (115
-  lines, a single `test(...)`, the rest module-level `comptime_expect_error(...)`),
-  so the fewest confounders. Per the section above, reduce it by deleting arms from
-  the real file, not by writing a new one.
-- **The 2 RED**: read the per-file logs from the `hollow-sweep-results` CI artifact
-  first — they do not reproduce on macOS, so local bisection will not work.
+Start with `safe_code_structural_gates.test.yo` — smallest (115 lines, a single
+`test(...)`, the rest module-level `comptime_expect_error(...)`), so the fewest
+confounders. Per "Do not extract a minimal `main`" above, reduce it by deleting
+arms from the real file rather than writing a new small one: both obvious
+extractions compile cleanly and prove nothing.
+
+Method note from the RED work that applies here too: the `hollow-sweep` CI job now
+uploads the per-file sweep logs alongside `results.txt`, so a failure that does not
+reproduce locally is still diagnosable from the artifact. That is what turned both
+RED files from "Linux-only mystery" into ordinary bugs in one CI cycle.

--- a/scripts/bootstrap/gates_fast.sh
+++ b/scripts/bootstrap/gates_fast.sh
@@ -64,9 +64,21 @@ for t in tests/comptime.test.yo tests/prelude.test.yo tests/arc.test.yo tests/as
   # the same reason.)
   YO_KEEP_BATCH=1 timeout 1200 "$S1" test "$t" &> "/tmp/${P}_${name}.log"
   rc=$?
-  c="$d/.yo_selftest_batch_1.bin.c"
+  # Check EVERY batch, not a hardcoded `.yo_selftest_batch_1.bin.c`: the runner
+  # now splits a file's tests into batches of TEST_BATCH_SIZE (mirroring TS's
+  # DEFAULT_TEST_BATCH_SIZE=100), so the artifacts are
+  # `.yo_selftest_batch_<file>_<batch>.bin.c` and a big file emits several. A
+  # hardcoded name reported hollow=NA for every file once batching landed, and
+  # would silently skip batches 2..N even if it still matched batch 1.
+  # hollow_sweep69.sh already globs the same way.
+  batch_cs=$(ls "$d"/.yo_selftest_batch_*.bin.c 2>/dev/null)
   hollow=NA
-  [ -f "$c" ] && { if sed -n '/^void __yo_user_main() {/,/^}/p' "$c" | grep -q 'Failed to transpile'; then hollow=1; else hollow=0; fi; }
+  if [ -n "$batch_cs" ]; then
+    hollow=0
+    for c in $batch_cs; do
+      if sed -n '/^void __yo_user_main() {/,/^}/p' "$c" | grep -q 'Failed to transpile'; then hollow=1; fi
+    done
+  fi
   echo "$name rc=$rc hollow=$hollow $(grep -oE '[0-9]+ passed' "/tmp/${P}_${name}.log" | tail -1)"
   if [ "$rc" != "0" ]; then
     fail "battery $name rc=$rc"

--- a/scripts/bootstrap/known-failing.tsv
+++ b/scripts/bootstrap/known-failing.tsv
@@ -23,12 +23,17 @@ tests/index.test.yo	HOLLOW
 tests/safe_code_structural_gates.test.yo	HOLLOW
 tests/variadic_comptime.test.yo	HOLLOW
 
-# --- RED: fail outright under the self-hosted compiler ON LINUX ONLY ---
-# Both PASS under the self-hosted binary on macOS arm64 and pass under the TS
-# compiler everywhere, so this is a platform-specific divergence in yo-self.
-# Neither file is in the 23-file gates_fast battery, so neither had ever been
-# run under the self-hosted compiler on Linux before this sweep existed.
-#   ref_local_binding: rc=1 after reporting "1 passed" -> a later test fails
-#   string/string:     rc=1 with no summary at all     -> dies before running
-tests/ref_local_binding.test.yo	RED
-tests/string/string.test.yo	RED
+# --- RED: none. ---
+# The two Linux-only RED files found by the first CI run of this sweep are FIXED:
+#   tests/string/string.test.yo      — the runner compiled all 252 tests as ONE
+#     batch, whose `cond` dispatch nests one brace level per test (261 deep),
+#     past clang's default -fbracket-depth=256. Fixed by porting TS's test
+#     batching (TEST_BATCH_SIZE=100).
+#   tests/ref_local_binding.test.yo  — the dup/drop pair optimizer walked the
+#     frame forwards where TS walks it reversed, so an alias binding's drop
+#     survived alongside the saved-old-value temp's: a double free on one rc=1
+#     object. Fixed in yo-self/evaluator/exprs/begin.yo.
+# Regression coverage for the second lives in tests/rc.test.yo ("aliasing a ref
+# local drops the object exactly once" + the reassignment variant), which counts
+# disposals so it fails on EVERY platform rather than only where the allocator
+# happens to detect the double free.

--- a/tests/rc.test.yo
+++ b/tests/rc.test.yo
@@ -902,3 +902,62 @@ test("statement-hidden mutation keeps the borrowed-projection dup", {
     "borrow survives a mutation behind a declaration"
   );
 });
+// Regression: aliasing a ref local must drop each object EXACTLY ONCE.
+//
+// `b := a` creates ONE deferred `___dup`, keyed under `a`. The dup/drop pair
+// optimizer cancels it against the scope-end drop of one variable in the alias
+// chain, and whichever it reaches first wins. yo-self walked the frame forwards
+// and cancelled the wrong one; TS iterates `getVariablesNeedingDrop`, which is
+// already reversed (src/env.ts:2304). The same root cause showed up as a DOUBLE
+// FREE in one shape (tests/ref_local_binding.test.yo, which aborted under glibc
+// and passed under macOS malloc) and as a LEAK in the reassignment shape below.
+//
+// Counting disposals is deliberate. The miscount happens at SCOPE END, after any
+// in-body assert could observe it, and whether a double free actually crashes is
+// allocator-dependent — which is exactly why this stayed invisible on macOS.
+// The counter is MODULE-LEVEL on purpose: module-level mutables have program
+// lifetime and are never dropped (getVariablesNeedingDrop skips isModuleLevel),
+// so it is still readable after the handles are gone. A counter stored INSIDE
+// the handle is not — passing it into the struct hands over ownership, so
+// disposing the handle frees the counter and reading it afterwards is a UAF.
+(g_alias_disposed : i32) = i32(0);
+AliasHandle :: ref(struct(tag : i32));
+impl(
+  AliasHandle,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      g_alias_disposed = (g_alias_disposed + i32(1));
+    })
+  )
+);
+// CONTROL, not the regression guard: this shape disposed correctly even before
+// the fix, so it cannot catch the original bug. It is kept because it DOES guard
+// the reversal itself — if walking the frame backwards ever broke the simple
+// single-alias case, this is what fails. The discriminating test is the next one.
+test("aliasing a ref local disposes the object exactly once", {
+  {
+    a := AliasHandle(tag : i32(1));
+    b := a;
+    assert(b.tag == i32(1), "the alias sees the same object");
+    assert(g_alias_disposed == i32(0), "nothing disposed while the scope is live");
+  };
+  assert(
+    g_alias_disposed == i32(1),
+    "the aliased object is disposed exactly once, not twice and not never"
+  );
+});
+test("reassigning after aliasing disposes both objects exactly once", {
+  {
+    a := AliasHandle(tag : i32(1));
+    b := a;
+    a = AliasHandle(tag : i32(2));
+    assert(b.tag == i32(1), "b keeps the original object alive");
+    assert(a.tag == i32(2), "a points at the replacement");
+  };
+  // Two objects were created, so two disposals. Before the fix this reported
+  // ONE — the original was never disposed at all.
+  assert(
+    g_alias_disposed == i32(2),
+    "both the original and the replacement are disposed exactly once each"
+  );
+});

--- a/yo-self/evaluator/exprs/begin.yo
+++ b/yo-self/evaluator/exprs/begin.yo
@@ -1052,8 +1052,22 @@ _optimize_dup_drop_pairs :: (
   //    e1-e7 gates plus the captured filter (begin.ts:1802-1804) so only
   //    variables the scheduler WOULD drop are optimized.
   remove_ids := HashSet(usize).new();
-  (vi : usize) = usize(0);
-  while(vi < fvars.len(), {
+  // Walk the frame in REVERSE declaration order. TS iterates
+  // `getVariablesNeedingDrop(env)` (begin.ts:1889, 1997), and that helper
+  // returns its list ALREADY REVERSED (env.ts:2304-2305, "Return in reverse
+  // order (end to start) for proper drop order"). Order is not cosmetic here:
+  // when several variables share one base — `a := Holder(...); b := a;` — the
+  // single collected dup can cancel the scope-end drop of EITHER of them, and
+  // whichever the loop reaches first wins. Walking forwards picked `a`, leaving
+  // `b`'s drop in place alongside the saved-old-value temp's, so the same rc=1
+  // object was decremented TWICE: a double free, which glibc aborts on and
+  // macOS malloc tolerates (hence "passes locally, fails on Linux CI").
+  // `_schedule_scope_end_drops` already reverses explicitly (see below); the
+  // optimizer was never brought in line.
+  // See issues/yo-self-hollow-language-test-files.md.
+  (vi : usize) = fvars.len();
+  while(vi > usize(0), {
+    vi = (vi - usize(1));
     match(
       fvars.get(vi),
       .Some(v) => {
@@ -1172,6 +1186,14 @@ _optimize_dup_drop_pairs :: (
                     );
                     rmi = (rmi + usize(1));
                   });
+                  // Clear the list (begin.ts:2108-2109, `dupCalls.length = 0`).
+                  // REQUIRED, not tidying: `dups` is the live ArrayList held in
+                  // `merged.dup_calls`, so emptying it means a LATER variable
+                  // sharing this same base sees no dups and therefore keeps its
+                  // own scope-end drop instead of cancelling a second time
+                  // against the one dup. Without it, reversing the walk above
+                  // just moves the double-drop from `b` to `a`.
+                  dups.clear();
                   // Consume at the dup's USE SITE when there is exactly one
                   // runtime dup (begin.ts:2019-2040): early returns AFTER the
                   // transfer must not re-drop the moved value; ones BEFORE it
@@ -1200,7 +1222,6 @@ _optimize_dup_drop_pairs :: (
       },
       .None => ()
     );
-    vi = (vi + usize(1));
   });
   // 4. Strip the cancelled dups from the tree (begin.ts:2056-2061).
   if(remove_ids.len() > usize(0), {

--- a/yo-self/main.yo
+++ b/yo-self/main.yo
@@ -1502,6 +1502,10 @@ TestDecl :: struct(name : String, body_src : String);
 /// (--parallel accepted for CLI compatibility), --bail and
 /// --test-name-pattern honored; per-test ✓/✗ lines + the Test Summary
 /// footer mirror the TS output (without durations/colors).
+///
+/// Tests are compiled in batches of `TEST_BATCH_SIZE`, mirroring TS's
+/// `DEFAULT_TEST_BATCH_SIZE` (src/test-runner.ts:54).
+TEST_BATCH_SIZE :: usize(100);
 run_test :: (
   fn(
     argv : ArrayList(String),
@@ -1586,117 +1590,142 @@ run_test :: (
     if(tests.len() == usize(0), {
       println(String.from("  (no tests)"));
     }, {
-      // Synthesize the batched program (mirror generateBatchedTestProgram).
-      prog_src := String.new();
-      (ni : usize) = usize(0);
-      while(ni < non_test.len(), {
-        match(
-          non_test.get(ni),
-          .Some(l) => {
-            prog_src.push_string(l.clone());
-            prog_src.push_str(";\n");
-          },
-          .None => ()
+      // Split the file's tests into batches of TEST_BATCH_SIZE, exactly as TS
+      // does (`DEFAULT_TEST_BATCH_SIZE = 100`, src/test-runner.ts:54, sliced at
+      // :1312-1315). This is not just parity — a single batch nests ONE BRACE
+      // LEVEL PER TEST in the emitted `cond` chain, so a file with >~250 tests
+      // exceeded clang's default `-fbracket-depth=256` and failed to compile at
+      // all: tests/string/string.test.yo (252 tests) emitted C nested 261 deep
+      // and died with "bracket nesting level exceeded maximum of 256". TS never
+      // hit it because it was already batching — its emit for the same file
+      // peaks at depth 105 across 3 batches.
+      // See issues/yo-self-hollow-language-test-files.md.
+      (batch_start : usize) = usize(0);
+      (bi : usize) = usize(0);
+      while((batch_start < tests.len()) && !(bailed), {
+        batch_end := cond(
+          ((batch_start + TEST_BATCH_SIZE) < tests.len()) => (batch_start + TEST_BATCH_SIZE),
+          true => tests.len()
         );
-        ni = (ni + usize(1));
-      });
-      prog_src.push_str("__yo_batch_env :: import(\"std/env\");\n");
-      prog_src.push_str("main :: (fn() -> unit)({\n");
-      prog_src.push_str("  io :: __yo_builtin_io;\n");
-      prog_src.push_str("  match(__yo_batch_env.env.get(`YO_TEST_INDEX`),\n");
-      prog_src.push_str("    .Some(__yo_test_idx) => cond(\n");
-      (ti : usize) = usize(0);
-      while(ti < tests.len(), {
-        t := match(tests.get(ti),.Some(x) => x,.None => TestDecl(name : String.from(""), body_src : String.from("()")));
-        prog_src.push_str("      (__yo_test_idx == `");
-        prog_src.push_string(ti.to_string());
-        prog_src.push_str("`) => { ");
-        prog_src.push_string(t.body_src.clone());
-        prog_src.push_str("; },\n");
-        ti = (ti + usize(1));
-      });
-      prog_src.push_str("      true => ()\n");
-      prog_src.push_str("    ),\n");
-      prog_src.push_str("    .None => ()\n");
-      prog_src.push_str("  );\n");
-      prog_src.push_str("});\n");
-      prog_src.push_str("export(main);\n");
-      // Write the batch program NEXT TO the test file (mirrors TS
-      // compileBatchedBinary: path.join(path.dirname(filePath), baseName)) —
-      // the batch must inherit the test file's relative-import base, so a
-      // /tmp placement breaks every `import("./...")` in non-test content.
-      batch_dir := match(
-        file.last_index_of(`/`),
-        .Some(sidx) => file.substring(usize(0), sidx),
-        .None => String.from(".")
-      );
-      tmp_yo := `${batch_dir}/.yo_selftest_batch_${fi.to_string()}.yo`;
-      tmp_bin := `${batch_dir}/.yo_selftest_batch_${fi.to_string()}.bin`;
-      io.await(write_file(Path.new(tmp_yo.clone()), prog_src.clone(), io), IoExn(io : io, exn : exn));
-      // Compile the batch in a CHILD PROCESS, not in-process.
-      //
-      // WHY: `run_compile` creates a fresh ExprInfoTable, but compiler state lives
-      // in module-level globals (func-type registry, specialization caches, impl
-      // registry, module cache, prelude env, ...) that OUTLIVE it. A second
-      // in-process compile therefore reused cached std ASTs whose ExprInfo was in
-      // the first batch's discarded table, and codegen emitted
-      // `// Failed to transpile` for std internals (ArrayList._length,
-      // String._bytes, Option.unwrap, std/env getenv). MEASURED 2026-08-05: 47
-      // markers on `test ./tests/string` — five ORDINARY language tests — and 59
-      // on tests/internal, while every one of those files passed ALONE. Batch 1
-      // and batch 2 had an IDENTICAL import list, so the trigger was purely
-      // "second compile in one process".
-      //
-      // TS gets fresh state per batch by construction: `src/test-runner.ts:503`
-      // does `moduleManager = new ModuleManager()`. yo-self has no instance to
-      // re-create, so a fresh PROCESS is the faithful equivalent — and it
-      // reproduces EXACTLY the standalone path, which is the verified-green one
-      // (all 58 tests/internal and all 187 ./tests files pass standalone).
-      //
-      // Uses argv(0), so the binary must be invoked by a usable path. CI and every
-      // gate script invoke it by explicit path (/tmp/yo-stage1,
-      // ./yo-self/yo-self-bin). See issues/fixed/yo-self-second-batch-in-process-ftt.md.
-      self_exe := argv(usize(0));
-      ccmd := Command.new(self_exe.clone());
-      ccmd.arg(String.from("compile"));
-      ccmd.arg(tmp_yo.clone());
-      ccmd.arg(String.from("-o"));
-      ccmd.arg(tmp_bin.clone());
-      bst := io.await(ccmd.status(io), IoExn(io : io, exn : exn));
-      if(bst.raw != i32(0), {
-        exn.throw(dyn(`test: batch compile failed (exit ${bst.raw.to_string()}) for ${tmp_yo}`));
-      });
-      // Run each test: YO_TEST_INDEX in the PARENT env (the spawn runtime
-      // passes environ through when envp is NULL).
-      (ri : usize) = usize(0);
-      while((ri < tests.len()) && !(bailed), {
-        t := match(tests.get(ri),.Some(x) => x,.None => TestDecl(name : String.from(""), body_src : String.from("()")));
-        idx_cstr := String.from("YO_TEST_INDEX").to_cstr().ptr().unwrap();
-        val_cstr := ri.to_string().to_cstr().ptr().unwrap();
-        _sv := unsafe(setenv(*(char)(idx_cstr), *(char)(val_cstr), int(1)));
-        tcmd := Command.new(tmp_bin.clone());
-        st := io.await(tcmd.status(io), IoExn(io : io, exn : exn));
-        if(st.success(), {
-          passed = (passed + usize(1));
-          println(`  ✓ ${t.name}`);
-        }, {
-          failed = (failed + usize(1));
-          println(`  ✗ ${t.name}`);
-          if(bail, {
-            bailed = true;
-          });
+        // Synthesize the batched program (mirror generateBatchedTestProgram).
+        prog_src := String.new();
+        (ni : usize) = usize(0);
+        while(ni < non_test.len(), {
+          match(
+            non_test.get(ni),
+            .Some(l) => {
+              prog_src.push_string(l.clone());
+              prog_src.push_str(";\n");
+            },
+            .None => ()
+          );
+          ni = (ni + usize(1));
         });
-        ri = (ri + usize(1));
-      });
-      // Clean up the batch artifacts (mirrors TS cleanup()) — they live in
-      // the test file's directory now, not /tmp. Debug affordance (yo-self
-      // only, no TS counterpart): YO_KEEP_BATCH=1 skips the cleanup so a
-      // failing batch's .yo/.c can be inspected — batch-only miscompiles
-      // (the collections residuals) are unreproducible otherwise.
-      if(proc_env.get(`YO_KEEP_BATCH`).is_none(), {
-        io.await(remove_file(Path.new(tmp_yo.clone()), io), IoExn(io : io, exn : exn));
-        io.await(remove_file(Path.new(tmp_bin.clone()), io), IoExn(io : io, exn : exn));
-        io.await(remove_file(Path.new(`${tmp_bin}.c`), io), IoExn(io : io, exn : exn));
+        prog_src.push_str("__yo_batch_env :: import(\"std/env\");\n");
+        prog_src.push_str("main :: (fn() -> unit)({\n");
+        prog_src.push_str("  io :: __yo_builtin_io;\n");
+        prog_src.push_str("  match(__yo_batch_env.env.get(`YO_TEST_INDEX`),\n");
+        prog_src.push_str("    .Some(__yo_test_idx) => cond(\n");
+        // Arms are numbered RELATIVE to the batch (0..n-1), so YO_TEST_INDEX below
+        // is the within-batch index, not the file-wide one.
+        (ti : usize) = batch_start;
+        while(ti < batch_end, {
+          t := match(tests.get(ti),.Some(x) => x,.None => TestDecl(name : String.from(""), body_src : String.from("()")));
+          prog_src.push_str("      (__yo_test_idx == `");
+          prog_src.push_string((ti - batch_start).to_string());
+          prog_src.push_str("`) => { ");
+          prog_src.push_string(t.body_src.clone());
+          prog_src.push_str("; },\n");
+          ti = (ti + usize(1));
+        });
+        prog_src.push_str("      true => ()\n");
+        prog_src.push_str("    ),\n");
+        prog_src.push_str("    .None => ()\n");
+        prog_src.push_str("  );\n");
+        prog_src.push_str("});\n");
+        prog_src.push_str("export(main);\n");
+        // Write the batch program NEXT TO the test file (mirrors TS
+        // compileBatchedBinary: path.join(path.dirname(filePath), baseName)) —
+        // the batch must inherit the test file's relative-import base, so a
+        // /tmp placement breaks every `import("./...")` in non-test content.
+        batch_dir := match(
+          file.last_index_of(`/`),
+          .Some(sidx) => file.substring(usize(0), sidx),
+          .None => String.from(".")
+        );
+        // The batch index is part of the name so a multi-batch file does not have
+        // its batches overwrite each other (and so YO_KEEP_BATCH leaves all of
+        // them behind for inspection).
+        tmp_yo := `${batch_dir}/.yo_selftest_batch_${fi.to_string()}_${bi.to_string()}.yo`;
+        tmp_bin := `${batch_dir}/.yo_selftest_batch_${fi.to_string()}_${bi.to_string()}.bin`;
+        io.await(write_file(Path.new(tmp_yo.clone()), prog_src.clone(), io), IoExn(io : io, exn : exn));
+        // Compile the batch in a CHILD PROCESS, not in-process.
+        //
+        // WHY: `run_compile` creates a fresh ExprInfoTable, but compiler state lives
+        // in module-level globals (func-type registry, specialization caches, impl
+        // registry, module cache, prelude env, ...) that OUTLIVE it. A second
+        // in-process compile therefore reused cached std ASTs whose ExprInfo was in
+        // the first batch's discarded table, and codegen emitted
+        // `// Failed to transpile` for std internals (ArrayList._length,
+        // String._bytes, Option.unwrap, std/env getenv). MEASURED 2026-08-05: 47
+        // markers on `test ./tests/string` — five ORDINARY language tests — and 59
+        // on tests/internal, while every one of those files passed ALONE. Batch 1
+        // and batch 2 had an IDENTICAL import list, so the trigger was purely
+        // "second compile in one process".
+        //
+        // TS gets fresh state per batch by construction: `src/test-runner.ts:503`
+        // does `moduleManager = new ModuleManager()`. yo-self has no instance to
+        // re-create, so a fresh PROCESS is the faithful equivalent — and it
+        // reproduces EXACTLY the standalone path, which is the verified-green one
+        // (all 58 tests/internal and all 187 ./tests files pass standalone).
+        //
+        // Uses argv(0), so the binary must be invoked by a usable path. CI and every
+        // gate script invoke it by explicit path (/tmp/yo-stage1,
+        // ./yo-self/yo-self-bin). See issues/fixed/yo-self-second-batch-in-process-ftt.md.
+        self_exe := argv(usize(0));
+        ccmd := Command.new(self_exe.clone());
+        ccmd.arg(String.from("compile"));
+        ccmd.arg(tmp_yo.clone());
+        ccmd.arg(String.from("-o"));
+        ccmd.arg(tmp_bin.clone());
+        bst := io.await(ccmd.status(io), IoExn(io : io, exn : exn));
+        if(bst.raw != i32(0), {
+          exn.throw(dyn(`test: batch compile failed (exit ${bst.raw.to_string()}) for ${tmp_yo}`));
+        });
+        // Run each test: YO_TEST_INDEX in the PARENT env (the spawn runtime
+        // passes environ through when envp is NULL).
+        (ri : usize) = batch_start;
+        while((ri < batch_end) && !(bailed), {
+          t := match(tests.get(ri),.Some(x) => x,.None => TestDecl(name : String.from(""), body_src : String.from("()")));
+          idx_cstr := String.from("YO_TEST_INDEX").to_cstr().ptr().unwrap();
+          val_cstr := (ri - batch_start).to_string().to_cstr().ptr().unwrap();
+          _sv := unsafe(setenv(*(char)(idx_cstr), *(char)(val_cstr), int(1)));
+          tcmd := Command.new(tmp_bin.clone());
+          st := io.await(tcmd.status(io), IoExn(io : io, exn : exn));
+          if(st.success(), {
+            passed = (passed + usize(1));
+            println(`  ✓ ${t.name}`);
+          }, {
+            failed = (failed + usize(1));
+            println(`  ✗ ${t.name}`);
+            if(bail, {
+              bailed = true;
+            });
+          });
+          ri = (ri + usize(1));
+        });
+        // Clean up the batch artifacts (mirrors TS cleanup()) — they live in
+        // the test file's directory now, not /tmp. Debug affordance (yo-self
+        // only, no TS counterpart): YO_KEEP_BATCH=1 skips the cleanup so a
+        // failing batch's .yo/.c can be inspected — batch-only miscompiles
+        // (the collections residuals) are unreproducible otherwise.
+        if(proc_env.get(`YO_KEEP_BATCH`).is_none(), {
+          io.await(remove_file(Path.new(tmp_yo.clone()), io), IoExn(io : io, exn : exn));
+          io.await(remove_file(Path.new(tmp_bin.clone()), io), IoExn(io : io, exn : exn));
+          io.await(remove_file(Path.new(`${tmp_bin}.c`), io), IoExn(io : io, exn : exn));
+        });
+        batch_start = batch_end;
+        bi = (bi + usize(1));
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes the two RED files that the new full-corpus hollow sweep surfaced on its first CI run (#81). They looked like one "Linux-only platform quirk"; they are two unrelated bugs, and **neither is really platform-specific** — Linux just exposes both.

## 1. `tests/string/string.test.yo` — a missing port, not a codegen bug

The self-hosted compiler could not build this file **at all** on Linux:

```
.yo_selftest_batch_1.bin.c:44334: fatal error:
  bracket nesting level exceeded maximum of 256
```

yo-self compiled every test in a file as **one batch**, and the generated `cond` dispatch nests **one brace level per test**. At 252 tests the emitted C nested **261 deep**, past clang's default `-fbracket-depth=256`.

TS never hit it because it was *already* batching — `DEFAULT_TEST_BATCH_SIZE = 100` (`src/test-runner.ts:54`, sliced at `:1312-1315`). Its emit for the same file peaks at depth **105** across 3 batches. `--test-batch-size` was already on the known list of unported `test` flags.

It only *looked* platform-specific: my local clang 21.1.7 defaults to a higher bracket depth than CI's. Forcing `-fbracket-depth=256` reproduced it exactly, which is what made it debuggable at all.

**Fix:** port the same batching. Tests are sliced into groups of `TEST_BATCH_SIZE` (100, matching TS); each group is synthesized, compiled and run as its own batch. Arms are numbered *relative* to the batch so `YO_TEST_INDEX` stays a within-batch index, and the batch index joins the filename so batches of one file cannot overwrite each other.

| | batches | worst brace depth |
| --- | --- | --- |
| before | 1 | **261** (fails at 256) |
| after | 3 | **109** |

252/252 pass, and every batch compiles cleanly under an explicit `-fbracket-depth=256` — the exact condition that failed in CI.

## 2. `tests/ref_local_binding.test.yo` — a double free, and it is the interesting one

Test `"binding the handle keeps an object alive"`:

```rust
a := Holder(s : String.from("kept"), n : i32(0));
b := a;
a = Holder(s : String.from("other"), n : i32(1));
assert(b.s == "kept", "b's handle keeps the original object alive");
```

Both compilers emit `b = a` with **no** `__yo_incr_rc`, plus a "Save old value for later use" temp. The divergence is entirely in the drops:

```c
// TS      — one drop of the old object
fn_..._drop(_yod1860e03_temp_43720);

// yo-self — TWO drops of the SAME rc=1 object
__yo_decr_rc((void*)(_file____User_temp_6785));
__yo_decr_rc((void*)(b));
```

**Root cause — iteration order.** `b := a` creates exactly one deferred `___dup`, keyed under `a`. That single dup can cancel the scope-end drop of *either* variable in the alias chain, and whichever the optimizer reaches first wins. TS iterates `getVariablesNeedingDrop(env)`, which returns its list **already reversed** (`src/env.ts:2304-2305`), so it reaches `b` and cancels `b`'s drop. yo-self's `_optimize_dup_drop_pairs` walked the frame **forwards**, cancelled `a`'s drop instead, and left `b`'s drop alongside the saved temp's — two releases of one `rc=1` object.

Notably the *sibling* function `_schedule_scope_end_drops` already reverses explicitly, with a comment citing that same `.reverse()`. The optimizer was simply never brought in line.

**Reversing alone is not sufficient**, and this is the part worth reviewing: it just moves the double-drop from `b` to `a`, because yo-self was also missing TS's `dupCalls.length = 0` (`src/evaluator/exprs/begin.ts:2108-2109`). That clear is what stops a *second* variable in the same chain from cancelling against the same dup. Both halves are required; either alone is still wrong.

After the fix yo-self emits `decr_rc(_6785)` + `decr_rc(a)` — the old object once, the replacement once — structurally identical to TS's `drop(_43720)` + `drop(a)`.

**Why it was invisible on macOS:** `__yo_decr_rc` twice on an `rc=1` object is a double free. glibc detects it and aborts; macOS malloc tolerated it. The test passed locally for the whole life of the bug — including under `MallocScribble`, which is why the obvious "allocator-masked UAF" hypothesis came back negative.

## Tests

Two new cases in `tests/rc.test.yo` (33 → 35). They count **disposals** through a `Dispose` impl rather than asserting on a value — the miscount happens at **scope end**, after any in-body assert could observe it, and whether a double free crashes is allocator-dependent. Counting makes it deterministic on every platform, so this cannot go quiet on macOS again.

- *reassigning after aliasing disposes both objects exactly once* — the **discriminating** one, verified red-first (pre-fix reports 1 disposal where 2 are due).
- *aliasing a ref local disposes the object exactly once* — labelled in-file as a **control**: it passes either way and cannot catch the original bug, but it does guard the reversal itself, so a future change that breaks the simple single-alias case fails here.

Two notes on getting the test right, both recorded in-file. The counter is **module-level** because those have program lifetime and are never dropped; my first draft stored it *inside* the handle, which hands ownership to the handle — so disposing it freed the counter and the read afterwards was a UAF that printed garbage under **both** compilers. And the original `ref_local_binding` test is not itself a guard on macOS: it passed there throughout.

## Also

- `scripts/bootstrap/gates_fast.sh` hardcoded `.yo_selftest_batch_1.bin.c`, so the batch rename made all 23 battery files report `hollow=NA`. It now globs **every** batch — which it must do regardless, since one file can emit several, and the old form would have silently skipped batches 2..N.
- `scripts/bootstrap/known-failing.tsv` drops both RED entries. The ratchet fails on stale entries by design, so leaving them would (correctly) break CI.

## Validation

| Gate | Result |
| --- | --- |
| Discriminating test, pre-fix | **FAIL** (red-first) |
| `tests/rc.test.yo`, post-fix | **35/35 under BOTH compilers** |
| Dispose-count probe (TS / pre / post) | 3 / **2** / 3 |
| `gates_fast.sh` | 0 failures, battery `hollow=0` |
| Differential corpus | 155 PASS / **0 DIFF** / 0 SELF-FAIL |
| `check ./std` | 153/153 |
| `check ./yo-self` | 238/238 |
| Stage-2 → clang → stage-3 | **FIXPOINT HOLDS** |
| Emit-diff, stage-2 | `incr_rc` 11508 → 11508; `decr_rc` 278853 → **279007** (up, never down) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
