### PR TITLE
Def-eval swallow: three more roots — comptime-only judgments and CTFE degrade scoped to trials

### DIFF
--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -22,6 +22,17 @@
 > the specialization re-eval, or (b) suppressed during trials — then land
 > the wip branch on top.
 >
+> **Repair 1's concrete entry point (measured on the preserved r4
+> binary):** `tests/collections/btree_map.test.yo`'s batch main fails
+> `check_if_function_parameter_matches_argument: arg has no ExprInfo` at a
+> CONCRETE `for((m.iter)(), ptr => ...)` — i.e. a TRIAL-time abstract match
+> during module eval left a durable write that redirects BATCH-time
+> resolution. Prime suspects inside `try_match_generic_impl`'s success
+> path: the "DURABLE assoc-type registration at first success"
+> (`register_type_trait_method` under the trial receiver's id) and
+> `register_some_resolved_concrete`. Instrument those two writes with the
+> trial flag on the wip branch and diff a batch run.
+>
 > **Repair 2 — SomeT-keyed type-constructor CTFE (roots 7623, 7837, 7942,
 > 7973).** TS RUNS type-ctor CTFE with SomeType args (`IterPair(usize, A)`
 > yields a real struct type with abstract fields); yo-self deliberately

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -1,5 +1,41 @@
 # The def-eval swallow: remaining roots, measured and attributed
 
+> **STATE 2026-08-13 (end of second session): 19 → 7 swallows.** Landed (PR
+> #115 + two follow-up commits on `fix/family-a-provisional-static`):
+> families A and B, cross-impl abstract bindings (trial-scoped), comptime
+> params bound UnknownVal, the ::-vs-:= and typed-binding comptime skips,
+> the comptime-CTFE non-FuncVal degrade. Every landed increment is
+> sweep-188/188-clean. **All 7 remaining roots are blocked on two
+> structural repairs:**
+>
+> **Repair 1 — trial-stamp staleness (roots #3-class: 797, 616, 537).**
+> Def-time trials stamp ExprInfos and side tables on SHARED body ASTs;
+> specialization re-eval overwrites the ExprInfoTable (id-keyed) but NOT
+> every side channel (method-callee value table, fid registrations,
+> runtime-arg exprs). Every dispatch loosening that lets trials resolve
+> MORE (the synthesis-layer work on `wip/root3-synthesis-layer` — struct
+> structural fallback + type-args abstract recovery — which DID fix the
+> dispatch) turns sweep files RED through those channels (10 REDs:
+> collections + iterator combinators + where_clause_fn_inference; the
+> abstract-spec class before it). Fix the overwrite contract first — make
+> every side-table write from a trial either (a) tagged and superseded by
+> the specialization re-eval, or (b) suppressed during trials — then land
+> the wip branch on top.
+>
+> **Repair 2 — SomeT-keyed type-constructor CTFE (roots 7623, 7837, 7942,
+> 7973).** TS RUNS type-ctor CTFE with SomeType args (`IterPair(usize, A)`
+> yields a real struct type with abstract fields); yo-self deliberately
+> skips it (`ou_all_known` — "a validation-pass SomeT TypeVal must not
+> mint, it would cache-key junk", the gap-6 lesson), so the callee
+> degrades to `UnknownVal(Type(1))` and every downstream member check
+> fails. The fix needs trial-scoped instantiation that does NOT pollute
+> the CTFE cache — e.g. a separate trial-era cache keyed by SomeT ids,
+> discarded with the trial, mirroring TS's shared-object model without its
+> in-place mutation.
+>
+> The endgame (fatal `_trial_eval_fn_body`) stays gated on all 7 + a
+> corpus-wide re-attempt.
+
 **Live inventory.** `_trial_eval_fn_body`
 (`yo-self/evaluator/calls/function_type.yo`) wraps definition-time body
 evaluation in a capture-free handler that unwinds `()` on ANY error, and the

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -551,6 +551,24 @@ suspected difference: the g\_ branch evaluates fields with
 `ctx.expected_type` = the trait's substituted field type, while the direct
 branch CLEARS expected_type.
 
+**ATTEMPTED AND REVERTED (branch `wip/root3-synthesis-layer`):** the
+synthesis-layer fixes for this — a trial-scoped struct-shape structural
+fallback in `synthesizer.yo`'s struct arm (the enum arm's twin) plus
+trial-scoped abstract acceptance in `_bind_forall_from_type_args` — DID
+resolve the dispatch (root 797/616 progressed into the ::-vs-:= comptime
+binding layer, canaries `imm_map`/`derive_clone_complex` both green), but
+the hollow sweep turned **10 files RED**: the whole `tests/collections/`
+family, `iter_filter_closure`, `iterator_combinators`,
+`where_clause_fn_inference`. The struct fallback alone (unscoped
+intermediate binary) already breaks `btree_map`, and the scoped r4 build
+fails it identically — the same structural lesson yet again: trial-time
+resolutions stamp shared body ASTs that codegen consumes, so ANY loosening
+that lets trials resolve more surfaces as miscompiles until the underlying
+staleness (specialization re-eval must OVERWRITE trial stamps) is fixed.
+**That staleness repair is the real prerequisite for the remaining roots**
+— take it up with fresh context; the WIP branch has the working
+synthesis-layer changes and the ::-check skip (stash) to rebase on top.
+
 **PINPOINTED (instrumented build, `YO_DEBUG_DISPATCH=1`):** the trait
 branch's trial binds `self` to a FRESH `G` instantiation minted by
 `_substitute_self_in_method_ty` (recv id 5094 ≠ the impl pattern 3377),

--- a/plans/HANDOVER_DEF_EVAL_SWALLOW.md
+++ b/plans/HANDOVER_DEF_EVAL_SWALLOW.md
@@ -1,5 +1,16 @@
 # Handover — the def-eval swallow endgame, and the three PRs behind it
 
+> **UPDATE 2026-08-13 (evening session).** §0's steps are DONE or superseded:
+> PR #110 MERGED; #98 → closed, rebased as **#113**; #112 → closed, reworked as
+> **#114** (RELEASE_PAT direct bump, stacked on #113). Family A §3 was
+> implemented and went much further than this doc's shape — the full record
+> (six landed fixes, three measured regressions and their scoping, the
+> remaining ~10 roots with root-#3 pinpointed to a `synthesize_types` gap) is
+> in `issues/def-eval-swallow-remaining-roots.md`, branch
+> `fix/family-a-provisional-static`: baseline swallows **19 → 10**, sweep
+> 188/188 GREEN, FIXPOINT_HOLDS, `check ./std` 154/154,
+> `check ./yo-self` 247/247. §2–§4 below are historical.
+
 **Written 2026-08-13.** Branch `fix/def-eval-swallow-sizing` = PR #110.
 Read this first, then `issues/def-eval-swallow-remaining-roots.md` for the full
 measurement record. This doc is the state, the traps, and the next move; that

--- a/yo-self/evaluator/calls/comptime_fn.yo
+++ b/yo-self/evaluator/calls/comptime_fn.yo
@@ -46,7 +46,8 @@ open(import("std/string"));
   ComptimeFnCallResult,
   FuncOrAsyncBlockCtx,
   FuncOrAsyncBlockKind,
-  ImplConcreteTypeInfo
+  ImplConcreteTypeInfo,
+  in_def_time_trial
 } :: import("../context.yo");
 { evaluate_begin_expression } :: import("../exprs/begin.yo");
 { format_error_message } :: import("../../error.yo");
@@ -489,6 +490,25 @@ evaluate_comptime_fn_call :: (
     function_value,
     .FuncVal(__fvd2, _) => __fvd2.*.body,
     _ => {
+      // Inside a DEFINITION-time body trial, a non-FuncVal callee is a
+      // dispatch product with no impl value yet (a where-constraint trait
+      // method on an abstract receiver — prelude's `~`/`-` comptime
+      // variants, roots #14/#15 of
+      // issues/def-eval-swallow-remaining-roots.md). TS never reaches its
+      // CTFE with a non-FunctionValue (typing) — such calls degrade to an
+      // unknown of the return type earlier. Mirror that here, scoped to
+      // the trial; everywhere else the throw stays (a genuine
+      // calling-a-non-function error must not be silently absorbed).
+      if(in_def_time_trial(), {
+        return(
+          ComptimeFnCallResult(
+            value : _ctfe_unknown(return_type, caller_env),
+            caller_env : caller_env,
+            callee_env : callee_env,
+            comptime_ref : Option(ComptimeRef).None
+          )
+        );
+      });
       exn.throw(
         dyn(
           format_error_message(

--- a/yo-self/evaluator/exprs/binding.yo
+++ b/yo-self/evaluator/exprs/binding.yo
@@ -27,7 +27,7 @@ open(import("std/fmt"));
 } :: import("../../expr.yo");
 { ExprInfo, new_expr_info, expr_info_table_get, expr_info_table_set, expr_info_paths_for_write, register_module_level_global } :: import("../../expr_info.yo");
 { Environment, add_variable_to_env, get_variables_from_env } :: import("../../env.yo");
-{ EvalContext, FuncOrAsyncBlockKind } :: import("../context.yo");
+{ EvalContext, FuncOrAsyncBlockKind, in_def_time_trial } :: import("../context.yo");
 { EvalValue, is_type_value, create_unknown_val } :: import("../../value.yo");
 { TypeValue } :: import("../../types/definitions.yo");
 { t_unit } :: import("../../types/creators.yo");
@@ -42,7 +42,8 @@ open(import("std/fmt"));
   prohibit_void_type,
   type_requires_comptime_modifier,
   type_prohibits_comptime_modifier,
-  type_contains_rc_type
+  type_contains_rc_type,
+  get_all_some_types
 } :: import("../../types/utils.yo");
 { format_error_message, format_error_messages, TokenAndError, YoError } :: import("../../error.yo");
 { type_implements_comptime, type_implements_runtime_full } :: import("../trait_checking.yo");
@@ -291,7 +292,17 @@ evaluate_binding :: (
   // Env-aware fallback for COMPOUND comptime-only types — see the twin gate
   // in initialization_assignment.yo.
   binding_requires_ct := (type_requires_comptime_modifier(user_defined_type) || (type_implements_comptime(user_defined_type, env) && !(type_implements_runtime_full(user_defined_type, env))));
-  if(binding_requires_ct && !(is_compile_time_only), {
+  // In a DEFINITION-time body trial a type still carrying unresolved SomeTs
+  // cannot be judged comptime-only — the twin of the ::-vs-:= skip in
+  // initialization_assignment.yo (root 7837, IterFilter's
+  // `(loop_result : Option(A)) = .None` — A is the where-constraint SomeT;
+  // issues/def-eval-swallow-remaining-roots.md). The specialization-time
+  // re-eval re-checks with concrete types.
+  binding_ct_check := cond(
+    ((in_def_time_trial() && binding_requires_ct) && (get_all_some_types(user_defined_type).len() > usize(0))) => false,
+    true => binding_requires_ct
+  );
+  if(binding_ct_check && !(is_compile_time_only), {
     ty_str := type_to_string(user_defined_type);
     exn.throw(
       dyn(

--- a/yo-self/evaluator/exprs/initialization_assignment.yo
+++ b/yo-self/evaluator/exprs/initialization_assignment.yo
@@ -46,7 +46,8 @@ open(import("std/string"));
 {
   EvalContext,
   ExpectedTypeCtx,
-  FuncOrAsyncBlockKind
+  FuncOrAsyncBlockKind,
+  in_def_time_trial
 } :: import("../context.yo");
 { EvalValue, create_unknown_val, is_runtime_only_unknown_val } :: import("../../value.yo");
 { TypeValue } :: import("../../types/definitions.yo");
@@ -58,7 +59,8 @@ open(import("std/string"));
   type_requires_comptime_modifier,
   type_prohibits_comptime_modifier,
   type_contains_rc_type,
-  type_is_control_bound
+  type_is_control_bound,
+  get_all_some_types
 } :: import("../../types/utils.yo");
 { convert_comptime_type_to_runtime_type } :: import("../../types/env_lookup.yo");
 { type_to_string } :: import("../../types/string.yo");
@@ -422,7 +424,18 @@ Bound type: ${type_to_string(rhs_info.ty)}`,
     // recursion (types/utils.ts:85-96). Use the env-aware derivation as
     // the fallback after the cheap tag path.
     lhs_requires_ct := (type_requires_comptime_modifier(lhs_type) || (type_implements_comptime(lhs_type, env) && !(type_implements_runtime_full(lhs_type, env))));
-    if(!(effective_is_compile_time_only) && lhs_requires_ct, {
+    // In a DEFINITION-time body trial a type still carrying unresolved
+    // SomeTs cannot be judged comptime-only (TS's auto-derive is
+    // conservative on SomeTypes; yo-self's trait check is optimistic, so
+    // `Option(T')` from an abstract cross-impl dispatch wrongly demanded
+    // `::` — the ::-vs-:= layer of roots 797/616/7905,
+    // issues/def-eval-swallow-remaining-roots.md). Skip; the
+    // specialization-time re-eval re-checks with concrete types.
+    lhs_ct_check := cond(
+      ((in_def_time_trial() && lhs_requires_ct) && (get_all_some_types(lhs_type).len() > usize(0))) => false,
+      true => lhs_requires_ct
+    );
+    if(!(effective_is_compile_time_only) && lhs_ct_check, {
       lhs_type_str := type_to_string(lhs_type);
       expr_str := ast_expr_to_string(expr);
       exn.throw(


### PR DESCRIPTION
Follow-up tranche to #115; std-baseline swallows go **10 → 7**.

- **Root 7905**: the `::`-vs-`:=` comptime-binding check skips SomeT-carrying types inside definition-time trials — the judgment is unknowable while SomeTs are unresolved (TS's Comptime auto-derive is conservative on SomeTypes; yo-self's is optimistic). The specialization-time re-eval re-checks with concrete types, so the real diagnostic is preserved.
- **Root 7837 (first layer)**: the typed-binding form (`(x : T) = v`) gets the twin skip in `binding.yo`.
- **Roots 578/599**: `evaluate_comptime_fn_call` degrades a non-FuncVal callee to an unknown of the return type inside trials (a where-constraint trait method on an abstract receiver has no impl value yet; TS's typing never reaches CTFE with a non-FunctionValue). Re-applied **in isolation** after an earlier bundled revert and measured innocent — the imm_map damage belonged to the SomeT-callee degrade it was bundled with.
- Docs: the two structural repairs that gate the remaining 7 roots (trial-stamp side-table staleness; SomeT-keyed type-ctor CTFE), each with its measured evidence and concrete entry point.

**Battery** (tree identical to the locally gated branch for `yo-self/` + `std/`): hollow sweep **188/188 GREEN**, canaries `imm_map` 21/21 / `derive_clone_complex` 15/15 / `btree_map` green, `check ./yo-self` 247/247, baseline reproducer rc=0 / 0 markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)