### PR TITLE
Fix five async-codegen miscompiles from the await-position matrix (two of them silent)

### DIFF
--- a/issues/await-in-branch-positions-matrix.md
+++ b/issues/await-in-branch-positions-matrix.md
@@ -163,6 +163,35 @@ incr/decr counts against the TS emit before believing any green.
 inputs by value (`future_lt` in `tests/async_await.test.yo`) rather than an
 inline closure capturing a mutable local.
 
+### Two `io.async` closures capturing the same local — TS emits invalid C
+
+**Reference compiler only; the self-hosted one is correct here.**
+
+```rust
+task := io.async((io : Io) => {
+  n := Box(i32)(5);
+  a := io.await(io.async((io2 : Io) => { io2.await(yield(io2), io2); return(n.*); }), io);
+  b := io.await(io.async((io2 : Io) => { io2.await(yield(io2), io2); return(n.* * i32(2)); }), io);
+  return(a + b);
+});
+```
+
+SELF: `r=15`. TS:
+
+```
+error: used type '__yo_struct_..._id_28' where arithmetic or pointer type is required
+  fn_..._id_40___drop((__yo_struct_..._id_28)(sm->await_future_1));
+```
+
+The scope-end drops try to drop each inline closure's CAPTURE STRUCT, but apply
+it to `sm->await_future_N` — a state machine POINTER — cast to the capture
+struct by value. Casting a pointer to a struct-by-value is not legal C.
+
+Looks like the `awaitFutureTempVarAliases` path: the temp holding the future is
+aliased to `await_future_N`, and a deferred drop on that temp resolves to the
+wrong type. Found 2026-08-09 while adding capture regression tests; loud, so not
+dangerous.
+
 ---
 
 ## Reproducing

--- a/issues/await-in-branch-positions-matrix.md
+++ b/issues/await-in-branch-positions-matrix.md
@@ -19,7 +19,7 @@ ages without trouble).
 | `match(await f, ...)` — SCRUTINEE                     | ✅ both           |
 | `while(await f, ...)` — CONDITION                     | ✅ both           |
 | `while(c, { ...await f... }, body)` — STEP            | ✅ both           |
-| `match(m, .Some(x) => { await f })` — ARM             | ✅ both (fixed)   |
+| `match(m, .Some(x) => { await f })` — ARM             | ✅ both           |
 | `if(!(await f), ...)` — await NESTED in a condition   | ⛔ rejected, both |
 | `cond(c1 => .., await f => .., ..)` — LATER condition | ⛔ rejected, both |
 
@@ -119,9 +119,7 @@ underscore either: `_v` and `v` behave the same.
 
 ---
 
-## Still open
-
-### `io.async` capture is not RC-incremented, so a future re-created in a loop is UAF
+### `io.async` capture fields were never RC-retained (a loop freed them)
 
 ```rust
 n := Box(i32)(0);
@@ -131,66 +129,51 @@ while(e.io.await(e.io.async((io2 : Io) => {
 }), e.io), { n.* = (n.* + i32(1)); });
 ```
 
-TS: `n=3`. SELF: **rc=139**. TS emits
-`__yo_new_X(fn___dup((struct){.n = sm->var_n}))`; SELF emits
-`__yo_new_X((__yo_t15){.n = sm->var_598000})` — the captured Box is never
-retained, so it is freed under the loop.
+TS: `n=3`. SELF: **rc=139** — the captured Box was freed under the loop.
 
