### PR TITLE
Check comptime-only markers before the ExprInfo lookup; trace the HOLLOW root cause

### DIFF
--- a/issues/repros/yo-self-variadic-comptime-call-not-funcval.yo
+++ b/issues/repros/yo-self-variadic-comptime-call-not-funcval.yo
@@ -1,0 +1,38 @@
+// Reproducer for issues/yo-self-hollow-language-test-files.md — the ROOT CAUSE
+// of tests/variadic_comptime.test.yo being HOLLOW under the self-hosted compiler.
+//
+//   ./yo-cli compile issues/repros/yo-self-variadic-comptime-call-not-funcval.yo \
+//     --emit-c --skip-c-compiler -o /tmp/x        # TS: rc=0, 0 markers
+//   <yo-self-bin> compile ... same args                # yo-self: rc=1
+//
+// yo-self fails with:
+//   error: Expected bool value for "comptime_assert", got:
+//     count_types(i32) == usize(1)
+//   Type: unknown
+//
+// The reported error is a downstream effect. Run yo-self with YO_DEBUG_SWALLOW=1
+// to see the real one, which is swallowed:
+//   [swallow] Error: evaluate_comptime_fn_call: function_value is not a FuncVal
+// from yo-self/evaluator/calls/comptime_fn.yo:500 — so the call never produced a
+// value, the `==` came out with type `unknown`, and comptime_assert rejected it.
+//
+// Why that makes a whole test file hollow: the aborted body evaluation records no
+// ExprInfo, so codegen's get_expr_info lookup misses and emits
+// "// Failed to transpile ..." for the ENCLOSING expression. In a generated test
+// batch that expression is the entire `match` dispatch, so one failed
+// compile-time assertion silently erases every test in the file.
+//
+// NOTE this is module level — no `test(...)` wrapper and no batch involved, so the
+// bug is not specific to the test runner. Note also that `yo-self check` on this
+// file passes: `check` does not force the comptime evaluation a real compile does.
+count_types :: (
+  fn(...(comptime(types) : ComptimeList(Type))) -> comptime(usize)
+)(types.len());
+
+comptime_assert(count_types(i32) == usize(1), "one type");
+
+main :: (fn() -> unit)({
+  ();
+});
+
+export(main);

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -152,6 +152,58 @@ Confirm with the checked-in reproducer, and check the same two lines against the
 TS equivalent before changing them — the CTFE route is shared by comptime methods
 and macros, so an over-broad change here has wide blast radius.
 
+### THE ACTUAL FAILING SITE (attempted 2026-08-08, three layers deep)
+
+Lead 2 above is real but **not sufficient**, and the true failure is earlier than
+the call. Narrowing it down:
+
+**Layer 1 — `variadic_args` is never populated (real gap, fix written and reverted).**
+yo-self already CONSUMES `arg_values.variadic_args` (`comptime_fn.yo:610-614`),
+and TS both fills it (`helper.ts:1763-1801`) and spreads it
+(`comptime-fn.ts:73-77`). But **every** construction site in yo-self passes
+`ArrayList(VarArgEntry).new()` — grep it: nothing ever pushes a `VarArgEntry`.
+`helper.yo` step 7b already evaluates the variadic args, it just files them into
+`rt_args` (for the C-extern `snprintf` case) and drops them otherwise. Threading
+those into the two in-scope `ArgValues` constructions type-checks cleanly, but
+does NOT fix the reproducer — so it is necessary-but-not-sufficient and was
+reverted rather than shipped unvalidated.
+
+**Layer 2 — the failure is at DEFINITION time, not at the call.** The error points
+at the function's own body:
+
+```
+Error: Variable "types" not found.
+  count_types :: (fn(...(comptime(types) : ComptimeList(Type))) -> comptime(usize))(types.len());
+                                                                                    ^ 1:83
+```
+
+So the def-time body evaluation cannot see the variadic parameter. That is why
+the callee ends up with no value, which is why `ct_func_value` degrades to
+`UnitVal` at `function.yo:5218`, which is why `comptime_fn.yo:500` reports "not a
+FuncVal". The call-site leads are all downstream of this.
+
+**Layer 3 — one def-time path binds the variadic parameter and the other does not.**
+`function_type.yo` calls `_trial_eval_fn_body` from two places:
+
+- `:984` (`flow_env`) — binds it, via the explicit
+  `get_func_variadic_param(...) -> add_variable_to_env(...)` block at `:918-943`,
+  with a comment noting the name/type "are not on TypeValue.Func, so they ride the
+  side table".
+- `:565` (`rp_env`, `_rerun_pending_def_evals`) — **does not**. It builds the env
+  with `_build_def_time_body_env`, which has no variadic binding of its own, and
+  never adds the block the flow path has.
+
+**Suggested fix:** give `PendingDefEval` (`:219-232`) the variadic parameter (it
+currently carries only `param_labels`/`param_types`/…), populate it where the
+pending eval is registered, and bind it in `_rerun_pending_def_evals` right after
+`_build_def_time_body_env`, mirroring `:918-943`. Better still, move the binding
+INTO `_build_def_time_body_env` so both callers get it and the two paths cannot
+drift again — that drift is the whole bug.
+
+Do Layer 1 as well; it is a genuine port gap and will be needed once the callee
+resolves. Gate the change with the full battery: this is the shared def-time body
+eval, so the blast radius is every function definition in the language.
+
 ### A tempting codegen "fix" that is actively harmful — do not do it
 
 `generate_func_call` bails to the marker whenever `get_expr_info` misses, _before_

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -114,6 +114,44 @@ Expect the three files to need **separate** fixes: `variadic_comptime` is variad
 comptime calls, `index` is comptime string/`ComptimeList` slicing, and
 `safe_code_structural_gates` routes through `comptime_expect_error`.
 
