### PR TITLE
Fix the 3 HOLLOW language test files: the sweep allowlist is now empty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -670,7 +670,7 @@ jobs:
   # `__yo_user_main` that is not a `// Failed to transpile` comment. A hollow
   # batch runs no assertions while still reporting "N passed" — the first sweep
   # found 3 such files, one of them claiming 49 passed
-  # (issues/yo-self-hollow-language-test-files.md).
+  # (issues/fixed/yo-self-hollow-language-test-files.md).
   #
   # Gated as a RATCHET against scripts/bootstrap/known-failing.tsv so it blocks
   # any NEW regression today while the known ones are worked down. It compares

--- a/issues/fixed/handover-yo-self-hollow-files.md
+++ b/issues/fixed/handover-yo-self-hollow-files.md
@@ -1,10 +1,58 @@
-# HANDOVER — the 3 HOLLOW test files
+# HANDOVER — the 3 HOLLOW test files (RESOLVED)
 
-**Written 2026-08-08** after four failed fix attempts. Everything here is
-verified unless explicitly marked as a hypothesis. Full history and the RED-file
-work live in
-[`yo-self-hollow-language-test-files.md`](yo-self-hollow-language-test-files.md);
-this file is the working brief.
+**Written 2026-08-08** after four failed fix attempts; **all three fixed the
+same day.** Full history and the RED-file work live in
+[`yo-self-hollow-language-test-files.md`](yo-self-hollow-language-test-files.md).
+
+---
+
+## 0. Resolution — and the one wrong assumption that cost four attempts
+
+**§4's failure chain is wrong at step 1, and that is why every attempt built on
+it failed.** It reads "evaluating `count_types`'s **body at definition time**,
+the variadic parameter `types` is not in scope". The error's token points at the
+definition line, so this looked certain — but the token points there only
+because that is where the BODY is; the failing evaluation was the **call**.
+
+One experiment settles it, and it needs no instrumentation at all:
+
+```bash
+# definition ALONE — rc=0, compiles clean
+count_types :: (fn(...(comptime(types) : ComptimeList(Type))) -> comptime(usize))(types.len());
+main :: (fn() -> unit)({ (); }); export(main);
+
+# definition + ONE call — rc=1, `Variable "types" not found`
+n :: count_types(i32);
+```
+
+The def-time body env **does** bind the variadic (`function_type.yo:918`, the
+`__DBG_VP` hit §6 measured). The **callee** env at a call site never did:
+`function.yo`'s inline FuncVal arm binds a `quote` variadic
+(`...(quote(elems))`, the `array_list`/`hash_map` macros) and had **no branch at
+all** for the comptime one. That is the whole of `variadic_comptime`.
+
+**Generalising the method note**: an error whose token sits inside a function
+body says nothing about WHO evaluated that body. Splitting the reproducer into
+"definition alone" vs "definition + call" costs one compile and is decisive —
+cheaper than the four speculative fixes, and cheaper than the instrumentation
+build in §6.
+
+The other two files were **not** the same root cause (§7 was right to assume
+separate bugs) and were **not** one bug each — they were four more, each hidden
+behind the next:
+
+| file                         | bugs                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index`                      | the `slice_copy` rewrite fired on COMPTIME receivers, so `x(0 .. 5)` on a `comptime_str` matched `str`'s runtime `slice_copy` (TS guards exactly this, function.ts:815-823) · `_check_range_type` matched a struct NAME that is structurally always empty, so no range was ever recognised · `Range` and `RangeInclusive` are both anonymous `struct(start : T, end : T)`, so type compatibility cannot tell them apart and every `..` resolved as `..=` |
+| `safe_code_structural_gates` | `comptime_expect_error` snapshotted the frame DEPTH only, and an expected throw can unwind past a `pop_frame` — measured 3 frames in, 2 out, the lost one being the MODULE frame · a rejected module-level binding still registered its name as a module-level global, so codegen module-qualified every later local of that name while its declaration stayed unqualified                                                                               |
+
+Each file surfaced its next bug only once the previous one was fixed, because a
+single swallowed error erases the batch's ENTIRE `__yo_user_main` dispatch. Budget
+for that shape: "the file still fails" after a correct fix is the expected
+intermediate state, not evidence the fix was wrong.
+
+Everything below is the brief as it stood before the fix, kept for the method
+notes and the four ruled-out attempts.
 
 ---
 

--- a/issues/fixed/yo-self-hollow-language-test-files.md
+++ b/issues/fixed/yo-self-hollow-language-test-files.md
@@ -1,5 +1,23 @@
 # 3 of 188 language test files are HOLLOW under the self-hosted compiler
 
+> **RESOLVED 2026-08-08.** All three are fixed and
+> `scripts/bootstrap/known-failing.tsv` is EMPTY — the full-corpus sweep now
+> demands a clean run on its own. What actually caused them, and why the first
+> four fix attempts all missed, is in
+> [`handover-yo-self-hollow-files.md`](handover-yo-self-hollow-files.md);
+> the short version is that **all three were five separate bugs**, each hidden
+> behind ONE swallowed error that erased the file's whole batch dispatch:
+>
+> | file                         | bug                                                                                                                                                                                                   |
+> | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+> | `variadic_comptime`          | a comptime variadic parameter was never bound into the CALLEE env (the `quote` sibling was; the comptime one had no branch at all)                                                                    |
+> | `index`                      | the `slice_copy` rewrite fired on comptime receivers; the range-type test matched a struct NAME that is always empty; `Range`/`RangeInclusive` are structurally identical so every `..` read as `..=` |
+> | `safe_code_structural_gates` | `comptime_expect_error` restored the frame DEPTH but not the frames themselves, losing the MODULE frame; and a rejected module-level binding leaked into the codegen module-global registry           |
+>
+> Validation used the bar this document itself sets: an injected
+> `assert(i32(1) == i32(2))` now FAILS in each of the three (it reported a
+> clean pass before).
+
 **Found 2026-08-08** by the first full-corpus hollow sweep. They exit 0 and report
 passing tests while **running no assertions at all**.
 

--- a/plans/PRE_P1_HANDOVER.md
+++ b/plans/PRE_P1_HANDOVER.md
@@ -12,10 +12,12 @@ Everything below is verified unless marked as a hypothesis.
 
 ## 0. TL;DR
 
-**One hard blocker** remaining:
+**No hard blockers remain.**
 
-1. The **3 HOLLOW test files** — 60 tests reporting success while running nothing.
-   Handed off; see [`issues/handover-yo-self-hollow-files.md`](../issues/handover-yo-self-hollow-files.md).
+~~1. The 3 HOLLOW test files~~ — **DONE 2026-08-08.** All three run their
+assertions, and `scripts/bootstrap/known-failing.tsv` is **empty**, so the
+full-corpus sweep now demands a clean run on its own. Five distinct bugs, not
+three; see [`issues/fixed/handover-yo-self-hollow-files.md`](../issues/fixed/handover-yo-self-hollow-files.md).
 
 ~~2. Branch protection is off~~ — **DONE 2026-08-08.** The `develop` ruleset is
 `enforcement: active` with **15** required status checks, up from a disabled
@@ -58,32 +60,41 @@ Gates that now exist and pass:
 
 ---
 
-## 2. Hard blockers
+## 2. Hard blockers — none left
 
-### 2.1 The 3 HOLLOW test files
+### 2.1 ~~The 3 HOLLOW test files~~ — RESOLVED 2026-08-08
 
-`tests/index.test.yo` (49), `tests/safe_code_structural_gates.test.yo` (1),
-`tests/variadic_comptime.test.yo` (10) exit 0 and report passing while executing
-**no assertions**. `index.test.yo` matters most: **31 of its 49 arms are ordinary
-runtime tests** lost as collateral.
+`tests/index.test.yo` (49), `tests/safe_code_structural_gates.test.yo` (1) and
+`tests/variadic_comptime.test.yo` (10) exited 0 and reported passing while
+executing **no assertions**. All three now run them, `known-failing.tsv` is
+**empty**, and the sweep demands a clean corpus on its own.
 
-Why this blocks P1 rather than riding along: after P2 the self-hosted binary's
-"N passed" is the _only_ signal there is. A silent-success failure mode is the
-worst thing to carry across that boundary, and P1 is the last phase where the TS
-compiler can adjudicate it.
+They were **five** bugs, not three, each hidden behind the next because one
+swallowed error erases a batch's entire `__yo_user_main` dispatch:
 
-Root-caused to the evaluator (not codegen), with a 5-line reproducer and **four
-ruled-out fix attempts**. Full brief:
-[`issues/handover-yo-self-hollow-files.md`](../issues/handover-yo-self-hollow-files.md).
+| file                         | bugs                                                                                                                                                                                                                    |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `variadic_comptime`          | a comptime variadic parameter was never bound into the CALLEE env — the `quote` sibling was, the comptime one had no branch at all                                                                                      |
+| `index`                      | the `slice_copy` rewrite fired on comptime receivers (TS guards it) · the range-type test matched a struct NAME that is always empty · `Range`/`RangeInclusive` are structurally identical, so every `..` read as `..=` |
+| `safe_code_structural_gates` | `comptime_expect_error` restored the frame DEPTH but not the frames, losing the MODULE frame outright · a rejected module-level binding leaked its name into the codegen module-global registry                         |
 
-> **Two warnings, both learned the expensive way.** `hollow=0` is **not** proof of
-> a fix — one attempt achieved it while the bodies still ran nothing, by moving the
-> failure into a comment the detector does not grep for. And `check` passes on all
-> of this, because it never forces the comptime evaluation a real compile does.
-> Validate with an injected `assert(i32(1) == i32(2))`, nothing less.
+**The method note worth keeping** — the previous four attempts all failed
+because the brief's step 1 was wrong, and it was wrong in a way that looked
+certain: the error's token pointed at the function's DEFINITION line, so the
+def-time body eval was blamed. The token points there only because that is where
+the body is. Compiling the definition **alone** (clean) versus definition + one
+call (fails) settles it in one compile, and is cheaper than either the four
+speculative fixes or the instrumented build that followed them. Full write-up:
+[`issues/fixed/handover-yo-self-hollow-files.md`](../issues/fixed/handover-yo-self-hollow-files.md).
 
-**Done means** `scripts/bootstrap/known-failing.tsv` is empty, at which point the
-gate demands a fully clean sweep on its own.
+> **Two warnings, both learned the expensive way, and still binding for the next
+> change in this area.** `hollow=0` is **not** proof of a fix — one attempt
+> achieved it while the bodies still ran nothing, by moving the failure into a
+> comment the detector does not grep for. And `check` passes on all of this,
+> because it never forces the comptime evaluation a real compile does. Validate
+> with an injected `assert(i32(1) == i32(2))`, nothing less. That is what was
+> used here: it now FAILS in all three files, where before it reported a clean
+> pass.
 
 ### 2.2 ~~Branch protection is disabled~~ — RESOLVED 2026-08-08
 
@@ -179,7 +190,7 @@ Two more scoping facts:
 
 ## 5. Suggested order
 
-1. **Fix the 3 HOLLOW files** (§2.1) — in flight with another agent.
+1. ~~Fix the 3 HOLLOW files~~ (§2.1) — **done**; the allowlist is empty.
 2. ~~Enable branch protection~~ — **done**; the gates are binding.
 3. **Start P1 with `init`.** It is genuinely ready (239 lines, complete
    `init_project`) and has **five observable divergences** a differential harness

--- a/plans/SELF_HOSTING_COMPLETION.md
+++ b/plans/SELF_HOSTING_COMPLETION.md
@@ -80,16 +80,14 @@ Also in scope:
   caveat recorded there: the TS formatter preserves existing line structure
   rather than canonicalizing it, so a raw "would format" count conflates real
   spacing bugs with line-breaking differences.
-- **The 3 hollow language test files**
-  ([`issues/yo-self-hollow-language-test-files.md`](../issues/yo-self-hollow-language-test-files.md)).
-  The first full-corpus sweep scored 185 GREEN / 3 HOLLOW — files that report
-  passes (one claims 49) while running no assertions. Its first CI run added **2 RED
-  files that pass on macOS but fail on Linux** (`ref_local_binding`,
-  `string/string`) — a platform divergence in `yo-self` that was invisible because
-  neither file is in the 23-file battery. CI now runs the sweep as a ratchet against
-  `scripts/bootstrap/known-failing.tsv`, so no NEW regression can land; all five
-  still need root-causing. For the HOLLOW ones, reduce by deleting arms from the
-  real file — both obvious minimal extractions compile cleanly and prove nothing.
+- ~~**The 3 hollow language test files**~~ — **RESOLVED 2026-08-08**
+  ([`issues/fixed/yo-self-hollow-language-test-files.md`](../issues/fixed/yo-self-hollow-language-test-files.md)).
+  The first full-corpus sweep scored 185 GREEN / 3 HOLLOW — files that reported
+  passes (one claimed 49) while running no assertions — and its first CI run added
+  **2 RED files that pass on macOS but fail on Linux** (`ref_local_binding`,
+  `string/string`). All five are now fixed and
+  `scripts/bootstrap/known-failing.tsv` is EMPTY, so the sweep ratchet demands a
+  fully clean corpus rather than a frozen one.
   For the RED ones, start from the `hollow-sweep-results` CI artifact; they do not
   reproduce on macOS.
 - Leftover from the port: activate `types/flowability.yo` (setter/caller

--- a/scripts/bootstrap/known-failing.tsv
+++ b/scripts/bootstrap/known-failing.tsv
@@ -12,16 +12,32 @@
 #
 # This is an ALLOWLIST OF KNOWN DEBT, not a permanent exemption. It exists so the
 # full-corpus sweep can gate CI TODAY — blocking any NEW failure — while these are
-# worked down. See issues/yo-self-hollow-language-test-files.md.
+# worked down. See issues/fixed/yo-self-hollow-language-test-files.md.
 #
 # The gate fails in BOTH directions: a failing file missing from this list fails,
 # and a listed file that now passes (or changed verdict) ALSO fails, so the list
 # cannot go stale. Fixing one means deleting its line.
 
-# --- HOLLOW: report passes while running nothing (found 2026-08-08) ---
-tests/index.test.yo	HOLLOW
-tests/safe_code_structural_gates.test.yo	HOLLOW
-tests/variadic_comptime.test.yo	HOLLOW
+# --- HOLLOW: none. ---
+# The list is EMPTY, which is the point: the sweep now demands a fully clean
+# corpus on its own, and any new failure — HOLLOW or RED — turns CI red.
+# The three HOLLOW files found 2026-08-08 are FIXED (2026-08-08):
+#   tests/variadic_comptime.test.yo          — a comptime variadic parameter
+#     (`...(comptime(t) : ComptimeList(T))`) was never bound into the CALLEE
+#     env, so every call ran the body with the name unbound. The quote sibling
+#     was bound; the comptime one had no branch at all.
+#   tests/index.test.yo                      — three layered range bugs: the
+#     slice_copy rewrite fired on comptime receivers (TS guards it), the
+#     range-type test matched on a struct NAME that is always empty, and
+#     Range/RangeInclusive are structurally identical so every `..` read as
+#     `..=`. Discriminated by the type constructor id.
+#   tests/safe_code_structural_gates.test.yo — `comptime_expect_error`'s
+#     restore snapshotted only the frame DEPTH, so a throw that unwound past a
+#     `pop_frame` lost the MODULE frame for good; and a rejected module-level
+#     binding left its name in the codegen module-global registry.
+# All three now run their assertions: verified with an injected
+# `assert(i32(1) == i32(2))`, which FAILS in each (it reported a clean pass
+# before). See issues/fixed/yo-self-hollow-language-test-files.md.
 
 # --- RED: none. ---
 # The two Linux-only RED files found by the first CI run of this sweep are FIXED:

--- a/yo-self/codegen/exprs/generation.yo
+++ b/yo-self/codegen/exprs/generation.yo
@@ -516,7 +516,7 @@ generate_func_call :: (fn(expr : AstExpr, indent : String, context : FunctionGen
   // tests/index.test.yo reported "49 passed" while running nothing; 31 of its
   // arms are ordinary runtime tests that were collateral.
   // TS checks the same list without needing ExprInfo (generation.ts:1081-1102).
-  // See issues/yo-self-hollow-language-test-files.md.
+  // See issues/fixed/yo-self-hollow-language-test-files.md.
   if(ast_expr_is_fn_call_of(expr, BF_COMPTIME_EXPECT_ERROR, Option(usize).None), return(String.from("")));
   if(ast_expr_is_fn_call_of(expr, BF_COMPTIME_ASSERT, Option(usize).None), return(String.from("")));
   if(ast_expr_is_fn_call_of(expr, BF_YO_VAR_PRINT_INFO, Option(usize).None), return(String.from("")));
@@ -538,7 +538,7 @@ generate_func_call :: (fn(expr : AstExpr, indent : String, context : FunctionGen
   // one — strictly worse. Verified by injecting `assert(i32(1) == i32(2))` into a
   // test body: with the hoist it still reported "10 passed".
   // The real cause is upstream, in the evaluator. See
-  // issues/yo-self-hollow-language-test-files.md.
+  // issues/fixed/yo-self-hollow-language-test-files.md.
   ei := match(
     context.base.get_expr_info(expr),
     .Some(e) => e,

--- a/yo-self/evaluator/builtins/comptime_expect_error.yo
+++ b/yo-self/evaluator/builtins/comptime_expect_error.yo
@@ -22,7 +22,7 @@ open(import("std/string"));
   make_err_expr
 } :: import("../../expr.yo");
 { ArrayList } :: import("std/collections/array_list");
-{ Environment, invalidate_frame_index } :: import("../../env.yo");
+{ Environment, Frame, invalidate_frame_index } :: import("../../env.yo");
 { EvalContext } :: import("../context.yo");
 { format_error_message } :: import("../../error.yo");
 { EvalValue, value_to_string } :: import("../../value.yo");
@@ -31,7 +31,9 @@ open(import("std/string"));
   new_expr_info,
   expr_info_table_set,
   branch_group_stack_len,
-  truncate_branch_group_stack
+  truncate_branch_group_stack,
+  module_global_recording_mark,
+  rollback_module_level_globals_to
 } :: import("../../expr_info.yo");
 { t_unit } :: import("../../types/creators.yo");
 { set_propagate_def_time_errors, set_cee_observed_error, clear_cee_observed_error, cee_observed_error } :: import("../../types/flowability.yo");
@@ -109,6 +111,30 @@ evaluate_comptime_expect_error :: (
   // (the algebraic_effects batch FTT). Restore env frame depth + the ctx
   // mode fields after the arg eval, success or throw.
   saved_frames_len := env.frames.len();
+  // Snapshot the FRAME OBJECTS, not just the depth. The expected throw can
+  // unwind past a `pop_frame` and leave the env SHORTER than it started —
+  // measured on `cee(begin((p : *(i32)) = i32(0), ()))`: 3 frames in, 2 out,
+  // and the frame that vanished was the MODULE frame. A depth-only restore
+  // can only pop, never re-push, so every module binding made BEFORE the
+  // `comptime_expect_error` was lost and the rest of the file could not see
+  // it ("Variable "assert" not found" from a later `test(...)` arm, which
+  // then hollowed the whole batch — tests/safe_code_structural_gates.test.yo).
+  // TS needs no equivalent: its envs are persistent values, so the rejected
+  // eval's env is simply discarded and the caller keeps the original.
+  saved_frames := ArrayList(Frame).new();
+  {
+    (sf_i : usize) = usize(0);
+    while(sf_i < env.frames.len(), {
+      match(
+        env.frames.get(sf_i),
+        .Some(sf) => {
+          saved_frames.push(sf);
+        },
+        .None => ()
+      );
+      sf_i = (sf_i + usize(1));
+    });
+  };
   // Per-frame variable counts: an EXPECTED throw can strand a half-made
   // binding in a surviving frame (e.g. `cee((z : Point1) := (3, 4))` adds
   // `z` before the type-mismatch throw). TS's persistent envs discard the
@@ -164,6 +190,9 @@ evaluate_comptime_expect_error :: (
   // The expected throw can strand cond.yo's branch-group entries (push
   // without pop) — truncate back to this depth after the arg eval.
   saved_branch_groups := branch_group_stack_len();
+  // Module-level globals registered by the (expected-to-fail) arg eval must
+  // not survive it — see expr_info.yo's rollback comment.
+  saved_mg_mark := module_global_recording_mark();
   set_propagate_def_time_errors(true);
   arg_threw := _comptime_expect_error_arg_threw(arg_expr.clone(), env, ctx);
   set_propagate_def_time_errors(false);
@@ -200,6 +229,20 @@ evaluate_comptime_expect_error :: (
   while(env.frames.len() > saved_frames_len, {
     env.pop_frame();
   });
+  // ...and re-push the ones it POPPED (see the snapshot comment above).
+  {
+    (rf_i : usize) = env.frames.len();
+    while(rf_i < saved_frames_len, {
+      match(
+        saved_frames.get(rf_i),
+        .Some(rf) => {
+          env.frames.push(rf);
+        },
+        .None => ()
+      );
+      rf_i = (rf_i + usize(1));
+    });
+  };
   // Drop variables the (expected-to-fail) arg eval stranded in surviving
   // frames — see the snapshot comment above.
   {
@@ -230,6 +273,7 @@ evaluate_comptime_expect_error :: (
     });
   };
   truncate_branch_group_stack(saved_branch_groups);
+  rollback_module_level_globals_to(saved_mg_mark);
   if(arg_threw, {
     out_unit := new_expr_info(env, t_unit());
     out_unit.value = Option(EvalValue).Some(EvalValue.UnitVal);

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -5141,7 +5141,7 @@ Fix: wrap the call:
         // `Variable "types" not found` from inside the body, the def-time
         // swallow hid it, and the failed comptime_assert erased the batch's
         // `__yo_user_main` — 10 tests reporting "passed" while running nothing
-        // (issues/handover-yo-self-hollow-files.md). The failure is at the CALL,
+        // (issues/fixed/handover-yo-self-hollow-files.md). The failure is at the CALL,
         // not at the definition: the definition alone compiles clean, because
         // the def-time body env DOES bind the variadic (function_type.yo:918).
         if(fv_variadic_is_comptime, {

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -1003,6 +1003,11 @@ _try_rewrite_range_index_to_slice_copy :: (
     func_expr : AstExpr,
     args : ArrayList(AstExpr),
     recv_ty : TypeValue,
+    /// The receiver's evaluated VALUE. A receiver that already holds a
+    /// CONCRETE comptime value (an array/slice literal, a `comptime_str`)
+    /// must keep the comptime slicing path in `try_to_call_with_index_trait`
+    /// — see the guard below.
+    recv_val : Option(EvalValue),
     env : Environment
   ) -> Option(AstExpr)
 )({
@@ -1023,6 +1028,29 @@ _try_rewrite_range_index_to_slice_copy :: (
   });
   // Function-typed receivers are real calls, not indexing.
   if(is_function_type(recv_ty), {
+    return(Option(AstExpr).None);
+  });
+  // COMPTIME-valued receivers keep the comptime slicing path (TS
+  // function.ts:815-823: `!isTypeValue(recvValue) && !recvHasComptimeSliceValue`,
+  // whose comment reads "Comptime-valued receivers (array/slice/comptime_str
+  // literals) keep the comptime slicing path in tryToCallWithIndexTrait").
+  // The rewrite proceeds ONLY for a receiver with no value or an unknown one
+  // — i.e. a genuinely runtime receiver.
+  //
+  // Unported until now, and it is what made tests/index.test.yo HOLLOW:
+  // `x :: "Hello World"; x(0 .. 5)` matched `str`'s `slice_copy` (measured:
+  // 1 method for recv=comptime_str), so the comptime string slice was
+  // rewritten into a RUNTIME `x.slice_copy(0 .. 5)` whose `Range(usize)`
+  // parameter then failed to unify with the `Range(comptime_int)` argument
+  // ("Cannot unify incompatible types") — one swallowed error that erased
+  // all 49 tests in the file's batch dispatch.
+  recv_has_comptime_slice_value := match(
+    recv_val,
+    .Some(rv) => (!(is_unknown_val(rv)) && !(is_type_val(rv))),
+    .None => false
+  );
+  recv_is_type_val := match(recv_val,.Some(rv2) => is_type_val(rv2),.None => false);
+  if(recv_is_type_val || recv_has_comptime_slice_value, {
     return(Option(AstExpr).None);
   });
   method_name := if(is_incl, String.from("slice_copy_inclusive"), String.from("slice_copy"));
@@ -5694,7 +5722,7 @@ Fix: wrap the call:
         // plans/archive/SLICE_REWORK.md Part C: range indexing on a runtime receiver
         // rewrites to slice_copy / slice_copy_inclusive method dispatch.
         match(
-          _try_rewrite_range_index_to_slice_copy(expr, func_expr, args, callee_ty, callee_env),
+          _try_rewrite_range_index_to_slice_copy(expr, func_expr, args, callee_ty, callee_value, callee_env),
           .Some(rewritten) => {
             return(recur(rewritten, env, t_unit(), Option(EvalValue).None, ctx, exn));
           },
@@ -6199,7 +6227,7 @@ Fix: wrap the call:
           // plans/archive/SLICE_REWORK.md Part C: range indexing on a runtime receiver
           // rewrites to slice_copy / slice_copy_inclusive method dispatch.
           match(
-            _try_rewrite_range_index_to_slice_copy(expr, func_expr, args, callee_ty_none, callee_env),
+            _try_rewrite_range_index_to_slice_copy(expr, func_expr, args, callee_ty_none, callee_value, callee_env),
             .Some(rewritten) => {
               return(recur(rewritten, env, t_unit(), Option(EvalValue).None, ctx, exn));
             },

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -86,7 +86,7 @@ open(import("std/fmt"));
   ArgEntry,
   VarArgEntry
 } :: import("../context.yo");
-{ is_pointer_type, is_type_hierarchy_type, is_comptime_string_type, is_comptime_int_type, is_comptime_float_type, is_some_type, is_array_type, is_function_type, is_function_type_generic, is_expr_list_type, is_fn_trait_type, is_unit_type, is_primitive_type, is_type_0 } :: import("../../types/guards.yo");
+{ is_pointer_type, is_type_hierarchy_type, is_comptime_string_type, is_comptime_int_type, is_comptime_float_type, is_some_type, is_array_type, is_function_type, is_function_type_generic, is_expr_list_type, is_comptime_list_type, is_fn_trait_type, is_unit_type, is_primitive_type, is_type_0 } :: import("../../types/guards.yo");
 { convert_comptime_type_to_runtime_type } :: import("../../types/env_lookup.yo");
 { are_types_compatible } :: import("../../types/compatibility.yo");
 { type_contains_some_type, type_contains_some_type_deep } :: import("../../types/utils.yo");
@@ -4046,12 +4046,22 @@ Fix: wrap the call:
         (fv_variadic_label : String) = String.from("...");
         (fv_variadic_ty : TypeValue) = t_unit();
         (fv_variadic_is_quote : bool) = false;
+        // A COMPTIME variadic (`...(comptime(name) : ComptimeList(T))`), the
+        // other named form. The side table registers only NAMED variadics —
+        // a bare `...` (C-extern) is skipped by `register_func_variadic_param`
+        // and `...(name)` is rejected at signature evaluation ("not supported
+        // yet", types/function.yo) — so a registered non-quote variadic is
+        // necessarily the comptime one. Mirrors the TS predicate
+        // `variadicParameter.isCompileTimeOnly &&
+        // isComptimeListType(variadicParameter.type)` (helper.ts:1834).
+        (fv_variadic_is_comptime : bool) = false;
         match(
           fv_variadic_entry_opt,
           .Some(vpe) => {
             fv_variadic_label = vpe.label;
             fv_variadic_ty = vpe.ty;
             fv_variadic_is_quote = is_expr_list_type(fv_variadic_ty.clone());
+            fv_variadic_is_comptime = (!(fv_variadic_is_quote) && is_comptime_list_type(fv_variadic_ty.clone()));
           },
           .None => ()
         );
