### PR TITLE
Def-eval swallow: nine roots fixed — sibling/forward/cross-impl dispatch and value binders now resolve at definition time

### DIFF
--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -530,6 +530,41 @@ product is kept out of codegen's channels (fid recording, spec minting).
 Any further degrade must answer "which codegen channel can this abstract
 value reach?" before landing.
 
+### Root #3 (797, Clone impl) — discriminator narrowed to the TRAIT-CONSTRUCTOR field path (2026-08-13, probes on the trial-scoped build)
+
+Probe series (`scratchpad` cc\_\* files, two impls on `G(T)` where the second
+calls the first's `len`; the CALLER must return a SomeT-containing type or no
+dg-trial runs and the pass is VACUOUS — `via2/via3` returning `usize` "passed"
+that way):
+
+| second impl's shape                                     | def-time trial |
+| ------------------------------------------------------- | -------------- |
+| direct field, `self : Self`, returns `Option(usize)`    | resolves       |
+| direct field, `inout(self) : Self`, returns `Option(…)` | resolves       |
+| direct field + `where(T <: Clone)`                      | (vacuous)      |
+| `Clone(clone : …)` trait constructor                    | **swallows**   |
+| CUSTOM trait constructor (`MyT(via5 : …)`)              | **swallows**   |
+
+So cross-impl dispatch inside a TRAIT-CONSTRUCTOR field's trial still fails
+where the direct branch (same receiver, same call) now succeeds. The
+suspected difference: the g\_ branch evaluates fields with
+`ctx.expected_type` = the trait's substituted field type, while the direct
+branch CLEARS expected_type.
+
+**PINPOINTED (instrumented build, `YO_DEBUG_DISPATCH=1`):** the trait
+branch's trial binds `self` to a FRESH `G` instantiation minted by
+`_substitute_self_in_method_ty` (recv id 5094 ≠ the impl pattern 3377),
+and `try_match_generic_impl(len's pattern 3170, recv 5094)` dies INSIDE
+`synthesize_types` (a `[tm-try]` with no `[tm-end]` = the synthesis
+exception fired) — unifying the pattern's `?*(T_len)` against the
+substituted copy's `?*(T_clone)` structure throws where TS unifies. So
+root #3 is a `types/synthesize.yo` SomeT-vs-SomeT gap, NOT a dispatch
+ranking problem. The direct branch never mints the substituted copy (no
+expected type), so its receiver IS the pattern instantiation and synthesis
+succeeds. Debug hooks left in-tree: `[dispatch-miss]` (env.yo,
+YO_DEBUG_DISPATCH), `[tm-try]/[tm-none]/[tm-end]` (impl.yo, same var),
+`[abstract-spec]` (function.yo, YO_DEBUG_SWALLOW).
+
 ### B. Impl-level VALUE binder bound as a TYPE (#4, #5, #6)
 
 ```rust

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -442,6 +442,53 @@ before. The entries carry real values and the Case-3-direct shape, so this is
 the faithful-port direction (TS shows in-flight evaluated fields to both
 paths); the full battery is the arbiter.
 
+### LANDED 2026-08-13 (branch `fix/family-a-provisional-static`) — families A and B, measured
+
+Three commits, each measured on the std baseline (importer of std/fmt):
+
+| stage                                                   | swallows |
+| ------------------------------------------------------- | -------- |
+| baseline (post-PR #110)                                 | 19       |
+| + per-field provisional registration (earlier siblings) | 18       |
+| + forward shells (later siblings) + trait-ctor + fam B  | 14       |
+
+Roots cleared: #1, #2 (slice_copy family, incl. the transient with_capacity
+and from_array layers), #4, #5 (Array slice_copy — family B), #7. #6
+progressed to its next layer (prelude 7623, SomeT callee).
+
+**Layered findings, in discovery order:**
+
+1. **Earlier siblings** (`Self.new()` before `slice_copy`): per-field
+   provisional registration with the REAL forall-stamped FuncVal; static
+   lookup consults provisional LAST (below the generic-impl fallback).
+2. **Shell values are uncallable** — a shell FuncVal carries an EMPTY
+   capture snapshot, and the inline-FuncVal call arm builds the body env
+   from it (`capture_env_for`), so calling a shell evaluated its body in an
+   env with NO module bindings (`Variable "GlobalAllocator" not found`,
+   push's body from slice_copy's trial). Provisional forward entries must
+   carry `value : None` — callable from the TYPE alone, the trait-splice
+   contract.
+3. **The eager pre-pass itself diverges imm_map** — experiment B (pre-pass
+   head-evals kept, registration DISABLED) still turned
+   `tests/imm_map.test.yo` RED: `Map(i32,i32).new()`'s batch-time
+   specialization failed `Type mismatch for type member "_root": Expected
+<enum>, Got Type(1)`. The poison is the EARLY evaluation of every
+   field's signature head (map.yo's `Map(K, U)` instantiations), not the
+   entries. A `YO_C2_PREPASS_SKIP` bisect build confirmed module locality:
+   skipping only imm/map went GREEN. The underlying instantiation-order
+   fragility is still unexplained — TS runs the same eager shape safely.
+4. **Resolution: lazy materialization.** Case 2 pushes an in-flight record
+   (receiver id, unevaluated colon-pair fields incl. trait-constructor
+   inners, forall env, ctx); env.yo's provisional-miss paths call
+   `materialize_in_flight_method` (callback slot), which head-evals ONLY
+   the sibling actually asked for, once per label. Sweep: 188/188 GREEN
+   expected (imm_map verified 21/21 directly; full sweep pending).
+5. **Family B**: name-only side table (`types/creators.yo`), registered
+   syntactically at the impl binder site, resolved PURELY (builtin scalar
+   names) in `_build_def_time_body_env`'s capture copy, cleared with the
+   impl. The forall-env binding stays `TypeVal(SomeT)` (load-bearing for
+   receiver-pattern eval).
+
 ### B. Impl-level VALUE binder bound as a TYPE (#4, #5, #6)
 
 ```rust

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -489,6 +489,47 @@ progressed to its next layer (prelude 7623, SomeT callee).
    impl. The forall-env binding stays `TypeVal(SomeT)` (load-bearing for
    receiver-pattern eval).
 
+### Abstract-binding acceptance (root #3 / cross-impl) — the ledger of scoping attempts
+
+The TS contract (tryMatchGenericImpl substitutions extraction): a binding
+unified to a DIFFERENT SomeType counts as bound. yo-self's
+`_resolve_one_forall_binding` rejected every SomeT. Landing the acceptance
+took three scopings, each measured:
+
+| variant                                           | swallows | canaries                                    |
+| ------------------------------------------------- | -------- | ------------------------------------------- |
+| accept everywhere (id + name channels)            | 4        | **std module eval BREAKS** (std/string)     |
+| id channel only                                   | 13       | all green — but array_list roots return     |
+| id always + name channel gated to def-time trials | 10       | imm_map green; **derive_clone_complex RED** |
+
+The name channel is what resolves array_list's cross-impl dispatch (the id
+channel misses those bindings); unscoped it picks up unrelated same-name
+SomeTs from outer scopes. `in_def_time_trial` (context.yo) is set around
+the three `_trial_eval_fn_body` call sites (a swallowed error unwinds OUT
+of the helper, so in-helper restore is unreachable — set/restore lives at
+the call sites) and `_materialize_default_body`'s call site.
+
+**derive_clone_complex regression (open):** the batch C calls
+`yo_id_..._rtparam0_R_gs_...` — a specialization MINTED WITH AN ABSTRACT
+type in its key. The emitter skips a SomeT-laden spec as hard-generic while
+the call site still emits the direct call. A guard skipping the mint when
+`in_def_time_trial() && (bindings or args contain SomeTs)` did NOT fix it —
+the mint happens OUTSIDE any flagged trial (context still unidentified; the
+`[abstract-spec]` YO_DEBUG_SWALLOW print at the mint's register site names
+fid + flag state for the next run). Two def-time degrades (comptime CTFE
+non-FuncVal → unknown; SomeT callee → unknown) were tried alongside and
+REVERTED: they let trials proceed deep enough to stamp partial ExprInfos
+that leak into emitted specializations (imm_map RED again, FTT comment
+INSIDE `map_values`' emitted C).
+
+**The structural lesson:** yo-self's def-time trials stamp ExprInfos on
+SHARED body ASTs that codegen consumes directly for some shapes (derive
+bodies, batch mains). Converting a MISSING stamp into an ABSTRACT stamp
+trades statement-level FTT markers for miscompiles unless every abstract
+product is kept out of codegen's channels (fid recording, spec minting).
+Any further degrade must answer "which codegen channel can this abstract
+value reach?" before landing.
+
 ### B. Impl-level VALUE binder bound as a TYPE (#4, #5, #6)
 
 ```rust

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -410,6 +410,38 @@ Next probe: extend the minimal generic-impl repro one property at a time toward
 the real ArrayList (optional-pointer field → many methods → a preceding failing
 trial) until it reproduces; that names the third factor without guessing.
 
+### IMPLEMENTED 2026-08-13 (branch `fix/family-a-provisional-static`) — the §3 handover shape, measurements pending
+
+The three-part fix from `plans/HANDOVER_DEF_EVAL_SWALLOW.md` §3, with one
+correction found by reading: **Case 3 needs NO new registration.** Its field
+loop already registers each method into the PERMANENT registry as the field
+completes (`impl.yo` `register_type_trait_method` in-loop, plus the
+forward-shell supersede), so static `Self.X` on a non-generic impl resolves
+mid-loop today. The gap is Case 2 only: methods accumulate into the
+`GenericImplEntry` registered only AFTER the loop, so nothing is visible
+mid-loop through any channel static dispatch consults. That also matches the
+probe log — every failing field was tagged `case2`.
+
+The change:
+
+1. Case 2's direct colon-pair branch registers each evaluated method into the
+   PROVISIONAL registry as its field completes — with the REAL forall-stamped
+   FuncVal (`value : .Some(m_to_push)`, `source_trait_id : ""`,
+   `self_type : None` — the same shape as Case 3's direct permanent entries),
+   NOT a valueless signature splice.
+2. `get_type_trait_methods_by_name_from_env` (env.yo) consults the provisional
+   registry as the LAST resort, ranked BELOW the generic-impl fallback (an
+   in-flight entry outranking a registered impl is how `imm_map` broke).
+3. Cleared at Case 2's field-loop end, next to the `self_type` restore.
+
+Known interaction accepted by design: the INSTANCE path
+(`get_receiver_methods_by_name_from_env`) also consults provisional when the
+permanent registry misses, so mid-loop instance calls (`self.len()`) may now
+resolve through these entries instead of whatever later fallback served them
+before. The entries carry real values and the Case-3-direct shape, so this is
+the faithful-port direction (TS shows in-flight evaluated fields to both
+paths); the full battery is the arbiter.
+
 ### B. Impl-level VALUE binder bound as a TYPE (#4, #5, #6)
 
 ```rust

--- a/yo-self/env.yo
+++ b/yo-self/env.yo
@@ -15,6 +15,7 @@
 pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
 open(import("std/fmt"));
+_(env : envdbg_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 { TypeValue } :: import("./types/definitions.yo");
@@ -3922,6 +3923,12 @@ get_receiver_methods_by_name_from_env :: (
         filtered_methods = _filter_receiver_methods(pf_generic, receiver_type, env, is_infix_operator_call);
       }
     );
+  });
+  // YO_DEBUG_DISPATCH=1: announce an instance-dispatch MISS (its call then
+  // degrades to the unit fallback — the def-eval swallow campaign's
+  // "usize vs unit" signature). Separate env var so swallow logs stay clean.
+  if(envdbg_env.get(`YO_DEBUG_DISPATCH`).is_some() && (filtered_methods.len() == usize(0)), {
+    eprintln(`[dispatch-miss] name=${method_name} recv=${type_id_or_empty(receiver_type)} raw=${methods.len().to_string()} resolved=${resolved_methods.len().to_string()}`);
   });
   filtered_methods
 });

