### PR TITLE
Def-eval swallow: roots 797 + 616 — synthesis-layer trial loosenings, made safe by the flag-semantics fix

### DIFF
--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -44,8 +44,24 @@
 > discarded with the trial, mirroring TS's shared-object model without its
 > in-place mutation.
 >
-> The endgame (fatal `_trial_eval_fn_body`) stays gated on all 7 + a
-> corpus-wide re-attempt.
+> The endgame (fatal `_trial_eval_fn_body`) stays gated on all remaining
+> roots + a corpus-wide re-attempt.
+>
+> **LATER SAME SESSION — repair 1 landed** (`wip/root3-synthesis-layer`,
+> PR #117): the flow-site `in_def_time_trial` flag was the leak (concrete
+> fns' trial stamps ARE codegen's input — batch mains included); with it
+> off, the synthesis loosenings are safe (sweep 188/188) and roots 797 +
+> 616 cleared. **5 roots remain.**
+>
+> **Root 537's frontier** (minimal repro `scratchpad/idx537.yo`, hooks
+> in-tree): the Index-impl trial's `_ptr.add(idx)` — dispatch, match, and
+> the finder's substitution are all CORRECT (`[fmg-cand]` shows
+> `fn(self : *(T)) -> *(T)` with T properly bound to the G-impl's SomeT —
+> both binders are NAMED T so the print looks unsubstituted). The doubling
+> to `*(*(T))` therefore happens in the CALL-SITE return resolution after
+> dispatch (the "call-time SomeT synthesis, whose frame levels are stale"
+> warning in find_methods_from_generic_impls' own comment). Next: trace
+> the runtime-return path's resolved_ret computation for this call.
 
 **Live inventory.** `_trial_eval_fn_body`
 (`yo-self/evaluator/calls/function_type.yo`) wraps definition-time body

--- a/yo-self/evaluator/calls/function_type.yo
+++ b/yo-self/evaluator/calls/function_type.yo
@@ -1160,9 +1160,17 @@ try_to_implement_function_by_function_type :: (
             });
           };
           push_active_where_trait_ids(flow_where_ids);
-          fl_prev_trial := set_in_def_time_trial(true);
+          // NOT flagged as a def-time trial: this is the CONCRETE-fn path
+          // (flow_body is Some only when should_defer_ft is false), and for
+          // a concrete fn this evaluation's stamps ARE what codegen emits —
+          // main's body included — with no specialization re-eval ever
+          // superseding them. The in_def_time_trial loosenings are only
+          // safe where stamps are discardable: the DEFERRED-generic trial
+          // (dg below) and the pending re-run. Flagging this site made the
+          // batch main's own trial resolve abstractly
+          // (tests/collections/btree_map.test.yo lost `for(m.iter())`'s
+          // closure-arg ExprInfo under the wip synthesis loosenings).
           _trial_eval_fn_body(fb, flow_env, flow_ctx, flow_out);
-          ___fl_tr := set_in_def_time_trial(fl_prev_trial);
           pop_active_where_trait_ids();
           // This body captured a VALUELESS forward-declared comptime fn
           // variable — its call-site infos are incomplete until that

--- a/yo-self/evaluator/types/synthesizer.yo
+++ b/yo-self/evaluator/types/synthesizer.yo
@@ -30,6 +30,7 @@ open(import("std/string"));
   synthetic_token
 } :: import("../../env.yo");
 { Token } :: import("../../token.yo");
+{ in_def_time_trial } :: import("../context.yo");
 { TypeValue } :: import("../../types/definitions.yo");
 { register_some_resolved_concrete, lookup_some_resolved_concrete, lookup_struct_ctor_fid } :: import("../../expr_info.yo");
 { type_value_tag, t_effects_row, t_usize, resolve_enum_shell } :: import("../../types/creators.yo");
@@ -1548,7 +1549,40 @@ _synthesize_types_impl :: (
       );
     });
     same_constructor3 := ((exp_eff_cfid.len() > usize(0)) && (exp_eff_cfid == giv_eff_cfid));
