### PR TITLE
ctl ABI: cast generic-ResumeType handler calls to the callee's real return type

### DIFF
--- a/issues/ctl-handler-void-signature-vs-sret-cast.md
+++ b/issues/ctl-handler-void-signature-vs-sret-cast.md
@@ -169,6 +169,45 @@ in `__yo_user_main` — the "yo-self: error: …" path. That is the outermost ha
 one a throw reaches whenever no nearer handler catches it, which makes the dangerous
 pairing ordinary rather than exotic.
 
+### MEASURED 2026-08-08 (round 2): the dynamic check, run
+
+The check the section below proposes has now been run, and it answers the open
+question. Method — take the stage-2 self-emit, build it with `-fsanitize=function`
+(works on macOS arm64; the CAST types it reports live in the C and so transfer to
+x86_64), and drive real error paths through it:
+
+```bash
+clang -std=c11 -fno-strict-aliasing -fwrapv -w -O1 -fsanitize=function \
+      /tmp/<P>_stage2.c -o /tmp/ubsan_s2
+YO_MAIN_STACK_MB=4096 /tmp/ubsan_s2 compile <file-with-a-real-error>.yo \
+      --emit-c --skip-c-compiler -o /tmp/x 2>&1 | grep "incorrect function type"
+```
+
+Findings across `check` and `compile` runs over several error shapes (including a
+parse error, which reaches the top-level "yo-self: error:" printer):
+
+1. **The `err`-reading handler IS reached through a mismatched call.** The parse-error
+   run flags `fn_yo_id_820940` — one of the 3 handlers that dereference `err` — called
+   through `struct __yo_t135_struct (*)(__yo_t852)`.
+2. **But every EXECUTED by-value throw cast is ≤ 16 bytes.** `__yo_t135` is the only
+   by-value struct return reached in any run, and `_Static_assert(sizeof(...) <= 16)`
+   passes for it. Every other flagged `exn.throw` cast returns a POINTER (8 bytes).
+   So all of them are REGISTER class: no hidden sret pointer, `err` is not displaced,
+   and the garbage return value is never read because the handler unwinds.
+
+**That reconciles the tension.** Today's green x86_64 suite is not luck about which
+handler wins — the `err`-reading top-level printer really is reached — it is that the
+error paths actually exercised sit at register-class sites. The 95 >16-byte sites are
+present in the emitted C but were not on any exercised error path here.
+
+**What this does NOT establish:** that no >16-byte site is reachable. The exercise
+covered a handful of error shapes, not the corpus. The pairing stays one refactor
+away — any handler that formats or inspects an error in a value position whose
+surrounding type exceeds 16 bytes moves a live site into the dangerous shape — so
+this is **still a real bug to fix, just not one that is firing today**. It is
+schedulable rather than urgent, and the TS-referee expiry at P2 remains the reason
+to do it before then.
+
 **Still not proven**, and it needs a dynamic check rather than more grepping: whether a
 throw at one of the 95 large-`ResumeType` sites actually reaches THIS handler rather than
 a nearer one. Two facts sit in tension and should be reconciled before the ABI work is

--- a/issues/fixed/ctl-handler-void-signature-vs-sret-cast.md
+++ b/issues/fixed/ctl-handler-void-signature-vs-sret-cast.md
@@ -1,5 +1,28 @@
 # `ctl` handlers are emitted `void` but called through value-returning casts (x86_64 ABI break)
 
+> **FIXED 2026-08-09.** Both compilers now cast a generic-`ResumeType` `ctl` call to
+> the CALLEE's real return type and use the zero-init-temp protocol, so the caller and
+> callee agree and no hidden sret pointer can displace `err`. TS emits handlers `void`
+> and casts `void`; yo-self emits `void*` and casts `void*`.
+>
+> Measured after the fix: **1037/1037** `exn.throw` casts in the TS emit and
+> **1036/1036** in yo-self's self-emit are now the callee's real type (before: 140
+> non-void, 95 of them >16-byte MEMORY class).
+>
+> The two repros this doc called "not yet built" are checked in —
+> `issues/repros/ctl-large-resume-type-sret.yo` (a 32-byte ResumeType thrown in value
+> position, handler derefs `err.vtable`; `-fsanitize=function` flags it before the fix,
+> clean after) and `issues/repros/ctl-large-resume-type-sret-abi-demo.c` (the same shape
+> in freestanding C; cross-compiled to x86_64 the call site emits
+> `leaq -40(%rbp), %rdi`, demonstrating the displacement).
+>
+> Validation: TS suite 2685/2685 · `gates_fast` failures=0 · FIXPOINT_HOLDS ·
+> full-corpus sweep 188/188 GREEN.
+>
+> **The guard is NOT yet enabled.** `-fsanitize=function` on test binaries is the
+> follow-up this doc recommends, and it should now be possible — that is deliberately
+> left as its own change so any fallout is separable.
+
 **Found 2026-08-06** while root-causing
 `issues/fixed/escape-path-drops-unwound-call-result-temp.md`.
 