--- a/yo-self/env.yo
+++ b/yo-self/env.yo
@@ -2783,11 +2783,25 @@ get_type_trait_methods_by_name_from_env :: (
       // method was found.
       cond(
         (result.len() > usize(0)) => result,
-        true => match(
-          _g_find_methods_from_generic_impls_fn,
-          .None => result,
-          .Some(f) => f(env, method_name, ty)
-        )
+        true => {
+          from_generic := match(
+            _g_find_methods_from_generic_impls_fn,
+            .None => ArrayList(MethodEntry).new(),
+            .Some(f) => f(env, method_name, ty)
+          );
+          // LAST-resort: in-flight impl methods (provisional registry).
+          // Live only while an impl's field loop is evaluating; lets a
+          // sibling's definition-time body trial resolve `Self.method()`
+          // on a GENERIC impl, whose methods reach the generic-impl
+          // registry only after the loop (impl.yo Case 2). Ranked BELOW
+          // the generic-impl fallback: an in-flight entry outranking a
+          // registered impl is how tests/imm_map.test.yo regressed
+          // (see issues/def-eval-swallow-remaining-roots.md).
+          cond(
+            (from_generic.len() > usize(0)) => from_generic,
+            true => get_provisional_trait_methods_by_name(id, method_name)
+          )
+        }
       )
     }
   )

--- a/yo-self/env.yo
+++ b/yo-self/env.yo
@@ -2713,6 +2713,30 @@ set_find_methods_from_generic_impls_fn :: (
   _g_find_methods_from_generic_impls_fn =
     Option(FindMethodsFromGenericImplsFn).Some(f);
 });
+/// Lazy in-flight-impl shell materializer (impl.yo's
+/// `materialize_in_flight_method`) — same callback-injection pattern as
+/// above, same module-cycle reason. Called when a provisional lookup
+/// misses, so a def-time body trial can forward-reference a LATER sibling
+/// of the impl currently being evaluated; returns true when a shell was
+/// registered (the caller then re-queries the provisional registry).
+MaterializeInFlightMethodFn :: (fn(type_id : String, method_name : String) -> bool);
+(_g_materialize_in_flight_method_fn : Option(MaterializeInFlightMethodFn)) =
+  Option(MaterializeInFlightMethodFn).None;
+set_materialize_in_flight_method_fn :: (
+  fn(f : MaterializeInFlightMethodFn) -> unit
+)({
+  _g_materialize_in_flight_method_fn =
+    Option(MaterializeInFlightMethodFn).Some(f);
+});
+_try_materialize_in_flight :: (fn(type_id : String, method_name : String) -> unit)({
+  match(
+    _g_materialize_in_flight_method_fn,
+    .Some(f) => {
+      ___m := f(type_id, method_name);
+    },
+    .None => ()
+  );
+});
 /// Look up the trait methods on a TYPE (not on a receiver value)
 /// that match `method_name`. Mirrors
 /// `getTypeTraitMethodsByNameFromEnv` in `src/env.ts:1070-1152`,
@@ -2796,10 +2820,21 @@ get_type_trait_methods_by_name_from_env :: (
           // registry only after the loop (impl.yo Case 2). Ranked BELOW
           // the generic-impl fallback: an in-flight entry outranking a
           // registered impl is how tests/imm_map.test.yo regressed
-          // (see issues/def-eval-swallow-remaining-roots.md).
+          // (see issues/def-eval-swallow-remaining-roots.md). A miss here
+          // lazily materializes a FORWARD-referenced sibling's shell, then
+          // re-queries.
           cond(
             (from_generic.len() > usize(0)) => from_generic,
-            true => get_provisional_trait_methods_by_name(id, method_name)
+            true => {
+              prov_hits := get_provisional_trait_methods_by_name(id, method_name);
+              cond(
+                (prov_hits.len() > usize(0)) => prov_hits,
+                true => {
+                  _try_materialize_in_flight(id, method_name);
+                  get_provisional_trait_methods_by_name(id, method_name)
+                }
+              )
+            }
           )
         }
       )
