### PR TITLE
Fix the native-Windows self-hosted compiler build (v0.2.0 seed-leg porting tail)

### DIFF
--- a/issues/fixed/windows-native-selfhosted-build-fails.md
+++ b/issues/fixed/windows-native-selfhosted-build-fails.md
@@ -1,0 +1,24 @@
+## FIXED (2026-08-11, branch fix/windows-native-selfhosted)
+
+All three classes, at their sources:
+
+1. `F_OK` — `yo-self/evaluator/exprs/import.yo` `_file_exists_sync` now uses
+   portable libc `stat` (MSVC-clean; mirrors TS `existsSync` and
+   `module_manager.yo`'s `_path_exists_sync`) instead of POSIX `access`.
+2. `setenv` — the self-hosted test runner (`yo-self/main.yo`) now sets
+   `YO_TEST_INDEX` through `std/env`'s portable `env.set` (which branches to
+   `_putenv_s` on Windows) instead of raw libc `setenv`.
+3. main-wrapper returns — TS's Windows/WASM `generateMainWrapper` branch now
+   emits module-level initialization into the same dedicated `void`
+   `__yo_main_module_init` helper the POSIX path uses (the effectful
+   initializers' bare `return;` escape checks were landing inside
+   `int main`). yo-self's port already had the helper (it was AHEAD — the
+   grep-yo-self-first rule) but was missing the post-init
+   `__yo_effect_escaped` checks on both paths; mirrored.
+
+Verified: full Windows cross-emit of `yo-self/main.yo` greps 0 for all
+three classes (remaining 3 "Unknown type:" markers are the benign
+comptime-only comment class present in working binaries); macOS suite
+162/162, corpus 27/27, FIXPOINT_HOLDS at s59. Final proof is the windows
+CI native-build step (lands via PR #95) going green — then flip it gating
+and promote the release windows-x64 leg.

--- a/src/codegen/functions/generation.ts
+++ b/src/codegen/functions/generation.ts
@@ -1066,7 +1066,23 @@ int main(int argc, char** argv) {
 }
 `);
     } else {
-      // Windows / WASM: run directly on the main thread.
+      // Windows / WASM: run directly on the main thread. Module-level
+      // initialization goes into the same dedicated `void` helper the POSIX
+      // path uses: an effectful initializer whose call escapes emits the
+      // effect-unwind check `if (__yo_effect_escaped) return;`, and that
+      // bare `return;` is a hard error inside `int main` (clang 21+
+      // -Wreturn-mismatch — the v0.2.0 windows seed leg failed on exactly
+      // this, three effectful initializers deep in the compiler's closure).
+      if (moduleLevelVars.length > 0) {
+        emitter.emitLine(`
+// Module-level mutable variable initialization (see the POSIX wrapper's note).
+static void __yo_main_module_init(void) {`);
+        for (const { cVarName, rhs } of moduleLevelVars) {
+          const rhsCode = generateExpr(rhs, "  ", context);
+          emitter.emitLine(`  ${cVarName} = ${rhsCode};`);
+        }
+        emitter.emitLine(`}`);
+      }
       emitter.emitLine(`
 // Main wrapper - calls __yo_user_main directly
 int main(int argc, char** argv) {
@@ -1076,14 +1092,10 @@ int main(int argc, char** argv) {
   __yo_args = (Slice_uint8_t_u42_){ .data = (uint8_t**)argv, .length = (size_t)argc };
   ${asyncInit}`);
 
-      // Generate module-level init code INSIDE main() so temp vars and function calls
-      // are valid C (not file-scope initializers).
       if (moduleLevelVars.length > 0) {
-        emitter.emitLine(`  // Initialize module-level mutable variables`);
-        for (const { cVarName, rhs } of moduleLevelVars) {
-          const rhsCode = generateExpr(rhs, "  ", context);
-          emitter.emitLine(`  ${cVarName} = ${rhsCode};`);
-        }
+        emitter.emitLine(`  // Initialize module-level mutable variables
+  __yo_main_module_init();
+  if (__yo_effect_escaped) return 0;`);
       }
 
       emitter.emitLine(`  // Call sync main

--- a/yo-self/codegen/functions/generation.yo
+++ b/yo-self/codegen/functions/generation.yo
@@ -903,7 +903,11 @@ generate_main_wrapper :: (fn(context : FunctionGenerationContext, module_vars : 
     context.consumed_var_pending_drops = saved_consumed;
   });
   if(is_target_posix(context.base.target_info), {
-    init_call := if(has_module_vars, String.from("  __yo_main_module_init();\n"), String.new());
+    // The escape check after module init mirrors TS generateMainWrapper: an
+    // effectful initializer that escapes must not fall through into user
+    // main. Bare `return NULL;`/`return 0;` are fine here (worker is void*,
+    // main is int) — the helper above is where a bare `return;` lives.
+    init_call := if(has_module_vars, String.from("  __yo_main_module_init();\n  if (__yo_effect_escaped) return NULL;\n"), String.new());
     block :=
       `
 // Program body runs on a large-stack worker thread (see generateMainWrapper).
@@ -943,7 +947,7 @@ int main(int argc, char** argv) {
 `;
     em.emit_string(block);
   }, {
-    init_call := if(has_module_vars, String.from("  __yo_main_module_init();\n"), String.new());
+    init_call := if(has_module_vars, String.from("  __yo_main_module_init();\n  if (__yo_effect_escaped) return 0;\n"), String.new());
     block :=
       `
 // Main wrapper - calls __yo_user_main directly

--- a/yo-self/evaluator/exprs/import.yo
+++ b/yo-self/evaluator/exprs/import.yo
@@ -30,17 +30,27 @@ open(import("std/string"));
 { Exception } :: import("std/error");
 { Path } :: import("std/path");
 { cwd } :: import("std/env");
-{ access, F_OK } :: import("std/libc/unistd");
+{ stat } :: import("std/libc/sys/stat");
+{ GlobalAllocator } :: import("std/allocator");
 { evaluate_expression } :: import("./expr.yo");
 { random_id } :: import("../../utils.yo");
 // ---------------------------------------------------------------------------
 // _file_exists_sync
 // ---------------------------------------------------------------------------
-/// Synchronous file existence check using POSIX `access(2)`.
+/// Synchronous file existence check via libc `stat` — portable to Windows
+/// (MSVC has stat in <sys/stat.h>; POSIX `access`/`F_OK` broke the v0.2.0
+/// windows seed leg). Mirrors TS `existsSync` and module_manager.yo's
+/// `_path_exists_sync`.
 _file_exists_sync :: (fn(absolute_path : String) -> bool)({
+  { malloc, free } :: GlobalAllocator;
   cstr := absolute_path.to_cstr();
   ptr := *(char)(cstr.ptr().unwrap());
-  unsafe(access(ptr, F_OK)) == int(0)
+  // 512 bytes comfortably exceeds `struct stat` on every supported target;
+  // only the return code is read.
+  buf := malloc(usize(512)).unwrap();
+  rc := unsafe(stat(ptr, buf));
+  free(.Some(buf));
+  rc == int(0)
 });
 // ---------------------------------------------------------------------------
 // Module path resolution (shared with main.yo's preload_module_tree)

--- a/yo-self/main.yo
+++ b/yo-self/main.yo
@@ -22,7 +22,7 @@ _(env : proc_env) :: import("std/env");
 { metadata } :: import("std/fs/metadata");
 { read_dir, FileType, remove_file } :: import("std/fs/dir");
 { Command } :: import("std/process/command");
-{ exit, setenv } :: import("std/libc/stdlib");
+{ exit } :: import("std/libc/stdlib");
 { ArrayList } :: import("std/collections/array_list");
 { AstExpr, BK_OPEN, BK_IMPORT, BK_TEST, ast_expr_is_fn_call_of, ast_expr_to_string, make_err_expr } :: import("./expr.yo");
 { ExprInfoTable, expr_info_table_new } :: import("./expr_info.yo");
@@ -1385,9 +1385,10 @@ run_test :: (
         (ri : usize) = batch_start;
         while((ri < batch_end) && !(bailed), {
           t := match(tests.get(ri), .Some(x) => x, .None => TestDecl(name : String.from(""), body_src : String.from("()")));
-          idx_cstr := String.from("YO_TEST_INDEX").to_cstr().ptr().unwrap();
-          val_cstr := (ri - batch_start).to_string().to_cstr().ptr().unwrap();
-          _sv := unsafe(setenv(*(char)(idx_cstr), *(char)(val_cstr), int(1)));
+          // std/env's portable wrapper, NOT raw libc setenv — Windows has no
+          // setenv (the v0.2.0 windows seed leg failed on it); env.set
+          // branches to _putenv_s there.
+          _sv := proc_env.set(String.from("YO_TEST_INDEX"), (ri - batch_start).to_string());
           tcmd := Command.new(tmp_bin.clone());
           st := io.await(tcmd.status(io), IoExn(io : io, exn : exn));
           if(st.success(), {


### PR DESCRIPTION
Fixes `issues/fixed/windows-native-selfhosted-build-fails.md` — the three error classes from the v0.2.0 windows-x64 seed leg, each at its source:

- **`F_OK`**: `_file_exists_sync` (import resolver) now uses portable libc `stat` (MSVC-clean, mirrors TS `existsSync`) instead of POSIX `access`.
- **`setenv`**: the self-hosted test runner sets `YO_TEST_INDEX` via `std/env`'s portable `env.set` (Windows `_putenv_s` branch).
- **main-wrapper returns**: the TS Windows/WASM wrapper now emits module-level init into the dedicated `void __yo_main_module_init` helper like POSIX (effectful initializers' bare `return;` escape checks were landing inside `int main`). yo-self already had the helper but lacked the post-init `__yo_effect_escaped` checks on both paths — mirrored.

Verified: a full Windows cross-emit of `yo-self/main.yo` greps **0** for all three classes (3 remaining `Unknown type:` markers are the benign comptime-only comment class present in working binaries); macOS suite 162/162, cli-diff corpus 27/27, FIXPOINT_HOLDS. The definitive proof is the windows CI native-build step (arrives via PR #95) going green — then it flips gating and the release windows-x64 leg gets promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)