--- a/issues/repros/ctl-large-resume-type-sret-abi-demo.c
+++ b/issues/repros/ctl-large-resume-type-sret-abi-demo.c
@@ -1,0 +1,8 @@
+typedef struct { void* data; void* vtable; } dyn_t;      /* 16B: REGISTER */
+typedef struct { long a, b, c, d; } Big;                 /* 32B: MEMORY  */
+typedef Big (*big_fn)(dyn_t);
+/* the real callee, as codegen emits it */
+void handler(dyn_t err);
+/* the call site, as codegen emits it: cast the void* slot to a
+   value-returning fn type */
+void call_site(void* slot, dyn_t err) { Big r = ((big_fn)slot)(err); (void)r; }

--- a/issues/repros/ctl-large-resume-type-sret.yo
+++ b/issues/repros/ctl-large-resume-type-sret.yo
@@ -1,6 +1,6 @@
 // Repro: a `ctl` whose ResumeType is a >16-byte struct (MEMORY class on
 // x86_64 SysV), thrown in VALUE position, with a handler that READS `err`.
-// See issues/ctl-handler-void-signature-vs-sret-cast.md.
+// See issues/fixed/ctl-handler-void-signature-vs-sret-cast.md.
 { Exception } :: import("std/error");
 open(import("std/fmt"));
 Big :: struct(a : i64, b : i64, c : i64, d : i64);