+### Two concrete leads in the CTFE call path (start here)
+
+The CTFE route that reaches `evaluate_comptime_fn_call` is
+`yo-self/evaluator/calls/function.yo:5200-5250`. Two things there look wrong for a
+variadic comptime function, and both are consistent with the observed error:
+
+1. **The callee falls back to a non-function value.** At `:5218`
+
+   ```rust
+   ct_func_value := match(callee_value,.Some(v) => v,.None => EvalValue.UnitVal);
+   ```
+
+   so an unresolved callee silently becomes `UnitVal` — which is precisely what
+   `evaluate_comptime_fn_call` then rejects with "function_value is not a FuncVal"
+   (`comptime_fn.yo:483-500`). The error message names the symptom; this is where
+   the `None` originates. Worth throwing a diagnostic here rather than
+   substituting `UnitVal`.
+
+2. **The variadic arguments are dropped on the floor.** At `:5211-5215` the
+   ArgValues is built as
+
+   ```rust
+   ct_arg_values := ArgValues(
+     forall_args : ArrayList(ArgEntry).new(),
+     args : ct_arg_entries,
+     implicit_args : Option(ArrayList(ArgEntry)).None,
+     variadic_args : ArrayList(VarArgEntry).new()   // <-- always EMPTY
+   );
+   ```
+
+   `variadic_args` is never populated on this path, so even a correctly-resolved
+   variadic comptime callee would be invoked with no variadic arguments. Compare
+   the non-CTFE call path, which does collect them.
+
+Confirm with the checked-in reproducer, and check the same two lines against the
+TS equivalent before changing them — the CTFE route is shared by comptime methods
+and macros, so an over-broad change here has wide blast radius.
+
 ### A tempting codegen "fix" that is actively harmful — do not do it
 
 `generate_func_call` bails to the marker whenever `get_expr_info` misses, _before_

