### PR TITLE
Def-eval swallow: the FINAL five roots — SomeT trial compatibility, unknown-arg type-ctor CTFE, and the root-537 pointer-conversion mis-port

### DIFF
--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -62,6 +62,40 @@
 > dispatch (the "call-time SomeT synthesis, whose frame levels are stale"
 > warning in find_methods_from_generic_impls' own comment). Next: trace
 > the runtime-return path's resolved_ret computation for this call.
+>
+> **REPAIR 2 RE-DIAGNOSED (2026-08-13, third session, `YO_DEBUG_CTFE`
+> instrumentation — comptime_fn.yo/function.yo/type.yo, in-tree).** The
+> "SomeT-keyed type-ctor CTFE" framing was WRONG for 3 of the 4 roots.
+> Measured per-root ground truth:
+>
+> - **7837, 7942, 7973 are ONE bug, and it is NOT CTFE.** The type-ctor
+>   CTFE **executes fine** with SomeT type args (`IterPair(usize, A)` →
+>   fresh anonymous struct per call; no cache under the SomeT carve-out —
+>   faithful enough for trials). The actual failure is the MEMBER
+>   compatibility check: `[tycall-mismatch] label=_1 expected=A got=Item`
+>   — yo-self's SomeT-vs-SomeT rule (name+frame_level identity,
+>   compatibility.yo) REJECTS two different type params, while TS
+>   (compatibility.ts:676-744) ACCEPTS different-id SomeTypes whenever the
+>   given side satisfies the expected side's constraint set (trivially
+>   true for an unconstrained forall `A`). Fix: trial-scoped, non-exact,
+>   empty-expected-constraints acceptance in compatibility.yo's SomeT arm
+>   (the flag storage moved to types/creators.yo `trial_flag_get` to avoid
+>   the evaluator-layer import cycle). NOT the full TS subset walk — that
+>   port self-recursed unboundedly (see the arm's history note).
+>   Note: in 7942/7973 the inner mismatch's exn.throw does NOT surface —
+>   evaluation continues and the OUTER `.Some(...)` member check reports
+>   `got=Type(1)` (a stale checking-phase stamp on the construction node),
+>   which is what made the message misattributable to CTFE.
+> - **7623 alone is the CTFE-degrade root**: `_ArrayIter(T, N)` carries a
+>   VALUE comptime param (`N : usize`, bound `<unknown: usize>` at def
+>   time) → `[ctfe-unk-arg]` (comptime_fn.yo's unknown-arg execution gate)
+>   → `_ctfe_unknown(Type)` = a fresh bare SomeT → "TypeVal SomeT callee
+>   without FnTrait (Phase 4)". TS EXECUTES type-ctor bodies with
+>   UnknownValue args (its recursion protection is the in-progress temp
+>   cache, comptime-fn.ts:188-203, pushed unconditionally). Candidate fix:
+>   during trials, let type-hierarchy-returning ctors execute despite
+>   unknown VALUE args; recursion safety needs a trial-era in-progress
+>   entry since the SomeT carve-out disables the durable cache.
 
 **Live inventory.** `_trial_eval_fn_body`
 (`yo-self/evaluator/calls/function_type.yo`) wraps definition-time body

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -1,5 +1,22 @@
 # The def-eval swallow: remaining roots, measured and attributed
 
+> **STATE 2026-08-13 (third session): 19 → 1 swallow. ONLY ROOT 537 REMAINS.**
+> Landed on `swallow/somet-compat-trial` (stacked on `wip/root3-synthesis-layer`,
+> PR #117):
+>
+> - **7837 + 7942 + 7973** — one bug: SomeT-vs-SomeT trial acceptance
+>   (compatibility.yo; TS's different-id rule for unconstrained expected
+>   params; flag storage moved to types/creators.yo `trial_flag_get`).
+> - **7623** — type-ctor CTFE now executes despite unknown VALUE args
+>   during trials (comptime_fn.yo unknown-arg gate carve-out,
+>   `trial_unknown_nocache` keeps the memo clean).
+>
+> Both increments: sweep 188/188 GREEN, canaries green (imm_map,
+> derive_clone_complex, btree_map, array), check ./std 154/154,
+> check ./yo-self 247/247; fixpoint run pending at time of writing.
+> Root 537's frontier is unchanged below. After 537: the fatal-handler
+> endgame + corpus re-attempt.
+
 > **STATE 2026-08-13 (end of second session): 19 → 7 swallows.** Landed (PR
 > #115 + two follow-up commits on `fix/family-a-provisional-static`):
 > families A and B, cross-impl abstract bindings (trial-scoped), comptime

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -1,5 +1,27 @@
 # The def-eval swallow: remaining roots, measured and attributed
 
+> **STATE 2026-08-13 (third session, later): 19 → 0. ALL ROOTS FIXED.**
+> Root 537's true root was a MIS-PORT in `_filter_receiver_methods`
+> (yo-self/env.yo): the pointee-vs-receiver check used the LENIENT
+> compatibility variant where TS passes `requireExactMatch=true`
+> (env.ts:1322-1329; compatibility.ts:823-827 makes an unconstrained
+> SomeType reject concrete types under exact rules). The lenient check
+> marked blanket `impl(generic(T), *(T), add)` methods with
+> `needs_pointer_conversion` for an ALREADY-POINTER receiver → `&`-wrap →
+> `T := *(T_arr)` synthesis → the `*(T)` return doubled to `*(*(T_arr))`.
+> Three resolution-side theories were built and REFUTED first (occurs
+> check; ownership-refined occurs; id-keyed synthesis channel — which
+> faithfully served the wrong binding, proving the writer upstream); the
+> `[s9-init]`/`[rsd-dbl]`/`[occ-pass]` YO_DEBUG_RET hooks carried the dig.
+> Fix commit `aac04c097` on `swallow/somet-compat-trial` (PR #119).
+> Battery: sweep 188/188 GREEN, canaries incl. ptr/unsafe/array_list all
+> green, check ./std 154/154, check ./yo-self 247/247, fixpoint pending.
+>
+> **NEXT: the endgame** — make `_trial_eval_fn_body` FATAL (TS parity,
+> function-type.ts:499) and re-attempt the corpus; the last fatal attempt
+> (2026-08-12) broke 10 files because the swallow was load-bearing, all
+> of whose roots are now fixed.
+
 > **STATE 2026-08-13 (third session): 19 → 1 swallow. ONLY ROOT 537 REMAINS.**
 > Landed on `swallow/somet-compat-trial` (stacked on `wip/root3-synthesis-layer`,
 > PR #117):

--- a/yo-self/env.yo
+++ b/yo-self/env.yo
@@ -33,7 +33,7 @@ _(env : envdbg_env) :: import("std/env");
 } :: import("./types/guards.yo");
 { t_i32, t_f64, t_str } :: import("./types/creators.yo");
 { type_contains_rc_type, get_all_some_types } :: import("./types/utils.yo");
-{ are_types_compatible } :: import("./types/compatibility.yo");
+{ are_types_compatible, are_types_compatible_exact } :: import("./types/compatibility.yo");
 {
   MethodEntry,
   get_type_trait_methods_by_name,
@@ -3052,8 +3052,19 @@ _filter_receiver_methods :: (
                     .SomeT({ name : sp_name }) => (sp_name == "Self"),
                     _ => false
                   );
+                  // EXACT compatibility, mirroring TS env.ts:1322-1329 passing
+                  // `true` (requireExactMatch) — under exact rules an
+                  // UNCONSTRAINED SomeType pointee does NOT accept a concrete
+                  // receiver (compatibility.ts:823-827 `if (requireExactMatch)
+                  // return false`). The lenient check marked a blanket
+                  // `impl(generic(T), *(T), add)` with needs_pointer_conversion
+                  // for a receiver that IS already `*(T_arr)`: the receiver got
+                  // `&`-wrapped to `*(*(T_arr))`, argument synthesis bound
+                  // `T := *(T_arr)`, and the method's `*(T)` return resolved to
+                  // `*(*(T_arr))` — the def-time doubling of root 537
+                  // (issues/def-eval-swallow-remaining-roots.md).
                   cond(
-                    (are_types_compatible(effective_receiver, pointee) || pointee_is_self) => {
+                    (are_types_compatible_exact(effective_receiver, pointee) || pointee_is_self) => {
                       // Materialise a new MethodEntry carrying
                       // the ptr-conversion flag. Mutating the
                       // input entry would leak across the

--- a/yo-self/evaluator/calls/comptime_fn.yo
+++ b/yo-self/evaluator/calls/comptime_fn.yo
@@ -16,6 +16,8 @@
 //!   - SomeType id comparison uses `SomeT.id` for exact identity.
 pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
+open(import("std/fmt"));
+_(env : ctfe_dbg_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
 { AstExpr, ast_expr_token, ast_expr_id, make_err_expr, clone_expr_fresh_ids } :: import("../../expr.yo");
 { ExprInfo, new_expr_info, expr_info_table_get, register_struct_ctor_fid, lookup_struct_ctor_fid, register_trait_ctor_fid, ComptimeRef } :: import("../../expr_info.yo");
@@ -500,6 +502,9 @@ evaluate_comptime_fn_call :: (
       // the trial; everywhere else the throw stays (a genuine
       // calling-a-non-function error must not be silently absorbed).
       if(in_def_time_trial(), {
+        if(ctfe_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+          eprintln(`[ctfe-nonfv] fid=${func_id_str}`);
+        });
         return(
           ComptimeFnCallResult(
             value : _ctfe_unknown(return_type, caller_env),
@@ -529,6 +534,9 @@ evaluate_comptime_fn_call :: (
   // During CTFE capability analysis, return an UnknownVal immediately without
   // executing the body. This prevents infinite recursion in the analysis pass.
   if(ctx.is_analyzing_ctfe_capability, {
+    if(in_def_time_trial() && ctfe_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+      eprintln(`[ctfe-ana-gate] fid=${func_id_str}`);
+    });
     return(
       ComptimeFnCallResult(
         value : _ctfe_unknown(return_type, caller_env),
@@ -574,6 +582,9 @@ evaluate_comptime_fn_call :: (
       (!(macro_return_is_unquote(func_id_str.clone())))
   ) &&
     (ctfe_gate_forall_n == usize(0)), {
+    if(in_def_time_trial() && ctfe_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+      eprintln(`[ctfe-check-gate] fid=${func_id_str}`);
+    });
     return(
       ComptimeFnCallResult(
         value : _ctfe_unknown(return_type, caller_env),
@@ -663,6 +674,22 @@ evaluate_comptime_fn_call :: (
       )
     );
   });
+  if(in_def_time_trial() && ctfe_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+    (dbge_args : String) = String.from("");
+    (dbge_i : usize) = usize(0);
+    while(dbge_i < all_arg_vals.len(), {
+      match(
+        all_arg_vals.get(dbge_i),
+        .Some(dv) => {
+          dbge_args.push_string(value_to_string(dv));
+          dbge_args.push_string(String.from(" | "));
+        },
+        .None => ()
+      );
+      dbge_i = (dbge_i + usize(1));
+    });
+    eprintln(`[ctfe-in] fid=${func_id_str} args=${dbge_args}`);
+  });
   // Execution gate for unknown arguments. TS never executes a comptime body
   // when an argument is a runtime unknown: its runtime-unknowns are
   // `undefined` and throw at the collect step above (comptime-fn.ts:78).
@@ -690,7 +717,36 @@ evaluate_comptime_fn_call :: (
       uai = (uai + usize(1));
     });
   };
-  if(any_arg_unknown, {
+  // TRIAL carve-out from the gate below: TS executes a TYPE-returning
+  // constructor's body even with UnknownValue args (comptime-fn.ts has no
+  // unknown-arg execution gate at all), so a def-time trial calling
+  // `_ArrayIter(T, N)` with the impl's value binder `N : usize` bound to an
+  // unknown must RUN the body — the degraded `_ctfe_unknown(Type)` is a
+  // fresh bare SomeT, which the callee-dispatch then cannot call ("TypeVal
+  // SomeT callee without FnTrait", root 7623 of
+  // issues/def-eval-swallow-remaining-roots.md). Scope: def-time trials
+  // AND type-hierarchy returns only. The gate's recursion concern
+  // (fold_range) is about VALUE-returning recursive fns — type ctors at
+  // trial time already execute today with SomeT type args (roots 7942/7973
+  // measured executing) under the same no-durable-cache regime.
+  trial_type_ctor_unknown_ok := (in_def_time_trial() && is_type_hierarchy_type(return_type));
+  if(any_arg_unknown && !(trial_type_ctor_unknown_ok), {
+    if(in_def_time_trial() && ctfe_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+      (dbg_args : String) = String.from("");
+      (dbg_i : usize) = usize(0);
+      while(dbg_i < all_arg_vals.len(), {
+        match(
+          all_arg_vals.get(dbg_i),
+          .Some(dv) => {
+            dbg_args.push_string(value_to_string(dv));
+            dbg_args.push_string(String.from(" | "));
+          },
+          .None => ()
+        );
+        dbg_i = (dbg_i + usize(1));
+      });
+      eprintln(`[ctfe-unk-arg] fid=${func_id_str} args=${dbg_args}`);
+    });
     return(
       ComptimeFnCallResult(
         value : _ctfe_unknown(return_type, caller_env),
@@ -700,6 +756,11 @@ evaluate_comptime_fn_call :: (
       )
     );
   });
+  // A trial-time unknown-arg type-ctor execution must NEVER cache (the
+  // unknown arg would collide distinct instantiations in the memo); the
+  // SomeT carve-outs below already disable caching for the common case,
+  // but unknown VALUE args (IntLit-typed binders) are invisible to them.
+  (trial_unknown_nocache : bool) = (any_arg_unknown && trial_type_ctor_unknown_ok);
   // Only cache CTFE calls that return a Type (TypeHierarchyType / TypeUni).
   // Pure type-constructor functions like Box(T), Vec(T) etc. are safe to cache.
   // Functions returning runtime values may have side effects and must not be cached.
@@ -736,7 +797,7 @@ evaluate_comptime_fn_call :: (
       ok2
     }
   );
-  (should_cache : bool) = (is_type_hierarchy_type(return_type) || all_args_are_types);
+  (should_cache : bool) = ((is_type_hierarchy_type(return_type) || all_args_are_types) && !(trial_unknown_nocache));
   // TS checking-phase parity (SomeT surgery slice 2b): a ctfe call whose TYPE
   // args still CONTAIN unresolved SomeTs (analysis/validation generations
   // evaluating a declaration with `Self` bound to a fresh SomeT — the
@@ -877,6 +938,9 @@ evaluate_comptime_fn_call :: (
   match(
     cached_result,
     .Some(cached_val) => {
+      if(in_def_time_trial() && ctfe_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+        eprintln(`[ctfe-hit] fid=${func_id_str} result=${value_to_string(cached_val)}`);
+      });
       return(
         ComptimeFnCallResult(
           value : cached_val,
@@ -1135,6 +1199,9 @@ evaluate_comptime_fn_call :: (
       },
       .None => ()
     );
+  });
+  if(in_def_time_trial() && ctfe_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+    eprintln(`[ctfe-out] fid=${func_id_str} result=${value_to_string(final_return_value)}`);
   });
   ComptimeFnCallResult(
     value : final_return_value,

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -127,7 +127,7 @@ MACRO_DISPATCH_ENABLED :: true;
 { try_to_call_function_with_arguments, resolve_param_types_from_expected, validate_where_constraints_for_call, reapply_where_clause_exprs_for_call, create_specialized_function_inline, _type_has_array_len_var, _trial_eval_ret_type_expr } :: import("./helper.yo");
 { get_func_type, register_func_type, is_control_fn } :: import("../../function_value.yo");
 { function_may_mutate_rc_storage } :: import("../effects/mutation_summary.yo");
-{ create_unknown_val, create_unknown_val_with_name, is_runtime_only_unknown_val } :: import("../../value.yo");
+{ create_unknown_val, create_unknown_val_with_name, is_runtime_only_unknown_val, value_to_string } :: import("../../value.yo");
 /// Named call-result unknown: promotes a Type-universe result to
 /// `TypeVal(SomeT)`. TS names every result UnknownValue (variableName is
 /// REQUIRED for Type-typed slots — createUnknownValue throws otherwise,
@@ -3333,6 +3333,9 @@ Fix: wrap the call:
               );
               fsi = (fsi + usize(1));
             });
+            if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+              eprintln(`[call-struct] id=${struct_id} name=${struct_name}`);
+            });
             call_result_s := try_to_call_type_with_arguments(fields_subst, func_expr, args, callee_env, ctx, false, exn);
             // Propagate io-builtin markers from extern function VALUES to the
             // constructed struct's FIELDS — faithful port of TS
@@ -3440,6 +3443,9 @@ Fix: wrap the call:
               });
               Option(EvalValue).Some(EvalValue.StructVal(struct_name.clone(), fnames_s, fvals_s))
             }, Option(EvalValue).None);
+            if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+              eprintln(`[call-struct-out] ty=${type_to_string(func_type)}`);
+            });
             out_s := new_expr_info(call_result_s.caller_env, func_type);
             out_s.value = struct_val;
             out_s.runtime_arg_exprs_in_order = Option(ArrayList(AstExpr)).Some(call_result_s.runtime_arg_exprs_in_order);
@@ -5592,6 +5598,9 @@ Fix: wrap the call:
             ct_out_val = create_unknown_val(resolved_ret_ct);
           });
           out_ct.value = Option(EvalValue).Some(ct_out_val);
+          if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+            eprintln(`[ctfe-stamp] ty=${type_to_string(resolved_ret_ct)} val=${value_to_string(ct_out_val)}`);
+          });
           expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_ct);
           param_vars;
           return(expr);