-**An earlier draft of this file blamed registry keying (that yo-self looks
-`___dup` up by `type_id_or_empty` where TS reads `type.trait.fields`). That
-diagnosis is WRONG — measured 2026-08-09.** For this program the self-hosted
-compiler emits **zero** `___dup` functions; TS emits 124. yo-self does not
-synthesize per-type dup helpers here at all, it works through inline
-`__yo_incr_rc` on the RC header (12 calls vs TS's 11). So there is no dup
-function to look up under any key, and the fix is not a lookup fix.
+**Root cause:** the state machine's dispose DOES drop the capture struct's RC
+fields, but nothing retained them. TS balances that by dupping the whole capture
+struct through its synthesized `___dup`; yo-self synthesizes no such helper —
+for this program it emits **zero** per-type `___dup` where TS emits **124** — and
+its deferred-dup path is deliberately skipped inside a state machine.
 
-What actually has to happen: in the state-machine context TS deliberately skips
-the deferred dups (they name variables that no longer exist there) and falls
-back to the capture struct's own `___dup`. yo-self has no such fallback, so the
-capture's RC-typed fields are simply never retained. It needs an explicit
-`__yo_incr_rc` per RC-typed capture field at construction — which means
-`_build_async_capture_struct_literal` has to emit statements, not just return an
-expression string.
+An earlier draft blamed registry keying (yo-self looking `___dup` up by
+`type_id_or_empty` where TS reads `type.trait.fields`). **That was wrong**: there
+is no capture dup to find under any key. It is also why a `type_key`-keyed
+fallback "fixed" the crash while returning `n=4640` — it resolved something
+else.
 
-**A shortcut was tried and reverted — do not repeat it.** Adding a
-`type_key`-keyed `___dup` fallback at the capture site removes the segfault but
-yields `n=4640` instead of `n=3` (it resolves _something_, and the something is
-wrong). A loud crash traded for a silent wrong answer is worse. This needs the
-RC increment done properly, with the usual RC discipline: diff the per-function
-incr/decr counts against the TS emit before believing any green.
+Fixed with `_rc_field_retain_line`, the exact mirror of the existing
+`_rc_field_drop_line`: every branch there has its counterpart here, so a field
+dropped on dispose is the one retained on construction. RC changes get an
+emit diff, not just a green suite — the capture repro went incr 11 -> 12 (exactly
+the one added retain) with decr unchanged, and two unrelated repros were
+byte-identical.
 
-**Workaround in use:** hoist the future into a top-level helper taking its
-inputs by value (`future_lt` in `tests/async_await.test.yo`) rather than an
-inline closure capturing a mutable local.
+### Two `io.async` closures capturing the same local emitted invalid C
 
-### Two `io.async` closures capturing the same local — TS emits invalid C
-
-**Reference compiler only; the self-hosted one is correct here.**
-
-```rust
-task := io.async((io : Io) => {
-  n := Box(i32)(5);
-  a := io.await(io.async((io2 : Io) => { io2.await(yield(io2), io2); return(n.*); }), io);
-  b := io.await(io.async((io2 : Io) => { io2.await(yield(io2), io2); return(n.* * i32(2)); }), io);
-  return(a + b);
-});
-```
-
-SELF: `r=15`. TS:
+**Was reference-compiler only; the self-hosted one happened to be correct, but
+had the same latent mismatch.**
 
 ```
 error: used type '__yo_struct_..._id_28' where arithmetic or pointer type is required
   fn_..._id_40___drop((__yo_struct_..._id_28)(sm->await_future_1));
 ```
 
-The scope-end drops try to drop each inline closure's CAPTURE STRUCT, but apply
-it to `sm->await_future_N` — a state machine POINTER — cast to the capture
-struct by value. Casting a pointer to a struct-by-value is not legal C.
+**Root cause:** an inline `io.async(...)` produces two temps that can share a
+generated name — the closure's CAPTURE STRUCT and the future itself. Only the
+future is stored in `await_future_N`, but the alias search matched on NAME
+alone, so it could pick the capture struct. Its deferred drop then ran against
+that field: a drop of a struct BY VALUE applied to a state machine POINTER.
 
-Looks like the `awaitFutureTempVarAliases` path: the temp holding the future is
-aliased to `await_future_N`, and a deferred drop on that temp resolves to the
-wrong type. Found 2026-08-09 while adding capture regression tests; loud, so not
-dangerous.
+Fixed in both compilers by requiring the aliased variable to actually be a
+future (`typeImplementsFuture` / `type_implements_future`). yo-self matched by
+name only too — it just didn't manifest on this repro — so the guard went in
+there as well rather than waiting for it to bite.
+
+## Still open
+
+_Nothing. All six are fixed, each covered by `tests/async_await.test.yo`._
 
 ---
 

--- a/issues/await-in-branch-positions-matrix.md
+++ b/issues/await-in-branch-positions-matrix.md
@@ -1,6 +1,7 @@
 # `io.await` in branch positions: what works, what is rejected
 
-**Measured 2026-08-09**, both compilers. Every row below was run, not inferred.
+**Measured 2026-08-09**, both compilers, re-measured after each fix. Every row
+below was run, not inferred.
 
 "TS" = the reference compiler (`src/`). "SELF" = the self-hosted binary built
 from `yo-self/`. All rows are inside an `io.async((e) => { ... })` block; outside
@@ -8,19 +9,19 @@ one, `io.await` is a synchronous drive loop and none of this applies (which is
 why `tests/fs/dir.test.yo` has used `cond(io.await(...) => ...)` at top level for
 ages without trouble).
 
-| shape                                                 | supported                       |
-| ----------------------------------------------------- | ------------------------------- |
-| `cond(c => { await f })` — branch VALUE               | ✅ both                         |
-| `if(c, { await f })` / `if`+`else` bodies             | ✅ both                         |
-| `x := await f; if(x, ...)` — hoisted                  | ✅ both                         |
-| `if(await f, ...)` — CONDITION                        | ✅ both                         |
-| `cond(await f => ...)` — FIRST condition              | ✅ both                         |
-| `match(await f, ...)` — SCRUTINEE                     | ✅ both                         |
-| `while(await f, ...)` — CONDITION                     | ✅ both                         |
-| `while(c, { ...await f... }, body)` — STEP            | ✅ both                         |
-| `if(!(await f), ...)` — await NESTED in a condition   | ⛔ rejected, both               |
-| `cond(c1 => .., await f => .., ..)` — LATER condition | ⛔ rejected, both               |
-| `match(m, .Some(x) => { await f })` — ARM             | ⚠️ TS works, SELF drops the arm |
+| shape                                                 | status            |
+| ----------------------------------------------------- | ----------------- |
+| `cond(c => { await f })` — branch VALUE               | ✅ both           |
+| `if(c, { await f })` / `if`+`else` bodies             | ✅ both           |
+| `x := await f; if(x, ...)` — hoisted                  | ✅ both           |
+| `if(await f, ...)` — CONDITION                        | ✅ both           |
+| `cond(await f => ...)` — FIRST condition              | ✅ both           |
+| `match(await f, ...)` — SCRUTINEE                     | ✅ both           |
+| `while(await f, ...)` — CONDITION                     | ✅ both           |
+| `while(c, { ...await f... }, body)` — STEP            | ✅ both           |
+| `match(m, .Some(x) => { await f })` — ARM             | ✅ both (fixed)   |
+| `if(!(await f), ...)` — await NESTED in a condition   | ⛔ rejected, both |
+| `cond(c1 => .., await f => .., ..)` — LATER condition | ⛔ rejected, both |
 
 The two rejections are deliberate and carry a diagnostic naming the fix:
 
@@ -31,63 +32,121 @@ The two rejections are deliberate and carry a diagnostic naming the fix:
 - **Later `cond` branch** — `cond` is lazy, so hoisting would await even when an
   earlier branch matches. That is a change of meaning, not just of timing.
 
-Three of these need follow-up. None blocks the `if`/`init` fix, and none is a
-regression from it — the last two rows were verified against a self-hosted
-binary built _before_ that work.
+Everything above is covered by `tests/async_await.test.yo` (139 tests, green
+under both compilers) and `src/tests/async-await-position-gate.test.ts` (the
+rejections must fail at COMPILE time, not silently).
 
-## 1. `match` arm containing an await is silently dropped by SELF
+---
 
-**The worst class in the table: rc=0, no diagnostic, wrong behaviour.**
+## Fixed
+
+### `match` arm containing an await was silently dropped by SELF
+
+**Was the worst class in the table: rc=0, no diagnostic, wrong behaviour.**
 
 ```rust
 m := Option(i32).Some(i32(1));
 match(m, .Some(x) => {
   v := e.io.await(num(e.io), e.io);
-  println(`arm ${x} ${v}`);      // TS prints "arm 1 7". SELF prints nothing.
+  println(`arm ${x} ${v}`);      // TS printed "arm 1 7". SELF printed nothing.
 }, .None => ());
 ```
 
-TS: `arm 1 7`. SELF: the arm body never runs; execution continues past the
-`match` as if no branch matched. The identical `match` **without** the await
-runs correctly under both, so the await is the trigger, not the pattern.
+**Root cause:** `generate_match_with_await` resolved the enum's C name with
+`context.base.types.get(enum_id)` — a faithful port of TS's
+`context.types[enumType.id]?.cName`. But yo-self's type registry is keyed by
+`type_key(t)`, **not** by the enum's `id` field, so the lookup missed for every
+generic enum instance (`Option(i32)` included). It then emitted
+`// Error: enum type has no C name` **as a C comment** and returned, and the
+caller went on to emit the await machinery with the arm bodies simply gone.
 
-Pre-existing — reproduced on a self-hosted binary built before any of this
-work. Nothing in the corpus covers it, which is why the full-corpus hollow
-sweep is green: `tests/async_await.test.yo` had `cond`-with-await coverage but
-no `match`-with-await coverage. Worth adding that coverage with the fix, since
-a silent wrong-answer is exactly what the sweep exists to catch.
+Fixed by using the accessor the non-async match generator already uses
+(`context.base.get_type_c_name(type_key(...))`, `exprs/match.yo:1205`), and by
+making the remaining failure a hard error instead of a comment — reaching it
+means the whole `match` disappears, so it can never be benign.
 
-## 2. `match(await f, ...)` emits invalid C in BOTH compilers
+This is the second instance of the same shape in a week: **a faithful port of a
+TS registry lookup is wrong when yo-self keys that registry differently.** TS
+reads values off the type/expr; yo-self resolves through a global table. Porting
+the lookup literally compiles fine and silently returns nothing.
+
+### `return(<compound expr>)` as a closure's FINAL expression emitted invalid C
 
 ```
-error: expected expression
-  sm->var_847275 = ;
+int32_t __yo_scope_ret = return _temp_5219;
 ```
 
-Same root cause as the `cond` condition case: the scrutinee's code comes back
-empty because the await was supposed to be split out, and nothing splits it.
-Loud, so not dangerous — but it should be rejected with the same
-"hoist it into a local" diagnostic the `cond` and `if` conditions now get.
-The guard would go in `generateMatchWithAwait` alongside the existing
-`awaitIsInCondPosition` check, keyed on args that are not `=>` pairs.
+**Root cause:** the B1 tail materialization (`codegen/functions/generation.yo`)
+wraps the tail expression's code in `T __yo_scope_ret = <code>;` when the body
+has drops and a non-unit return. yo-self's `return(...)` codegen yields a
+COMPLETE `return X` statement (and emits the scope-end drops itself), where TS
+yields the value temp and lets the caller emit the return. So the statement got
+spliced into an initialiser.
 
-Nothing in the corpus uses this shape (`grep -rn --include='*.yo' 'match(.*\.await('`
-over `std yo-self tests src/tests` returns nothing), so adding the rejection is
-safe.
+A SIMPLE `return(n.*)` was fine — the materialization only kicks in for the
+compound case — which is why this hid.
 
-## 3. Two yo-self-only gaps found while testing this
+Fixed by detecting an already-complete `return` and emitting it verbatim.
 
-Neither is a regression from the await-position work; both reproduce with **no
-await at all**, and the tests in `tests/async_await.test.yo` are shaped around
-them rather than depending on them.
+---
 
-- **`return(expr)` as a closure's FINAL expression** emits
-  `int32_t __yo_scope_ret = return X;` — invalid C. Use a plain trailing
-  expression instead.
-- **An `io.async` closure capturing a mutable local, re-created every
-  iteration**, omits the capture `___dup` that TS emits, so the captured Box is
-  freed under the loop (rc=139). This is why the while-condition tests use a
-  top-level `future_lt` helper rather than an inline closure.
+## Still open
+
+### 1. `io.async` capture is not dup'd, so a future re-created in a loop is UAF
+
+```rust
+n := Box(i32)(0);
+while(e.io.await(e.io.async((io2 : Io) => {
+  io2.await(yield(io2), io2);
+  return(n.* < i32(3));
+}), e.io), { n.* = (n.* + i32(1)); });
+```
+
+TS: `n=3`. SELF: **rc=139**. TS emits
+`__yo_new_X(fn___dup((struct){.n = sm->var_n}))`; SELF emits
+`__yo_new_X((__yo_t15){.n = sm->var_600288})` — no dup, so the captured Box is
+freed under the loop.
+
+**Same registry-keying shape as the `match` bug above.** TS's
+`getDupFunctionForType` reads `type.trait.fields` off the TYPE VALUE, so it
+finds the `___dup` of a synthesized capture struct. yo-self's `_method_c_name`
+resolves through the method registry keyed by `type_id_or_empty(type)`, and the
+capture struct is registered under its instantiation-precise `type_key` — so it
+misses. (`get_dispose_function_for_type` already documents and keys around
+exactly this.)
+
+**A naive fix is WRONG — do not repeat it.** Adding a `type_key`-keyed fallback
+for `___dup` at the capture site removes the segfault but yields `n=4640`
+instead of `n=3`: a loud crash traded for a silent wrong answer, which is worse.
+The dup alone is not the whole story; the capture's ownership across iterations
+needs to be worked out properly before touching this. Reverted rather than
+shipped.
+
+**Workaround in use:** hoist the future into a top-level helper that takes its
+inputs by value (`future_lt` in `tests/async_await.test.yo`) instead of an
+inline closure capturing a mutable local.
+
+### 2. An await-result binding plus a compound `return` tail loses its SM field
+
+Both compilers:
+
+```rust
+task := io.async((io : Io) => {
+  n := Box(i32)(3);
+  v := io.await(future_with_returned_state(i32(1), io), io);
+  return((n.* * i32(10)) + n.*)      // <- compound return, does not read `v`
+});
+```
+
+```
+error: no member named 'var_yoebb42233_v' in 'struct ..._state_t_struct'
+```
+
+Not the underscore (`_v` and `v` behave identically) and not "unused" on its own
+— `_x := io.await(...)` in a `while` step is fine. It is the combination with a
+compound `return` tail. Loud, so not dangerous.
+
+---
 
 ## Reproducing
 
@@ -105,5 +164,6 @@ main :: (fn(io : Io, exn : Exception) -> unit)({
 });
 ```
 
-`END` alone in the output means the branch body was skipped — that is how row 7
-was caught. A harness that only checks the exit code passes it.
+`END` alone in the output means the branch body was skipped — that is how the
+dropped `match` arm was caught. A harness that only checks the exit code passes
+it, which is why the corpus never noticed.

--- a/issues/await-in-branch-positions-matrix.md
+++ b/issues/await-in-branch-positions-matrix.md
@@ -88,11 +88,40 @@ compound case — which is why this hid.
 
 Fixed by detecting an already-complete `return` and emitting it verbatim.
 
+### An await whose result is never read broke the SM struct
+
+Both compilers:
+
+```rust
+task := io.async((io : Io) => {
+  n := Box(i32)(3);
+  v := io.await(future_with_returned_state(i32(1), io), io);
+  return(n.*);          // `v` is never read
+});
+```
+
+```
+error: no member named 'var_yoebb42233_v' in 'struct ..._state_t_struct'
+```
+
+**Root cause:** the struct only gets a field for variables that cross a state
+boundary, and a target nothing ever reads does not — but the extraction wrote
+`sm-><field>` regardless.
+
+An earlier note here called this "the combination with a compound `return`
+tail". **That was wrong**: `return(n.*)`, a compound return, and a plain
+assignment tail all fail identically, and reading the value anywhere makes all
+of them pass. Being unread is the whole trigger; the tail shape is irrelevant.
+
+Fixed by skipping the store when the target has no field — which is what the
+linear-await path already does when there is no target at all. Not the
+underscore either: `_v` and `v` behave the same.
+
 ---
 
 ## Still open
 
-### 1. `io.async` capture is not dup'd, so a future re-created in a loop is UAF
+### `io.async` capture is not RC-incremented, so a future re-created in a loop is UAF
 
 ```rust
 n := Box(i32)(0);
@@ -104,47 +133,35 @@ while(e.io.await(e.io.async((io2 : Io) => {
 
 TS: `n=3`. SELF: **rc=139**. TS emits
 `__yo_new_X(fn___dup((struct){.n = sm->var_n}))`; SELF emits
-`__yo_new_X((__yo_t15){.n = sm->var_600288})` — no dup, so the captured Box is
-freed under the loop.
+`__yo_new_X((__yo_t15){.n = sm->var_598000})` — the captured Box is never
+retained, so it is freed under the loop.
 
-**Same registry-keying shape as the `match` bug above.** TS's
-`getDupFunctionForType` reads `type.trait.fields` off the TYPE VALUE, so it
-finds the `___dup` of a synthesized capture struct. yo-self's `_method_c_name`
-resolves through the method registry keyed by `type_id_or_empty(type)`, and the
-capture struct is registered under its instantiation-precise `type_key` — so it
-misses. (`get_dispose_function_for_type` already documents and keys around
-exactly this.)
+**An earlier draft of this file blamed registry keying (that yo-self looks
+`___dup` up by `type_id_or_empty` where TS reads `type.trait.fields`). That
+diagnosis is WRONG — measured 2026-08-09.** For this program the self-hosted
+compiler emits **zero** `___dup` functions; TS emits 124. yo-self does not
+synthesize per-type dup helpers here at all, it works through inline
+`__yo_incr_rc` on the RC header (12 calls vs TS's 11). So there is no dup
+function to look up under any key, and the fix is not a lookup fix.
 
-**A naive fix is WRONG — do not repeat it.** Adding a `type_key`-keyed fallback
-for `___dup` at the capture site removes the segfault but yields `n=4640`
-instead of `n=3`: a loud crash traded for a silent wrong answer, which is worse.
-The dup alone is not the whole story; the capture's ownership across iterations
-needs to be worked out properly before touching this. Reverted rather than
-shipped.
+What actually has to happen: in the state-machine context TS deliberately skips
+the deferred dups (they name variables that no longer exist there) and falls
+back to the capture struct's own `___dup`. yo-self has no such fallback, so the
+capture's RC-typed fields are simply never retained. It needs an explicit
+`__yo_incr_rc` per RC-typed capture field at construction — which means
+`_build_async_capture_struct_literal` has to emit statements, not just return an
+expression string.
 
-**Workaround in use:** hoist the future into a top-level helper that takes its
-inputs by value (`future_lt` in `tests/async_await.test.yo`) instead of an
+**A shortcut was tried and reverted — do not repeat it.** Adding a
+`type_key`-keyed `___dup` fallback at the capture site removes the segfault but
+yields `n=4640` instead of `n=3` (it resolves _something_, and the something is
+wrong). A loud crash traded for a silent wrong answer is worse. This needs the
+RC increment done properly, with the usual RC discipline: diff the per-function
+incr/decr counts against the TS emit before believing any green.
+
+**Workaround in use:** hoist the future into a top-level helper taking its
+inputs by value (`future_lt` in `tests/async_await.test.yo`) rather than an
 inline closure capturing a mutable local.
-
-### 2. An await-result binding plus a compound `return` tail loses its SM field
-
-Both compilers:
-
-```rust
-task := io.async((io : Io) => {
-  n := Box(i32)(3);
-  v := io.await(future_with_returned_state(i32(1), io), io);
-  return((n.* * i32(10)) + n.*)      // <- compound return, does not read `v`
-});
-```
-
-```
-error: no member named 'var_yoebb42233_v' in 'struct ..._state_t_struct'
-```
-
-Not the underscore (`_v` and `v` behave identically) and not "unused" on its own
-— `_x := io.await(...)` in a `while` step is fine. It is the combination with a
-compound `return` tail. Loud, so not dangerous.
 
 ---
 

--- a/src/codegen/async/state-machine.ts
+++ b/src/codegen/async/state-machine.ts
@@ -288,10 +288,24 @@ export function computeCrossBoundaryVariables(
     const tempVarName = futureArg.$?.variableName;
     if (!tempVarName) continue;
 
-    // Find the captured variable matching this temp var name
+    // Find the captured variable matching this temp var name.
+    //
+    // Match on the TYPE too, not just the name: an inline `io.async(...)`
+    // produces two temps that can share the generated name — the closure's
+    // CAPTURE STRUCT and the future itself. Only the future is stored in
+    // await_future_N. Aliasing the capture struct instead made its deferred
+    // drop run against that field, emitting a drop of a struct BY VALUE applied
+    // to a state machine POINTER:
+    //
+    //   fn_..._id_40___drop((__yo_struct_..._id_28)(sm->await_future_1));
+    //
+    // which is not legal C. It showed up with two inline async closures over
+    // the same local in one state machine.
     const capturedVar = capturedVariables.find(
       (v) =>
-        v.kind === "local" && (v.name === tempVarName || v.id === tempVarName)
+        v.kind === "local" &&
+        (v.name === tempVarName || v.id === tempVarName) &&
+        typeImplementsFuture(v.type)
     );
     if (capturedVar) {
       awaitFutureTempVarAliases.set(capturedVar.id, `await_future_${ap.index}`);

--- a/src/codegen/async/state-machine.ts
+++ b/src/codegen/async/state-machine.ts
@@ -578,7 +578,14 @@ export function generateAsyncBlockResumeFunction(
   analysis: AwaitAnalysisResult,
   futureType: SomeType | DynType,
   captureType: StructType | undefined,
-  context: FunctionGenerationContext
+  context: FunctionGenerationContext,
+  /**
+   * Variable IDs that actually got a struct field. An await's target variable
+   * is NOT among them when nothing ever reads it — the value never crosses a
+   * state boundary, so no field is emitted for it. The extraction below has to
+   * know that, or it writes to a member that does not exist.
+   */
+  crossBoundaryIds?: Set<string>
 ): string[] {
   const emitter = context.emitter;
 
@@ -701,7 +708,14 @@ export function generateAsyncBlockResumeFunction(
         let resultTarget: string | undefined;
         if (useAwaitResultField) {
           resultTarget = `sm->await_result_${stateNumber - 1}`;
-        } else if (prevAwait.targetVariableId) {
+        } else if (
+          prevAwait.targetVariableId &&
+          awaitTargetHasStructField(
+            prevAwait.targetVariableId,
+            crossBoundaryIds,
+            context
+          )
+        ) {
           const fieldName = getStateMachineFieldName(
             prevAwait.targetVariableId,
             "local",
@@ -2747,4 +2761,28 @@ function emitWhileConditionAwaitResume(
   emitter.emitLine(``);
   emitter.emitLine(`      after_while_loop_${loopIndex}:`);
   emitter.emitLine(``);
+}
+
+/**
+ * Whether an await's target variable has a state machine struct field.
+ *
+ * A target that nothing ever reads does not cross a state boundary, so no field
+ * is emitted for it (`emitAsyncBlockStructDefinition` filters local variables by
+ * `crossBoundaryIds`). Storing the result into `sm-><field>` anyway produced
+ * `error: no member named 'var_..._v'` — the result is simply unused, and
+ * skipping the store is what the linear-await path already does when there is no
+ * target at all.
+ *
+ * Aliased ids still have storage (an `await_future_N` or an overlapping slot),
+ * so they count as present.
+ */
+function awaitTargetHasStructField(
+  targetVariableId: string,
+  crossBoundaryIds: Set<string> | undefined,
+  context: FunctionGenerationContext
+): boolean {
+  // No analysis available — keep the previous unconditional behaviour.
+  if (!crossBoundaryIds) return true;
+  if (crossBoundaryIds.has(targetVariableId)) return true;
+  return context.stateMachineFieldAliases?.has(targetVariableId) ?? false;
 }

--- a/src/codegen/exprs/async.ts
+++ b/src/codegen/exprs/async.ts
@@ -1539,7 +1539,8 @@ export function generateDeferredAsyncBlocks(
       filteredAnalysis,
       futureType,
       captureType,
-      context
+      context,
+      crossBoundaryIds
     );
 
     // Emit the set_effect impl before restoring context, so the SM-var

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -3219,3 +3219,39 @@ test("Test return of a compound expression as the final expression", {
   r := io.await(task, io);
   assert(r == i32(33), "a compound return in tail position must compile");
 });
+// ---------------------------------------------------------------------------
+// An await whose result is never read.
+//
+// The state machine struct only gets a field for variables that cross a state
+// boundary, and a target nothing ever reads does not. The extraction wrote to
+// `sm-><field>` regardless, so the C referenced a member that was never
+// declared: `error: no member named 'var_..._v'`. Reading the value anywhere
+// hid it — which is why every existing test passed.
+// ---------------------------------------------------------------------------
+test("Test await whose result is never read", {
+  task := io.async((io : Io) => {
+    n := Box(i32)(3);
+    _v := io.await(future_with_returned_state(i32(1), io), io);
+    return(n.*);
+  });
+  r := io.await(task, io);
+  assert(r == i32(3), "an unread await result must not break the SM struct");
+});
+test("Test await whose result is never read, with a compound tail", {
+  task := io.async((io : Io) => {
+    n := Box(i32)(3);
+    _v := io.await(future_with_returned_state(i32(1), io), io);
+    return((n.* * i32(10)) + n.*)
+  });
+  r := io.await(task, io);
+  assert(r == i32(33), "same, with the tail materialization in play");
+});
+test("Test await whose result IS read (control)", {
+  task := io.async((io : Io) => {
+    n := Box(i32)(3);
+    v := io.await(future_with_returned_state(i32(1), io), io);
+    return((n.* * i32(10)) + v);
+  });
+  r := io.await(task, io);
+  assert(r == i32(32), "control: reading the result keeps the field");
+});

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -3284,3 +3284,31 @@ test("Test io.async closure capturing a local, re-created each iteration", {
   r := io.await(task, io);
   assert(r == i32(3), "the captured Box must survive every iteration");
 });
+test("Test two io.async closures capturing the same local", {
+  // An inline `io.async(...)` produces two temps that can share a generated
+  // name — the closure's CAPTURE STRUCT and the future. Only the future lives
+  // in `await_future_N`; aliasing the capture struct instead made its deferred
+  // drop run against that field, emitting a drop of a struct BY VALUE applied
+  // to a state machine POINTER, which is not legal C. Two inline closures over
+  // one local in a single state machine is what exposed it.
+  task := io.async((io : Io) => {
+    n := Box(i32)(5);
+    a := io.await(
+      io.async((io2 : Io) => {
+        io2.await(yield(io2), io2);
+        return(n.*);
+      }),
+      io
+    );
+    b := io.await(
+      io.async((io2 : Io) => {
+        io2.await(yield(io2), io2);
+        return(n.* * i32(2));
+      }),
+      io
+    );
+    return(a + b);
+  });
+  r := io.await(task, io);
+  assert(r == i32(15), "5 + 10 — the capture is still live for the second");
+});

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -3255,3 +3255,32 @@ test("Test await whose result IS read (control)", {
   r := io.await(task, io);
   assert(r == i32(32), "control: reading the result keeps the field");
 });
+// ---------------------------------------------------------------------------
+// An `io.async` closure that captures a mutable local, re-created every
+// iteration of a loop.
+//
+// The state machine's dispose drops the capture's RC-bearing fields, but
+// nothing retained them: TS balances that by dupping the whole capture struct
+// through its synthesized `___dup`, and yo-self synthesizes no such helper (it
+// emits ZERO per-type `___dup` where TS emits 124) while its deferred-dup path
+// is deliberately skipped inside a state machine. So each iteration dropped a
+// reference nobody took, and the captured Box was freed under the loop —
+// rc=139 in the self-hosted compiler, correct output in the reference one.
+// ---------------------------------------------------------------------------
+test("Test io.async closure capturing a local, re-created each iteration", {
+  task := io.async((io : Io) => {
+    n := Box(i32)(0);
+    while(io.await(
+      io.async((io2 : Io) => {
+        io2.await(yield(io2), io2);
+        return(n.* < i32(3));
+      }),
+      io
+    ), {
+      n.* = (n.* + i32(1));
+    });
+    return(n.*);
+  });
+  r := io.await(task, io);
+  assert(r == i32(3), "the captured Box must survive every iteration");
+});

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -3139,3 +3139,83 @@ test("Test await in a while step matches the non-await control", {
   r := io.await(task, io);
   assert(r == i32(33), "control: the awaited-step loop must agree with this");
 });
+// ---------------------------------------------------------------------------
+// `match` ARM containing an await.
+//
+// The self-hosted compiler silently DROPPED the whole match: its
+// `generate_match_with_await` looked the enum's C name up by the enum's `id`
+// (faithful to TS, whose registry is id-keyed), but yo-self's registry is keyed
+// by `type_key`, so every generic enum instance missed and the match was
+// emitted as a C comment. rc=0, no diagnostic, the arm never ran — nothing in
+// the corpus covered it, so the hollow sweep stayed green.
+// ---------------------------------------------------------------------------
+test("Test await inside a match arm", {
+  task := io.async((io : Io) => {
+    m := Option(i32).Some(i32(1));
+    acc := Box(i32)(0);
+    match(
+      m,
+      .Some(x) => {
+        v := io.await(future_with_returned_state(i32(41), io), io);
+        acc.* = (v + x);
+      },
+      .None => ()
+    );
+    return(acc.*);
+  });
+  r := io.await(task, io);
+  assert(r == i32(43), "the matched arm must run its await and its body");
+});
+test("Test await inside a match arm that is not selected", {
+  task := io.async((io : Io) => {
+    m := Option(i32).None;
+    acc := Box(i32)(7);
+    match(
+      m,
+      .Some(x) => {
+        v := io.await(future_with_returned_state(i32(41), io), io);
+        acc.* = (v + x);
+      },
+      .None => ()
+    );
+    return(acc.*);
+  });
+  r := io.await(task, io);
+  assert(r == i32(7), "an unselected arm must not run its await");
+});
+test("Test statement after a match arm that awaits", {
+  task := io.async((io : Io) => {
+    m := Option(i32).Some(i32(1));
+    acc := Box(i32)(0);
+    match(
+      m,
+      .Some(_x) => {
+        v := io.await(future_with_returned_state(i32(41), io), io);
+        acc.* = v;
+      },
+      .None => ()
+    );
+    acc.* = (acc.* + i32(100));
+    return(acc.*);
+  });
+  r := io.await(task, io);
+  assert(r == i32(142), "code after the match must still execute");
+});
+// ---------------------------------------------------------------------------
+// `return(<compound expression>)` as an async closure's FINAL expression.
+//
+// yo-self's return codegen yields a COMPLETE `return X` statement (and emits
+// the scope-end drops itself), where TS yields the value temp and lets the
+// caller emit the return. Feeding that statement into the tail materialization
+// produced `int32_t __yo_scope_ret = return X;` — invalid C. A SIMPLE
+// `return(n.*)` was fine, which is why this hid: it only shows when the
+// materialization kicks in.
+// ---------------------------------------------------------------------------
+test("Test return of a compound expression as the final expression", {
+  task := io.async((io : Io) => {
+    n := Box(i32)(3);
+    return((n.* * i32(10)) + n.*)
+  });
+  r := io.await(task, io);
+  assert(r == i32(33), "a compound return in tail position must compile");
+});

--- a/yo-self/codegen/async/state_code_gen.yo
+++ b/yo-self/codegen/async/state_code_gen.yo
@@ -26,7 +26,7 @@ open(import("std/fmt"));
 { emit_async_future_completion } :: import("../exprs/async_completion.yo");
 { is_unit_type, is_enum_type } :: import("../../types/guards.yo");
 { EvalValue, type_of_eval_value } :: import("../../value.yo");
-{ get_type_string, sanitize_for_c_identifier, can_optimize_as_nullable_pointer, get_enum_variant_c_name } :: import("../utils/index.yo");
+{ get_type_string, sanitize_for_c_identifier, can_optimize_as_nullable_pointer, get_enum_variant_c_name, type_key } :: import("../utils/index.yo");
 { get_state_machine_field_name } :: import("./state_machine_naming.yo");
 { generate_comptime_value } :: import("../exprs/comptime_value.yo");
 { TypeValue } :: import("../../types/definitions.yo");
@@ -2186,10 +2186,19 @@ generate_match_with_await :: (
           variant_names := match(match_value_type, .EnumT({ variant_names : vns }) => vns, _ => ArrayList(String).new());
           variant_fields := match(match_value_type, .EnumT({ variant_fields : vfs }) => vfs, _ => ArrayList(ArrayList(TypeValue)).new());
           variant_field_labels := match(match_value_type, .EnumT({ variant_field_labels : vfls }) => vfls, _ => ArrayList(ArrayList(String)).new());
-          enum_c_name := match(context.base.types.get(enum_id), .Some(e) => e.c_name, .None => String.from(""));
+          // TS reads `context.types[enumType.id].cName` (state-code-gen.ts).
+          // yo-self's registry is keyed by `type_key(t)`, not by the enum's
+          // `id` field, so the id-keyed lookup MISSED for every generic enum
+          // instance — `Option(i32)` included. The whole `match` was then
+          // dropped as a C comment: rc=0, no diagnostic, the arm never ran.
+          // Use the same accessor the non-async match generator uses
+          // (exprs/match.yo:1205).
+          enum_c_name := match(context.base.get_type_c_name(type_key(match_value_type)), .Some(n) => n, .None => String.from(""));
           if(enum_c_name.len() == usize(0), {
-            em.emit_string_line(`${indent}// Error: enum type has no C name`);
-            return();
+            // Never emit a comment and carry on here: the caller goes on to
+            // emit the await machinery, and the arm bodies are simply gone.
+            eprintln(`generate_match_with_await: no C name for match value type ${type_key(match_value_type)} (enum id ${enum_id})`);
+            __yo_panic("match with await: enum type not registered in context.types (see stderr)");
           });
           nullable := can_optimize_as_nullable_pointer(match_value_type);
           match(

--- a/yo-self/codegen/async/state_machine.yo
+++ b/yo-self/codegen/async/state_machine.yo
@@ -1655,6 +1655,26 @@ _emit_last_segment_completion :: (
     emit_async_future_completion(em, `      `, Option(String).None, Option(String).Some(String.from("Future %p completed")));
   });
 });
+/// Whether an await's target variable has a state machine struct field.
+///
+/// A target that nothing ever reads does not cross a state boundary, so no
+/// field is emitted for it (the struct emitter filters locals by
+/// `cross_boundary_ids`). Storing the result into `sm-><field>` anyway produced
+/// `error: no member named 'var_...'` — the result is simply unused, and
+/// skipping the store is what the no-target path already does.
+///
+/// Aliased ids still have storage (an `await_future_N` or an overlapping slot),
+/// so they count as present. Mirrors `awaitTargetHasStructField`
+/// (state-machine.ts).
+_await_target_has_struct_field :: (
+  fn(target_variable_id : String, cross_boundary_ids : Option(HashSet(String)), context : FunctionGenerationContext) -> bool
+)({
+  cbi := match(cross_boundary_ids, .Some(c) => c, .None => return(true));
+  if(cbi.contains(target_variable_id.clone()), {
+    return(true);
+  });
+  match(context.state_machine_field_aliases, .Some(a) => a.contains_key(target_variable_id), .None => false)
+});
 /// Emit the previous-await result extraction at the top of a resume state: the
 /// abort check (Future state == -2 → escape), the result copy (into
 /// `await_result_N` for cond awaits, or directly into the target SM var for
@@ -1663,7 +1683,7 @@ _emit_last_segment_completion :: (
 /// `generateAsyncBlockResumeFunction` (state-machine.ts:661). Caller guarantees
 /// `state_number >= 1`.
 _emit_prev_await_result_extraction :: (
-  fn(async_block_id : String, state_number : usize, prev_await : AwaitPoint, analysis : AwaitAnalysisResult, context : FunctionGenerationContext) -> unit
+  fn(async_block_id : String, state_number : usize, prev_await : AwaitPoint, analysis : AwaitAnalysisResult, context : FunctionGenerationContext, cross_boundary_ids : Option(HashSet(String))) -> unit
 )({
   em := context.base.emitter;
   pffn := get_future_field_name(prev_await, analysis);
@@ -1697,12 +1717,12 @@ _emit_prev_await_result_extraction :: (
     }, {
       match(
         prev_await.base.target_variable_id,
-        .Some(tvid) => {
+        .Some(tvid) => if(_await_target_has_struct_field(tvid.clone(), cross_boundary_ids, context), {
           fname := get_state_machine_field_name(tvid, Option(String).Some(String.from("local")), context.state_machine_field_aliases);
           rt := String.from("sm->");
           rt.push_string(fname);
           result_target = Option(String).Some(rt);
-        },
+        }),
         .None => ()
       );
     });
@@ -2641,7 +2661,12 @@ generate_async_block_resume_function :: (
     analysis : AwaitAnalysisResult,
     future_type : TypeValue,
     capture_type : Option(TypeValue),
-    context : FunctionGenerationContext
+    context : FunctionGenerationContext,
+    /// Variable IDs that actually got a struct field. An await's target
+    /// variable is NOT among them when nothing ever reads it — the value never
+    /// crosses a state boundary, so no field is emitted. The extraction has to
+    /// know that, or it writes to a member that does not exist.
+    cross_boundary_ids : Option(HashSet(String))
   ) -> ArrayList(String)
 )({
   em := context.base.emitter;
@@ -2693,7 +2718,7 @@ generate_async_block_resume_function :: (
               if(in_cond, {
                 em.emit_string_line(`      if (sm->${pffn} != NULL) {`);
               });
-              _emit_prev_await_result_extraction(async_block_id, segment.state_number, prev_await, analysis, context);
+              _emit_prev_await_result_extraction(async_block_id, segment.state_number, prev_await, analysis, context, cross_boundary_ids);
               _emit_cond_branch_continuation(async_block_id, prev_await, segment, body_expr, future_type, capture_type, analysis, context);
               if(in_cond, {
                 em.emit_string_line(`      }`);

--- a/yo-self/codegen/async/state_machine.yo
+++ b/yo-self/codegen/async/state_machine.yo
@@ -610,6 +610,15 @@ compute_cross_boundary_variables :: (
                   tmp_name_opt,
                   .Some(temp_var_name) => {
                     // Find the captured local matching this temp var name/id.
+                    //
+                    // Match on the TYPE too, not just the name: an inline
+                    // `io.async(...)` produces two temps that can share the
+                    // generated name — the closure's CAPTURE STRUCT and the
+                    // future itself. Only the future is stored in
+                    // await_future_N. Aliasing the capture struct instead makes
+                    // its deferred drop run against that field, emitting a drop
+                    // of a struct BY VALUE applied to a state machine POINTER
+                    // (not legal C). Mirrors state-machine.ts.
                     (cfi : usize) = usize(0);
                     (matched : Option(String)) = Option(String).None;
                     while((cfi < captured_variables.len()) && matched.is_none(), {
@@ -617,7 +626,8 @@ compute_cross_boundary_variables :: (
                         captured_variables.get(cfi),
                         .Some(cv2) => {
                           is_local := match(cv2.kind, .Local => true, .Outer => false);
-                          if(is_local && ((cv2.base.name == temp_var_name) || (cv2.base.id == temp_var_name)), {
+                          name_matches := ((cv2.base.name == temp_var_name) || (cv2.base.id == temp_var_name));
+                          if((is_local && name_matches) && type_implements_future(cv2.base.ty), {
                             matched = Option(String).Some(cv2.base.id.to_string());
                           });
                         },

--- a/yo-self/codegen/exprs/async.yo
+++ b/yo-self/codegen/exprs/async.yo
@@ -1046,6 +1046,36 @@ emit_deferred_async_block_struct_definitions :: (fn(context : FunctionGeneration
     ei = (ei + usize(1));
   });
 });
+/// The RETAIN line for an RC-bearing capture field at `field_ref`, or `None` if
+/// the type needs none. The exact mirror of `_rc_field_drop_line` below — every
+/// branch there has its counterpart here, so a field that gets dropped on
+/// dispose is the one that gets retained on construction.
+///
+/// Needed because the state machine's dispose DOES drop these fields, but
+/// nothing retained them. TS closes that by dupping the whole capture struct
+/// through its synthesized `___dup`; yo-self synthesizes no such helper (it
+/// emits ZERO per-type `___dup` functions where TS emits 124 — measured), and
+/// its deferred-dup path is deliberately skipped inside a state machine. The
+/// result was an unbalanced drop: a future re-created each iteration of a loop
+/// freed the captured value under the loop (rc=139).
+/// See issues/await-in-branch-positions-matrix.md.
+_rc_field_retain_line :: (fn(field_ref : String, field_type : TypeValue, indent : String, context : FunctionGenerationContext) -> Option(String))(
+  cond(
+    is_dyn_type(field_type) => Option(String).Some(`${indent.clone()}if ((${field_ref.clone()}).data != NULL) { __yo_incr_rc((void*)(${field_ref.clone()}).data); }`),
+    (is_iso_type(field_type) || is_atomic_reference_struct_type(field_type)) => Option(String).Some(`${indent.clone()}if (${field_ref.clone()} != NULL) { __yo_incr_rc_atomic((void*)${field_ref.clone()}); }`),
+    (is_reference_struct_type(field_type) || (is_some_type(field_type) && is_rc_type(field_type))) => match(
+      get_dup_function_for_type(field_type, context),
+      .Some(dup_fn) => Option(String).Some(`${indent.clone()}if (${field_ref.clone()} != NULL) { ${dup_fn}(${field_ref.clone()}); }`),
+      .None => Option(String).Some(`${indent.clone()}if (${field_ref.clone()} != NULL) { __yo_incr_rc((void*)${field_ref.clone()}); }`)
+    ),
+    type_contains_rc_type(field_type) => match(
+      get_dup_function_for_type(field_type, context),
+      .Some(dup_fn) => Option(String).Some(`${indent.clone()}${field_ref.clone()} = ${dup_fn}(${field_ref.clone()});`),
+      .None => Option(String).None
+    ),
+    true => Option(String).None
+  )
+);
 /// The drop line for an RC-bearing field/local at `field_ref`, or `None` if the
 /// type needs no drop. Mirrors the per-field drop branches shared by the capture
 /// struct + local-variable cleanup in `generateAsyncBlockStateDisposeFunction`.
@@ -1423,7 +1453,52 @@ _build_async_capture_struct_literal :: (
     match(
       get_dup_function_for_type(capture_type, context),
       .Some(dup_fn) => return(`${dup_fn}(${literal})`),
-      .None => ()
+      // No per-type `___dup` helper — yo-self does not synthesize them for
+      // capture structs. Retain each RC-bearing field individually instead, so
+      // the state machine's dispose (which DOES drop them) is balanced. Without
+      // this, a future re-created every loop iteration frees its captured value
+      // under the loop. Materialize into a temp first: the fields have to be
+      // reachable as lvalues to retain them.
+      .None => {
+        // Name the temp FIRST so each retain line is built against it — the
+        // lines have to be lvalue references into the materialized struct.
+        tmp := String.from("__yo_cap_");
+        tmp.push_string(random_id(String.from("")));
+        retain_lines := ArrayList(String).new();
+        (ri : usize) = usize(0);
+        while(ri < fields.len(), {
+          match(
+            fields.get(ri),
+            .Some(f) => if(!(f.is_effect_param), {
+              match(
+                _rc_field_retain_line(`${tmp.clone()}.${f.label.clone()}`, f.ty, indent.clone(), context),
+                .Some(line) => {
+                  _r := retain_lines.push(line);
+                },
+                .None => ()
+              );
+            }),
+            .None => ()
+          );
+          ri = (ri + usize(1));
+        });
+        if(retain_lines.len() > usize(0), {
+          em := context.base.emitter;
+          em.emit_string_line(`${indent.clone()}${capture_struct_name.clone()} ${tmp.clone()} = ${literal.clone()};`);
+          (li : usize) = usize(0);
+          while(li < retain_lines.len(), {
+            match(
+              retain_lines.get(li),
+              .Some(line) => {
+                em.emit_string_line(line);
+              },
+              .None => ()
+            );
+            li = (li + usize(1));
+          });
+          return(tmp);
+        });
+      }
     );
   });
   literal

--- a/yo-self/codegen/exprs/async.yo
+++ b/yo-self/codegen/exprs/async.yo
@@ -1968,7 +1968,7 @@ _emit_one_deferred_async_block :: (fn(block : DeferredAsyncBlock, context : Func
   });
   context.state_machine_field_aliases = Option(HashMap(String, String)).Some(merged_aliases);
   // Resume function (returns local-var drops).
-  local_var_drops := generate_async_block_resume_function(block.body_expr, block.async_block_id.clone(), block.struct_name.clone(), block.resume_function_name.clone(), filtered_analysis, block.future_type, block.capture_type, context);
+  local_var_drops := generate_async_block_resume_function(block.body_expr, block.async_block_id.clone(), block.struct_name.clone(), block.resume_function_name.clone(), filtered_analysis, block.future_type, block.capture_type, context, Option(HashSet(String)).Some(cross_boundary_ids));
   em.emit_string_line(String.from(""));
   // set_effect impl (emitted while SM vars are still in context).
   sync_param_slot := match(

--- a/yo-self/codegen/functions/generation.yo
+++ b/yo-self/codegen/functions/generation.yo
@@ -277,6 +277,20 @@ generate_function_body :: (fn(body_expr : AstExpr, function_type : TypeValue, in
               em.emit_string_line(ftl);
               return(());
             });
+            // The tail expression IS a `return(...)`. yo-self's return codegen
+            // yields a COMPLETE `return X` statement and has already emitted the
+            // scope-end drops (the "// Drop local variables before early return"
+            // block); TS instead yields the value temp and lets this site emit
+            // the return. Feeding a statement into either path below produced
+            // invalid C — `T __yo_scope_ret = return X;` via the B1
+            // materialization, or `return return X;` without it.
+            if(expr_code.starts_with("return ") || (expr_code == "return"), {
+              rline := indent.clone();
+              rline.push_string(expr_code);
+              rline.push_str(";");
+              em.emit_string_line(rline);
+              return(());
+            });
             has_drops := match(context.base.get_expr_info(body_expr), .Some(bei) => match(bei.deferred_drop_expressions, .Some(d) => (d.len() > usize(0)), .None => false), .None => false);
             mat_ty := cond(
               ((has_drops && (!(result_is_unit))) && (expr_code.len() > usize(0))) => ret_ty_opt,


### PR DESCRIPTION
Works through `issues/await-in-branch-positions-matrix.md` until **nothing is left open**. Five bugs, each with a regression test.

| # | bug | was | compilers |
|---|---|---|---|
| 1 | `match` arm containing an await **silently dropped** | rc=0, arm never ran | yo-self |
| 2 | `return(<compound>)` as a closure's final expression | invalid C | yo-self |
| 3 | unread await result → missing state-machine field | invalid C | **both** |
| 4 | `io.async` capture never RC-retained | rc=139 in a loop | yo-self |
| 5 | capture-struct/future alias matched on name alone | invalid C | **both** (latent in yo-self) |

## 1. A `match` arm containing an await was silently dropped

The worst class — **rc=0, no diagnostic, the arm never ran**. `generate_match_with_await` resolved the enum's C name with `context.base.types.get(enum_id)`, a faithful port of TS's `context.types[enumType.id]?.cName`. But **yo-self's registry is keyed by `type_key(t)`, not the enum's `id`**, so it missed for every generic enum instance (`Option(i32)` included), emitted `// Error: enum type has no C name` **as a C comment**, and returned — while the caller kept emitting the await machinery around a now-empty match.

The residual failure is now a hard error, not a comment: reaching it means the whole `match` disappears, so it can never be benign.

## 2. `return(<compound expr>)` in tail position

The B1 tail materialization wraps the tail expression's code, but yo-self's `return(...)` codegen yields a **complete `return X` statement** (having already emitted the scope-end drops), where TS yields the value temp. A simple `return(n.*)` was fine — the materialization only kicks in for the compound case — which is why it hid.

## 3. An await whose result is never read

The struct only gets a field for variables crossing a state boundary, and a target nothing reads does not — but the extraction wrote `sm-><field>` regardless. Now skipped, which is what the linear-await path already does when there is no target at all.

## 4. `io.async` capture fields were never RC-retained

The state machine's dispose **does** drop the capture's RC fields; nothing retained them. TS balances that by dupping the whole capture struct through its synthesized `___dup`. yo-self synthesizes no such helper — for that program it emits **zero** per-type `___dup` where TS emits **124** — and its deferred-dup path is deliberately skipped inside a state machine.

An earlier draft of the issue blamed registry keying. **That was wrong**: there is no capture dup to find under any key, which is also why a `type_key`-keyed fallback "fixed" the crash while returning `n=4640`. `_rc_field_retain_line` is now the exact mirror of the existing `_rc_field_drop_line`, branch for branch.

RC changes get an emit diff, not just a green suite:

```
capture repro    incr 11 → 12  (exactly the one added retain), decr unchanged
box-eq repro     incr/decr unchanged
arc-spawn repro  incr/decr/atomic unchanged
```

## 5. Capture-struct vs future alias

An inline `io.async(...)` produces two temps that can share a generated name — the closure's CAPTURE STRUCT and the future. Only the future lives in `await_future_N`, but the alias search matched on **name alone**, so it could pick the capture struct; its deferred drop then ran against that field:

```
fn_..._id_40___drop((__yo_struct_..._id_28)(sm->await_future_1));
```

a drop of a struct **by value** applied to a state machine **pointer**. Fixed in both compilers by requiring the aliased variable to actually be a future — yo-self matched by name only too, it just hadn't manifested yet.

## The wasm CI red on an earlier push was infrastructure

The job log shows the failure *before any test ran*:

```
curl: (35) Recv failure: Connection reset by peer
Error: Could not download Wasmtime version 'v47.0.3'
```

No wasmtime → every wasm test reported `exit code undefined signal=null`. Running CI's exact command locally (wasmtime and emcc both present) passes **2355/2355**. Checked rather than assumed, since this branch touches RC emission.

## Validation

```
bun test src/tests/                      293/293
./yo-cli test ./tests --exclude internal  2713/2713
wasm-wasi (CI's exact command, local)     2355/2355
async_await.test.yo, self-hosted binary   144/144
gates_fast.sh                             failures=0
fixpoint_only.sh                          FIXPOINT_HOLDS
```

Two of my own earlier notes in the issue file were wrong and are corrected there: #3 was written up as "the combination with a compound return tail" (it is not — being unread is the whole trigger), and #4's registry-keying diagnosis, above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)