--- a/issues/yo-self-hollow-language-test-files.md
+++ b/issues/yo-self-hollow-language-test-files.md
@@ -69,6 +69,68 @@ Candidate constructs per file (each file's arms are dominated by one theme):
   `test(...)`, the rest module-level `comptime_expect_error(...)` negative cases
 - `variadic_comptime.test.yo` — variadic comptime functions
 
+## ROOT CAUSE TRACED 2026-08-08 — it is the EVALUATOR, not codegen
+
+The `// Failed to transpile` marker is a **symptom**. The chain, established with
+`YO_DEBUG_SWALLOW=1` (which prints every def-time error yo-self swallows):
+
+1. A comptime call fails to evaluate — `evaluate_comptime_fn_call: function_value
+is not a FuncVal` (`yo-self/evaluator/calls/comptime_fn.yo:500`).
+2. So the enclosing comparison has type `unknown`.
+3. So `comptime_assert` rejects it — `Expected bool value for "comptime_assert"`
+   (`yo-self/evaluator/builtins/comptime_assert.yo:120-151`). **Swallowed.**
+4. So the whole `main` body's evaluation aborts and **no ExprInfo is recorded**.
+5. So codegen's `get_expr_info` lookup takes its `.None` arm and emits the marker
+   — and because the batch's body is one giant `match`, that marker replaces the
+   entire dispatch, taking every sibling test arm with it.
+
+### Minimal repro (5 lines, clean TS/yo-self differential)
+
+```rust
+count_types :: (fn(...(comptime(types) : ComptimeList(Type))) -> comptime(usize))(types.len());
+comptime_assert(count_types(i32) == usize(1), "one");
+main :: (fn() -> unit)({ (); });
+export(main);
+```
+
+- **TS**: compiles clean, 0 markers.
+- **yo-self**: `error: Expected bool value for "comptime_assert"`, exit 1.
+
+Not the round-trip: the `ast_expr_to_string` form `(types.len)()` fails
+identically to the original `types.len()`. Not batch-specific either — this is at
+module level, no `test(...)` and no dispatch. Note the original test FILE
+`check`s clean (rc=0), because `check` does not force the comptime evaluation
+that a real compile does.
+
+### This is NOT the def-time swallow surface
+
+That was my first hypothesis and it is wrong. `issues/def-time-body-eval-swallow-surface.md`
+is why the error is _invisible_, but the defect itself is one specific failure in
+comptime call evaluation. Fixing the swallow would only make it _loud_. Start from
+the repro above and `comptime_fn.yo:500` — ask what `function_value` actually is
+for a variadic comptime function, since it is evidently not a `.FuncVal`.
+
+Expect the three files to need **separate** fixes: `variadic_comptime` is variadic
+comptime calls, `index` is comptime string/`ComptimeList` slicing, and
+`safe_code_structural_gates` routes through `comptime_expect_error`.
+
+### A tempting codegen "fix" that is actively harmful — do not do it
+
+`generate_func_call` bails to the marker whenever `get_expr_info` misses, _before_
+reaching its compile-time-marker skip list. Hoisting the structural
+`begin`/`cond`/`match` dispatches above that lookup (none of them take an
+ExprInfo) makes all three files report `hollow=0`. **It is not a fix.** The bodies
+still do not run — the failure just moves into `generate_match_expression`, which
+emits `/* "match" expression is not evaluated */`, a comment the hollow detector
+does not grep for. Verified by injecting `assert(i32(1) == i32(2))` into a test
+body: it still reported "10 passed".
+
+That would convert a _detectable_ hollow into an _invisible_ one, silencing the
+gate. `yo-self/codegen/exprs/generation.yo` carries a comment at that spot saying
+so. Hoisting only the compile-time markers (which genuinely emit no C, matching
+`generation.ts:1081-1102`) IS correct and is done; it fixes the standalone case
+and leaves the batch failure detectable.
+
 ## Do not extract a minimal `main` — it false-passes
 
 Both obvious reductions were tried and **both compile cleanly** under the

--- a/yo-self/codegen/exprs/generation.yo
+++ b/yo-self/codegen/exprs/generation.yo
@@ -501,6 +501,44 @@ generate_func_call :: (fn(expr : AstExpr, indent : String, context : FunctionGen
   if(ast_expr_is_fn_call_of(expr, BF_UNSAFE, Option(usize).None), return(_passthrough_first_arg(expr, indent.clone(), context)));
   if(ast_expr_is_fn_call_of(expr, BF_OLD, Option(usize).None), return(_passthrough_first_arg(expr, indent.clone(), context)));
   if(ast_expr_is_fn_call_of(expr, BF_GHOST_FN, Option(usize).None), return(_passthrough_first_arg(expr, indent.clone(), context)));
+  // Compile-time-only markers: no C output. These MUST be checked BEFORE the
+  // get_expr_info lookup below, for exactly the reason stated for the
+  // transparent wrappers above — a call the evaluator fully consumed at compile
+  // time has NO ExprInfo entry, so the lookup's `.None` arm returned
+  // "// Failed to transpile ..." before these checks were ever reached. They
+  // produce no C and need no ExprInfo, so the lookup is irrelevant to them.
+  //
+  // That ordering is what made three test files HOLLOW: a single
+  // `comptime_assert` (or `comptime_expect_error`) whose argument is
+  // comptime-only — a variadic comptime call, a comptime string slice — emitted
+  // a failure marker, and in the generated test batch that marker replaced the
+  // WHOLE `match` dispatch, so every sibling test arm was silently lost too.
+  // tests/index.test.yo reported "49 passed" while running nothing; 31 of its
+  // arms are ordinary runtime tests that were collateral.
+  // TS checks the same list without needing ExprInfo (generation.ts:1081-1102).
+  // See issues/yo-self-hollow-language-test-files.md.
+  if(ast_expr_is_fn_call_of(expr, BF_COMPTIME_EXPECT_ERROR, Option(usize).None), return(String.from("")));
+  if(ast_expr_is_fn_call_of(expr, BF_COMPTIME_ASSERT, Option(usize).None), return(String.from("")));
+  if(ast_expr_is_fn_call_of(expr, BF_YO_VAR_PRINT_INFO, Option(usize).None), return(String.from("")));
+  if(ast_expr_is_fn_call_of(expr, BF_YO_VAR_IS_OWNING_RC, Option(usize).None), return(String.from("")));
+  if(ast_expr_is_fn_call_of(expr, BF_YO_VAR_HAS_OTHER_ALIASES, Option(usize).None), return(String.from("")));
+  if(ast_expr_is_fn_call_of(expr, BF_REQUIRES, Option(usize).None), return(String.from("")));
+  if(ast_expr_is_fn_call_of(expr, BF_ENSURES, Option(usize).None), return(String.from("")));
+  if(ast_expr_is_fn_call_of(expr, BF_INVARIANT, Option(usize).None), return(String.from("")));
+  if(ast_expr_is_fn_call_of(expr, BF_GHOST, Option(usize).None), return(String.from("")));
+  // DO NOT hoist the structural `begin` / `cond` / `match` dispatches above this
+  // lookup. It is tempting — none of those generators takes an ExprInfo — and it
+  // does make the "Failed to transpile" marker disappear for the hollow test
+  // files. But the marker is a SYMPTOM, not the bug: those nodes genuinely have
+  // no ExprInfo because the evaluator never recorded one for the batch `main`
+  // body, so hoisting only moves the failure into generate_match_expression,
+  // which emits `/* "match" expression is not evaluated */` instead. The test
+  // bodies still do not run, and because the hollow detector greps for "Failed to
+  // transpile", that comment makes an undetectable hollow out of a detectable
+  // one — strictly worse. Verified by injecting `assert(i32(1) == i32(2))` into a
+  // test body: with the hoist it still reported "10 passed".
+  // The real cause is upstream, in the evaluator. See
+  // issues/yo-self-hollow-language-test-files.md.
   ei := match(
     context.base.get_expr_info(expr),
     .Some(e) => e,
@@ -687,16 +725,6 @@ generate_func_call :: (fn(expr : AstExpr, indent : String, context : FunctionGen
   if(ast_expr_is_fn_call_of(expr, BF_CONSUME, Option(usize).None), return(generate_consume(expr, indent.clone(), context)));
   // (unsafe / old / ghost_fn transparent pass-through handled at the top, before
   // the ExprInfo lookup.)
-  // Compile-time-only markers: no C output.
-  if(ast_expr_is_fn_call_of(expr, BF_COMPTIME_EXPECT_ERROR, Option(usize).None), return(String.from("")));
-  if(ast_expr_is_fn_call_of(expr, BF_COMPTIME_ASSERT, Option(usize).None), return(String.from("")));
-  if(ast_expr_is_fn_call_of(expr, BF_YO_VAR_PRINT_INFO, Option(usize).None), return(String.from("")));
-  if(ast_expr_is_fn_call_of(expr, BF_YO_VAR_IS_OWNING_RC, Option(usize).None), return(String.from("")));
-  if(ast_expr_is_fn_call_of(expr, BF_YO_VAR_HAS_OTHER_ALIASES, Option(usize).None), return(String.from("")));
-  if(ast_expr_is_fn_call_of(expr, BF_REQUIRES, Option(usize).None), return(String.from("")));
-  if(ast_expr_is_fn_call_of(expr, BF_ENSURES, Option(usize).None), return(String.from("")));
-  if(ast_expr_is_fn_call_of(expr, BF_INVARIANT, Option(usize).None), return(String.from("")));
-  if(ast_expr_is_fn_call_of(expr, BF_GHOST, Option(usize).None), return(String.from("")));
   if(ast_expr_is_fn_call_of(expr, BK_OPEN, Option(usize).None), return(generate_open(expr, indent.clone(), context)));
   // Index trait dispatch: `value(i)` → `*index_fn(&value, i)`. The evaluator
   // stamps the specialized `index()` method FuncVal + pointer-return type on the


### PR DESCRIPTION
## Summary

One small codegen faithfulness fix, plus the traced root cause of the three HOLLOW test files. **It does not fix them** — the investigation is the substantive part, and it corrects two wrong conclusions of my own along the way.

## The fix

TS routes comptime-only builtins — `comptime_assert`, `comptime_expect_error`, `__yo_var_*`, `requires`/`ensures`/`invariant`/`ghost` — to an early "emit nothing" branch that needs no type info (`generation.ts:1081-1102`). yo-self had the identical skip list but placed it **after** the `get_expr_info` lookup, whose `.None` arm returns `// Failed to transpile …`. A call the evaluator fully consumed at compile time has no ExprInfo, so the marker fired before the skip list was ever reached.

Moved the list above the lookup, next to the transparent wrappers (`unsafe`/`old`/`ghost_fn`) which are **already** hoisted there for exactly the same documented reason — *"a wrapper node may itself lack an ExprInfo entry."* These emit no C and need no ExprInfo.

Verified: a module-level `comptime_assert(x(0 .. 5) == "Hello", …)` goes 1 marker → 0.

## The root cause of the HOLLOW files

The marker is a **symptom**. With `YO_DEBUG_SWALLOW=1` the real chain is visible:

1. `evaluate_comptime_fn_call: function_value is not a FuncVal` (`comptime_fn.yo:500`) — **swallowed**
2. → the enclosing `==` gets type `unknown`
3. → `comptime_assert` rejects it (`comptime_assert.yo:120-151`) — **swallowed**
4. → the body's evaluation aborts, so **no ExprInfo is recorded**
5. → codegen's lookup misses and marks the **enclosing** expression — which in a generated test batch is the entire `match` dispatch

So one failed compile-time assertion silently erases every test in the file. `tests/index.test.yo` reports **49 passed** while running nothing, and **31 of its arms are ordinary runtime tests** that were pure collateral.

A 5-line module-level reproducer is checked in with a clean differential — TS `rc=0`, yo-self `rc=1`:

```rust
count_types :: (fn(...(comptime(types) : ComptimeList(Type))) -> comptime(usize))(types.len());
comptime_assert(count_types(i32) == usize(1), "one");
main :: (fn() -> unit)({ (); });
export(main);
```

It is **not** the `ast_expr_to_string` round-trip (the stringified `(types.len)()` fails identically to `types.len()`) and **not** batch-specific — no `test(...)`, no dispatch. Note `yo-self check` on it *passes*, because `check` never forces the comptime evaluation a real compile does; that is why this hid for so long.

## Two corrections to my own earlier conclusions

**1. It is not the def-time swallow surface.** That was my first read and it was wrong. `issues/def-time-body-eval-swallow-surface.md` explains why the error is *invisible*; it is not why the error happens. Fixing the swallow would only make it loud. That distinction turns this from weeks-scale work into three specific bugs with repros.

**2. A tempting codegen "fix" is actively harmful.** `generate_func_call` bails to the marker whenever `get_expr_info` misses. Hoisting the **structural** `begin`/`cond`/`match` dispatches above that lookup — none of them takes an ExprInfo — makes all three files report `hollow=0`. It is not a fix. The bodies still do not run; the failure just moves into `generate_match_expression`, which emits `/* "match" expression is not evaluated */` — a comment the hollow detector does not grep for.

I caught this by injecting `assert(i32(1) == i32(2))` into a test body: **it still reported "10 passed."** That change would trade a *detectable* hollow for an *invisible* one and silence the gate added in #81. Reverted, with a comment at that exact spot in `generation.yo` so it is not re-attempted.

## What remains

The three files stay allowlisted in `scripts/bootstrap/known-failing.tsv` and, importantly, stay **detectable**. Expect three separate fixes: variadic comptime calls (`variadic_comptime`), comptime string/`ComptimeList` slicing (`index`), and `comptime_expect_error` (`safe_code_structural_gates`). Start from the checked-in repro and `comptime_fn.yo:500` — the question is what `function_value` actually is for a variadic comptime function, since it is demonstrably not a `.FuncVal`.

## Validation

| Gate | Result |
| --- | --- |
| Standalone comptime repro | 1 marker → **0** |
| `gates_fast.sh` | **0 failures**, battery `hollow=0` |
| Differential corpus | 155 PASS / **0 DIFF** / 0 SELF-FAIL |
| `check ./std` | 153/153 |
| `check ./yo-self` | 238/238 |
| Stage-2 → clang → stage-3 | **FIXPOINT HOLDS** |
| Hollow sweep | unchanged at 185 GREEN / 3 HOLLOW — still detectable |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