@@ -6367,6 +6376,9 @@ Fix: wrap the call:
               ),
               _ => ()
             );
+          });
+          if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+            eprintln(`[call-none] ret=${type_to_string(ret_type_none)} callee=${ast_expr_to_string(func_expr)}`);
           });
           out_none := new_expr_info(call_result_none.caller_env, ret_type_none);
           out_none.value = Option(EvalValue).Some(_call_result_unknown(ret_type_none, callee_env));

--- a/yo-self/evaluator/calls/helper.yo
+++ b/yo-self/evaluator/calls/helper.yo
@@ -99,8 +99,10 @@ open(import("std/fmt"));
   CapturedVarInfo,
   SpecializingFunctionInfo,
   SpecializedFunctionCache,
-  SpecializedFunctionCacheEntry
+  SpecializedFunctionCacheEntry,
+  in_def_time_trial
 } :: import("../context.yo");
+_(env : helper_dbg_env) :: import("std/env");
 {
   PathCollection,
   path_collection_new,
@@ -5905,6 +5907,10 @@ try_to_call_function_with_arguments :: (
       // Step 9: Evaluate return type.
       // ----------------------------------------------------------------
       (return_type : TypeValue) = evaluate_function_return_type_again(ret_b, callee_env_m, ctx);
+      s9_dbg := (in_def_time_trial() && helper_dbg_env.get(`YO_DEBUG_RET`).is_some());
+      if(s9_dbg, {
+        eprintln(`[s9-init] declared=${type_to_string(ret_b)} after-rte=${type_to_string(return_type)}`);
+      });
       // Per-call forall substitution INTO a def-era NOMINAL return record.
       // A generic method's declared return can be pre-instantiated at
       // definition time into ONE Struct record (`IterFilter(Self, F)` →
@@ -6025,6 +6031,9 @@ try_to_call_function_with_arguments :: (
             s9_cand := substitute(s9, return_type);
             if((get_all_some_types(s9_cand).len() == usize(0)) || type_somes_all_resolve_concrete(s9_cand), {
               return_type = s9_cand;
+              if(s9_dbg, {
+                eprintln(`[s9-subst] ret=${type_to_string(return_type)}`);
+              });
             });
           });
         });
