### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shd101wyy/yo",
   "displayName": "Yo",
-  "version": "0.1.35",
+  "version": "0.2.0",
   "main": "./out/cjs/index.cjs",
   "module": "./out/esm/index.mjs",
   "types": "./out/types/src/index.d.ts",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Yo Language",
   "description": "Yo language syntax highlighting",
   "icon": "Yo_logo.png",
-  "version": "0.1.35",
+  "version": "0.2.0",
   "categories": [
     "Programming Languages"
   ],


### PR DESCRIPTION
Version bump from the v0.2.0 release (the workflow's fallback branch — its gh pr create lacked permission, fixed in PR #95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)