### PR TITLE
Restore the seed trust chain: a self-built compiler can build the compiler again

### DIFF
--- a/issues/fixed/seed-built-stage1-miscompiles-current-source.md
+++ b/issues/fixed/seed-built-stage1-miscompiles-current-source.md
@@ -1,0 +1,189 @@
+# 2.3 blocker: the v0.2.0 seed binary mis-handles compiling current yo-self
+
+**Status: OPEN** (2026-08-11). Found by PR #98's first seed-driven CI run
+and reproduced locally.
+
+- **Linux CI (hollow sweep)**: seed-built stage-1 completes but the produced
+  compiler FAILS `tests/comptime.test.yo` + `tests/fn.test.yo` (RED) — both
+  pass under a TS-built stage-1 of the same source.
+- **macOS local**: the v0.2.0 binary compiling current `yo-self/main.yo`
+  errors out with `mimalloc: mi_free: invalid pointer` (stage-1 never
+  produced).
+
+## Why this was expected eventually
+
+A release binary IS a stage-2-class binary. The yo-self codegen still
+carries known self-built-only debt — most prominently the async match
+scrutinee-store family (`_store_temp_var_to_state_machine_if_needed` is a
+documented no-op stub; the TS-side fixes from PR #92/#93 were never
+ported), plus whatever new code shapes landed since v0.2.0 (TestSuite.
+exclude, the #95 yo-self changes) that the seed never compiled before.
+Compiling current source is the heaviest RC/async workload there is, so the
+debt surfaces as invalid frees / subtle miscompiles.
+
+## Path forward (ordered)
+
+1. **Port the scrutinee-store family to yo-self codegen** (the standing
+   "yo-self port pending" item) + rerun the fixpoint AND a seed-style
+   self-build-of-self battery locally (a self-built binary building the
+   source again — stage-2 building stage-1 — is the new pre-release gate).
+2. Ship that as v0.2.2-class release; only then bump SEED_VERSION and land
+   PR #98 (2.3). v0.2.1 (same codegen, current fixes) may improve things
+   but carries the same stub debt — verify before trusting.
+3. PR #98 stays open until a seed exists whose self-built stage-1 passes
+   the full sweep. The 2.3 workflow changes themselves are correct.
+
+## Repro
+
+```bash
+curl -fsSL https://github.com/shd101wyy/Yo/releases/download/v0.2.0/yo-v0.2.0-macos-arm64.tar.gz | tar -xz
+YO_MAIN_STACK_MB=4096 ./yo-v0.2.0-macos-arm64/bin/yo compile yo-self/main.yo --release --allocator mimalloc -o /tmp/yo-seedstage1
+# macOS: mi_free invalid-pointer errors; Linux: binary produced but
+# tests/comptime.test.yo + tests/fn.test.yo RED under it.
+```
+
+## Progress (2026-08-11, evening)
+
+The scrutinee-store port landed (`_store_temp_var_to_state_machine_if_needed`
+is real in yo-self; s60 battery fully green incl. FIXPOINT_HOLDS with the
+stores in the emitted C). The stage-2 gate moved but is not closed:
+
+- stage-2-built binary: async_await 162/162 ✓ (was part of the crash class)
+- `comptime.test.yo` / `fn.test.yo`: the binary now SEGVS (exit 11) while
+  COMPILING the generated batch program (`--verbose` shows "batch compile
+  failed (exit 11)"; non-verbose confusingly exits 0 — separate runner bug
+  worth a look). Same family, next layer.
+
+Next: rerun the failing batch with --keep-generated-files (if supported) or
+regenerate it, compile it directly under /tmp/local_s2 vs /tmp/yo-s60 to
+isolate evaluator-vs-codegen phase, then bisect the batch contents. The
+remaining unported family pieces are the match.ts:279 + state-code-gen.ts:1644
+scrutinee-store call-site mirrors and the binding-registration/dispose-skip
+pair (yo-self match.yo has NO SM handling at all — 19 TS call sites total,
+inventory pending).
+
+## ROOT CAUSE ISOLATED (2026-08-11, late)
+
+Minimal repro (`/tmp/v2.yo`, stage-2 rc=139, stage-1 rc=0):
+
+```rust
+main :: (fn() -> unit)({
+  io :: __yo_builtin_io;
+  begin(comptime_expect_error(comptime_assert(i32 == i32, "x")), ());
+});
+```
+
+Probes: `comptime_expect_error(comptime_assert(false, "boom"))` OK, bare
+`comptime_expect_error(i32 == i32)` OK, undefined-name OK — the throw must
+happen INSIDE `evaluate_comptime_assert`'s ARG evaluation.
+
+Function-body diff between the TS-emitted C (`/tmp/ts_stage1.c:502451`) and
+the yo-self-emitted C (`/tmp/local_stage2.c:1044848`, `yo_id_369945`) of
+`evaluate_comptime_assert` (yo-self/evaluator/builtins/comptime_assert.yo:38),
+at the `__yo_effect_escaped` early-return after
+`evaluate_expression(arg_expr, ...)`:
+
+```c
+// TS (correct):
+fn_..___drop(msg_expr_opt);
+fn_..___drop(arg_expr_opt);      // drops the OWNING Option locals
+
+// yo-self (the bug):
+__yo_decr_rc((void*)(arg_expr)); // drops the BORROWED match binding (.Some(arg_expr) =>)
+switch (msg_expr_opt.tag) { case SOME: __yo_decr_rc(msg_expr_opt.data.Some.value); ... }
+```
+
+The borrowed `arg_expr` (bound by `.Some(arg_expr) =>` with no dup) gets a
+raw decr — over-drop → the AST node dies → codegen later walks it
+(`expr_contains_return_statement` reading `e->tag` at offset 0x40) → SEGV.
+This is the escape-cleanup borrow-binding class: TS guards with
+`resolveDropTargetInScope` (return.ts ~line 336: "match the drop target by
+variable identity, not just name — a match-arm payload borrow must not
+stand in for the outer variable"). Suspect either `_keep_pending_drop` /
+the drop-target C-name resolution in `yo-self/codegen/exprs/return.yo`
+resolving the pending drop (which TS resolves to `arg_expr_opt`) to the
+inner binding, or the inline drop generator choosing the binding name.
+
+NEXT: instrument/inspect `generate_pending_deferred_drops`'s target
+resolution in return.yo for this shape; the extracted bodies are in
+/tmp/fn_ts.c and /tmp/fn_s2.c; rebuild s61 + rerun /tmp/v2.yo emit under a
+fresh stage-2 to verify any fix (then comptime/fn tests + sweep + fixpoint).
+
+## Minimization status (handoff)
+
+Two mini attempts (/tmp/mini.yo, /tmp/mini2.yo: ref-enum Option binding, arm
+calls a throwing fn, single/double binding use) do NOT reproduce — both
+codegens emit only temp drops in the arm's escape block, never the binding.
+The real comptime_assert arm differs in: the binding is used in a LATER
+nested exn.throw inside a TEMPLATE STRING (`${ast_expr_to_string(arg_expr)}`),
+there are TWO fn-level Option locals (arg_expr_opt/msg_expr_opt) whose
+fn-level deferred drops stack with the arm's, and the arm's begin holds
+multiple := declarations. Next repro attempt should copy the arm shape
+verbatim (nested match + conditional throw using the binding in a template).
+
+Alternative (likely faster): compare the EVALUATOR-side drop sets directly —
+run both compilers on yo-self/evaluator/builtins/comptime_assert.yo alone
+(check/emit) with a temporary debug print of deferred_drop_expressions for
+the `.Some(arg_expr)` arm's begin (TS: log in match.ts/begin.ts where
+deferredDropExpressions is read; yo-self: eprintln in codegen/exprs/match.yo
+generate_case_body where cur_drops is read), and diff the entry lists. If
+the LISTS match, the bug is yo-self's codegen-side emission (drop-target
+name resolution); if they differ, it is evaluator drop policy (the
+RC_POLICY_MECHANISM_SPLIT policy-patch family).
+
+Key artifacts: /tmp/v2.yo (6-line crash repro, stage-2 rc=139),
+/tmp/fn_ts.c + /tmp/fn_s2.c (the diverging emitted bodies), /tmp/local_s2 +
+/tmp/yo-s60 (binaries), /tmp/ts_stage1.c + /tmp/local_stage2.c (full C).
+
+## Analysis trail (2026-08-11, night — for the instrumentation session)
+
+- The buggy escape block (full view, /tmp/fn_s2_full.c lines 40-60) drops
+  BOTH `arg_expr` (raw decr — ref-typed, so the entry genuinely targets the
+  BINDING) AND `arg_expr_opt`'s payload (inline Option switch) — same node,
+  twice. TS drops only the two Options. The delta is exactly ONE extra
+  entry: drop(arg_expr). It recurs at ~10 escape points in the fn.
+- Ruled out: yo-self's `_resolve_drop_target_in_scope` is a faithful port
+  (identity-based); bindings are CREATED non-owning in both evaluators
+  (match.ts:921/972 `isOwningTheRcValue: false`; match.yo:2100/2138 pass
+  false); BOTH sides have the all-cases-own propagation (expr.ts:2223-2233,
+  utils.yo:1592-1595) — so no obvious one-sided flip.
+- Mini repros do NOT reproduce (mini/mini2/mini3 in /tmp — arm binding +
+  throwing call + reuse + nested-match template throw all emit correct
+  escape drops under BOTH codegens). The trigger is something else in
+  comptime_assert.yo's arm (candidates: the `(x : Option(T)) = match(...)`
+  TYPED fn-level declarations; is_comptime scrutinee flag; the arm being
+  inside `if(validating || !executing)`; interaction with the all-cases-own
+  merge across the arm's NESTED match).
+- NEXT (do this first): instrument — in yo-self/codegen/exprs/return.yo's
+  generate_pending_deferred_drops, before emission, eprintln each kept
+  drop's `get_deferred_drop_target_atom_name` WHEN it equals "arg_expr",
+  plus whether the entry came from pending vs expr-info; rebuild stage-1
+  (TS-built, ~10 min), fixpoint stage-2 emit of yo-self, and observe which
+  path emits it. Also instrument the all-cases-own flip (utils.yo:1593) to
+  eprintln when it flips a var named "arg_expr" — if it fires during the
+  stage-2 emit's EVALUATION of comptime_assert.yo, compare with a matching
+  console.log in expr.ts:2223 under `./yo-cli check
+yo-self/evaluator/builtins/comptime_assert.yo`. REVERT instrumentation
+  after.
+
+## FIXED (2026-08-11, night) — 13 lines in yo-self/codegen/exprs/return.yo
+
+Final root cause (three probe rounds; instrumentation reverted): the
+executing path's `arg_expr := match(arg_expr_opt, …)` — a LATER fn-level
+owning local — has its pending scope drop evaluated at the VALIDATION arm's
+`__yo_effect_escaped` cleanup points. That escape path deliberately runs
+with `skip_env_check=true` (an earlier stage-2 leak fix) whose liveness
+signal is the block-scope stack keyed by C NAME — and the arm's same-named
+match binding `.Some(arg_expr)` makes the name look declared, so the later
+variable's drop emitted a raw decr against the BORROWED binding.
+
+Fix: the reduced (escape) filter in `_keep_pending_drop` now also applies
+the positional guard the full env branch has — the drop's TARGET variable
+(resolved by identity from the drop expr) initialized AFTER the cleanup
+point is skipped. Mirrors TS's "declared after this cleanup point" skip.
+
+Verified: FIXPOINT_HOLDS; the 6-line repro emits rc=0 under a stage-2
+binary; a STAGE-2-BUILT compiler passes tests/comptime.test.yo 30/30,
+tests/fn.test.yo 24/24, tests/async_await.test.yo 162/162 (the v0.2.0-seed
+RED set); stage-1 suites + 27/27 corpus green. The seed-trust chain is
+restored — SEED_VERSION bumps to the first release containing this fix.