@@ -6063,6 +6072,9 @@ try_to_call_function_with_arguments :: (
                   .Some(rte9_ty) => {
                     if((((get_all_some_types(rte9_ty).len() == usize(0)) || type_somes_all_resolve_concrete(rte9_ty)) && !(_type_has_array_len_var(rte9_ty))) && !(is_unit_type(rte9_ty)), {
                       return_type = rte9_ty;
+                      if(s9_dbg, {
+                        eprintln(`[s9b-rte] ret=${type_to_string(return_type)}`);
+                      });
                     });
                   },
                   .None => ()
@@ -6093,6 +6105,9 @@ try_to_call_function_with_arguments :: (
             );
             callee_env_m = synth_ret.expected_env;
             return_type = evaluate_function_return_type_again(ret_b, callee_env_m, ctx);
+            if(s9_dbg, {
+              eprintln(`[s10-synth] ret=${type_to_string(return_type)} expected=${type_to_string(et.ty)}`);
+            });
             // When the (re-evaluated) return type is compatible with the
             // caller's expected type and the expected type is fully concrete,
             // ADOPT the expected type as the call's return type. Mirrors TS
@@ -6594,6 +6609,9 @@ try_to_call_function_with_arguments :: (
             s1i = (s1i + usize(1));
           });
         });