--- a/issues/repros/ctl-large-resume-type-sret.yo
+++ b/issues/repros/ctl-large-resume-type-sret.yo
@@ -1,0 +1,27 @@
+// Repro: a `ctl` whose ResumeType is a >16-byte struct (MEMORY class on
+// x86_64 SysV), thrown in VALUE position, with a handler that READS `err`.
+// See issues/ctl-handler-void-signature-vs-sret-cast.md.
+{ Exception } :: import("std/error");
+open(import("std/fmt"));
+Big :: struct(a : i64, b : i64, c : i64, d : i64);
+make_big :: (fn(flag : bool, exn : Exception) -> Big)(
+  cond(
+    flag => exn.throw(dyn(`boom`)),
+    true => Big(a : i64(1), b : i64(2), c : i64(3), d : i64(4))
+  )
+);
+main :: (fn() -> unit)({
+  exn := Exception(
+    throw : (
+      (err) -> {
+        println(`Error: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  ok := make_big(false, exn);
+  println(`ok.a=${ok.a}`);
+  bad := make_big(true, exn);
+  println(`unreachable ${bad.a}`);
+});
+export(main);

--- a/plans/PRE_P1_HANDOVER.md
+++ b/plans/PRE_P1_HANDOVER.md
@@ -142,9 +142,9 @@ Revert, if ever needed: `gh api -X PUT repos/shd101wyy/Yo/rulesets/13548862 --in
 
 ---
 
-## 3. Decide consciously — the `ctl` ABI issue
+## 3. ~~Decide consciously — the `ctl` ABI issue~~ — FIXED 2026-08-09
 
-[`issues/ctl-handler-void-signature-vs-sret-cast.md`](../issues/ctl-handler-void-signature-vs-sret-cast.md)
+[`issues/fixed/ctl-handler-void-signature-vs-sret-cast.md`](../issues/fixed/ctl-handler-void-signature-vs-sret-cast.md)
 
 Filed as _latent_ on the premise that no reachable `ctl` has a `ResumeType` over
 16 bytes. **Measurement refuted that premise**, in yo-self's own emitted C:
@@ -166,10 +166,15 @@ printer, which a throw reaches whenever no nearer handler catches it.
 Today's green suite therefore rests on an **accidental pairing**, not on anything
 the compiler enforces.
 
-**Not a P1 blocker** — P1 is CLI parity. But it needs the TS referee, and P2
-retires that. One cheap check remains: build x86_64 with `-fsanitize=function` and
-run `check` over a deliberately broken file; that flags the mismatched call
-directly, without needing a static argument about which handler wins.
+**Resolved rather than decided.** The cheap check was run (`-fsanitize=function`,
+which works on arm64 — only the consequences are x86_64-specific) and answered the
+open question: the `err`-reading top-level handler IS reached through a mismatched
+call, but every EXECUTED by-value throw cast was <= 16 bytes, so the exercised paths
+sat in the register class. That downgraded it from urgent to schedulable — and it was
+then fixed rather than scheduled, in both compilers, with the >16-byte reproducer the
+issue had called "not yet built". All `exn.throw` casts now use the callee's real
+return type. Remaining follow-up: enable `-fsanitize=function` on test binaries as the
+standing guard, deliberately left as its own change.
 
 ---
 

--- a/plans/PRE_P1_HANDOVER.md
+++ b/plans/PRE_P1_HANDOVER.md
@@ -24,9 +24,12 @@ three; see [`issues/fixed/handover-yo-self-hollow-files.md`](../issues/fixed/han
 ruleset naming 4 (one of them a `test` context that no longer existed). Every gate
 below is now binding rather than advisory.
 
-**One thing to decide consciously, not by default**: the `ctl` ABI issue. It is
-no longer latent, and adjudicating it gets permanently harder once P2 retires the
-TypeScript reference compiler.
+~~3. One thing to decide consciously: the `ctl` ABI issue~~ — **DONE 2026-08-09.**
+Resolved rather than decided: the check §3 proposed was run, it downgraded the bug
+from urgent to schedulable, and it was then fixed in BOTH compilers with the
+
+> 16-byte reproducer the issue had called "not yet built". Follow-up left open on
+> purpose: enable `-fsanitize=function` as the standing guard.
 
 **Three corrections to P1's plan** — `build` is hollow rather than unwired, `doc`
 is ~3,800 lines short, and `module-manager.ts` has no counterpart at all.
@@ -42,6 +45,10 @@ is ~3,800 lines short, and `module-manager.ts` has no counterpart at all.
 | #82 | Both Linux-only RED files: test batching, and a dup/drop double free          |
 | #83 | Comptime markers checked before the ExprInfo lookup; HOLLOW root cause traced |
 | #84 | Handover brief for the HOLLOW files (docs)                                    |
+| #85 | This document                                                                 |
+| #86 | Recorded the repository-admin bypass on the `develop` ruleset                 |
+| #87 | **All 3 HOLLOW files fixed** — five bugs; allowlist now empty                 |
+| #88 | **`ctl` ABI fixed** in both compilers, with the >16-byte reproducer built     |
 
 Gates that now exist and pass:
 
@@ -116,13 +123,26 @@ Two notes for whoever maintains it:
 
   ```bash
   gh api repos/shd101wyy/Yo/rulesets/13548862 \
-    --jq '[.rules[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context]' \
-    | diff - <(gh api repos/shd101wyy/Yo/actions/runs/<recent-run-id>/jobs --paginate --jq '[.jobs[].name]|sort')
+    --jq '[.rules[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context]|sort|.[]' \
+    | diff - <(gh api repos/shd101wyy/Yo/actions/runs/<recent-run-id>/jobs --paginate --jq '[.jobs[].name]|sort|.[]')
   ```
+
+  **Re-run 2026-08-09 against PR #87's run: 15 required, 15 jobs, IN SYNC.**
+  (Note the `|.[]` — without it `diff` compares two single JSON blobs and reports
+  a difference for any ordering change, which reads as a false alarm.)
 
 - `strict_required_status_checks_policy` is `true`, so a PR must be up to date
   with `develop` to merge. With ~55 min CI that means re-running when someone
   lands ahead of you; flip it to `false` if that becomes a tax.
+
+- **Stacked PRs get NO CI** (learned 2026-08-09 on #88). `test.yml` triggers on
+  `pull_request: branches: [develop]`, so a PR based on another feature branch
+  runs nothing — and the green checkmark you are not seeing is not a failure, it
+  is an absence. When the parent merges, GitHub retargets the child to `develop`
+  but that fires `edited`, **not** `synchronize`, so still no run: you must push
+  the branch (a rebase onto `develop` does both — it triggers CI and clears the
+  `BEHIND` state that `strict` requires). Widening the trigger to `branches: ['**']`
+  would fix it at the cost of the full ~55 min matrix on every stacked PR.
 
 - **Repository admins can bypass** (`bypass_actors: [{RepositoryRole 5, always}]`),
   added deliberately the same day. It was `[]` at first, which meant _nobody_ —
@@ -185,11 +205,11 @@ PORTED as libraries … the work is CLI wiring + flag parity + differential
 validation."_ That is true for `init`, `fetch`, `install`, `cache`, `version`,
 `lock_file`, `pkg_config`. It is **false** in three places:
 
-| Subcommand              | Reality                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`build`**             | **Hollow, not unwired.** `_parse_registry_from_json` (`build_runner.yo:810-814`) returns an empty `BuildRegistry` regardless of input, and `evaluate_build_file` shells out to `yo-cli build --serialize-registry` — **a flag that does not exist in `src/`** (zero grep hits). `yo build` would build an empty DAG and exit 0. Upstream cause: yo-self's build builtins deliberately never populate the registry ("Registry population is deferred"), and there is no `get_build_registry`/`swap_build_registry` at all. |
-| **`doc`**               | **~3,800 lines unported.** `src/doc/builder.ts` (1564), `render-html.ts` (1883), `render-json.ts` (25) and `doc-command.ts` (352) have no yo-self counterpart, so the default `--format html` path cannot work.                                                                                                                                                                                                                                                                                                           |
-| **`module-manager.ts`** | **458 lines, no counterpart.** It is the shared "evaluate a `.yo` file and read its exports/registry" service that `build`, `fetch`, `install`, `doc`, `test-runner` and `codegen` all import. This is a prerequisite, not a subcommand.                                                                                                                                                                                                                                                                                  |
+| Subcommand              | Reality                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`build`**             | **Hollow, not unwired.** `_parse_registry_from_json` (`build_runner.yo:810-814`) returns an empty `BuildRegistry` regardless of input, and `evaluate_build_file` shells out to `yo-cli build --serialize-registry` — **a flag that does not exist in `src/`** (zero grep hits). `yo build` would build an empty DAG and exit 0. Upstream cause: yo-self's build builtins deliberately never populate the registry ("Registry population is deferred"), and there is no `get_build_registry`/`swap_build_registry` at all.                                                                                                                                                        |
+| **`doc`**               | **~3,800 lines unported — but the extraction half IS ported** (re-verified 2026-08-09; the original wording read as if `doc` were untouched). `yo-self/doc/` exists with 1,773 lines: `extractor.yo` (587), `render_markdown.yo` (800), `model.yo` (201), `sections.yo` (185). What is missing is the RENDER/DRIVE half — `src/doc/builder.ts` (1564), `render-html.ts` (1883), `render-json.ts` (25) and `doc-command.ts` (352) = 3,824 lines, none with a counterpart — so the default `--format html` path cannot work and the CLI is unwired (`doc` appears once in `main.yo`). Scope it as "port builder + html/json renderers + wire the CLI", not as a from-scratch port. |
+| **`module-manager.ts`** | **458 lines, no counterpart.** It is the shared "evaluate a `.yo` file and read its exports/registry" service that `build`, `fetch`, `install`, `doc`, `test-runner` and `codegen` all import. This is a prerequisite, not a subcommand.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 
 Two more scoping facts:
 
@@ -230,15 +250,44 @@ Two more scoping facts:
 
 ## 6. Known debt — tracked, not blocking
 
-- **`fmt` parity** — the self-hosted formatter disagrees with the reference on
-  **315 files** (down from 417 after one bug fix). Two rule classes remain: a space
-  before `)` and a space before `.`. This is P1-critical rather than cosmetic: at
-  P2 the self-hosted formatter becomes canonical and `fmt --check` becomes
-  self-referential, so the first `yo fmt` would silently restyle hundreds of files
-  with nothing able to notice. **Caveat that shapes the fix**: the TS formatter
-  _preserves_ existing line structure rather than canonicalizing, so a raw "would
-  format" count conflates real spacing bugs with benign line-breaking differences.
+- **`fmt` parity** — **re-measured 2026-08-09: 339 of 808 files diverge** (the
+  earlier "315, two rule classes remain" was both stale and too optimistic).
+  Method, reproducible in ~25 min — format a copy of every `std`/`tests`/`yo-self`
+  file with BOTH formatters and `cmp` the outputs:
+
+  ```bash
+  for f in $(find std tests yo-self -name '*.yo'); do
+    cp "$f" /tmp/a.yo; cp "$f" /tmp/b.yo
+    ./yo-cli fmt /tmp/a.yo >/dev/null; "$S1" fmt /tmp/b.yo >/dev/null
+    cmp -s /tmp/a.yo /tmp/b.yo || echo "$f"
+  done | wc -l
+  ```
+
+  Two corrections that change how this should be scoped:
+
+  1. **It is NOT two rule classes.** On a 250-file sample, 50 files diverge and only
+     **12 (24%) become identical once dot-spacing is normalized** — so roughly
+     three quarters of the diverging files carry at least one other difference.
+     Budget accordingly; "fix two spacing rules" will not close the gate.
+  2. **The dot class is the TS formatter's bug, not yo-self's** — the opposite of
+     what this section used to imply. Matched pairs: TS emits `self._ptr =.Some(x)`,
+     `_ptr :.Some(y)`, `.None =>.Err(z)`; **yo-self already emits the spaced form**
+     (`= .Some(x)`, `: .Some(y)`). Root cause is the Dot case calling
+     `trimTrailingHorizontalWhitespace()` and eating the space the preceding
+     Comma/operator case established with `ensureSpace()`. So this class closes by
+     fixing `src/formatter.ts`, and yo-self may need no change at all — see
+     [`plans/PREFIX_OPERATOR_OPERAND_RULE.md`](PREFIX_OPERATOR_OPERAND_RULE.md),
+     which diagnosed it independently.
+
+  Still P1-critical rather than cosmetic: at P2 the self-hosted formatter becomes
+  canonical and `fmt --check` becomes self-referential, so the first `yo fmt` would
+  silently restyle hundreds of files with nothing able to notice. **Caveat that
+  shapes the fix**: the TS formatter _preserves_ existing line structure rather than
+  canonicalizing, so a raw "would format" count conflates real spacing bugs with
+  benign line-breaking differences — which is why the measurement above compares
+  BOTH formatters' output on the same input instead of counting `--check` hits.
   [`issues/yo-self-formatter-diverges-from-ts.md`](../issues/yo-self-formatter-diverges-from-ts.md)
+
 - **Depth-8 RC cap** — `_type_contains_rc_inner` returns `false` past 8 levels
   where TS uses an unbounded visited set, so an object nested >8 aggregate levels
   deep is never torn down. **Blast radius on today's code is nil** (the marker fired
@@ -270,3 +319,21 @@ Two more scoping facts:
   at least these two distinct explanations.
 - Never run two heavy jobs at once on a 16 GB box; they swap and manufacture
   failures that do not reproduce in isolation.
+- **An error token inside a function body says nothing about WHO evaluated that
+  body.** It points there because that is where the body is; a CALL that executes
+  it reports the identical location. Split the reproducer — definition ALONE vs
+  definition + one call — before instrumenting. One compile each, and it decides
+  def-time vs call-time outright. This is what four failed attempts on the HOLLOW
+  files missed (§2.1).
+- **One swallowed error hides a STACK of bugs.** A hollow file's failing arm
+  erases the whole batch dispatch, so the next bug only surfaces once the previous
+  one is fixed — `index.test.yo` took three rounds. "Still fails after a correct
+  fix" is the expected intermediate state, not evidence the fix was wrong. Read
+  WHICH arm the new last swallowed error names; a different arm means progress.
+- **`-fsanitize=function` adjudicates ABI mismatches on arm64.** Only the
+  _consequences_ of a mismatched call are x86_64-specific — the cast types live in
+  the emitted C, so a local run answers "is this call really mismatched, and with
+  what return type?" without an x86_64 host. Pair it with
+  `_Static_assert(sizeof(T) <= 16, ...)` appended to the emitted C to size the
+  return decisively, and `clang --target=x86_64-... -S` on an 8-line freestanding
+  repro to _show_ the register displacement rather than argue it (§3).

--- a/src/codegen/exprs/other-fn-call.ts
+++ b/src/codegen/exprs/other-fn-call.ts
@@ -1664,7 +1664,35 @@ export function generateOtherFunctionCall(
           }
           // Dead code removed: using() call-site evidence resolution
           // Effects are now explicit regular params
-          const fnPtrCast = `((${returnTypeStr} (*)(${ptrParamTypeStrs.join(", ")}))${funcCode})`;
+          // ABI: a `ctl` whose ResumeType is GENERIC (`Exception.throw`'s
+          // `ctl(generic(ResumeType : Type), ...) -> ResumeType`) is emitted as a
+          // SINGLE `void`-returning C function — one handler serves every
+          // instantiation, so it cannot return a ResumeType it does not know, and
+          // `generation.ts` deliberately keeps SomeType → void for effect record
+          // members. But `expr.$.type` here is the INSTANTIATED type at this call
+          // site, so the cast said e.g. `Big (*)(dyn)` while the callee really is
+          // `void f(dyn)`.
+          //
+          // That is UB in C at any size, and on x86_64 SysV it CORRUPTS THE
+          // CALLEE'S ARGUMENT when the instantiated type is >16 bytes (MEMORY
+          // class): the caller passes a hidden sret pointer, which consumes RDI,
+          // displacing `err` to RSI/RDX — so a handler that reads `err.vtable`
+          // dispatches through the caller's stack slot. Demonstrated in
+          // issues/repros/ctl-large-resume-type-sret{.yo,-abi-demo.c}: the
+          // cross-compiled call site emits `leaq -40(%rbp), %rdi`.
+          //
+          // Cast to the callee's REAL return type and use the zero-init-temp
+          // protocol below. That is exactly what the evidence-parameter call path
+          // already does (`handlerReturnsVoid`, generateEvidenceCallSite) — the
+          // two protocols disagreeing is the bug. Note assigning a void call's
+          // "result" to a typed temp is itself UB and once crashed on WASM, hence
+          // the declare-then-call shape rather than a cast at the assignment.
+          // See issues/ctl-handler-void-signature-vs-sret-cast.md.
+          const calleeEmittedVoid =
+            isFunctionType(functionType) &&
+            functionType.isControl &&
+            isSomeType(functionType.return.type);
+          const fnPtrCast = `((${calleeEmittedVoid ? "void" : returnTypeStr} (*)(${ptrParamTypeStrs.join(", ")}))${funcCode})`;
 
           // Cast each runtime arg to its corresponding parameter type. This
           // avoids -Wincompatible-pointer-types errors from strict C compilers
@@ -1819,9 +1847,22 @@ export function generateOtherFunctionCall(
                 ) {
                   context.emitter.emitLine(`${indent}__yo_effect_escaped = 0;`);
                 }
-                context.emitter.emitLine(
-                  `${indent}${getTypeString(typeToUse, context)} ${tempVar} = ${fnPtrCast}(${castedArgsList});`
-                );
+                if (calleeEmittedVoid) {
+                  // Declare the temp BEFORE the call (escape-path drops may
+                  // reference it) and call as void. A generic-ResumeType handler
+                  // cannot resume with a value, so the zero-init IS the result.
+                  const voidTempType = getTypeString(typeToUse, context);
+                  context.emitter.emitLine(
+                    `${indent}${voidTempType} ${tempVar} = (${voidTempType}){0};`
+                  );
+                  context.emitter.emitLine(
+                    `${indent}${fnPtrCast}(${castedArgsList});`
+                  );
+                } else {
+                  context.emitter.emitLine(
+                    `${indent}${getTypeString(typeToUse, context)} ${tempVar} = ${fnPtrCast}(${castedArgsList});`
+                  );
+                }
                 context.declaredCVarNames?.add(tempVar);
               }
               storeTempVarToStateMachineIfNeeded(tempVar, indent, context);

--- a/src/codegen/exprs/other-fn-call.ts
+++ b/src/codegen/exprs/other-fn-call.ts
@@ -1687,7 +1687,7 @@ export function generateOtherFunctionCall(
           // two protocols disagreeing is the bug. Note assigning a void call's
           // "result" to a typed temp is itself UB and once crashed on WASM, hence
           // the declare-then-call shape rather than a cast at the assignment.
-          // See issues/ctl-handler-void-signature-vs-sret-cast.md.
+          // See issues/fixed/ctl-handler-void-signature-vs-sret-cast.md.
           const calleeEmittedVoid =
             isFunctionType(functionType) &&
             functionType.isControl &&

--- a/yo-self/codegen/exprs/other_fn_call.yo
+++ b/yo-self/codegen/exprs/other_fn_call.yo
@@ -1703,6 +1703,24 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
   // resolved_concrete from expected/enclosing-return). Prefer it: reading the
   // DECLARED result emitted `void*` fn-ptr casts/temps merge-assigned to
   // concrete locals (the IoError.check stage-2 family).
+  // A generic-ResumeType `ctl` (`Exception.throw`) is emitted as ONE
+  // `void*`-returning C function — one handler serves every instantiation, so
+  // it cannot return a ResumeType it does not know. The per-call resolution
+  // below is right for the TEMP's type but WRONG for the fn-pointer CAST: it
+  // made the cast claim the instantiated type while the callee is `void*`, and
+  // on x86_64 SysV an instantiated type over 16 bytes (MEMORY class) then
+  // displaces `err` out of RDI into the hidden sret slot — a handler that reads
+  // `err.vtable` dispatches through the caller's stack.
+  // See issues/ctl-handler-void-signature-vs-sret-cast.md and its two repros.
+  ctl_generic_ret := (
+    is_some_type(result_type) &&
+      match(function_type,.Func({ meta : __ctlm }) => __ctlm.*.is_control, _ => false)
+  );
+  ctl_callee_ret_str := if(
+    ctl_generic_ret,
+    get_type_string(result_type, context.base),
+    String.new()
+  );
   if(is_some_type(result_type) && !(is_unit_type(ei.ty)), {
     result_type = ei.ty;
   });
@@ -1875,7 +1893,13 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
         o2.push_str(")");
         arm_out = o2;
       }, {
-        ret_str := get_type_string(result_type, context.base);
+        // The CALLEE's real return type, not this call site's instantiation —
+        // see the ctl_generic_ret comment above.
+        ret_str := if(
+          ctl_generic_ret,
+          ctl_callee_ret_str.clone(),
+          get_type_string(result_type, context.base)
+        );
         cast := String.from("(");
         cast.push_string(ret_str);
         cast.push_str(" (*)(");
@@ -1959,16 +1983,26 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
         }
       );
       fpc := get_type_string(result_type, context.base);
-      fline := indent.clone();
-      fline.push_string(fpc);
-      fline.push_str(" ");
-      fline.push_string(fp_tv.clone());
-      fline.push_str(" = ");
-      fline.push_string(out.clone());
-      fline.push_str(";");
       // Clear __yo_effect_escaped before the indirect call
       em.emit_string_line(`${indent.clone()}__yo_effect_escaped = 0;`);
-      em.emit_string_line(fline);
+      if(ctl_generic_ret, {
+        // Declare the temp BEFORE the call — escape-path drops reference it —
+        // and call as a STATEMENT. A generic-ResumeType handler cannot resume
+        // with a value, so the zero-init IS the result. Assigning a
+        // differently-typed call's result to it would reintroduce the very
+        // mismatch this guards against.
+        em.emit_string_line(`${indent.clone()}${fpc.clone()} ${fp_tv.clone()} = (${fpc.clone()}){0};`);
+        em.emit_string_line(`${indent.clone()}${out.clone()};`);
+      }, {
+        fline := indent.clone();
+        fline.push_string(fpc);
+        fline.push_str(" ");
+        fline.push_string(fp_tv.clone());
+        fline.push_str(" = ");
+        fline.push_string(out.clone());
+        fline.push_str(";");
+        em.emit_string_line(fline);
+      });
     });
     generate_deferred_drop_expressions(expr, indent.clone(), context, true);
     emit_effect_unwind_check(indent.clone(), context, ou_is_install, expr);

--- a/yo-self/codegen/exprs/other_fn_call.yo
+++ b/yo-self/codegen/exprs/other_fn_call.yo
@@ -1711,7 +1711,7 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
   // on x86_64 SysV an instantiated type over 16 bytes (MEMORY class) then
   // displaces `err` out of RDI into the hidden sret slot — a handler that reads
   // `err.vtable` dispatches through the caller's stack.
-  // See issues/ctl-handler-void-signature-vs-sret-cast.md and its two repros.
+  // See issues/fixed/ctl-handler-void-signature-vs-sret-cast.md and its two repros.
   ctl_generic_ret := (
     is_some_type(result_type) &&
       match(function_type,.Func({ meta : __ctlm }) => __ctlm.*.is_control, _ => false)


### PR DESCRIPTION
**Stacked on #87** — base is `fix/yo-self-hollow-files`, so review that one first. Only the last four commits belong to this PR.

Fixes [`issues/ctl-handler-void-signature-vs-sret-cast.md`](issues/fixed/ctl-handler-void-signature-vs-sret-cast.md), the item [`plans/PRE_P1_HANDOVER.md`](plans/PRE_P1_HANDOVER.md) §3 left as *"decide consciously, not by default"*. It is now resolved rather than decided.

## First, the measurement the issue was waiting on

The open question was whether a throw at one of the 95 >16-byte `ResumeType` sites actually reaches one of the 3 handlers that **dereference `err`**, or whether nearer handlers always win. Grepping couldn't answer it; `-fsanitize=function` can, and works on macOS arm64 (only the *consequences* are x86_64-specific — the cast types live in the C).

- **The `err`-reading handler IS reached through a mismatched call.** A parse error, which routes to the top-level `yo-self: error:` printer, flags `fn_yo_id_820940` called through `struct __yo_t135_struct (*)(__yo_t852)`.
- **But every EXECUTED by-value throw cast was ≤ 16 bytes** — register class, so `err` is never displaced and the garbage return is never read.

That reconciles the doc's tension: today's green suite isn't luck about *which handler wins*; it's that the exercised error paths sit in the register class. Which downgraded this from urgent to schedulable — and then it was cheap enough to just fix.

## The bug

A `ctl` with a **generic** ResumeType — `Exception.throw`'s `ctl(generic(ResumeType : Type), err : AnyError) -> ResumeType` — is emitted as **one** `void`-returning C function: a single handler serves every instantiation, so it cannot return a ResumeType it doesn't know. But the fn-pointer call path built its cast from `expr.$.type`, the **instantiated** type at that call site.

UB at any size; on x86_64 SysV it **corrupts the callee's argument** once the instantiated type exceeds 16 bytes: the hidden sret pointer consumes RDI and displaces `err` to RSI/RDX.

## Two reproducers — the issue called this one "not yet built"

- `issues/repros/ctl-large-resume-type-sret.yo` — 32-byte ResumeType thrown in value position, handler **does** deref `err.vtable->to_string`. UBSan flags it before, clean after.
- `issues/repros/ctl-large-resume-type-sret-abi-demo.c` — same shape in 8 lines of freestanding C. Cross-compiled with `--target=x86_64-unknown-linux-gnu`, the call site emits **`leaq -40(%rbp), %rdi`** — the displacement demonstrated, not argued.

## The fix

Cast to the callee's **real** return type and use the zero-init-temp protocol: declare the temp before the call (escape-path drops reference it), call as a statement, check `__yo_effect_escaped`. That is exactly what the evidence-parameter path already did (`handlerReturnsVoid`) — **the two protocols disagreeing is the bug**, as the issue's implementation notes suspected. Assigning a void call's "result" to a typed temp is itself UB and once crashed on WASM, hence declare-then-call.

Mirrored in yo-self, which has the same mismatch from the other side (it emits these handlers `void*`). Both compilers are now internally consistent: TS `void`/`void`, yo-self `void*`/`void*` — both register class.

| | before | after |
| --- | --- | --- |
| `exn.throw` casts, TS emit of yo-self | 140 non-void, **95 >16-byte MEMORY class** | **1037/1037 `void`** |
| `exn.throw` casts, yo-self self-emit | same mismatch, `void*` handlers | **1036/1036 `void*`** |

## Validation

- TS language suite — **2685/2685 passed**
- `gates_fast.sh` — **failures=0** (repros, 23-file battery all `hollow=0`, corpus diff-test, `check ./std` 153/153, `check ./yo-self` 238/238)
- `fixpoint_only.sh` — **FIXPOINT_HOLDS**, stage-2 `hollow=0`
- `hollow_sweep69.sh` — **188/188 GREEN**, allowlist empty
- The repro is UBSan-clean after the fix and still prints correct output

## Deliberately not included

Enabling `-fsanitize=function` on test binaries as the standing guard. The issue recommends it *after* the signatures are fixed (before, it fails the suite wholesale) — kept as its own change so any fallout is separable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