--- a/plans/P2_RETIRE_SRC.md
+++ b/plans/P2_RETIRE_SRC.md
@@ -267,3 +267,61 @@ mimalloc`), smoke-tests it from OUTSIDE the checkout
 2.1 (seed release) is the maintainer's cut — everything else here can land
 first. The practical order: finish 2.2 (self-build verified both ways) →
 2.4 ports → 2.3 CI swap on a seed release → 2.5 retire → 2.6 docs.
+
+## 2.3 — CI migration: the seed replaces bun/node (campaign design, started 2026-08-11, branch `p2/ci-migration`)
+
+Prereqs all DONE: seed v0.2.0 shipped (self-locating bundles), repo-root
+`yo build` verified, all five targets prove the native build on PRs
+(PR #95). Pin `SEED_VERSION: v0.2.0` once at the top of test.yml; bump it
+each release.
+
+Common step (per job/leg): download
+`yo-$SEED_VERSION-<target>.tar.gz` from the GitHub Release, extract, put
+`bin/` on PATH — no YO_STD needed (bundles self-locate). Target mapping
+follows the seed matrix (ubuntu-latest→linux-x64, ubuntu-24.04-arm→
+linux-arm64, macos-latest→macos-arm64, macos-26-intel→macos-x64,
+windows-latest→windows-x64).
+
+Job-by-job treatment:
+
+| job                                     | 2.3 change                                                                                                                                                                                                                    |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test` (5 legs)                         | bun STAYS for the TS unit tests until 2.5. The native-probe step switches its builder: seed `yo build` compiles yo-self (previous release builds current compiler — the real trust-chain dogfood) instead of the TS compiler. |
+| `bootstrap-fixpoint` + stage-3          | stage-1 built by the SEED (`yo build`), not TS. Chain becomes: previous release → stage-1 → stage-2 ≡ stage-3.                                                                                                                |
+| self-hosted tier-1 gates                | stage-1 via seed.                                                                                                                                                                                                             |
+| internal-tests self-hosted differential | stage-1 via seed; the TS shards stay as ground truth until 2.5.                                                                                                                                                               |
+| hollow sweep                            | stage-1 via seed.                                                                                                                                                                                                             |
+| wasm / TSan legs                        | unchanged until 2.5 (TS-driven).                                                                                                                                                                                              |
+| vscode-extension packaging              | keeps bun forever (by design).                                                                                                                                                                                                |
+
+Gate for 2.3: all self-hosted arms green with NO TS involvement in their
+stage-1 builds. The "no bun/node anywhere" gate is 2.5's, not 2.3's — the
+TS unit tests and TS differential arms retire together with src/.
+
+Windows follow-up (from the PR #95 iterations): the probe SEGVs (rc=139)
+on the child-compile-FAILURE error path natively — only reachable when a
+compile fails; tracked in issues/fixed/windows-native-selfhosted-build-fails.md
+(iteration-3 note). Promote the release windows-x64 leg after the next
+release proves it E2E.
+
+## 2.5 — retire `src/`: sequence (written 2026-08-11, blocked on 2.3)
+
+Remaining bun/node consumers once 2.3 lands (inventory):
+
+| consumer                                                               | retire move                                                                                                                |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| TS unit tests (`bun test`, `src/tests/*.test.ts`)                      | 2.4 already re-expressed the coverage; delete with `src/`                                                                  |
+| internal-tests TS shards (ground truth)                                | ground truth becomes the SEED-built stage-1 (the differential arm keeps its shape; the shards retire)                      |
+| `test` job's `bun run build` + unit-test/fmt/smoke steps via `out/cjs` | replace with the seed binary (`yo fmt --check`, `yo init`+`yo build run` smoke); unit-test step deleted                    |
+| wasm legs (emcc via TS CLI)                                            | drive with the seed binary (`--target wasm32-*` works self-hosted)                                                         |
+| TSan leg                                                               | seed binary compiles the sync tests; no TS involvement needed                                                              |
+| `yo-cli` bash + `yo-cli.ps1` shims                                     | re-point from `node out/cjs/yo-cli.cjs` to the installed native binary (P3 item 2's shim)                                  |
+| `package.json`/`bun.lock`/`build.js`/`out/`/`node_modules`             | delete from root; `vscode-extension/` keeps its own lockfile (stays TS by design)                                          |
+| `scripts/build-site.ts` (docs site, runs under bun)                    | rewrite as a Yo program or keep bun in the RELEASE workflow only (release already needs node for vsce; acceptable)         |
+| `computeDependencyHash` open question                                  | decide with 2.5: the TS-only dep-hash path either ports or the lock format drops it — resolve when deleting `src/fetch.ts` |
+
+Sequence: 2.3 green on a trusted seed → convert the remaining test.yml
+steps job-by-job (each PR keeps the suite green) → freeze `src/` (attic
+tag `src-attic-final`) → delete + root cleanup → re-point shims → 2.6 docs
+sweep (AGENTS.md build/test commands, `.github/instructions/`, skills —
+everything that says `bun run build`).

--- a/plans/P3_DISTRIBUTION.md
+++ b/plans/P3_DISTRIBUTION.md
@@ -1,0 +1,106 @@
+# P3 — distribution: installers, the releases channel, static musl
+
+**Working doc for Phase 3 of
+[`SELF_HOSTING_COMPLETION.md`](SELF_HOSTING_COMPLETION.md).** Same contract
+as `P1_CLI_PARITY.md`/`P2_RETIRE_SRC.md`: measured numbers, live status,
+traps recorded as found. Drafted 2026-08-11, while P2's last blocker (the
+seed-trust UAF) was in flight.
+
+## What P2 already delivered that P3 builds on
+
+- **v0.2.1 ships all five native bundles** (linux-x64, linux-arm64,
+  macos-arm64, macos-x64, windows-x64), each `bin/yo` + `std/` +
+  `vendor/mimalloc/` + LICENSE, **self-locating** (`--std-path` → `YO_STD` →
+  exe-relative walk-up → `./std`) — an installer only extracts and puts
+  `bin/` on PATH.
+- **Releases are atomic** (draft until required legs upload, then a publish
+  job flips it) — `latest` can never point at a bundle-less release, which
+  is the invariant `install.sh` needs.
+- **npm publishing stopped at v0.2.0** — the npm-based `yo version` cache is
+  dead for new versions, making item 2 here the most urgent.
+- Release-pipeline traps already handled: personal-repo rulesets can't
+  bypass the Actions integration (bump lands via `[skip ci]` PR; gate falls
+  back to the parent SHA); `macos-26-intel` is the last Intel runner label.
+
+## Item 1 — `util/install.sh` + `util/install.bat` (Koka model)
+
+Reference: `~/Workspace/koka/util/install.sh` (719 lines) / `install.bat`
+(610). Shape to copy: single POSIX-sh script, curl-pipe-able,
+version-selectable (`--version vX.Y.Z`, default latest), `--prefix`
+override (`/usr/local` default; `%LOCALAPPDATA%\yo` on Windows), uninstall
+mode, dry-run, os/arch sniffing, PATH guidance, optional `--vscode` flag
+(`code --install-extension`).
+
+- Download URL: `https://github.com/shd101wyy/Yo/releases/download/<tag>/yo-<tag>-<os>-<arch>.tar.gz`
+  (exactly what the seed jobs publish today).
+- **Install INTO the per-version cache layout** (item 2's layout), with a
+  `yo` shim on PATH that resolves `.yo-version` pins — the installer and
+  `yo version install X` become two front-ends to one mechanism. Do item 2
+  first or together; a `--prefix`-only installer now would be rework.
+- Host both scripts at the Pages site root (`scripts/build-site.ts` grows a
+  copy step); the canonical one-liner
+  `curl -sSL https://shd101wyy.github.io/Yo/install.sh | sh` stays stable
+  across releases while release CI bumps the default version inside it.
+
+## Item 2 — `yo version` re-pointed at GitHub Releases (URGENT)
+
+Today (`src/version-cache.ts` + `yo-self/version_cache.yo`):
+`~/.cache/yo/versions/<version>/` holds an **npm package** (package.json +
+node_modules) and downloads from the npm registry — dead for ≥ v0.2.0.
+
+Redesign:
+
+- Cache layout becomes the native bundle: `~/.cache/yo/versions/<v>/bin/yo`
+  - `std/` + `vendor/` (exactly a bundle extraction; self-locating, so no
+    per-version env wiring).
+- `version list --remote` reads the GitHub Releases API (no auth for public
+  repos; handle rate-limit 403 gracefully).
+- `version install X` downloads + extracts the bundle for the HOST platform
+  (reuse the os/arch sniff from item 1 — implement once in Yo, both
+  front-ends call it).
+- `.yo-version` pinning semantics unchanged; the shim (`yo-cli` bash /
+  `yo-cli.ps1`, re-pointed at native binaries by 2.5) resolves the pinned
+  version's `bin/yo`.
+- BOTH compilers until 2.5 lands (src/version-cache.ts + version_cache.yo,
+  1:1); differential cases for `version list`/`install` (network-gated,
+  `network=1` in the corpus opts).
+
+## Item 3 — static-musl Linux bundles
+
+One fully static musl binary per arch (Zig/Deno/Bun model) replaces both
+glibc Linux legs; a glibc `yo` cannot run on Alpine (different ld.so +
+symbol versioning). Constraints (from `BUILD_SYSTEM.md` + the plan):
+
+- Yo cannot cross-compile gnu→musl — release CI builds inside an Alpine
+  container (`container:` on the linux legs, or a docker-run step).
+- `liburing` must be statically linked; validate io_uring, mimalloc, and
+  worker-thread stack sizing under musl once (`x86_64-linux-musl` target
+  exists for this).
+- User programs are unaffected (compiled on the user's machine against
+  their libc) — this is only the `yo` binary's portability.
+- Fallback if musl validation surfaces real problems: Koka-style separate
+  `-gnu`/`-musl` bundles + distro sniffing in install.sh.
+
+## Item 4 — release hardening (carried from P2 notes)
+
+- Per-platform fixpoint (byte-identity) as a scheduled or release-time job
+  with the linux job's memory tuning — each self-emit holds ~9-11.5 GB, so
+  it cannot ride the 7 GB suite runners (P2_RETIRE_SRC.md §2.2 note).
+- The windows error-path rc=139 follow-up (probe SEGV on a failed child
+  compile) — issues/fixed/windows-native-selfhosted-build-fails.md
+  iteration-3 note.
+
+## Gate
+
+Fresh VM/container per platform: `curl … | sh` (or `install.bat`), then
+`yo init && yo build test` succeeds with no toolchain present except a C
+compiler (document clang/gcc as the one prerequisite). Alpine is one of the
+containers (proves musl). `yo version install <prev>` + `.yo-version`
+pinning round-trips.
+
+## Sequencing
+
+Item 2 first (it unblocks version management NOW and defines the cache
+layout item 1 installs into) → item 1 (installer over that mechanism) →
+item 3 (musl bundles; installer needs no change if names stay
+`linux-<arch>`) → item 4 opportunistically. P4 (LSP) stays separate.

--- a/yo-self/codegen/exprs/other_fn_call.yo
+++ b/yo-self/codegen/exprs/other_fn_call.yo
@@ -29,7 +29,8 @@ open(import("std/string"));
 { FunctionGenerationContext } :: import("../functions/context.yo");
 { get_type_string, get_variable_type_string, get_variable_name_for_codegen, sanitize_for_c_identifier, is_function_value_with_only_builtin_yo_inline_function_call, type_key, get_runtime_struct_fields, RuntimeStructField, can_optimize_as_nullable_pointer, can_optimize_as_simple_enum, get_enum_variant_c_name, ImplClosureCallInfo, scope_stack_contains } :: import("../utils/index.yo");
 { resolve_some_type_to_concrete } :: import("./closures.yo");
-{ extract_fn_trait_from_type } :: import("../../evaluator/trait_checking.yo");
+{ extract_fn_trait_from_type, type_implements_future } :: import("../../evaluator/trait_checking.yo");
+{ CapturedVariable } :: import("../../evaluator/async/await_analysis_types.yo");
 { generate_comptime_value } :: import("./comptime_value.yo");
 { generate_deferred_drop_expressions, emit_deferred_dup_or_code } :: import("./drop_dup.yo");
 { generate_yo_inline_function_call } :: import("./inline_fns.yo");
@@ -249,11 +250,53 @@ _split_top_level_args_list :: (fn(s : String) -> ArrayList(String))({
 _resolve_var_name_in_context :: (fn(var_name : String, context : FunctionGenerationContext) -> String)(
   var_name
 );
-/// SM temp-var store (Phase 5) — no-op outside a state machine. Mirrors
-/// `storeTempVarToStateMachineIfNeeded`.
-_store_temp_var_to_state_machine_if_needed :: (fn(temp_var : String, indent : String, context : FunctionGenerationContext) -> unit)(
-  ()
-);
+/// SM temp-var store — the REAL port of `storeTempVarToStateMachineIfNeeded`
+/// (other-fn-call.ts:237; was a documented no-op stub until 2026-08-11).
+/// Inside a state machine, a local temp declared as a C local must ALSO be
+/// stored to its `sm->var_<id>` field, or every deferred drop naming that
+/// field is a silent no-op on calloc zero (the async-match-scrutinee leak
+/// family). The stub's absence surfaced as mi_free invalid-pointer crashes
+/// the moment a SELF-BUILT binary compiled the compiler — see
+/// issues/fixed/seed-built-stage1-miscompiles-current-source.md.
+_store_temp_var_to_state_machine_if_needed :: (fn(temp_var : String, indent : String, context : FunctionGenerationContext) -> unit)({
+  if(context.in_async_state_machine.is_none(), return(()));
+  smv := match(
+    context.state_machine_variables,
+    .Some(m) => m,
+    .None => return(())
+  );
+  // Lookup by id key first, then FIRST-MATCH-BY-NAME reading ENTRY fields
+  // (never derive emitted names from map keys — the PR #92 capture lesson).
+  (found : Option(CapturedVariable)) = smv.get(temp_var);
+  if(found.is_none(), {
+    vals := smv.values();
+    (go : bool) = true;
+    while(go, {
+      match(
+        vals.next(),
+        .Some(cv) => if(cv.base.name == temp_var, {
+          found = Option(CapturedVariable).Some(cv);
+          go = false;
+        }),
+        .None => {
+          go = false;
+        }
+      );
+    });
+  });
+  match(
+    found,
+    .None => (),
+    .Some(cv) => {
+      match(cv.kind, .Outer => return(()), .Local => ());
+      // Skip Future-typed temps — their lifecycle is managed by the await
+      // logic (await_future_X fields); storing here would double-free.
+      if(type_implements_future(cv.base.ty), return(()));
+      em := context.base.emitter;
+      em.emit_string_line(`${indent}sm->var_${cv.base.id} = ${sanitize_for_c_identifier(temp_var.clone(), false)};`);
+    }
+  );
+});
 /// The container-pointer C code for an interior `ref` argument (an Index-trait
 /// expression), or `.None`. Mirrors `getInteriorRefContainerCode`.
 _get_interior_ref_container_code :: (fn(arg_expr : AstExpr, param_is_ref : bool, indent : String, context : FunctionGenerationContext) -> Option(String))(

--- a/yo-self/codegen/exprs/return.yo
+++ b/yo-self/codegen/exprs/return.yo
@@ -243,6 +243,19 @@ _keep_pending_drop :: (fn(drop_expr : AstExpr, expr : AstExpr, already : HashSet
         if(consumed_esc, {
           return(false);
         });
+        // Positional guard, ALSO on the escape path: a drop whose TARGET
+        // variable is initialized AFTER this cleanup point must not fire —
+        // the scope-stack name signal below cannot tell two SAME-NAMED
+        // variables apart (a later `x := …` vs an in-scope match binding
+        // `.Some(x)`: the binding's open frame makes `x` look declared, and
+        // the emitted drop then raw-decrs the BORROWED binding — the
+        // seed-trust UAF, issues/fixed/seed-built-stage1-miscompiles-current-source.md).
+        // Mirrors the full env branch's initialized-after skip (TS
+        // return.ts "declared after this cleanup point").
+        init_after := match(tv.initialized_at_token, .Some(it) => _variable_initialized_after_cleanup_point(it, expr), .None => false);
+        if(init_after, {
+          return(false);
+        });
       },
       .None => ()
     );


### PR DESCRIPTION
Split from PR #98 so the compiler fixes land green ahead of the seed-driven CI (which needs a release containing them).

- **`storeTempVarToStateMachineIfNeeded` is now real in yo-self** (was a documented no-op stub) — SM-local temps store to their `sm->var_<id>` fields.
- **Escape-path drop filter gains the positional guard**: a later `x := …` local's pending drop no longer fires at an earlier same-named match binding's escape cleanup — the raw decr of the borrowed binding was the v0.2.0-seed rc=139 UAF (write-up: `issues/fixed/seed-built-stage1-miscompiles-current-source.md`, three instrumentation rounds).

Verified: FIXPOINT_HOLDS; a **stage-2-built compiler** passes the v0.2.0-RED set (comptime 30/30, fn 24/24, async 162/162); stage-1 suites + 27/27 corpus. Sequencing: merge → v0.2.2 release → PR #98 bumps `SEED_VERSION` and its seed-driven jobs go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)