@@ -4530,7 +4540,16 @@ Fix: wrap the call:
               }
             );
             _push_arg := evaled_arg_infos.push(arg_info);
-            rt_arg_is_ct := match(rt_ct_flags_args.get(ai),.Some(f) => f,.None => false);
+            // A COMPTIME variadic's trailing args (indices >= n_p) are not C
+            // arguments either — `rt_ct_flags_args` only covers the FIXED
+            // params, so without this they fell through the `.None => false`
+            // default and were spliced into the emitted call. TS pushes a
+            // variadic arg to `runtimeArgExprsInOrder` only when
+            // `!variadicParameter.isCompileTimeOnly` (helper.ts:1802).
+            rt_arg_is_ct := cond(
+              (fv_variadic_is_comptime && (ai >= n_p)) => true,
+              true => match(rt_ct_flags_args.get(ai),.Some(f) => f,.None => false)
+            );
             if(!(rt_arg_is_ct), {
               _push_rt := runtime_arg_exprs.push(evaled_arg);
             });
@@ -5074,6 +5093,51 @@ Fix: wrap the call:
             fv_variadic_label.clone(),
             fv_variadic_ty.clone(),
             Option(EvalValue).Some(EvalValue.ComptimeListVal(velems)),
+            true,
+            false,
+            false,
+            false,
+            tok
+          );
+        });
+        // Bind a COMPTIME VARIADIC parameter (`...(comptime(types) :
+        // ComptimeList(Type))`): gather the EVALUATED trailing args
+        // (regular-arg indices n_p..n_supplied_reg) into a `ComptimeList` and
+        // bind it under the variadic's name in `fresh_env` — the env this arm
+        // hands to `evaluate_comptime_fn_call` below as the callee env. The
+        // quote sibling above binds RAW AST; this one binds VALUES, matching
+        // TS's two branches (helper.ts:1810 vs :1834).
+        //
+        // Unported until now, and the whole of tests/variadic_comptime.test.yo
+        // rode on it: with the name unbound, EVERY call site threw
+        // `Variable "types" not found` from inside the body, the def-time
+        // swallow hid it, and the failed comptime_assert erased the batch's
+        // `__yo_user_main` — 10 tests reporting "passed" while running nothing
+        // (issues/handover-yo-self-hollow-files.md). The failure is at the CALL,
+        // not at the definition: the definition alone compiles clean, because
+        // the def-time body env DOES bind the variadic (function_type.yo:918).
+        if(fv_variadic_is_comptime, {
+          ct_velems := ArrayList(EvalValue).new();
+          (ct_vidx : usize) = n_p;
+          while(ct_vidx < n_supplied_reg, {
+            match(
+              evaled_arg_infos.get(ct_vidx),
+              .Some(ct_vinfo) => match(
+                ct_vinfo.value,
+                .Some(ct_vv) => {
+                  _ctvp := ct_velems.push(ct_vv);
+                },
+                .None => ()
+              ),
+              .None => ()
+            );
+            ct_vidx = (ct_vidx + usize(1));
+          });
+          _ctvbind := add_variable_to_env(
+            fresh_env,
+            fv_variadic_label.clone(),
+            fv_variadic_ty.clone(),
+            Option(EvalValue).Some(EvalValue.ComptimeListVal(ct_velems)),
             true,
             false,
             false,

--- a/yo-self/evaluator/calls/index_trait.yo
+++ b/yo-self/evaluator/calls/index_trait.yo
@@ -9,7 +9,6 @@
 //! For runtime values: looks up the index method and returns UnknownVal.
 //!
 //! Phase 3u simplifications:
-//!   - _check_range_type: uses struct name heuristic (no CTFE resolution)
 //!   - Custom type ComptimeIndex: dispatched via _try_comptime_custom_type_index
 //!   - has_index_impl: Array fast path + trait-field/registry method lookup
 pragma(Pragma.AllowUnsafe);
@@ -17,10 +16,10 @@ open(import("std/string"));
 { str_lit_unquote_bytes } :: import("../../utils.yo");
 { ArrayList } :: import("std/collections/array_list");
 { AstExpr, ast_expr_token, ast_expr_id, make_err_expr } :: import("../../expr.yo");
-{ Environment, get_receiver_methods_by_name_from_env, add_variable_to_env, synthetic_token } :: import("../../env.yo");
+{ Environment, get_receiver_methods_by_name_from_env, get_variables_from_env, add_variable_to_env, synthetic_token } :: import("../../env.yo");
 { TypeValue } :: import("../../types/definitions.yo");
-{ t_unit, t_ptr } :: import("../../types/creators.yo");
-{ is_array_type, is_pointer_type, is_trait_type } :: import("../../types/guards.yo");
+{ t_unit, t_ptr, t_usize, t_type } :: import("../../types/creators.yo");
+{ is_array_type, is_pointer_type, is_trait_type, is_struct_type, is_function_type } :: import("../../types/guards.yo");
 {
   EvalValue,
   is_array_val,
@@ -85,21 +84,198 @@ _str_quote :: (fn(s : String) -> String)(
 // ---------------------------------------------------------------------------
 // _check_range_type
 // ---------------------------------------------------------------------------
-/// Returns a `_RangeCheck` based on the struct type name heuristic.
-///   "RangeInclusive..." → { is_range: true,  is_inclusive: true  }
-///   "Range..."          → { is_range: true,  is_inclusive: false }
-///   other              → { is_range: false, is_inclusive: false }
-_check_range_type :: (fn(arg_type : TypeValue) -> _RangeCheck)(
+/// CTFE-call one candidate constructor with `usize`; a resolved struct type
+/// rides out via `out`. The swallowing handler is a capture-free `->` that
+/// unwinds UNIT — never the resolved type: `unwind(v)` memcpys `v` into the
+/// fixed 64-byte `__yo_unwind_value` buffer, and a `TypeValue` does not fit
+/// (same constraint as `_trial_eval_fn_body`, function_type.yo:239).
+_try_ctfe_range_ctor :: (
+  fn(
+    fn_ty : TypeValue,
+    fn_val : EvalValue,
+    env : Environment,
+    ctx : EvalContext,
+    out : ArrayList(TypeValue)
+  ) -> unit
+)({
+  local_exn := Exception(
+    throw : (
+      (_e) -> unwind(())
+    )
+  );
+  ct_args := ArrayList(ArgEntry).new();
+  ct_args.push(
+    ArgEntry(
+      value : Option(EvalValue).Some(EvalValue.TypeVal(t_usize())),
+      parameter_type : t_type(),
+      arg_type : t_type()
+    )
+  );
+  res := evaluate_comptime_fn_call(
+    Option(AstExpr).None,
+    fn_ty,
+    fn_val,
+    ArgValues(
+      forall_args : ArrayList(ArgEntry).new(),
+      args : ct_args,
+      implicit_args : Option(ArrayList(ArgEntry)).None,
+      variadic_args : ArrayList(VarArgEntry).new()
+    ),
+    env,
+    env,
+    ctx,
+    local_exn
+  );
   match(
-    arg_type,
-    .Struct({ name }) => {
-      is_incl := name.starts_with(`RangeInclusive`);
-      is_rng := (is_incl || name.starts_with(`Range`));
-      _RangeCheck(is_range : is_rng, is_inclusive : is_incl)
-    },
-    _ => _RangeCheck(is_range : false, is_inclusive : false)
+    res.value,
+    .TypeVal(rt) => if(is_struct_type(rt.clone()), {
+      out.push(rt);
+    }),
+    _ => ()
+  );
+});
+/// Resolve a prelude type constructor (`Range` / `RangeInclusive`) applied to
+/// `usize`, by looking the constructor up in `env` and CTFE-calling it.
+/// 1:1 port of `resolvePreludeTypeWithUsize` (index-trait.ts:663-711); the
+/// constructor call is run under a swallowing local exn, matching TS's
+/// `try { … } catch { return undefined }`.
+_resolve_prelude_range_type :: (
+  fn(name : String, env : Environment, ctx : EvalContext) -> Option(TypeValue)
+)({
+  vars := get_variables_from_env(env, name.clone());
+  out := ArrayList(TypeValue).new();
+  (vi : usize) = usize(0);
+  while((vi < vars.len()) && (out.len() == usize(0)), {
+    match(
+      vars.get(vi),
+      .Some(v) => match(
+        v.value.get(usize(0)),
+        .Some(fv) => if(is_func_val(fv) && is_function_type(v.ty), {
+          _try_ctfe_range_ctor(v.ty, fv, env, ctx, out);
+        }),
+        .None => ()
+      ),
+      .None => ()
+    );
+    vi = (vi + usize(1));
+  });
+  out.get(usize(0))
+});
+/// The type constructor a struct type came from (`""` when it was not built
+/// by one). See `_check_range_type`.
+_struct_ctor_fid :: (fn(t : TypeValue) -> String)(
+  match(
+    t,
+    .Struct({ constructor_func_id : cfid }) => cfid,
+    _ => String.from("")
   )
 );
+/// False when `a` and `b` are structs built by DIFFERENT type constructors —
+/// a nominal distinction `are_types_compatible` cannot make for two anonymous
+/// structs of the same shape. `""` on either side means "unknown", which
+/// defers to the structural check.
+_ctor_ids_agree :: (fn(a : TypeValue, b : TypeValue) -> bool)({
+  a_fid := _struct_ctor_fid(a);
+  b_fid := _struct_ctor_fid(b);
+  if((a_fid.len() > usize(0)) && (b_fid.len() > usize(0)), {
+    return(a_fid == b_fid);
+  });
+  true
+});
+/// Process-lifetime cache for `Range(usize)` / `RangeInclusive(usize)` —
+/// TS caches these in a WeakMap keyed on the first env frame
+/// (index-trait.ts:714-737). Both come from the prelude, which is shared by
+/// every module in a compilation, so a plain global is the same thing here.
+/// Only SUCCESSFUL resolutions are cached, so an early call against an env
+/// that cannot see the prelude does not poison later ones.
+(g_range_ty_cache : ArrayList(TypeValue)) = ArrayList(TypeValue).new();
+(g_range_incl_ty_cache : ArrayList(TypeValue)) = ArrayList(TypeValue).new();
+_cached_range_type :: (
+  fn(inclusive : bool, env : Environment, ctx : EvalContext) -> Option(TypeValue)
+)({
+  cache := if(inclusive, g_range_incl_ty_cache, g_range_ty_cache);
+  match(
+    cache.get(usize(0)),
+    .Some(hit) => Option(TypeValue).Some(hit),
+    .None => {
+      name := if(inclusive, String.from("RangeInclusive"), String.from("Range"));
+      resolved := _resolve_prelude_range_type(name, env, ctx);
+      match(
+        resolved,
+        .Some(rt) => {
+          cache.push(rt.clone());
+          Option(TypeValue).Some(rt)
+        },
+        .None => Option(TypeValue).None
+      )
+    }
+  )
+});
+/// Is `arg_type` a `Range(...)` / `RangeInclusive(...)`?
+///
+/// 1:1 port of `checkRangeType` (index-trait.ts:745-775): resolve the prelude
+/// constructors applied to `usize` and ask `are_types_compatible`. The
+/// previous implementation matched on the struct's NAME (`starts_with("Range")`),
+/// a Phase-3u shortcut that never fired — `Range :: (fn(comptime(T) : Type) ->
+/// comptime(Type))(struct(start : T, end : T))` yields an ANONYMOUS struct, so
+/// the name is empty and every range was reported as a non-range. Comptime
+/// STRING slicing is the one caller that needs a `true` here (the array caller
+/// only uses it to fall through to the runtime path, which is also what a
+/// wrong `false` did), so `x(0 .. 5)` on a `comptime_str` took the
+/// single-character branch — one swallowed error that hollowed all 49 tests
+/// in tests/index.test.yo.
+_check_range_type :: (
+  fn(arg_type : TypeValue, env : Environment, ctx : EvalContext) -> _RangeCheck
+)({
+  if(!(is_struct_type(arg_type.clone())), {
+    return(_RangeCheck(is_range : false, is_inclusive : false));
+  });
+  // The TYPE CONSTRUCTOR's id is the discriminator, not the shape.
+  // `Range` and `RangeInclusive` are BOTH `struct(start : T, end : T)` and
+  // both anonymous, so `are_types_compatible` says yes to either — with
+  // the inclusive test first (TS's order), every exclusive `a .. b` was
+  // read as INCLUSIVE and `"Hello World"(0 .. 5)` sliced one byte too far.
+  // TS distinguishes them nominally; yo-self's equivalent is
+  // `Struct.constructor_func_id`, stamped by `evaluate_comptime_fn_call`
+  // on every comptime type-constructor result — and shared by all of one
+  // constructor's instantiations, so the `Range(comptime_int)` argument
+  // matches the `Range(usize)` probe. `are_types_compatible` stays as the
+  // fallback for a struct that carries no constructor id.
+  arg_fid := _struct_ctor_fid(arg_type.clone());
+  ri_opt := _cached_range_type(true, env, ctx);
+  r_opt := _cached_range_type(false, env, ctx);
+  if(arg_fid.len() > usize(0), {
+    match(
+      ri_opt,
+      .Some(ri_ty) => if(_struct_ctor_fid(ri_ty) == arg_fid, {
+        return(_RangeCheck(is_range : true, is_inclusive : true));
+      }),
+      .None => ()
+    );
+    match(
+      r_opt,
+      .Some(r_ty) => if(_struct_ctor_fid(r_ty) == arg_fid, {
+        return(_RangeCheck(is_range : true, is_inclusive : false));
+      }),
+      .None => ()
+    );
+  });
+  match(
+    ri_opt,
+    .Some(ri_ty2) => if(are_types_compatible(arg_type.clone(), ri_ty2), {
+      return(_RangeCheck(is_range : true, is_inclusive : true));
+    }),
+    .None => ()
+  );
+  match(
+    r_opt,
+    .Some(r_ty2) => if(are_types_compatible(arg_type.clone(), r_ty2), {
+      return(_RangeCheck(is_range : true, is_inclusive : false));
+    }),
+    .None => ()
+  );
+  _RangeCheck(is_range : false, is_inclusive : false)
+});
 // ---------------------------------------------------------------------------
 // _extract_range_indices
 // ---------------------------------------------------------------------------
@@ -533,7 +709,7 @@ _try_comptime_array_index :: (
   caller_env := info.env;
   arg_type := info.ty;
   arg_val := info.value;
-  rc := _check_range_type(arg_type);
+  rc := _check_range_type(arg_type, env, ctx);
   if(rc.is_range, {
     // Range slicing is no longer a comptime operation — fall through to the
     // runtime path (slice_copy rewriting happens before Index dispatch;
@@ -744,7 +920,7 @@ _try_comptime_string_index :: (
   );
   caller_env := info.env;
   arg_type := info.ty;
-  rc := _check_range_type(arg_type);
+  rc := _check_range_type(arg_type, env, ctx);
   result_val := _compute_comptime_string_index(
     str_value,
     arg_val,
@@ -878,7 +1054,16 @@ _find_comptime_index_method :: (
                       // (index-trait.ts:404-406), but ITS first position is `expected` and
                       // its second is `given` — the opposite order from yo-self's, so a
                       // faithful port must swap.
-                      p1_compatible := are_types_compatible(arg_type, p1);
+                      // Range vs RangeInclusive are BOTH `struct(start : T, end : T)` and
+                      // both anonymous, so `are_types_compatible` accepts either for either
+                      // and the FIRST registered impl won: `l(usize(1) ..= usize(3))` on a
+                      // ComptimeList picked prelude's `ComptimeIndex(Range(usize))` (declared
+                      // first) and sliced EXCLUSIVELY — 2 elements where 3 were asserted.
+                      // Discriminate by the type CONSTRUCTOR (see `_check_range_type`):
+                      // two structs built by DIFFERENT constructors are different types,
+                      // while `Range(comptime_int)` and `Range(usize)` share one and stay
+                      // compatible. Only fires when both sides carry a constructor id.
+                      p1_compatible := (_ctor_ids_agree(arg_type, p1) && are_types_compatible(arg_type, p1));
                       ret_is_ptr := is_pointer_type(ci_result);
                       if(((p0_is_ptr || p0_is_ref) && p1_compatible) && ret_is_ptr, {
                         // Comptime-parameter gate (TS index-trait.ts:414).

--- a/yo-self/evaluator/exprs/begin.yo
+++ b/yo-self/evaluator/exprs/begin.yo
@@ -1064,7 +1064,7 @@ _optimize_dup_drop_pairs :: (
   // macOS malloc tolerates (hence "passes locally, fails on Linux CI").
   // `_schedule_scope_end_drops` already reverses explicitly (see below); the
   // optimizer was never brought in line.
-  // See issues/yo-self-hollow-language-test-files.md.
+  // See issues/fixed/yo-self-hollow-language-test-files.md.
   (vi : usize) = fvars.len();
   while(vi > usize(0), {
     vi = (vi - usize(1));

--- a/yo-self/expr_info.yo
+++ b/yo-self/expr_info.yo
@@ -894,8 +894,48 @@ _mg_canon :: (fn(module_path : String) -> String)({
 });
 /// Record that module `module_path` declared the module-level runtime
 /// global `name`.
+/// Rollback support for `comptime_expect_error`. A module-level binding
+/// inside a REJECTED `comptime_expect_error(...)` still reaches
+/// `register_module_level_global` before the expected error is raised, and
+/// the entry outlived the rejection: codegen then module-qualified every
+/// LATER local of that name while its declaration stayed unqualified —
+/// `cee(begin(x := i32(0), (p : *(i32)) = &(x), ()))` made a later
+/// `x := i32(1)` emit `int32_t x = 1;` and read `x_m<hash>`, an undeclared
+/// identifier (tests/safe_code_structural_gates.test.yo).
+///
+/// Recording is a mark/rollback pair over an append-only key list, the same
+/// shape as `branch_group_stack_len` / `truncate_branch_group_stack`, so
+/// nested `comptime_expect_error`s nest correctly. Only keys this recording
+/// window ADDED are rolled back; a name already registered stays.
+(g_mg_recording_depth : usize) = usize(0);
+(g_mg_recorded_keys : ArrayList(String)) = ArrayList(String).new();
+module_global_recording_mark :: (fn() -> usize)({
+  g_mg_recording_depth = (g_mg_recording_depth + usize(1));
+  g_mg_recorded_keys.len()
+});
+rollback_module_level_globals_to :: (fn(mark : usize) -> unit)({
+  while(g_mg_recorded_keys.len() > mark, {
+    match(
+      g_mg_recorded_keys.get(g_mg_recorded_keys.len() - usize(1)),
+      .Some(k) => {
+        g_module_level_globals.remove(k);
+        ()
+      },
+      .None => ()
+    );
+    g_mg_recorded_keys.pop();
+    ()
+  });
+  if(g_mg_recording_depth > usize(0), {
+    g_mg_recording_depth = (g_mg_recording_depth - usize(1));
+  });
+});
 register_module_level_global :: (fn(module_path : String, name : String) -> unit)({
-  g_module_level_globals.set(`${_mg_canon(module_path)}|#|${name}`, true);
+  mg_key := `${_mg_canon(module_path)}|#|${name}`;
+  if((g_mg_recording_depth > usize(0)) && g_module_level_globals.get(mg_key.clone()).is_none(), {
+    g_mg_recorded_keys.push(mg_key.clone());
+  });
+  g_module_level_globals.set(mg_key, true);
   ()
 });
 /// True if module `module_path` declared the module-level runtime global
@@ -1376,6 +1416,7 @@ export(record_io_builtin_struct_field, lookup_io_builtin_struct_field, record_io
 export(record_method_callee_value, lookup_method_callee_value);
 export(register_extern_c_global, is_extern_c_global, get_extern_c_global_type);
 export(register_module_level_global, is_module_level_global, module_global_c_suffix);
+export(module_global_recording_mark, rollback_module_level_globals_to);
 export(register_some_resolved_concrete, lookup_some_resolved_concrete, unregister_some_resolved_concrete);
 export(
   register_struct_ctor_fid,

--- a/yo-self/main.yo
+++ b/yo-self/main.yo
@@ -1599,7 +1599,7 @@ run_test :: (
       // and died with "bracket nesting level exceeded maximum of 256". TS never
       // hit it because it was already batching — its emit for the same file
       // peaks at depth 105 across 3 batches.
-      // See issues/yo-self-hollow-language-test-files.md.
+      // See issues/fixed/yo-self-hollow-language-test-files.md.
       (batch_start : usize) = usize(0);
       (bi : usize) = usize(0);
       while((batch_start < tests.len()) && !(bailed), {


### PR DESCRIPTION
Fixes the last hard blocker in [`plans/PRE_P1_HANDOVER.md`](plans/PRE_P1_HANDOVER.md): the 3 HOLLOW language test files — 60 tests reporting success while running **no assertions at all**.

**The full-corpus sweep now scores 188/188 GREEN with an EMPTY allowlist**, so the ratchet demands a clean corpus rather than freezing known debt.

## They were five bugs, not three

Each was hidden behind the next, because one swallowed error erases a batch's entire `__yo_user_main` dispatch.

| # | Where | Bug |
| --- | --- | --- |
| 1 | `calls/function.yo` | A **comptime variadic** (`...(comptime(t) : ComptimeList(T))`) was never bound into the CALLEE env. The `quote` sibling (`array_list`/`hash_map` macros) was; the comptime one had **no branch at all**, so every call ran the body with the name unbound. Ports TS `helper.ts:1834-1858`. |
| 2 | `calls/function.yo` | The `slice_copy` rewrite fired on **comptime receivers**. TS guards it (`function.ts:815-823`, "Comptime-valued receivers keep the comptime slicing path"); yo-self checked only `is_function_type`, so `comptime_str` matched `str`'s runtime `slice_copy` and its `Range(usize)` parameter could not unify with the `Range(comptime_int)` argument. |
| 3 | `calls/index_trait.yo` | `_check_range_type` matched on a struct **NAME** — a Phase-3u shortcut that could never fire, since `Range` is a comptime constructor returning an ANONYMOUS struct. Replaced with the real port of TS `checkRangeType` (resolve `Range(usize)`/`RangeInclusive(usize)` by CTFE and compare). |
| 4 | `calls/index_trait.yo` | `Range` and `RangeInclusive` are **both** `struct(start : T, end : T)` and both anonymous, so type compatibility cannot separate them: every `..` read as `..=`, and `l(usize(1) ..= usize(3))` on a ComptimeList picked prelude's `ComptimeIndex(Range(usize))` (declared first) and sliced 2 elements where 3 were asserted. Discriminated by `Struct.constructor_func_id` — yo-self's stand-in for TS's nominal identity, shared across one constructor's instantiations — with the structural check kept as fallback. |
| 5 | `builtins/comptime_expect_error.yo`, `expr_info.yo` | The cee restore snapshotted only the frame **DEPTH**, and an expected throw can unwind past a `pop_frame` — measured **3 frames in, 2 out, and the lost one was the MODULE frame**. It could pop but never re-push, so every module binding made before the `comptime_expect_error` vanished (`Variable "assert" not found` from a later `test(...)` arm). Separately, a REJECTED module-level binding still registered its name as a module-level global, so codegen module-qualified every later local of that name while its declaration stayed unqualified (`int32_t x = 1;` declared, `x_m<hash>` read). |

## The method note worth keeping

Four earlier attempts (recorded in the handover brief) all failed because its failure chain was **wrong at step 1**, in a way that looked certain: the error's token pointed at the function's DEFINITION line, so def-time body evaluation was blamed. **A token inside a body says nothing about who evaluated that body.** Compiling the definition *alone* (clean) versus definition + one call (fails) settles it in a single compile — cheaper than the four speculative fixes, and cheaper than the instrumented build that followed them.

## Validation — `hollow=0` is not proof, so it was not used as proof

The bar the handover sets is an injected `assert(i32(1) == i32(2))`, because one earlier attempt reached `hollow=0` while the bodies still ran nothing.

| check | before | after |
| --- | --- | --- |
| `index.test.yo` probe | **49 passed** (assert never ran) | **48 passed, 1 failed** |
| `safe_code_structural_gates.test.yo` probe | **1 passed** | **1 failed** |
| `variadic_comptime.test.yo` probe | **10 passed** | **9 passed, 1 failed** |

All on the **final tree's** binary:

- `hollow_sweep69.sh` — **188/188 GREEN**, allowlisted known-failing **0**, `SWEEP_GATE_OK`; the three files report `hollow=0 markers=0`
- `gates_fast.sh` — **failures=0** (repros, 23-file battery all `hollow=0`, corpus diff-test, `check ./std` 153/153, `check ./yo-self` 238/238)
- `fixpoint_only.sh` — **FIXPOINT_HOLDS**, stage-2 `hollow=0`

`src/` is untouched, so the TypeScript suite cannot regress; `tests/internal` runs in CI.

## One assumption worth knowing

The `Range(usize)`/`RangeInclusive(usize)` probe is cached in a process-lifetime global (TS uses a WeakMap keyed on `env.frames[0]`). That is sound because a compile evaluates the prelude once — the invariant `run_compile` already documents and enforces by compiling each test batch in a **child process**. If a second in-process compile is ever reintroduced, that cache needs the same treatment as `clear_module_cache()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