+      });
+      if(s9_dbg, {
+        eprintln(`[s-final] ret=${type_to_string(return_type)}`);
       });
       FuncCallResult(
         callee_env : callee_env_m,

--- a/yo-self/evaluator/calls/type.yo
+++ b/yo-self/evaluator/calls/type.yo
@@ -14,6 +14,8 @@
 //! - `isComptimeOnlyType` is approximated via `_is_comptime_only_type_approx`.
 pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
+open(import("std/fmt"));
+_(env : tycall_dbg_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 {
@@ -39,8 +41,8 @@ open(import("std/string"));
 { type_to_string } :: import("../../types/string.yo");
 { are_types_compatible } :: import("../../types/compatibility.yo");
 { convert_comptime_type_to_runtime_type } :: import("../../types/env_lookup.yo");
-{ EvalContext, ExpectedTypeCtx, TypeCallResult } :: import("../context.yo");
-{ EvalValue } :: import("../../value.yo");
+{ EvalContext, ExpectedTypeCtx, TypeCallResult, in_def_time_trial } :: import("../context.yo");
+{ EvalValue, value_to_string } :: import("../../value.yo");
 { TypeField } :: import("../types/field.yo");
 { set_expr_as_needs_to_call_dup } :: import("../utils.yo");
 { evaluate_expression } :: import("../exprs/expr.yo");
@@ -320,6 +322,11 @@ try_to_call_type_with_arguments :: (
     );
     // Type compatibility check.
     if(!(are_types_compatible(arg_type, member_element.ty)), {
+      if(in_def_time_trial() && tycall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+        eprintln(
+          `[tycall-mismatch] label=${member_element.label} expected=${type_to_string(member_element.ty)} got=${type_to_string(arg_type)} argval=${match(arg_info.value, .Some(av) => value_to_string(av), .None => String.from("<none>"))}`
+        );
+      });
       exn.throw(
         dyn(
           format_error_message(

--- a/yo-self/evaluator/context.yo
+++ b/yo-self/evaluator/context.yo
@@ -21,6 +21,7 @@ open(import("std/string"));
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
 { TypeValue } :: import("../types/definitions.yo");
+{ trial_flag_get, trial_flag_set } :: import("../types/creators.yo");
 { EvalValue } :: import("../value.yo");
 { Environment, Variable, _frame_positions } :: import("../env.yo");
 { AstExpr } :: import("../expr.yo");
@@ -795,13 +796,11 @@ call_rerun_pending_def_evals :: (fn(env : Environment, ctx : EvalContext) -> uni
 /// ("Incompatible function return type", measured 2026-08-13), while at
 /// def time it is what lets a sibling impl's method dispatch resolve
 /// (array_list's Clone -> len, family A root #3).
-(g_in_def_time_trial : bool) = false;
-in_def_time_trial :: (fn() -> bool)(g_in_def_time_trial);
-set_in_def_time_trial :: (fn(v : bool) -> bool)({
-  prev := g_in_def_time_trial;
-  g_in_def_time_trial = v;
-  prev
-});
+/// Storage lives in types/creators.yo (`trial_flag_get`/`trial_flag_set`)
+/// so types/compatibility.yo can read the flag without an evaluator-layer
+/// import cycle; these accessors remain the public API.
+in_def_time_trial :: (fn() -> bool)(trial_flag_get());
+set_in_def_time_trial :: (fn(v : bool) -> bool)(trial_flag_set(v));
 
 export(
   PathCollection,

--- a/yo-self/types/compatibility.yo
+++ b/yo-self/types/compatibility.yo
@@ -14,7 +14,7 @@ pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
 { ArrayList } :: import("std/collections/array_list");
 { TypeValue } :: import("./definitions.yo");
-{ type_value_tag, resolve_enum_shell } :: import("./creators.yo");
+{ type_value_tag, resolve_enum_shell, trial_flag_get } :: import("./creators.yo");
 { is_int_type, is_float_type, is_some_type, is_dyn_type } :: import("./guards.yo");
 { type_contains_some_type, get_all_some_types } :: import("./utils.yo");
 { TypeTag } :: import("./tags.yo");
@@ -929,6 +929,20 @@ _compat_impl :: (
       expected,
       .SomeT(name : ename, frame_level : elvl, required_trait_types : ertt) => cond(
         ((aname == ename) && (alvl == elvl)) => true,
+        // Definition-time-trial acceptance, ported from TS's different-id
+        // SomeType rule (compatibility.ts:676-744): two distinct type
+        // parameters are compatible when the GIVEN side satisfies every
+        // constraint the EXPECTED side carries — trivially true for an
+        // unconstrained forall (`A` in `where(I <: Iterator(Item := A))`
+        // accepting the trait's raw `Item`). Scoped to (a) NON-exact
+        // comparisons — the exact mode keys spec/CTFE caches, where
+        // collapsing `Box(V)`/`Box(T)` is the gap-6 identity-split family —
+        // and (b) def-time trials, whose stamps are discardable (the
+        // repair-1 contract); unscoped, yo-self's compensations around the
+        // stricter name+level rule regress (the refuted full-port note
+        // above). EMPTY expected-constraint lists only: the trait-SUBSET
+        // walk of the full TS rule is what self-recursed unboundedly.
+        (((!(require_exact)) && trial_flag_get()) && (ertt.len() == usize(0))) => true,
         true => {
           (xw_ok : bool) = (
             ((aname == ename) && (artt.len() == ertt.len()))

--- a/yo-self/types/creators.yo
+++ b/yo-self/types/creators.yo
@@ -673,6 +673,18 @@ register_some_binder_kind :: (
 clear_some_binder_kind :: (fn(name : String, lvl : usize) -> unit)({
   _some_binder_kinds.remove(`${name}@${lvl.to_string()}`);
 });
+/// Definition-time-trial flag STORAGE. The flag's semantics and public
+/// accessors live in evaluator/context.yo (`in_def_time_trial` /
+/// `set_in_def_time_trial` delegate here); the storage sits in the types
+/// layer so types/compatibility.yo can read it without an evaluator-layer
+/// import cycle (same layering reason as `_some_binder_kinds` above).
+(g_in_def_time_trial_cell : bool) = false;
+trial_flag_get :: (fn() -> bool)(g_in_def_time_trial_cell);
+trial_flag_set :: (fn(v : bool) -> bool)({
+  prev := g_in_def_time_trial_cell;
+  g_in_def_time_trial_cell = v;
+  prev
+});
 /// PURE resolution: builtin scalar names only — a non-builtin annotation
 /// returns `.None` and the binder keeps its (SomeT) binding. `Type` never
 /// registers, so type binders are unaffected.
@@ -733,6 +745,8 @@ export(
   t_c_ulong,
   t_c_longlong,
   register_some_binder_kind,
+  trial_flag_get,
+  trial_flag_set,
   clear_some_binder_kind,
   resolve_some_binder_kind,
   t_c_ulonglong,


### PR DESCRIPTION
Tranche 4 (final) of the def-eval swallow campaign — **clears ALL five remaining roots: 19 → 0 swallows** on the measurement repro. Stacked on #118; retarget to develop before merging #118.

**Roots 7837 + 7942 + 7973 (one bug):** yo-self's SomeT-vs-SomeT compatibility (name+frame-level identity) is stricter than TS's different-id rule (compatibility.ts:676-744). Ported the empty-expected-constraints acceptance, scoped to non-exact comparisons + def-time trials. Trial-flag storage moves to `types/creators.yo` (layer-cycle avoidance).

**Root 7623:** the unknown-arg CTFE gate degraded `_ArrayIter(T, N)` (unknown `N : usize` at def time) to an uncallable bare SomeT. TS runs type-ctor bodies with unknown args; carve-out scoped to trials + type-hierarchy returns, never cached.

**Root 537 (the last one, and the deepest):** a mis-port in `_filter_receiver_methods` — the pointee-vs-receiver check used lenient compatibility where TS passes `requireExactMatch=true` (env.ts:1322-1329; compatibility.ts:823-827). The lenient check marked blanket `impl(generic(T), *(T), add)` with `needs_pointer_conversion` for an already-pointer receiver → `&`-wrap → synthesis bound `T := *(T_arr)` → the `*(T)` return doubled to `*(*(T_arr))`. Three resolution-side theories were built and measurably refuted first (occurs check, ownership-refined occurs, id-keyed synthesis channel); the commit history and `issues/def-eval-swallow-remaining-roots.md` carry the dig. Debug hooks (`YO_DEBUG_CTFE`, `YO_DEBUG_RET`) are in-tree and env-gated.

**Battery on the tip:** hollow sweep 188/188 GREEN, canaries green (ptr 2/2, unsafe 8/8, imm_map 21/21, derive_clone_complex 15/15, btree_map 25/25, array 12/12, array_list 87/87), `check ./std` 154/154, `check ./yo-self` 247/247, fixpoint running locally at push time.

**Next (separate PR):** the endgame — make `_trial_eval_fn_body` fatal (TS parity) + corpus re-attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)