@@ -3219,6 +3254,13 @@ get_receiver_methods_by_name_from_env :: (
   // classify() returned 89 for every input).
   if((methods.len() == usize(0)) && (outer_id != ""), {
     prov := get_provisional_trait_methods_by_name(outer_id, method_name);
+    // Miss → lazily materialize a FORWARD-referenced sibling of the
+    // in-flight impl (slice_copy -> get), then re-query. No-op unless an
+    // impl on this exact receiver id is mid-evaluation.
+    if(prov.len() == usize(0), {
+      _try_materialize_in_flight(outer_id, method_name);
+      prov = get_provisional_trait_methods_by_name(outer_id, method_name);
+    });
     np := prov.len();
     (pi : usize) = usize(0);
     while(pi < np, {
@@ -3234,6 +3276,10 @@ get_receiver_methods_by_name_from_env :: (
   });
   if(((methods.len() == usize(0)) && (deref_id != "")) && (deref_id != outer_id), {
     prov_d := get_provisional_trait_methods_by_name(deref_id, method_name);
+    if(prov_d.len() == usize(0), {
+      _try_materialize_in_flight(deref_id, method_name);
+      prov_d = get_provisional_trait_methods_by_name(deref_id, method_name);
+    });
     npd := prov_d.len();
     (pdi : usize) = usize(0);
     while(pdi < npd, {
@@ -3938,5 +3984,7 @@ export(
   get_type_trait_methods_by_name_from_env,
   get_receiver_methods_by_name_from_env,
   FindMethodsFromGenericImplsFn,
-  set_find_methods_from_generic_impls_fn
+  set_find_methods_from_generic_impls_fn,
+  MaterializeInFlightMethodFn,
+  set_materialize_in_flight_method_fn
 );

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -14,6 +14,7 @@
 pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
 open(import("std/fmt"));
+_(env : fncall_dbg_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
 {
   AstExpr,
@@ -84,7 +85,8 @@ open(import("std/fmt"));
   TraitSpecializationResult,
   ArgValues,
   ArgEntry,
-  VarArgEntry
+  VarArgEntry,
+  in_def_time_trial
 } :: import("../context.yo");
 { is_pointer_type, is_type_hierarchy_type, is_comptime_string_type, is_comptime_int_type, is_comptime_float_type, is_some_type, is_array_type, is_function_type, is_function_type_generic, is_expr_list_type, is_comptime_list_type, is_fn_trait_type, is_unit_type, is_primitive_type, is_type_0 } :: import("../../types/guards.yo");
 { convert_comptime_type_to_runtime_type } :: import("../../types/env_lookup.yo");
@@ -2286,6 +2288,15 @@ _evaluate_funcval_runtime_call :: (
     spec_ty_fixed := if(is_ret_regression, base_spec_ty, spec_ty_candidate);
     if(!(is_ret_regression), {
       register_func_type(spec_fid.clone(), spec_ty_fixed);
+    });
+    // YO_DEBUG_SWALLOW: announce a spec minted with SomeTs in its signature
+    // — an abstract-keyed spec is skipped by the emitter while its call
+    // site still emits (the derive_clone_complex 'undeclared function'
+    // class). Prints the mint context so the guard can be scoped right.
+    if(fncall_dbg_env.get(`YO_DEBUG_SWALLOW`).is_some(), {
+      if((get_all_some_types(spec_ty_fixed).len() > usize(0)) && (spec_fid.len() > usize(0)), {
+        eprintln(`[abstract-spec] fid=${spec_fid} trial=${in_def_time_trial().to_string()}`);
+      });
     });
     spec_callee_info := new_expr_info(env, spec_ty_fixed);
     spec_callee_info.value = Option(EvalValue).Some(spec_fv);

--- a/yo-self/evaluator/calls/function_type.yo
+++ b/yo-self/evaluator/calls/function_type.yo
@@ -66,7 +66,8 @@ _(env : fnty_env) :: import("std/env");
   ExpectedTypeCtx,
   CapturedVarInfo,
   ImplConcreteTypeInfo,
-  set_rerun_pending_def_evals_fn
+  set_rerun_pending_def_evals_fn,
+  set_in_def_time_trial
 } :: import("../context.yo");
 { random_id } :: import("../../utils.yo");
 { register_func_type } :: import("../../function_value.yo");
@@ -223,6 +224,7 @@ PendingDefEval :: ref(
     param_types : ArrayList(TypeValue),
     param_is_ref : ArrayList(bool),
     param_is_owning : ArrayList(bool),
+    param_is_comptime : ArrayList(bool),
     result_ty : TypeValue,
     where_entries : ArrayList(WhereConstraintEntry),
     function_type : TypeValue,
@@ -389,6 +391,17 @@ _build_def_time_body_env :: (
     /// param's def-time binding must be created OWNING so the function-body
     /// begin block's parameters-frame drop pass releases it at scope end.
     param_is_owning : ArrayList(bool),
+    /// Per-parameter `comptime(...)` flags (the fn-type side table). TS binds
+    /// `value: isCompileTimeOnly ? [createUnknownValue(...)] : undefined`
+    /// (function-type.ts:346) — a comptime VALUE param must carry an
+    /// UnknownVal or every builtin the body hands it to throws its
+    /// "expects a compile-time known value" error at definition time and
+    /// the trial swallows the body (prelude's `Array.fill` /
+    /// `ComptimeList.car`, family C of
+    /// issues/def-eval-swallow-remaining-roots.md). RUNTIME params keep NO
+    /// value — binding them UnknownVal breaks the dup accounting (see the
+    /// pv comment below).
+    param_is_comptime : ArrayList(bool),
     // The signature's evaluated result type — scanned (with param_types)
     // for the SIGNATURE's own SomeT objects so comptime type params bind
     // the SAME SomeT identity the signature mentions. Minting fresh
@@ -645,7 +658,16 @@ _build_def_time_body_env :: (
     // value-branch early-returned and a borrowed-param tail (`to_string :
     // (...)(self)`) lost its balancing ___dup — println(s) then freed the
     // caller's String buffer (net −1 per call).
-    pv := if(is_type_0(pt), _type_binder_env_value(pn.clone(), sig_some_ts, where_entries, pf_level), Option(EvalValue).None);
+    p_ct := match(param_is_comptime.get(pi), .Some(b) => b, .None => false);
+    pv := if(
+      is_type_0(pt),
+      _type_binder_env_value(pn.clone(), sig_some_ts, where_entries, pf_level),
+      if(
+        p_ct,
+        Option(EvalValue).Some(create_unknown_val(pt)),
+        Option(EvalValue).None
+      )
+    );
     add_parameter_to_env(
       fresh_env,
       pn,
@@ -686,6 +708,7 @@ _rerun_pending_def_evals :: (fn(caller_env : Environment, ctx : EvalContext) -> 
           pd.param_types,
           pd.param_is_ref,
           pd.param_is_owning,
+          pd.param_is_comptime,
           pd.result_ty,
           pd.where_entries,
           pd.function_type,
@@ -708,7 +731,9 @@ _rerun_pending_def_evals :: (fn(caller_env : Environment, ctx : EvalContext) -> 
         );
         rp_ctx := create_function_body_evaluation_context(pd.function_type, rp_fv, rp_env, ctx);
         rp_out := ArrayList(AstExpr).new();
+        rp_prev_trial := set_in_def_time_trial(true);
         _trial_eval_fn_body(pd.body.clone(), rp_env, rp_ctx, rp_out);
+        ___rp_tr := set_in_def_time_trial(rp_prev_trial);
         if(pd.attempts > usize(1), {
           pd.attempts = (pd.attempts - usize(1));
           kept.push(pd);
@@ -1051,12 +1076,19 @@ try_to_implement_function_by_function_type :: (
               get_func_where_constraints(ast_expr_id(dwe_ft_box).to_string()),
             .Atom(_, _) => ArrayList(WhereConstraintEntry).new()
           );
+          def_ct_flags := match(
+            expr,
+            .FnCall(_, ctf_ft_box, _, _, _) =>
+              get_func_param_comptime(ast_expr_id(ctf_ft_box).to_string()),
+            .Atom(_, _) => ArrayList(bool).new()
+          );
           flow_env := _build_def_time_body_env(
             caller_env,
             param_labels,
             param_types,
             param_is_ref,
             param_is_owning,
+            def_ct_flags,
             result_box,
             def_where_entries,
             function_type,
@@ -1128,7 +1160,9 @@ try_to_implement_function_by_function_type :: (
             });
           };
           push_active_where_trait_ids(flow_where_ids);
+          fl_prev_trial := set_in_def_time_trial(true);
           _trial_eval_fn_body(fb, flow_env, flow_ctx, flow_out);
+          ___fl_tr := set_in_def_time_trial(fl_prev_trial);
           pop_active_where_trait_ids();
           // This body captured a VALUELESS forward-declared comptime fn
           // variable — its call-site infos are incomplete until that
@@ -1145,6 +1179,7 @@ try_to_implement_function_by_function_type :: (
                 param_types : param_types,
                 param_is_ref : param_is_ref,
                 param_is_owning : param_is_owning,
+                param_is_comptime : def_ct_flags,
                 result_ty : result_box,
                 where_entries : def_where_entries,
                 function_type : function_type,
@@ -1282,12 +1317,18 @@ try_to_implement_function_by_function_type :: (
               .FnCall(_, dg_ft_box, _, _, _) => get_func_where_constraints(ast_expr_id(dg_ft_box).to_string()),
               .Atom(_, _) => ArrayList(WhereConstraintEntry).new()
             );
+            dg_ct_flags := match(
+              expr,
+              .FnCall(_, dgc_ft_box, _, _, _) => get_func_param_comptime(ast_expr_id(dgc_ft_box).to_string()),
+              .Atom(_, _) => ArrayList(bool).new()
+            );
             dg_env := _build_def_time_body_env(
               caller_env,
               param_labels,
               param_types,
               param_is_ref,
               param_is_owning,
+              dg_ct_flags,
               result_box,
               dg_where,
               function_type,
@@ -1337,7 +1378,9 @@ try_to_implement_function_by_function_type :: (
               });
             };
             push_active_where_trait_ids(dg_where_ids);
+            dg_prev_trial := set_in_def_time_trial(true);
             _trial_eval_fn_body(body_expr.clone(), dg_env, dg_ctx, dg_out);
+            ___dg_tr := set_in_def_time_trial(dg_prev_trial);
             pop_active_where_trait_ids();
             // A violation flagged by THIS trial must not leak into a later
             // definition's re-raise (TS's catch{} discards everything).

--- a/yo-self/evaluator/calls/function_type.yo
+++ b/yo-self/evaluator/calls/function_type.yo
@@ -39,7 +39,7 @@ _(env : fnty_env) :: import("std/env");
 } :: import("../../expr_info.yo");
 { Environment, Variable, add_variable_to_env, add_parameter_to_env, synthetic_token, snapshot_env } :: import("../../env.yo");
 { TypeValue } :: import("../../types/definitions.yo");
-{ t_unit, t_some_t, t_ptr } :: import("../../types/creators.yo");
+{ t_unit, t_some_t, t_ptr, resolve_some_binder_kind } :: import("../../types/creators.yo");
 { is_type_0, is_some_type, is_unit_type, is_function_type } :: import("../../types/guards.yo");
 { wrap_function_body_with_contracts } :: import("../builtins/contracts.yo");
 { EvalValue, FuncValData, create_unknown_val, create_type_value, is_unknown_val } :: import("../../value.yo");
@@ -454,12 +454,45 @@ _build_def_time_body_env :: (
               );
               if(keep_cv && !(cv.name == "__recur_fn"), {
                 cap_value := match(cv.value.get(usize(0)), .Some(actual) => Option(EvalValue).Some(actual), .None => Option(EvalValue).None);
-                is_ct := match(cap_value, .Some(_) => true, .None => false);
+                // Family B re-kind: an impl-level VALUE binder
+                // (`impl(generic(T : Type, N : usize), ...)`) is bound
+                // `TypeVal(SomeT)` in the impl's forall env — load-bearing
+                // there for receiver-pattern evaluation — but a def-time
+                // BODY env must see an unknown VALUE of the declared type
+                // (TS createUnknownValue(declaredType)), or `r.end > N`
+                // fails "Cannot unify usize and Type". The kind comes from
+                // the NAME-only side table registered at the impl binder
+                // site and resolved PURELY (builtin scalars, no env) —
+                // every env-involved resolution measurably broke the
+                // circular-import order (see resolve_some_binder_kind).
+                (cap_ty_final : TypeValue) = cv.ty;
+                (cap_value_final : Option(EvalValue)) = cap_value;
+                match(
+                  cap_value,
+                  .Some(cv_ev) => match(
+                    cv_ev,
+                    .TypeVal(cv_tv) => match(
+                      cv_tv,
+                      .SomeT(_, cv_sname, cv_slvl, _, _, _, _, _, _, _, _) => match(
+                        resolve_some_binder_kind(cv_sname, cv_slvl),
+                        .Some(cv_bty) => {
+                          cap_ty_final = cv_bty.clone();
+                          cap_value_final = Option(EvalValue).Some(create_unknown_val(cv_bty));
+                        },
+                        .None => ()
+                      ),
+                      _ => ()
+                    ),
+                    _ => ()
+                  ),
+                  .None => ()
+                );
+                is_ct := match(cap_value_final, .Some(_) => true, .None => false);
                 // Carry `is_reassignable` — module globals (`(x : T) = v;`)
                 // ARE reassignable from fn bodies; rebinding them read-only
                 // made std/log.yo's `_global_level = level` def-eval fail
                 // "Cannot reassign".
-                copied_var_opt := add_variable_to_env(fresh_env, cv.name, cv.ty, cap_value, is_ct, cv.is_reassignable, false, false, synthetic_token(cv.name, module_path));
+                copied_var_opt := add_variable_to_env(fresh_env, cv.name, cap_ty_final, cap_value_final, is_ct, cv.is_reassignable, false, false, synthetic_token(cv.name, module_path));
                 // Carry `is_module_level` — TS REUSES the definition env's
                 // Variable objects for def-time body eval (function-type.ts:499),
                 // so every flag survives there. This flattening copy loses

--- a/yo-self/evaluator/context.yo
+++ b/yo-self/evaluator/context.yo
@@ -786,6 +786,22 @@ call_rerun_pending_def_evals :: (fn(env : Environment, ctx : EvalContext) -> uni
     .None => ()
   )
 );
+/// True while a DEFINITION-time body trial is running
+/// (`_trial_eval_fn_body`, calls/function_type.yo — set/restored at its
+/// call sites, since a swallowed error unwinds out of the helper itself).
+/// Read by impl.yo's `_resolve_one_forall_binding`: the NAME-channel
+/// acceptance of an abstract (different-SomeT) generic binding is scoped
+/// to def-time trials — unscoped it broke std module evaluation
+/// ("Incompatible function return type", measured 2026-08-13), while at
+/// def time it is what lets a sibling impl's method dispatch resolve
+/// (array_list's Clone -> len, family A root #3).
+(g_in_def_time_trial : bool) = false;
+in_def_time_trial :: (fn() -> bool)(g_in_def_time_trial);
+set_in_def_time_trial :: (fn(v : bool) -> bool)({
+  prev := g_in_def_time_trial;
+  g_in_def_time_trial = v;
+  prev
+});
 
 export(
   PathCollection,
@@ -829,5 +845,7 @@ export(
   get_pointer_type_call_result,
   track_variable_usage,
   set_rerun_pending_def_evals_fn,
-  call_rerun_pending_def_evals
+  call_rerun_pending_def_evals,
+  in_def_time_trial,
+  set_in_def_time_trial
 );

--- a/yo-self/evaluator/exprs/identifer_and_operator.yo
+++ b/yo-self/evaluator/exprs/identifer_and_operator.yo
@@ -11,6 +11,8 @@
 //!   - Self, SelfTrait, SelfModule context references
 //!   - Variable lookup with closure-capture tracking
 open(import("std/string"));
+open(import("std/fmt"));
+_(env : ident_dbg_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
 { AstExpr, ast_expr_token, ast_expr_id } :: import("../../expr.yo");
 {
@@ -199,6 +201,9 @@ evaluate_identifier_and_operator :: (
         return(expr);
       });
       // Ordinary identifiers throw.
+      if(ident_dbg_env.get(`YO_DEBUG_SWALLOW`).is_some(), {
+        eprintln(`[var-miss] name=${identifier_string} env_module=${env.module_path} frames=${env.frames.len().to_string()}`);
+      });
       exn.throw(
         dyn(
           format_error_message(

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -53,7 +53,8 @@ _(env : impl_dbg_env) :: import("std/env");
   get_variables_from_env,
   snapshot_env,
   synthetic_token,
-  set_find_methods_from_generic_impls_fn
+  set_find_methods_from_generic_impls_fn,
+  set_materialize_in_flight_method_fn
 } :: import("../../env.yo");
 {
   MethodEntry,
@@ -204,6 +205,27 @@ GenericImplEntry :: struct(
 (g_impl_registry_keys : ArrayList(String)) = ArrayList(String).new();
 (g_impl_registry_entry_lists : ArrayList(ArrayList(GenericImplEntry))) =
   ArrayList(ArrayList(GenericImplEntry)).new();
+/// One IN-FLIGHT Case-2 (generic) impl: enough state to lazily
+/// forward-declare a not-yet-evaluated sibling field when a def-time body
+/// trial asks for it (env.yo's provisional-lookup miss path →
+/// `materialize_in_flight_method`). A stack, since impl evaluation can
+/// nest (derive expansions mid-field-loop); pushed at Case-2 entry,
+/// popped where the provisional registry is cleared.
+C2InFlightImpl :: ref(
+  struct(
+    recv_id : String,
+    receiver_pattern : TypeValue,
+    /// Every direct colon-pair field plus trait-constructor INNER colon
+    /// pairs, unevaluated.
+    colon_pair_fields : ArrayList(AstExpr),
+    eval_env : Environment,
+    eval_ctx : EvalContext,
+    /// Labels already looked up (whether or not a shell materialized) —
+    /// each is attempted at most once.
+    attempted : ArrayList(String)
+  )
+);
+(g_c2_in_flight : ArrayList(C2InFlightImpl)) = ArrayList(C2InFlightImpl).new();
 /// ENV-THREADING variant of the hook — the port of TS's full
 /// `typeImplementsTrait` (`{ implemented, env }`). `TraitCheckResult` lives in
 /// trait_checking.yo (importing it here would be circular), so the adapter
@@ -2120,6 +2142,95 @@ _try_create_forward_shell :: (
     }
   )
 });
+/// Lazily materialize a forward-declared sibling of an IN-FLIGHT Case-2
+/// impl into the PROVISIONAL registry. Called (via env.yo's callback slot)
+/// when a provisional lookup for `type_id` misses `method_name` during the
+/// impl's own field loop — i.e. a def-time body trial forward-references a
+/// later sibling (array_list's slice_copy -> get). The shell carries
+/// `value : None` (callable from its TYPE alone — the trait-splice
+/// contract; a shell FuncVal has an EMPTY capture snapshot, and the
+/// inline-FuncVal call arm builds the body env from it, measured as
+/// `Variable "GlobalAllocator" not found`). Head evaluation happens ONLY
+/// here, on demand: evaluating every field's signature head eagerly
+/// diverged tests/imm_map.test.yo even with registration disabled
+/// (experiment B — map.yo's early `Map(K, U)` instantiations poison a
+/// CTFE/instantiation order the batch main later depends on).
+/// Returns true when a shell was registered.
+materialize_in_flight_method :: (
+  fn(type_id : String, method_name : String) -> bool
+)({
+  // Find the NEWEST in-flight record for this receiver id.
+  (rec_opt : Option(C2InFlightImpl)) = Option(C2InFlightImpl).None;
+  (ri2 : usize) = g_c2_in_flight.len();
+  while((ri2 > usize(0)) && rec_opt.is_none(), {
+    ri2 = (ri2 - usize(1));
+    match(
+      g_c2_in_flight.get(ri2),
+      .Some(cand) => {
+        if(cand.recv_id == type_id, {
+          rec_opt = Option(C2InFlightImpl).Some(cand);
+        });
+      },
+      .None => ()
+    );
+  });
+  rec := match(
+    rec_opt,
+    .Some(r) => r,
+    .None => {
+      return(false);
+    }
+  );
+  // At most one attempt per label (also the re-entrancy guard: the head
+  // eval below can itself trigger lookups).
+  (seen : bool) = false;
+  {
+    (ai : usize) = usize(0);
+    while((ai < rec.attempted.len()) && !(seen), {
+      if(match(rec.attempted.get(ai), .Some(a) => (a == method_name), .None => false), {
+        seen = true;
+      });
+      ai = (ai + usize(1));
+    });
+  };
+  if(seen, {
+    return(false);
+  });
+  rec.attempted.push(method_name.clone());
+  // Find the field with this label and try to shell it.
+  (made : bool) = false;
+  (fi3 : usize) = usize(0);
+  while((fi3 < rec.colon_pair_fields.len()) && !(made), {
+    field_e := match(rec.colon_pair_fields.get(fi3), .Some(e) => e, .None => make_err_expr());
+    fi3 = (fi3 + usize(1));
+    field_lbl := match(
+      field_e,
+      .FnCall(_, _, fca, _, _) => match(
+        fca.get(usize(0)),
+        .Some(le) => ast_expr_token(le).value.clone(),
+        .None => String.from("")
+      ),
+      .Atom(_, _) => String.from("")
+    );
+    if(field_lbl == method_name, {
+      match(
+        _try_create_forward_shell(field_e, rec.eval_env, rec.eval_ctx, rec.receiver_pattern),
+        .Some(sh_entry) => {
+          sh_entry.value = Option(EvalValue).None;
+          register_provisional_trait_method(type_id.clone(), sh_entry);
+          made = true;
+        },
+        .None => {
+          if(impl_dbg_env.get(`YO_DEBUG_SWALLOW`).is_some(), {
+            sh_miss_tok := ast_expr_token(field_e);
+            eprintln(`[c2shell-miss] ${sh_miss_tok.module_path}:${sh_miss_tok.row.to_string()}:${sh_miss_tok.column.to_string()}`);
+          });
+        }
+      );
+    });
+  });
+  made
+});
 /// Parse an impl's `where(...)` clause into parallel constraint arrays for
 /// `GenericImplEntry`. For each `X <: Trait` constraint whose LHS `X` is a
 /// generic type param, append (the generic SomeT for `X`, the evaluated `Trait`)
@@ -2435,51 +2546,32 @@ evaluate_module_value :: (
     // Receiver id for the per-field PROVISIONAL registration below.
     // Empty for receivers without an id — skip, mirroring Case 3's guard.
     c2_recv_id := type_id_or_empty(receiver_type_pattern);
-    // Forward-shell pre-pass — Case 2 twin of the Case 3 pre-pass below,
-    // but into the PROVISIONAL registry (cleared at loop end). Registering
-    // Case 2 shells PERMANENTLY is the measured tests/imm_map.test.yo
-    // regression: Case 2 has no permanent supersede path, so the shells
-    // became the only entries under the receiver id, each carrying an
-    // unevaluated body (issues/def-eval-swallow-remaining-roots.md).
-    // Later siblings' def-time body trials resolve forward references
-    // (array_list's slice_copy -> get) through these; the field loop below
-    // supersedes each shell in place as the real value evaluates.
+    // LAZY forward declarations — push an in-flight record instead of the
+    // TS-shaped eager shell pre-pass. Eagerly evaluating EVERY field's
+    // signature head before the loop measurably diverged
+    // tests/imm_map.test.yo (experiment B, 2026-08-13, registration
+    // disabled and still RED): map.yo's early `Map(K, U)`-signature
+    // instantiations poison a CTFE/instantiation order the batch main
+    // later depends on. Lazily materializing a shell only when a def-time
+    // trial actually ASKS for that sibling (env.yo's provisional-lookup
+    // miss path calls `materialize_in_flight_method` via the callback
+    // slot) keeps the blast radius to fields genuinely forward-referenced
+    // (array_list's slice_copy -> get / push) — map.yo's trials never ask,
+    // so its poisonous early instantiations never happen. The field loop
+    // below supersedes any materialized shell in place, exactly as it
+    // supersedes the per-field registrations.
     if(c2_recv_id != "", {
+      c2_if_fields := ArrayList(AstExpr).new();
       (c2_pp : usize) = (receiver_arg_idx + usize(1));
       while(c2_pp < n_args, {
         c2_pp_expr := match(args.get(c2_pp), .None => make_err_expr(), .Some(e) => e);
         c2_pp = (c2_pp + usize(1));
-        match(
-          _try_create_forward_shell(c2_pp_expr, forall_env, ctx, receiver_type_pattern),
-          .Some(c2_shell_entry) => {
-            // Strip the shell FuncVal: a provisional entry must be callable
-            // from its TYPE alone (`value : None`, the trait-splice contract
-            // at type_trait_methods.yo:187-204 — TS's assignedValue is
-            // undefined mid-window and the call never evaluates the body).
-            // Keeping the shell value routes def-time calls through the
-            // inline-FuncVal arm (calls/function.yo), which builds the body
-            // env from the FuncVal's flat capture snapshot — EMPTY for a
-            // shell — so the body threw `Variable "GlobalAllocator" not
-            // found` from an env with no module bindings (measured on
-            // array_list's push, called from slice_copy's trial).
-            c2_shell_entry.value = Option(EvalValue).None;
-            register_provisional_trait_method(c2_recv_id.clone(), c2_shell_entry);
-          },
-          .None => {
-            // Only worth reporting for direct colon pairs — the helper
-            // returns None for every non-fn-shaped field as well.
-            if(impl_dbg_env.get(`YO_DEBUG_SWALLOW`).is_some() && (ast_expr_is_fn_call(c2_pp_expr) && ast_expr_is_fn_call_of(c2_pp_expr, BK_COLON, .Some(usize(2)))), {
-              c2_miss_tok := ast_expr_token(c2_pp_expr);
-              eprintln(`[c2shell-miss] ${c2_miss_tok.module_path}:${c2_miss_tok.row.to_string()}:${c2_miss_tok.column.to_string()}`);
-            });
-          }
-        );
-        // Trait-constructor fields (`Trait(name : fn, ...)`): pre-declare
-        // the INNER colon pairs the same way — the direct try above returns
-        // None for them (its shape check requires the field itself to be a
-        // colon pair). array_list's Clone/Index/Iterator impls are this
-        // shape; their method bodies call siblings and methods of other
-        // impls on Self at def time (root #3 of
+        if(ast_expr_is_fn_call(c2_pp_expr) && ast_expr_is_fn_call_of(c2_pp_expr, BK_COLON, .Some(usize(2))), {
+          c2_if_fields.push(c2_pp_expr);
+        });
+        // Trait-constructor fields (`Trait(name : fn, ...)`): their INNER
+        // colon pairs are forward-declarable the same way (array_list's
+        // Clone/Index/Iterator impls — root #3 of
         // issues/def-eval-swallow-remaining-roots.md).
         if((ast_expr_is_fn_call(c2_pp_expr) && !(ast_expr_is_fn_call_of(c2_pp_expr, BK_COLON, .Some(usize(2))))) && (!(ast_expr_is_fn_call_of(c2_pp_expr, BK_WHERE, .None)) && !(ast_expr_is_fn_call_of(c2_pp_expr, "!", .Some(usize(1))))), {
           c2_ta := match(
@@ -2491,17 +2583,22 @@ evaluate_module_value :: (
           while(c2_ti < c2_ta.len(), {
             c2_te := match(c2_ta.get(c2_ti), .Some(e) => e, .None => make_err_expr());
             c2_ti = (c2_ti + usize(1));
-            match(
-              _try_create_forward_shell(c2_te, forall_env, ctx, receiver_type_pattern),
-              .Some(c2_tshell) => {
-                c2_tshell.value = Option(EvalValue).None;
-                register_provisional_trait_method(c2_recv_id.clone(), c2_tshell);
-              },
-              .None => ()
-            );
+            if(ast_expr_is_fn_call(c2_te) && ast_expr_is_fn_call_of(c2_te, BK_COLON, .Some(usize(2))), {
+              c2_if_fields.push(c2_te);
+            });
           });
         });
       });
+      g_c2_in_flight.push(
+        C2InFlightImpl(
+          recv_id : c2_recv_id.clone(),
+          receiver_pattern : receiver_type_pattern,
+          colon_pair_fields : c2_if_fields,
+          eval_env : forall_env,
+          eval_ctx : ctx,
+          attempted : ArrayList(String).new()
+        )
+      );
     });
     (fj : usize) = (receiver_arg_idx + usize(1));
     while(fj < n_args, {
@@ -2872,6 +2969,7 @@ evaluate_module_value :: (
     // Case 3 clear and TS restoring receiverType.trait (trait-type.ts:512).
     if(c2_recv_id != "", {
       clear_provisional_trait_methods(c2_recv_id);
+      ___c2_pop := g_c2_in_flight.pop();
     });
     // Drop the binder-kind registrations (same lifetime as the impl:
     // clearing an unregistered name is a no-op, so type binders are fine).
@@ -3717,6 +3815,7 @@ _impl_generic_impl_fallback_init := (fn() -> bool)({
   set_find_methods_from_generic_impls_fn(
     _find_methods_from_generic_impls_as_method_entries
   );
+  set_materialize_in_flight_method_fn(materialize_in_flight_method);
   true
 })();
 export(evaluate_module_value);

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -691,7 +691,13 @@ try_match_generic_impl :: (
   // `check` paid a growing clone per candidate per lookup). SomeT /
   // TypeAppT pattern roots always proceed (they can bind anything).
   if(!(_root_shapes_could_match(entry.receiver_type_pattern, resolved_concrete)), {
+    if(impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some(), {
+      eprintln(`[tm-none] reason=prefilter recv=${type_id_or_empty(resolved_concrete)} pat=${type_id_or_empty(entry.receiver_type_pattern)}`);
+    });
     return(Option(ArrayList(TypeValue)).None);
+  });
+  if(impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some(), {
+    eprintln(`[tm-try] recv=${type_id_or_empty(resolved_concrete)} pat=${type_id_or_empty(entry.receiver_type_pattern)} trial=${in_def_time_trial().to_string()}`);
   });
   // 2. Build unify_env: snapshot the env (share frames — TS `pushEnvFrame`
   //    at impl.ts:2243 copies only the frame-pointer array) and push a fresh
@@ -1028,6 +1034,9 @@ try_match_generic_impl :: (
         dar_fi = (dar_fi + usize(1));
       });
     });
+  });
+  if(impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some(), {
+    eprintln(`[tm-end] recv=${type_id_or_empty(resolved_concrete)} pat=${type_id_or_empty(entry.receiver_type_pattern)} all_bound=${all_bound.to_string()}`);
   });
   cond(
     all_bound => Option(ArrayList(TypeValue)).Some(bindings),

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -77,7 +77,7 @@ _(env : impl_dbg_env) :: import("std/env");
 { random_id } :: import("../../utils.yo");
 { register_func_type } :: import("../../function_value.yo");
 { EvalValue, FuncValData, create_type_value, create_unknown_val } :: import("../../value.yo");
-{ EvalContext, ExpectedTypeCtx, in_def_time_trial } :: import("../context.yo");
+{ EvalContext, ExpectedTypeCtx, in_def_time_trial, set_in_def_time_trial } :: import("../context.yo");
 { evaluate_expression_raw } :: import("../exprs/expr.yo");
 { evaluate_anonymous_module_begin_exprs } :: import("./anonymous_module.yo");
 { format_error_message } :: import("../../error.yo");
@@ -446,14 +446,18 @@ _resolve_one_forall_binding :: (
   if(!(is_some_type(bound_type)), {
     return(Option(TypeValue).Some(bound_type));
   });
-  // Accept a DIFFERENT-id SomeT from the ID-keyED channel ONLY: that is a
-  // genuine unification (T := the CALLER's own binder — the cross-impl
-  // def-time dispatch case, root #3). The NAME-based fallback below stays
-  // concrete-only: name lookup can hit an unrelated same-name SomeT from
-  // an outer scope, and accepting those broke std module evaluation
-  // ("Incompatible function return type" from std/string — measured).
+  // Accept a DIFFERENT-id SomeT binding ONLY inside a definition-time body
+  // trial (both channels): a trial's stamps are discardable/superseded, so
+  // abstract resolutions are safe there and are what resolve cross-impl
+  // dispatch (array_list's Clone -> len, root #3). OUTSIDE trials the old
+  // concrete-only rule stays — derive validation and specialization body
+  // evals produce stamps codegen consumes directly, and an abstract match
+  // there minted an abstract-keyed spec the emitter skips while the call
+  // site still emits it (tests/derive_clone_complex.test.yo 'call to
+  // undeclared function', measured; std/string module eval broke under the
+  // unscoped name channel too).
   bt_id := match(bound_type, .SomeT({ id : __bti }) => __bti, _ => String.from(""));
-  if((bt_id.len() > usize(0)) && (bt_id != fa_some_id), {
+  if((in_def_time_trial() && (bt_id.len() > usize(0))) && (bt_id != fa_some_id), {
     return(Option(TypeValue).Some(bound_type));
   });
   // Name-based fallback: look up `fa_name` directly in `expected_env`.
@@ -2011,6 +2015,9 @@ _materialize_default_body :: (
   fn(body : AstExpr, env : Environment, ctx : EvalContext, out : ArrayList(AstExpr)) -> unit
 )({
   inner_exn := Exception(throw : ((_err) -> unwind(())));
+  // A DEF-time contained-swallow evaluation like _trial_eval_fn_body — the
+  // in_def_time_trial flag is set/restored AT THE CALL SITES (a swallowed
+  // error unwinds out of this helper, skipping any in-fn restore).
   evaluated := evaluate_expression_raw(body, env, ctx, inner_exn);
   out.push(evaluated);
 });

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -77,7 +77,7 @@ _(env : impl_dbg_env) :: import("std/env");
 { random_id } :: import("../../utils.yo");
 { register_func_type } :: import("../../function_value.yo");
 { EvalValue, FuncValData, create_type_value, create_unknown_val } :: import("../../value.yo");
-{ EvalContext, ExpectedTypeCtx } :: import("../context.yo");
+{ EvalContext, ExpectedTypeCtx, in_def_time_trial } :: import("../context.yo");
 { evaluate_expression_raw } :: import("../exprs/expr.yo");
 { evaluate_anonymous_module_begin_exprs } :: import("./anonymous_module.yo");
 { format_error_message } :: import("../../error.yo");
@@ -431,8 +431,29 @@ register_negative_impl :: (fn(type_id : String, trait_id : String) -> unit)({
 _resolve_one_forall_binding :: (
   fn(expected_env : Environment, fa_some : TypeValue, fa_name : String) -> Option(TypeValue)
 )({
+  // TS parity (impl.ts tryMatchGenericImpl, substitutions extraction): a
+  // binding unified to a DIFFERENT SomeType is a binding — "include the
+  // substitution if resolved to a concrete type, OR unified to a different
+  // SomeType; only skip when it is still its own original SomeType". A
+  // cross-impl method call at DEFINITION time is exactly this case: the
+  // Clone impl's `self.len()` matches the inherent `ArrayList(T)` impl
+  // against `ArrayList(T')`, binding T := T' (abstract). Rejecting every
+  // SomeT here made the call degrade to unit and the def-time trial
+  // swallow the whole body (root #3 of
+  // issues/def-eval-swallow-remaining-roots.md).
+  fa_some_id := match(fa_some, .SomeT({ id : __fsi }) => __fsi, _ => String.from(""));
   bound_type := get_value_of_some_type_from_env(expected_env, fa_some);
   if(!(is_some_type(bound_type)), {
+    return(Option(TypeValue).Some(bound_type));
+  });
+  // Accept a DIFFERENT-id SomeT from the ID-keyED channel ONLY: that is a
+  // genuine unification (T := the CALLER's own binder — the cross-impl
+  // def-time dispatch case, root #3). The NAME-based fallback below stays
+  // concrete-only: name lookup can hit an unrelated same-name SomeT from
+  // an outer scope, and accepting those broke std module evaluation
+  // ("Incompatible function return type" from std/string — measured).
+  bt_id := match(bound_type, .SomeT({ id : __bti }) => __bti, _ => String.from(""));
+  if((bt_id.len() > usize(0)) && (bt_id != fa_some_id), {
     return(Option(TypeValue).Some(bound_type));
   });
   // Name-based fallback: look up `fa_name` directly in `expected_env`.
@@ -448,7 +469,21 @@ _resolve_one_forall_binding :: (
       ev,
       .TypeVal(b) => cond(
         !(is_some_type(b)) => Option(TypeValue).Some(b),
-        true => Option(TypeValue).None
+        // Abstract (different-id SomeT) name-channel binding: accepted ONLY
+        // inside a definition-time body trial. There it is what resolves a
+        // sibling impl's method dispatch (array_list's Clone impl calling
+        // the inherent impl's `len` on ArrayList(T') — matching binds
+        // T := T'); everywhere else name lookup can hit an unrelated
+        // same-name SomeT from an outer scope, and unscoped acceptance
+        // broke std module evaluation ("Incompatible function return
+        // type" — measured 2026-08-13).
+        true => {
+          nb_id := match(b, .SomeT({ id : __nbi }) => __nbi, _ => String.from(""));
+          cond(
+            ((in_def_time_trial() && (nb_id.len() > usize(0))) && (nb_id != fa_some_id)) => Option(TypeValue).Some(b),
+            true => Option(TypeValue).None
+          )
+        }
       ),
       // VALUE-level generic (`generic(U : usize)` array lengths): the
       // synthesizer binds the variable to an IntLit. Represent the

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -68,7 +68,7 @@ _(env : impl_dbg_env) :: import("std/env");
 } :: import("./type_trait_methods.yo");
 { FuncMeta, TypeValue } :: import("../../types/definitions.yo");
 { type_to_string } :: import("../../types/string.yo");
-{ t_unit, t_type, t_some_t, t_usize } :: import("../../types/creators.yo");
+{ t_unit, t_type, t_some_t, t_usize, register_some_binder_kind, clear_some_binder_kind } :: import("../../types/creators.yo");
 { is_some_type, is_function_type, is_expr_type } :: import("../../types/guards.yo");
 { is_implicitly_unsafe_capable_file } :: import("../memory_safety.yo");
 { subst_new, subst_add, subst_set_self, substitute } :: import("../../types/substitution.yo");
@@ -2337,6 +2337,17 @@ evaluate_module_value :: (
           .Atom(_, _) => ArrayList(AstExpr).new()
         );
         lhs2 := match(colon_args2.get(usize(0)), .Some(e) => e, .None => make_err_expr());
+        // Register the binder's declared KIND, name-only (no evaluation —
+        // resolution happens purely in _build_def_time_body_env; see
+        // resolve_some_binder_kind in types/creators.yo). Only value-binder
+        // kinds matter, so `: Type` is skipped.
+        rhs2 := match(colon_args2.get(usize(1)), .Some(e) => e, .None => make_err_expr());
+        if(ast_expr_is_atom(rhs2), {
+          rhs2_name := ast_expr_token(rhs2).value.clone();
+          if(rhs2_name != "Type", {
+            register_some_binder_kind(ast_expr_token(lhs2).value.clone(), frame_lvl, rhs2_name);
+          });
+        });
         Option(String).Some(ast_expr_token(lhs2).value.clone())
       }, if(
         ast_expr_is_atom(fp_expr),
@@ -2441,6 +2452,17 @@ evaluate_module_value :: (
         match(
           _try_create_forward_shell(c2_pp_expr, forall_env, ctx, receiver_type_pattern),
           .Some(c2_shell_entry) => {
+            // Strip the shell FuncVal: a provisional entry must be callable
+            // from its TYPE alone (`value : None`, the trait-splice contract
+            // at type_trait_methods.yo:187-204 — TS's assignedValue is
+            // undefined mid-window and the call never evaluates the body).
+            // Keeping the shell value routes def-time calls through the
+            // inline-FuncVal arm (calls/function.yo), which builds the body
+            // env from the FuncVal's flat capture snapshot — EMPTY for a
+            // shell — so the body threw `Variable "GlobalAllocator" not
+            // found` from an env with no module bindings (measured on
+            // array_list's push, called from slice_copy's trial).
+            c2_shell_entry.value = Option(EvalValue).None;
             register_provisional_trait_method(c2_recv_id.clone(), c2_shell_entry);
           },
           .None => {
@@ -2452,6 +2474,33 @@ evaluate_module_value :: (
             });
           }
         );
+        // Trait-constructor fields (`Trait(name : fn, ...)`): pre-declare
+        // the INNER colon pairs the same way — the direct try above returns
+        // None for them (its shape check requires the field itself to be a
+        // colon pair). array_list's Clone/Index/Iterator impls are this
+        // shape; their method bodies call siblings and methods of other
+        // impls on Self at def time (root #3 of
+        // issues/def-eval-swallow-remaining-roots.md).
+        if((ast_expr_is_fn_call(c2_pp_expr) && !(ast_expr_is_fn_call_of(c2_pp_expr, BK_COLON, .Some(usize(2))))) && (!(ast_expr_is_fn_call_of(c2_pp_expr, BK_WHERE, .None)) && !(ast_expr_is_fn_call_of(c2_pp_expr, "!", .Some(usize(1))))), {
+          c2_ta := match(
+            c2_pp_expr,
+            .FnCall(_, _, ta, _, _) => ta,
+            .Atom(_, _) => ArrayList(AstExpr).new()
+          );
+          (c2_ti : usize) = usize(0);
+          while(c2_ti < c2_ta.len(), {
+            c2_te := match(c2_ta.get(c2_ti), .Some(e) => e, .None => make_err_expr());
+            c2_ti = (c2_ti + usize(1));
+            match(
+              _try_create_forward_shell(c2_te, forall_env, ctx, receiver_type_pattern),
+              .Some(c2_tshell) => {
+                c2_tshell.value = Option(EvalValue).None;
+                register_provisional_trait_method(c2_recv_id.clone(), c2_tshell);
+              },
+              .None => ()
+            );
+          });
+        });
       });
     });
     (fj : usize) = (receiver_arg_idx + usize(1));
@@ -2698,6 +2747,50 @@ evaluate_module_value :: (
                   g_to_push = _stamp_impl_forall_on_method(g_mval, forall_names);
                 });
                 g_method_values.push(g_to_push);
+                // Supersede this method's pre-pass shell in the PROVISIONAL
+                // registry (or register fresh) so later siblings' def-time
+                // body trials see the real value — the trait-constructor
+                // twin of the direct colon-pair branch below. Tagged with
+                // the trait's id (Case 3's fresh-registration semantics:
+                // inherent-first resolution reads source_trait_id).
+                if(c2_recv_id != "", {
+                  c2g_src_tid := match(
+                    g_trait_ty_opt,
+                    .Some(c2g_tt) => type_id_or_empty(c2g_tt),
+                    .None => String.from("")
+                  );
+                  (c2g_superseded : bool) = false;
+                  c2g_prior := get_provisional_trait_methods_by_name(c2_recv_id, g_mname);
+                  (c2g_pi : usize) = usize(0);
+                  while((c2g_pi < c2g_prior.len()) && !(c2g_superseded), {
+                    match(
+                      c2g_prior.get(c2g_pi),
+                      .Some(c2g_e) => {
+                        if(c2g_e.source_trait_id == "__forward_shell", {
+                          c2g_e.ty = gfi.ty;
+                          c2g_e.value = Option(EvalValue).Some(g_to_push);
+                          c2g_e.source_trait_id = c2g_src_tid.clone();
+                          c2g_superseded = true;
+                        });
+                      },
+                      .None => ()
+                    );
+                    c2g_pi = (c2g_pi + usize(1));
+                  });
+                  if(!(c2g_superseded), {
+                    register_provisional_trait_method(
+                      c2_recv_id.clone(),
+                      MethodEntry(
+                        label : g_mname.clone(),
+                        ty : gfi.ty,
+                        value : Option(EvalValue).Some(g_to_push),
+                        source_trait_id : c2g_src_tid,
+                        needs_pointer_conversion : false,
+                        self_type : Option(TypeValue).None
+                      )
+                    );
+                  });
+                });
               }
             );
           });
@@ -2780,6 +2873,19 @@ evaluate_module_value :: (
     if(c2_recv_id != "", {
       clear_provisional_trait_methods(c2_recv_id);
     });
+    // Drop the binder-kind registrations (same lifetime as the impl:
+    // clearing an unregistered name is a no-op, so type binders are fine).
+    {
+      (sbk_i : usize) = usize(0);
+      while(sbk_i < forall_names.len(), {
+        match(
+          forall_names.get(sbk_i),
+          .Some(sbk_n) => clear_some_binder_kind(sbk_n, frame_lvl),
+          .None => ()
+        );
+        sbk_i = (sbk_i + usize(1));
+      });
+    };
     // For inherent impls, trait_type = Unit (empty key — correct for registry).
     (trait_ty : TypeValue) = t_unit();
     trait_key_str := get_trait_key(trait_ty);

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -15,6 +15,8 @@
 //!   - Methods are added to env with qualified names (ReceiverType.method_name).
 pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
+open(import("std/fmt"));
+_(env : impl_dbg_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 {
@@ -60,6 +62,7 @@ open(import("std/string"));
   get_type_trait_methods_by_name,
   get_trait_default,
   register_provisional_trait_method,
+  get_provisional_trait_methods_by_name,
   clear_provisional_trait_methods,
   type_id_or_empty
 } :: import("./type_trait_methods.yo");
@@ -1961,7 +1964,21 @@ _trial_eval_fn_type_head :: (
     ctx : EvalContext
   ) -> Option(TypeValue)
 )({
-  inner_exn := Exception(throw : ((_err) -> unwind(Option(TypeValue).None)));
+  // YO_DEBUG_SWALLOW=1 prints the swallowed signature-eval error — a shell
+  // that silently fails to materialize is why a forward-referenced sibling
+  // later swallows its whole body (family A's second half; see
+  // issues/def-eval-swallow-remaining-roots.md). Capture-free `->` handler,
+  // same pattern as function_type.yo's `[swallow]` hook.
+  inner_exn := Exception(
+    throw : (
+      (_err) -> {
+        if(impl_dbg_env.get(`YO_DEBUG_SWALLOW`).is_some(), {
+          eprintln(`[shell-head-swallow] ${_err.to_string()}`);
+        });
+        unwind(Option(TypeValue).None);
+      }
+    )
+  );
   evaluated := evaluate_expression_raw(fn_type_expr, env, ctx, inner_exn);
   match(
     expr_info_table_get(ctx.expr_info_table, ast_expr_id(evaluated)),
@@ -2404,6 +2421,39 @@ evaluate_module_value :: (
     // bodies.
     old_self_type_g := ctx.self_type;
     ctx.self_type = .Some(receiver_type_pattern);
+    // Receiver id for the per-field PROVISIONAL registration below.
+    // Empty for receivers without an id — skip, mirroring Case 3's guard.
+    c2_recv_id := type_id_or_empty(receiver_type_pattern);
+    // Forward-shell pre-pass — Case 2 twin of the Case 3 pre-pass below,
+    // but into the PROVISIONAL registry (cleared at loop end). Registering
+    // Case 2 shells PERMANENTLY is the measured tests/imm_map.test.yo
+    // regression: Case 2 has no permanent supersede path, so the shells
+    // became the only entries under the receiver id, each carrying an
+    // unevaluated body (issues/def-eval-swallow-remaining-roots.md).
+    // Later siblings' def-time body trials resolve forward references
+    // (array_list's slice_copy -> get) through these; the field loop below
+    // supersedes each shell in place as the real value evaluates.
+    if(c2_recv_id != "", {
+      (c2_pp : usize) = (receiver_arg_idx + usize(1));
+      while(c2_pp < n_args, {
+        c2_pp_expr := match(args.get(c2_pp), .None => make_err_expr(), .Some(e) => e);
+        c2_pp = (c2_pp + usize(1));
+        match(
+          _try_create_forward_shell(c2_pp_expr, forall_env, ctx, receiver_type_pattern),
+          .Some(c2_shell_entry) => {
+            register_provisional_trait_method(c2_recv_id.clone(), c2_shell_entry);
+          },
+          .None => {
+            // Only worth reporting for direct colon pairs — the helper
+            // returns None for every non-fn-shaped field as well.
+            if(impl_dbg_env.get(`YO_DEBUG_SWALLOW`).is_some() && (ast_expr_is_fn_call(c2_pp_expr) && ast_expr_is_fn_call_of(c2_pp_expr, BK_COLON, .Some(usize(2)))), {
+              c2_miss_tok := ast_expr_token(c2_pp_expr);
+              eprintln(`[c2shell-miss] ${c2_miss_tok.module_path}:${c2_miss_tok.row.to_string()}:${c2_miss_tok.column.to_string()}`);
+            });
+          }
+        );
+      });
+    });
     (fj : usize) = (receiver_arg_idx + usize(1));
     while(fj < n_args, {
       mf_expr := match(args.get(fj), .None => make_err_expr(), .Some(e) => e);
@@ -2491,6 +2541,63 @@ evaluate_module_value :: (
               false,
               mname_tok
             );
+            // Also register the evaluated method PROVISIONALLY under the
+            // receiver pattern's id. Case 2 has no per-field permanent
+            // registration (methods accumulate into the GenericImplEntry,
+            // registered only after this loop), so a LATER sibling's
+            // definition-time body trial cannot resolve `Self.method()` —
+            // static dispatch (get_type_trait_methods_by_name_from_env)
+            // sees neither the permanent registry nor the generic-impl
+            // registry mid-loop, the call degrades to unit, and the trial
+            // swallows the body (array_list slice_copy, roots #1-#3 in
+            // issues/def-eval-swallow-remaining-roots.md). Entries carry
+            // the REAL evaluated value (unlike the value:None signature
+            // splice at the Case 3 site) and are cleared at loop end.
+            // If the pre-pass above created a forward shell for this
+            // method, UPDATE it in place (MethodEntry is reference
+            // semantics — sibling dispatch results holding the entry see
+            // the real method) and record the shell→real redirect, exactly
+            // like Case 3's supersede. Mirrors TS evaluateImplFieldList
+            // assigning each evaluated field into the cloned
+            // receiverType.trait.fields as it goes.
+            if(c2_recv_id != "", {
+              (c2_superseded : bool) = false;
+              c2_prior := get_provisional_trait_methods_by_name(c2_recv_id, mname);
+              (c2_pi : usize) = usize(0);
+              while((c2_pi < c2_prior.len()) && !(c2_superseded), {
+                match(
+                  c2_prior.get(c2_pi),
+                  .Some(c2_e) => {
+                    if(c2_e.source_trait_id == "__forward_shell", {
+                      c2_shell_fid := match(c2_e.value, .Some(sv) => match(sv, .FuncVal(__c2f1, _) => __c2f1.*.func_id, _ => String.new()), .None => String.new());
+                      c2_real_fid := match(m_to_push, .FuncVal(__c2f2, _) => __c2f2.*.func_id, _ => String.new());
+                      if((c2_shell_fid.len() > usize(0)) && (c2_real_fid.len() > usize(0)), {
+                        register_shell_redirect(c2_shell_fid, c2_real_fid);
+                      });
+                      c2_e.ty = mfi.ty;
+                      c2_e.value = Option(EvalValue).Some(m_to_push);
+                      c2_e.source_trait_id = String.from("");
+                      c2_superseded = true;
+                    });
+                  },
+                  .None => ()
+                );
+                c2_pi = (c2_pi + usize(1));
+              });
+              if(!(c2_superseded), {
+                register_provisional_trait_method(
+                  c2_recv_id.clone(),
+                  MethodEntry(
+                    label : mname.clone(),
+                    ty : mfi.ty,
+                    value : Option(EvalValue).Some(m_to_push),
+                    source_trait_id : String.from(""),
+                    needs_pointer_conversion : false,
+                    self_type : Option(TypeValue).None
+                  )
+                );
+              });
+            });
           }
         );
       });
@@ -2667,6 +2774,12 @@ evaluate_module_value :: (
     });
     // Restore self_type so the impl's parent scope sees its prior value.
     ctx.self_type = old_self_type_g;
+    // Field loop done — drop the in-flight provisional entries (the real
+    // methods live in the GenericImplEntry registered below). Mirrors the
+    // Case 3 clear and TS restoring receiverType.trait (trait-type.ts:512).
+    if(c2_recv_id != "", {
+      clear_provisional_trait_methods(c2_recv_id);
+    });
     // For inherent impls, trait_type = Unit (empty key — correct for registry).
     (trait_ty : TypeValue) = t_unit();
     trait_key_str := get_trait_key(trait_ty);

--- a/yo-self/types/creators.yo
+++ b/yo-self/types/creators.yo
@@ -16,6 +16,7 @@
 //! TypeValue enum) and `creators.ts` (constructors).
 open(import("std/string"));
 { ArrayList } :: import("std/collections/array_list");
+{ HashMap } :: import("std/collections/hash_map");
 { TypeValue, FuncMeta } :: import("./definitions.yo");
 { TypeTag } :: import("./tags.yo");
 // ---------------------------------------------------------------------------
@@ -648,6 +649,55 @@ resolve_struct_shell :: (fn(t : TypeValue) -> TypeValue)(
   )
 );
 
+/// Impl-level generic VALUE-binder kinds (`N : usize` in
+/// `impl(generic(T : Type, N : usize), ...)`), registered SYNTACTICALLY at
+/// impl evaluation (evaluator/values/impl.yo) and consumed by
+/// `_build_def_time_body_env`'s capture copy (calls/function_type.yo).
+/// The binder must stay `TypeVal(SomeT)` in the impl's forall env — that
+/// binding is load-bearing for receiver-pattern evaluation (`Array(T, N)`)
+/// — but a def-time BODY env must see an unknown VALUE of the declared
+/// type, or the body's `r.end > N` fails "Cannot unify usize and Type"
+/// (family B of issues/def-eval-swallow-remaining-roots.md). Resolving the
+/// annotation at impl-eval time (or via env lookup at body-env-build time)
+/// triggers lazy module resolution mid-import-cycle — measured 160/247 and
+/// 238/247 there — so registration is NAME-only and resolution below is
+/// PURE: builtin scalar names, no env involvement. Keyed by
+/// `<name>@<frame level>` (the SomeT's identity pair); cleared when the
+/// impl's evaluation finishes.
+(_some_binder_kinds : HashMap(String, String)) = HashMap(String, String).new();
+register_some_binder_kind :: (
+  fn(name : String, lvl : usize, kind_name : String) -> unit
+)({
+  ___sbk := _some_binder_kinds.set(`${name}@${lvl.to_string()}`, kind_name);
+});
+clear_some_binder_kind :: (fn(name : String, lvl : usize) -> unit)({
+  _some_binder_kinds.remove(`${name}@${lvl.to_string()}`);
+});
+/// PURE resolution: builtin scalar names only — a non-builtin annotation
+/// returns `.None` and the binder keeps its (SomeT) binding. `Type` never
+/// registers, so type binders are unaffected.
+resolve_some_binder_kind :: (fn(name : String, lvl : usize) -> Option(TypeValue))(
+  match(
+    _some_binder_kinds.get(`${name}@${lvl.to_string()}`),
+    .Some(kind_name) => cond(
+      (kind_name == "usize") => Option(TypeValue).Some(t_usize()),
+      (kind_name == "isize") => Option(TypeValue).Some(t_isize()),
+      (kind_name == "u8") => Option(TypeValue).Some(t_u8()),
+      (kind_name == "u16") => Option(TypeValue).Some(t_u16()),
+      (kind_name == "u32") => Option(TypeValue).Some(t_u32()),
+      (kind_name == "u64") => Option(TypeValue).Some(t_u64()),
+      (kind_name == "i8") => Option(TypeValue).Some(t_i8()),
+      (kind_name == "i16") => Option(TypeValue).Some(t_i16()),
+      (kind_name == "i32") => Option(TypeValue).Some(t_i32()),
+      (kind_name == "i64") => Option(TypeValue).Some(t_i64()),
+      (kind_name == "f32") => Option(TypeValue).Some(t_f32()),
+      (kind_name == "f64") => Option(TypeValue).Some(t_f64()),
+      (kind_name == "bool") => Option(TypeValue).Some(t_bool()),
+      true => Option(TypeValue).None
+    ),
+    .None => Option(TypeValue).None
+  )
+);
 export(register_enum_final, resolve_enum_shell, _patch_self_shell);
 export(register_struct_final, resolve_struct_shell);
 export(
@@ -682,6 +732,9 @@ export(
   t_c_long,
   t_c_ulong,
   t_c_longlong,
+  register_some_binder_kind,
+  clear_some_binder_kind,
+  resolve_some_binder_kind,
   t_c_ulonglong,
   t_c_longdouble,
   t_ptr,


### PR DESCRIPTION
Continues the campaign PR #110 landed (`issues/def-eval-swallow-remaining-roots.md` is the full measurement record). Std-baseline swallows go **19 → 10**; every fix is a faithful port of a TS behavior yo-self was missing.

## The six commits

1. **Case-2 (generic impl) per-field provisional registration** — a later sibling's def-time trial can now resolve an EARLIER sibling (`Self.new()` before `slice_copy`): each direct colon-pair field registers its real forall-stamped FuncVal into the provisional registry as it completes, superseded in place, cleared at loop end. The static lookup consults provisional LAST (below the generic-impl fallback — outranking it is the measured imm_map regression of the reverted 2026-08-12 attempt).
2. **Trait-constructor coverage + family B** — trait-ctor inner fields get the same treatment; impl-level VALUE binders (`impl(generic(T : Type, N : usize), …)`) are re-kinded to `UnknownVal(usize)` in def-time body envs via a NAME-only side table resolved purely (every env-involved resolution measurably broke the circular-import order: 87–160/247 files).
3. **Lazy on-demand forward shells** — forward references (`slice_copy → get`) resolve through shells materialized ONLY when a trial asks for that sibling. The eager TS-shaped pre-pass measurably diverged `tests/imm_map.test.yo` even with registration disabled (map.yo's early signature instantiations poison a CTFE/instantiation order the batch main depends on).
4. **Abstract generic bindings (TS parity) + comptime params bound `UnknownVal`** — cross-impl dispatch at def time (`Clone` impl calling the inherent `len`) binds `T := T'`; comptime VALUE params carry `createUnknownValue(declaredType)` like TS (runtime params stay valueless — the dup-accounting fix is preserved).
5. **Abstract bindings scoped STRICTLY to def-time trials** — outside trials (derive validation, spec body evals) stamps feed codegen directly, and an abstract match there minted an abstract-keyed specialization the emitter skips while the call site still emits (`derive_clone_complex` 'call to undeclared function'). Bisected against per-increment binaries.
6. **Debug hooks** (`YO_DEBUG_DISPATCH`, `[abstract-spec]`) + root-#3's diagnosis: the remaining trait-branch failure is a `synthesize_types` SomeT-vs-SomeT gap, pinpointed and recorded.

## Battery (all on this exact tree)

| gate | result |
|---|---|
| hollow sweep (188 language files, self-hosted) | **188/188 GREEN** |
| bootstrap fixpoint | **FIXPOINT_HOLDS** |
| `check ./std` | 154/154 |
| `check ./yo-self` | 247/247 |
| canaries (`imm_map`, `derive_clone_complex`) | 21/21, 15/15 |
| `tests/internal` (self-hosted) | running locally; CI's differential covers it |

Remaining roots (~10) and the endgame (fatal trial handler) continue in the issue doc — root #3's next move is the synthesizer gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)