-    if((exp_id3 != giv_id3) && !(same_constructor3), {
+    // Structural fallback when the cfid guard would reject — the STRUCT twin
+    // of the enum arm's below: an instantiation minted on a path that
+    // bypasses the ctor stamp (fn-specialization bodies, def-time trial
+    // substitutions — the trait-constructor branch's trial receiver, root #3
+    // of issues/def-eval-swallow-remaining-roots.md) carries no recorded
+    // cfid, so `G(T)`-pattern vs the fresh `G` instance threw "Cannot unify
+    // incompatible struct types" before field unification could bind T.
+    // Same name AND identical field-label lists → proceed to the per-field
+    // unification below, which still does the real structural checking.
+    // SCOPED to definition-time trials: unscoped, the looser matching
+    // reached specialization/codegen channels and re-broke
+    // tests/derive_clone_complex.test.yo (the session's recurring lesson —
+    // abstract/looser products must stay out of stamps codegen consumes).
+    (same_shape3 : bool) = false;
+    if(((exp_id3 != giv_id3) && !(same_constructor3)) && in_def_time_trial(), {
+      exp_snm := match(expected_ty, .Struct({ name : n }) => n, _ => String.from(""));
+      giv_snm := match(given_ty, .Struct({ name : n }) => n, _ => String.from(""));
+      exp_lbls := match(expected_ty, .Struct({ field_labels : l }) => l, _ => ArrayList(String).new());
+      giv_lbls := match(given_ty, .Struct({ field_labels : l }) => l, _ => ArrayList(String).new());
+      if(((exp_snm == giv_snm) && (exp_lbls.len() > usize(0))) && (exp_lbls.len() == giv_lbls.len()), {
+        (sl_i : usize) = usize(0);
+        (sl_eq : bool) = true;
+        while((sl_i < exp_lbls.len()) && sl_eq, {
+          sl_e := match(exp_lbls.get(sl_i), .Some(x) => x, .None => String.from(""));
+          sl_g := match(giv_lbls.get(sl_i), .Some(x) => x, .None => String.from(""));
+          if(sl_e != sl_g, {
+            sl_eq = false;
+          });
+          sl_i = (sl_i + usize(1));
+        });
+        same_shape3 = sl_eq;
+      });
+    });
+    if(((exp_id3 != giv_id3) && !(same_constructor3)) && !(same_shape3), {
       exn.throw(
         dyn(
           format_error_message(

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -460,6 +460,9 @@ _resolve_one_forall_binding :: (
   if((in_def_time_trial() && (bt_id.len() > usize(0))) && (bt_id != fa_some_id), {
     return(Option(TypeValue).Some(bound_type));
   });
+  if(impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some(), {
+    eprintln(`[rfb-id-miss] name=${fa_name} own_id=${fa_some_id} bound_id=${bt_id} trial=${in_def_time_trial().to_string()}`);
+  });
   // Name-based fallback: look up `fa_name` directly in `expected_env`.
   name_vars := get_variables_from_env(expected_env, fa_name);
   n_nvars := name_vars.len();
@@ -635,6 +638,20 @@ _bind_forall_from_type_args :: (
         .Some(ct) => if(!(is_some_type(ct)), {
           return(Option(TypeValue).Some(ct));
         }, {
+          // Trial-scoped abstract acceptance — same contract as
+          // _resolve_one_forall_binding: inside a definition-time body
+          // trial a DIFFERENT-id SomeT type argument IS the binding
+          // (ArrayList(T_pattern) matched against the Clone impl's
+          // ArrayList(T'), root #3 — field synthesis leaves T unbound
+          // because ?*(T) unification binds neither side, and this
+          // type-args recovery was the only channel left).
+          {
+            ct_abs_id := match(ct, .SomeT({ id : __cai }) => __cai, _ => String.from(""));
+            fa_abs_id := match(fa_some, .SomeT({ id : __fai }) => __fai, _ => String.from(""));
+            if((in_def_time_trial() && (ct_abs_id.len() > usize(0))) && (ct_abs_id != fa_abs_id), {
+              return(Option(TypeValue).Some(ct));
+            });
+          };
           // `ct` is still a SomeType. For an async future's output type, yo-self
           // KEEPS the output unresolved through eval (the FSM/future machinery
           // keys on that SomeType identity), and the concrete type lands in the
@@ -744,8 +761,12 @@ try_match_generic_impl :: (
   exn_match := Exception(
     throw : (
       (err) -> {
-        // Synthesis failed → no match.
-        err;
+        // Synthesis failed → no match. YO_DEBUG_DISPATCH prints the
+        // swallowed error (capture-free handler, same pattern as the
+        // [swallow] hook) — pairs with the [tm-try] line above it.
+        if(impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some(), {
+          eprintln(`[tm-synth-swallow] ${err.to_string()}`);
+        });
         unwind(Option(ArrayList(TypeValue)).None);
       }
     )

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -444,6 +444,9 @@ _resolve_one_forall_binding :: (
   fa_some_id := match(fa_some, .SomeT({ id : __fsi }) => __fsi, _ => String.from(""));
   bound_type := get_value_of_some_type_from_env(expected_env, fa_some);
   if(!(is_some_type(bound_type)), {
+    if(impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some(), {
+      eprintln(`[rfb-bound] name=${fa_name} via=id-concrete ty=${type_to_string(bound_type)} trial=${in_def_time_trial().to_string()}`);
+    });
     return(Option(TypeValue).Some(bound_type));
   });
   // Accept a DIFFERENT-id SomeT binding ONLY inside a definition-time body

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -478,7 +478,12 @@ _resolve_one_forall_binding :: (
     .Some(ev) => match(
       ev,
       .TypeVal(b) => cond(
-        !(is_some_type(b)) => Option(TypeValue).Some(b),
+        !(is_some_type(b)) => {
+          if(impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some(), {
+            eprintln(`[rfb-bound] name=${fa_name} via=name-concrete ty=${type_to_string(b)} trial=${in_def_time_trial().to_string()}`);
+          });
+          Option(TypeValue).Some(b)
+        },
         // Abstract (different-id SomeT) name-channel binding: accepted ONLY
         // inside a definition-time body trial. There it is what resolves a
         // sibling impl's method dispatch (array_list's Clone impl calling

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -1416,9 +1416,13 @@ find_methods_from_generic_impls :: (
               // exact-equality test compare EnumT(id, Some(T)) against
               // EnumT(id, Some(Node)) and silently never fire.
               subst_set_self(spec_s, entry.receiver_type_pattern, resolved);
+              fmg_spec_ty := substitute(spec_s, ftype);
+              if(impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some(), {
+                eprintln(`[fmg-cand] method=${method_name} recv=${type_to_string(resolved)} raw=${type_to_string(ftype)} spec=${type_to_string(fmg_spec_ty)} trial=${in_def_time_trial().to_string()}`);
+              });
               results.push(
                 MethodCandidate(
-                  method_type : substitute(spec_s, ftype),
+                  method_type : fmg_spec_ty,
                   method_value : _inject_forall_captures(fvalue, entry.forall_names, match_bindings, match_binding_vals),
                   source_trait_id : entry.trait_key.clone()
                 )

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -1394,6 +1394,18 @@ find_methods_from_generic_impls :: (
               // synthesis, whose frame levels are stale at the call site — the
               // same reason `_substitute_self_in_method_ty` exists.
               spec_s := subst_new();
+              // Collect the method type's OWN SomeT instances once: a forall
+              // name can appear at DIFFERENT frame levels inside one method
+              // type (the pointer-arithmetic impl's `add` carries `*(T)`
+              // params at the impl forall's level but a return `*(T)` minted
+              // at another — `[fmg-cand]` showed the param substituted and
+              // the return left RAW, whose stale-level `T` then resolved
+              // against the receiver at the call site: `*(*(T))`, root 537
+              // of issues/def-eval-swallow-remaining-roots.md). Substitute
+              // every same-NAME occurrence at its own level — the forall
+              // twin of _substitute_self_in_method_ty's "EVERY Self at its
+              // OWN frame level" rule above.
+              ft_all_somes := get_all_some_types(ftype);
               (sb_i : usize) = usize(0);
               while(sb_i < entry.forall_names.len(), {
                 sb_name := match(entry.forall_names.get(sb_i), .Some(n) => n, .None => String.from(""));
@@ -1401,7 +1413,24 @@ find_methods_from_generic_impls :: (
                 sb_ty := match(match_bindings.get(sb_i), .Some(t) => t, .None => t_unit());
                 match(
                   sb_some,
-                  .SomeT(_, _, lvl, _, _, _, _, _, _, _, _) => subst_add(spec_s, sb_name, lvl, sb_ty),
+                  .SomeT(_, _, lvl, _, _, _, _, _, _, _, _) => {
+                    subst_add(spec_s, sb_name, lvl, sb_ty);
+                    (fts_i : usize) = usize(0);
+                    while(fts_i < ft_all_somes.len(), {
+                      match(
+                        ft_all_somes.get(fts_i),
+                        .Some(fts_t) => match(
+                          fts_t,
+                          .SomeT(_, fts_n, fts_lvl, _, _, _, _, _, _, _, _) => if((fts_n == sb_name) && (fts_lvl != lvl), {
+                            subst_add(spec_s, sb_name, fts_lvl, sb_ty);
+                          }),
+                          _ => ()
+                        ),
+                        .None => ()
+                      );
+                      fts_i = (fts_i + usize(1));
+                    });
+                  },
                   _ => ()
                 );
                 sb_i = (sb_i + usize(1));

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -1003,7 +1003,13 @@ try_match_generic_impl :: (
   // record's type id lets every later resolution channel (step-4 assoc
   // check, find_associated_type_from_generic_impls step 1, my wcr recovery)
   // read them from the registry directly. Concrete-only + deduped.
-  if(all_bound, {
+  // DEF-time trials must not make DURABLE registrations: a trial-time
+  // abstract match (the trial-scoped acceptance above) registering assoc
+  // types under the trial receiver's id redirected BATCH-time resolution —
+  // tests/collections/btree_map.test.yo's main lost the `for(m.iter())`
+  // closure arg's ExprInfo (repair 1 of
+  // issues/def-eval-swallow-remaining-roots.md).
+  if(all_bound && !(in_def_time_trial()), {
     dar_tid := type_id_or_empty(resolved_concrete);
     if(dar_tid.len() > usize(0), {
       dar_s := subst_new();


### PR DESCRIPTION
Supersedes #117 (closed by GitHub when its stacked base \`swallow/roots-batch-2\` was deleted on #116's merge; the branch is rebased onto develop, so reopening was not possible).

Carries tranche 3 of the def-eval swallow campaign (see \`issues/def-eval-swallow-remaining-roots.md\`):

- **Root #3 second half**: trial-scoped struct-shape synthesis fallback + type-args abstract recovery (synthesizer.yo, impl.yo).
- **Repair 1 — the flag-semantics fix that makes the loosenings safe**: \`in_def_time_trial\` is OFF for concrete-fn body evals (their trial stamps ARE codegen's input; only deferred-generic trials and pending re-runs are discardable). This is what stopped the 10-file sweep regression every earlier loosening attempt hit.
- **Generic-impl method substitution**: substitute a forall name at EVERY frame level it occurs in the method type (same-named binders at different levels left the return type raw).
- Debug hooks: \`YO_DEBUG_DISPATCH\` [rfb-bound]/[fmg-cand] prints; root 537 frontier documented.

Battery on the tip: hollow sweep 188/188 GREEN, fixpoint holds, canaries green, \`check ./std\` 154/154, \`check ./yo-self\` 247/247.

Roots 797 (ArrayList Clone impl) and 616 (Iterator next) cleared; 19 → 7 → 5 swallows at this tranche's tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)