### PR TITLE
Def-eval swallow, corpus phase: the hash_set/hash_map family — matcher env leaks and placeholder bindings

### DIFF
--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -33,12 +33,40 @@
 >   object eval runs it (property_access.yo:547) but the node carries no
 >   ExprInfo afterwards ([pa-fallthrough] prop=key obj_ty=<no-info>), and
 >   NO `prop=*` fallthrough prints, so the deref neither took the
->   pointer-deref arm's stamping paths nor the final fallback. Next: print
->   `bucket_ptr`'s own stamped ty at that point, and check whether the
->   deref FnCall's returned node id matches the id `.key` looks up (an
->   id-mismatch after clone_expr_fresh_ids would explain a stamped-but-
->   invisible deref). Hooks in-tree: [rm-early], [rcv-swallow],
->   [pa-fallthrough] (all YO_DEBUG_CTFE-gated).
+>   pointer-deref arm's stamping paths nor the final fallback.
+>   **LAYER 4 (probed via `[pa-deref-in]`):** the deref DOES enter
+>   `evaluate_property_access`'s deref arm, but `bucket_ptr` itself is
+>   stamped as a BARE STRUCT — `obj_ty=<struct:struct_yo_id_3384>`
+>   (generic `Bucket(K,V)`), no pointer wrapper — so every pointer path
+>   in the arm misses and it exits without stamping. The healthy sibling
+>   line shows what it should be: `(data_ptr.add)((self._index))
+obj_ty=*(<struct:struct_yo_id_3134>)`. `bucket_ptr` is bound by the
+>   match binder from `it.next()`'s return type `enum_yo_id_3386` =
+>   def-time-evaluated `Option(*(Bucket(K, V)))` — and the binder binds
+>   `variant_fields_wf.get(i)` verbatim, so enum 3386's `Some` field
+>   holds the bare struct: **the `*(...)` wrap was lost when enum 3386
+>   was CREATED** — so it first looked like a lost `*` wrap.
+>   **ROOT FOUND (layer 5, `[arg-eval]` probe):** enum 3386 is not a
+>   mangled `Option(*(Bucket))` at all — it is the perfectly healthy
+>   return type of THE WRONG `next`. `[arg-eval]` showed the re-eval
+>   evaluating literal AST `Option(Bucket(K, V))` — hash_map.yo:512, the
+>   BY-VALUE iterator `HashMapIter`'s `next`. `[tm-try]`/`[fmg-cand]`
+>   confirmed the dispatch: for receiver `HashMapIterPtr(K,V)` (struct 3503) BOTH `next` candidates bind — `pat=struct_3370` (HashMapIter →
+>   enum 3386) FIRST, `pat=struct_3458` (HashMapIterPtr → enum 3137 =
+>   `Option(*(Bucket))`) second — and the first wins. They unify because
+>   the trial-scoped STRUCTURAL fallback in the synthesizer's
+>   struct-vs-struct arm (added for original root #3) accepts same name
+>   - same field labels, and the two iterator structs are both ANONYMOUS
+>     (`name=""`) with identical fields `(_map, _index)`. Structural
+>     checking can never separate them; only nominal identity (ctor fid)
+>     can — TS compares funcIds (synthesizer.ts:662). **FIX:** the shape
+>     fallback now requires a MISSING effective cfid on at least one side
+>     (its original rescue purpose); when both cfids are known and differ,
+>     the pair rejects nominally (`cfid_unknown3` gate,
+>     evaluator/types/synthesizer.yo). Hooks in-tree: [rm-early],
+>     [rcv-swallow], [pa-fallthrough], [pa-deref-in], [ptr-call],
+>     [match-bind], [arg-eval] (YO_DEBUG_CTFE2), `[ctfe-in] callee=` (all
+>     YO_DEBUG_CTFE-gated unless noted).
 >
 > Debug hooks added this phase (all env-gated, in-tree): `[rm-miss]`,
 > `[fmg-try]`, `[tm-frames]`, `[call-none] callee_ty`, and

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -4,7 +4,9 @@
 > WIDER corpus (self-compile of yo-self: 3603 trials; fast repro:
 > `issues/repros/`-adjacent driver importing hash_map THEN hash_set)
 > exposed a pre-existing family the minimal repro never reached — 5
-> swallows, three stacked roots, two FIXED:
+> swallows, three stacked roots, **ALL FIXED — the full self-compile
+> corpus is now SWALLOW-FREE (3603 trials, 0 swallows, 0 FTT markers,
+> fix tip `1dce05268` on PR #120)**:
 >
 > - **hash_set ×4 ("Failed to evaluate, got ((ctrl_ptr.add)(i).(\*))") —
 >   FIXED** (`5c748639e`): `try_match_generic_impl` passed the caller env
@@ -18,7 +20,7 @@
 >   value.type parity — and its in-place path preserves the old
 >   variable's type.
 > - **hash_map:714 ("Cannot unify u64 and unit" in the Clone impl's
->   trial) — OPEN, frontier:** the failure is GARBAGE-IN: inside the
+>   trial) — FIXED (`1dce05268`, dig record below):** the failure is GARBAGE-IN: inside the
 >   Clone body's nested `result.set(k, v)` eval, `k` is ALREADY
 >   unit-typed — the degrade happens in the
 >   `it.next()` → `bucket_ptr.*.key.clone()` chain (hash_map.yo:719-733)

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -28,10 +28,17 @@
 >   (Unit-placeholder guard in `_bind_forall_from_type_args`;
 >   trial-scoped callee-env scratch isolation in helper.yo Step 7 —
 >   which contained the previously DURABLE cross-trial variant of the
->   K-junk, `[bind-T]` fid-verified). **Next probe: which link of the
->   next()/deref/field/clone chain first degrades** — run the
->   hash_map+hash_set driver (scratchpad hs_driver3.yo) with
->   YO_DEBUG_RET/YO_DEBUG_CTFE and trace the `nxt` payload's type.
+>   K-junk, `[bind-T]` fid-verified). **Frontier (probed to the exact link):** the deref
+>   `bucket_ptr.(*)` inside the Clone body ends up UNSTAMPED — `.key`'s
+>   object eval runs it (property_access.yo:547) but the node carries no
+>   ExprInfo afterwards ([pa-fallthrough] prop=key obj_ty=<no-info>), and
+>   NO `prop=*` fallthrough prints, so the deref neither took the
+>   pointer-deref arm's stamping paths nor the final fallback. Next: print
+>   `bucket_ptr`'s own stamped ty at that point, and check whether the
+>   deref FnCall's returned node id matches the id `.key` looks up (an
+>   id-mismatch after clone_expr_fresh_ids would explain a stamped-but-
+>   invisible deref). Hooks in-tree: [rm-early], [rcv-swallow],
+>   [pa-fallthrough] (all YO_DEBUG_CTFE-gated).
 >
 > Debug hooks added this phase (all env-gated, in-tree): `[rm-miss]`,
 > `[fmg-try]`, `[tm-frames]`, `[call-none] callee_ty`, and

--- a/issues/def-eval-swallow-remaining-roots.md
+++ b/issues/def-eval-swallow-remaining-roots.md
@@ -1,5 +1,43 @@
 # The def-eval swallow: remaining roots, measured and attributed
 
+> **CORPUS PHASE (2026-08-13, after the minimal-repro 19 → 0).** The
+> WIDER corpus (self-compile of yo-self: 3603 trials; fast repro:
+> `issues/repros/`-adjacent driver importing hash_map THEN hash_set)
+> exposed a pre-existing family the minimal repro never reached — 5
+> swallows, three stacked roots, two FIXED:
+>
+> - **hash_set ×4 ("Failed to evaluate, got ((ctrl_ptr.add)(i).(\*))") —
+>   FIXED** (`5c748639e`): `try_match_generic_impl` passed the caller env
+>   RAW as the given side, so every candidate probe's given-side
+>   shadow-binds landed durably in the shared trial env; one hash_map-era
+>   probe's `T := <hash_map struct>` junk then broke the blanket pointer
+>   impl's `T` resolution for every later `.add`. Fix: scratch frame on
+>   the given side (TS discards its chains, impl.ts:2243). Also fixed
+>   upstream layer (`53ad21724`): `_bind_some_type` now binds a type
+>   variable with its KIND (`type_of_type`), not the bound type — TS
+>   value.type parity — and its in-place path preserves the old
+>   variable's type.
+> - **hash_map:714 ("Cannot unify u64 and unit" in the Clone impl's
+>   trial) — OPEN, frontier:** the failure is GARBAGE-IN: inside the
+>   Clone body's nested `result.set(k, v)` eval, `k` is ALREADY
+>   unit-typed — the degrade happens in the
+>   `it.next()` → `bucket_ptr.*.key.clone()` chain (hash_map.yo:719-733)
+>   before `set` runs; `set`'s param synthesis then binds `K := unit`
+>   (call-scoped, legitimately) and the sibling `_find_bucket` spec
+>   mints `key : unit`. Two defensive fixes landed alongside
+>   (Unit-placeholder guard in `_bind_forall_from_type_args`;
+>   trial-scoped callee-env scratch isolation in helper.yo Step 7 —
+>   which contained the previously DURABLE cross-trial variant of the
+>   K-junk, `[bind-T]` fid-verified). **Next probe: which link of the
+>   next()/deref/field/clone chain first degrades** — run the
+>   hash_map+hash_set driver (scratchpad hs_driver3.yo) with
+>   YO_DEBUG_RET/YO_DEBUG_CTFE and trace the `nxt` payload's type.
+>
+> Debug hooks added this phase (all env-gated, in-tree): `[rm-miss]`,
+> `[fmg-try]`, `[tm-frames]`, `[call-none] callee_ty`, and
+> `[bind-T]`/`YO_DEBUG_BIND=<name>` (write-side frame-id tracing in
+> `_bind_some_type`).
+
 > **STATE 2026-08-13 (third session, later): 19 → 0. ALL ROOTS FIXED.**
 > Root 537's true root was a MIS-PORT in `_filter_receiver_methods`
 > (yo-self/env.yo): the pointee-vs-receiver check used the LENIENT

--- a/issues/repros/hashset-where-hash-dispatch-poisons-type-binder-driver.yo
+++ b/issues/repros/hashset-where-hash-dispatch-poisons-type-binder-driver.yo
@@ -1,0 +1,4 @@
+_ :: import("./hashset-where-hash-dispatch-poisons-type-binder.yo");
+
+main :: (fn() -> unit)(());
+export(main);

--- a/issues/repros/hashset-where-hash-dispatch-poisons-type-binder.yo
+++ b/issues/repros/hashset-where-hash-dispatch-poisons-type-binder.yo
@@ -1,0 +1,61 @@
+pragma(Pragma.AllowUnsafe);
+
+HashSet :: (
+  fn(
+    comptime(T) : Type,
+    where(T <: (Eq(T), Hash))
+  ) -> comptime(Type)
+)(
+  ref(
+    struct(
+      data : ?*(T),
+      capacity : usize
+    )
+  )
+);
+
+impl(
+  generic(T : Type),
+  where(T <: (Eq(T), Hash)),
+  HashSet(T),
+  _alloc_with_capacity : (fn(capacity : usize) -> Result(Self, u8))(
+    .Ok(Self(data : .None, capacity : capacity))
+  ),
+  _data_ptr : (fn(self : Self) -> *(T))(
+    match(
+      self.data,
+      .Some(ptr) => ptr,
+      .None => __yo_panic("null")
+    )
+  ),
+  _resize : (fn(self : Self, new_capacity : usize) -> Result(unit, u8))({
+    data_ptr := Self._data_ptr(self);
+    element := data_ptr.*;
+    hash := element.hash();
+    cond(
+      Type.contains_rc_type(T) => (),
+      true => ()
+    );
+    .Ok(())
+  }),
+  add : (fn(self : Self, element : T) -> Result(bool, u8))({
+    resize_check := Self._resize(self, usize(2));
+    match(
+      resize_check,
+      .Err(err) => .Err(err),
+      .Ok(_) => .Ok(true)
+    )
+  }),
+  union : (fn(self : Self, e : T) -> Result(Self, u8))({
+    result_set_result := Self._alloc_with_capacity(usize(16));
+    match(
+      result_set_result,
+      .Err(err) => .Err(err),
+      .Ok(result_set) => {
+        result_set.add(e);
+        .Ok(result_set)
+      }
+    )
+  })
+);
+export(HashSet);

--- a/yo-self/evaluator/calls/comptime_fn.yo
+++ b/yo-self/evaluator/calls/comptime_fn.yo
@@ -19,7 +19,7 @@ open(import("std/string"));
 open(import("std/fmt"));
 _(env : ctfe_dbg_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
-{ AstExpr, ast_expr_token, ast_expr_id, make_err_expr, clone_expr_fresh_ids } :: import("../../expr.yo");
+{ AstExpr, ast_expr_token, ast_expr_id, ast_expr_to_string, make_err_expr, clone_expr_fresh_ids } :: import("../../expr.yo");
 { ExprInfo, new_expr_info, expr_info_table_get, register_struct_ctor_fid, lookup_struct_ctor_fid, register_trait_ctor_fid, ComptimeRef } :: import("../../expr_info.yo");
 { Variable, Environment, snapshot_env } :: import("../../env.yo");
 { TypeValue } :: import("../../types/definitions.yo");
@@ -688,7 +688,12 @@ evaluate_comptime_fn_call :: (
       );
       dbge_i = (dbge_i + usize(1));
     });
-    eprintln(`[ctfe-in] fid=${func_id_str} args=${dbge_args}`);
+    dbge_callee := match(
+      function_callee_expr,
+      .Some(fce) => ast_expr_to_string(fce),
+      .None => String.from("<none>")
+    );
+    eprintln(`[ctfe-in] fid=${func_id_str} callee=${dbge_callee} args=${dbge_args}`);
   });
   // Execution gate for unknown arguments. TS never executes a comptime body
   // when an argument is a runtime unknown: its runtime-unknowns are

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -4617,6 +4617,14 @@ Fix: wrap the call:
                 new_expr_info(env, t_unit())
               }
             );
+            if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE2`).is_some(), {
+              ae_val_str := match(
+                arg_info.value,
+                .Some(aev) => value_to_string(aev),
+                .None => String.from("<no-val>")
+              );
+              eprintln(`[arg-eval] expr=${ast_expr_to_string(arg_expr_eff)} ty=${type_to_string(arg_info.ty)} val=${ae_val_str}`);
+            });
             _push_arg := evaled_arg_infos.push(arg_info);
             // A COMPTIME variadic's trailing args (indices >= n_p) are not C
             // arguments either — `rt_ct_flags_args` only covers the FIXED

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -220,7 +220,18 @@ ReceiverMethodResult :: struct(
 _try_eval_receiver_node :: (
   fn(arg : AstExpr, env : Environment, ctx : EvalContext, out : ArrayList(AstExpr)) -> unit
 )({
-  rcv_exn := Exception(throw : ((_e) -> unwind(())));
+  rcv_exn := Exception(
+    throw : (
+      (_e) -> {
+        // Capture-free swallow; YO_DEBUG_CTFE surfaces the error (the same
+        // pattern as _trial_eval_fn_body's [swallow] hook).
+        if(fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+          eprintln(`[rcv-swallow] ${_e.to_string()}`);
+        });
+        unwind(());
+      }
+    )
+  );
   rcv_evaled := evaluate_expression_raw(arg, env, ctx, rcv_exn);
   out.push(rcv_evaled);
 });
@@ -281,10 +292,16 @@ _try_find_receiver_method :: (
             ri2
           },
           .None => {
+            if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+              eprintln(`[rm-early] reason=recv-eval-no-info recv=${ast_expr_to_string(receiver_expr)}`);
+            });
             return(Option(ReceiverMethodResult).None);
           }
         ),
         .None => {
+          if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+            eprintln(`[rm-early] reason=recv-eval-failed recv=${ast_expr_to_string(receiver_expr)}`);
+          });
           return(Option(ReceiverMethodResult).None);
         }
       )

--- a/yo-self/evaluator/calls/function.yo
+++ b/yo-self/evaluator/calls/function.yo
@@ -330,6 +330,9 @@ _try_find_receiver_method :: (
     )
   );
   if(hits.len() == usize(0), {
+    if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+      eprintln(`[rm-miss] name=${method_name} recv=${type_to_string(receiver_type)} static=${is_static.to_string()}`);
+    });
     return(Option(ReceiverMethodResult).None);
   });
   // Take the first hit (mirrors the prior "first match wins"
@@ -6378,7 +6381,7 @@ Fix: wrap the call:
             );
           });
           if(in_def_time_trial() && fncall_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
-            eprintln(`[call-none] ret=${type_to_string(ret_type_none)} callee=${ast_expr_to_string(func_expr)}`);
+            eprintln(`[call-none] ret=${type_to_string(ret_type_none)} callee=${ast_expr_to_string(func_expr)} callee_ty=${type_to_string(callee_ty_none)}`);
           });
           out_none := new_expr_info(call_result_none.caller_env, ret_type_none);
           out_none.value = Option(EvalValue).Some(_call_result_unknown(ret_type_none, callee_env));

--- a/yo-self/evaluator/calls/helper.yo
+++ b/yo-self/evaluator/calls/helper.yo
@@ -5544,6 +5544,23 @@ try_to_call_function_with_arguments :: (
       arg_vals := ArrayList(ArgEntry).new();
       rt_args := ArrayList(AstExpr).new();
       (callee_env_m : Environment) = callee_env;
+      // Def-time-trial isolation: a nested method call's `callee_env` is the
+      // FuncVal's captured DEFINITION env — a SHARED, durable frame stack.
+      // Step-6 generic synthesis and Step-9 param binds below write into its
+      // TOP frame; during a trial those writes are junk the moment the trial
+      // ends, but the shared frame keeps them (the [bind-T] K := unit write
+      // into hash_map's def frame that later specialized `_find_bucket` with
+      // `key : unit` — hash_map:714 of the corpus family). TS's persistent
+      // chains scope these automatically (updates fork the chain); the
+      // yo-self equivalent is a scratch frame on a LOCAL copy — the body
+      // eval threads callee_env_m and sees every binding, the shared def
+      // env object never does. Trials only: the concrete path's frame
+      // arithmetic (function_declaration_frame_level readers) keeps its
+      // long-standing layout.
+      if(in_def_time_trial(), {
+        callee_env_m = snapshot_env(callee_env);
+        callee_env_m.push_frame(false);
+      });
       (caller_env_m : Environment) = caller_env;
       // io.async: evaluate the closure ARGUMENT under async-block context
       // (mirrors TS helper.ts:1314-1315 setting isInsideIoAsyncCall in

--- a/yo-self/evaluator/calls/pointer.yo
+++ b/yo-self/evaluator/calls/pointer.yo
@@ -21,7 +21,8 @@ open(import("std/fmt"));
   expr_info_table_set
 } :: import("../../expr_info.yo");
 { Environment } :: import("../../env.yo");
-{ EvalContext } :: import("../context.yo");
+{ EvalContext, in_def_time_trial } :: import("../context.yo");
+_(env : ptr_dbg_env) :: import("std/env");
 { EvalValue, create_type_value, is_type_value } :: import("../../value.yo");
 { TypeValue } :: import("../../types/definitions.yo");
 { t_ptr, t_i32 } :: import("../../types/creators.yo");
@@ -129,6 +130,9 @@ If you need to thread a handler through code, pass it by value (handlers are fn-
       });
       ptr_ty := t_ptr(inner_ty);
       ptr_val := create_type_value(ptr_ty);
+      if(in_def_time_trial() && ptr_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+        eprintln(`[ptr-call] inner=${type_to_string(inner_ty)} out=${type_to_string(ptr_ty)}`);
+      });
       meta_ty := type_of_type(ptr_ty);
       next_env := arg_info.env;
       out_info := new_expr_info(next_env, meta_ty);

--- a/yo-self/evaluator/exprs/match.yo
+++ b/yo-self/evaluator/exprs/match.yo
@@ -33,7 +33,9 @@ open(import("std/string"));
 } :: import("../../expr_info.yo");
 { Environment, Variable, pop_env_frame } :: import("../../env.yo");
 { add_variable_to_env, get_variables_from_env } :: import("../../env.yo");
-{ EvalContext, ExpectedTypeCtx } :: import("../context.yo");
+{ EvalContext, ExpectedTypeCtx, in_def_time_trial } :: import("../context.yo");
+open(import("std/fmt"));
+_(env : match_dbg_env) :: import("std/env");
 {
   EvalValue,
   create_unknown_val,
@@ -2134,6 +2136,9 @@ evaluate_match :: (
                     .Atom(_, tok) => tok.value.clone(),
                     .FnCall(_, _, _, _, tok) => tok.value.clone()
                   );
+                  if(in_def_time_trial() && match_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+                    eprintln(`[match-bind] name=${param_name} enum=${type_to_string(matched_type)} field=${type_to_string(field_type_pos)}`);
+                  });
                   if(!(param_name == "_"), {
                     _added_pos := add_variable_to_env(
                       env,

--- a/yo-self/evaluator/exprs/property_access.yo
+++ b/yo-self/evaluator/exprs/property_access.yo
@@ -558,6 +558,14 @@ evaluate_property_access :: (
     },
     .None => ()
   );
+  if((ast_expr_is_atom(property_expr) && ast_expr_is_atom_of(property_expr, "*")) && pa_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+    pa_deref_obj_ty := match(
+      obj_info_opt,
+      .Some(pd_oi) => type_to_string(pd_oi.ty),
+      .None => String.from("<no-info>")
+    );
+    eprintln(`[pa-deref-in] obj=${ast_expr_to_string(object_expr)} obj_ty=${pa_deref_obj_ty}`);
+  });
   // -------------------------------------------------------------------------
   // `.*` dereference
   // -------------------------------------------------------------------------

--- a/yo-self/evaluator/exprs/property_access.yo
+++ b/yo-self/evaluator/exprs/property_access.yo
@@ -15,6 +15,8 @@
 //! - `ModuleVal.isLoading` check — skipped (no such flag in yo-self).
 pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
+open(import("std/fmt"));
+_(env : pa_dbg_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
 {
   AstExpr,
@@ -1987,6 +1989,14 @@ Raw pointer operations may dereference invalid memory.`,
   // Return expr without setting ExprInfo — codegen / function.ts will handle.
   // Mirrors `expr.$ = undefined; return(expr);` in TypeScript.
   // -------------------------------------------------------------------------
+  if(pa_dbg_env.get(`YO_DEBUG_CTFE`).is_some(), {
+    pa_obj_ty := match(
+      expr_info_table_get(ctx.expr_info_table, ast_expr_id(object_expr)),
+      .Some(pa_oi) => type_to_string(pa_oi.ty),
+      .None => String.from("<no-info>")
+    );
+    eprintln(`[pa-fallthrough] prop=${ast_expr_token(property_expr).value} obj_ty=${pa_obj_ty}`);
+  });
   expr
 });
 export(evaluate_property_access);

--- a/yo-self/evaluator/types/synthesizer.yo
+++ b/yo-self/evaluator/types/synthesizer.yo
@@ -32,6 +32,7 @@ open(import("std/string"));
 { Token } :: import("../../token.yo");
 { in_def_time_trial } :: import("../context.yo");
 { TypeValue } :: import("../../types/definitions.yo");
+{ type_of_type } :: import("../../types/hierarchy.yo");
 { register_some_resolved_concrete, lookup_some_resolved_concrete, lookup_struct_ctor_fid } :: import("../../expr_info.yo");
 { type_value_tag, t_effects_row, t_usize, resolve_enum_shell } :: import("../../types/creators.yo");
 {
@@ -251,6 +252,21 @@ _bind_some_type :: (
   ) -> unit
 )({
   token := match(tok, .Some(t) => t, .None => synthetic_token(name, env.module_path));
+  // The bound VARIABLE's declared type is the KIND of the bound value —
+  // TS binds `type: value.type` where createTypeValue computes
+  // `typeOfType(value)` (synthesizer.ts:259-271, value.ts:442-448), so a
+  // type binder `T` always carries `Type`/`Trait` as its variable type.
+  // Passing the bound TYPE ITSELF (a SomeT or concrete) made a later read
+  // of the `T` atom stamp `info.ty = <the SomeT>`, and kind-checking
+  // builtins rejected it ("__yo_type_contains_rc_type: expected a Type
+  // argument, got: T : (Eq + Hash)" — the hash_set family of
+  // issues/def-eval-swallow-remaining-roots.md). Non-TypeVal values keep
+  // the caller's ty.
+  bind_ty := match(
+    val,
+    .TypeVal(bt_payload) => type_of_type(bt_payload),
+    _ => ty
+  );
   vars := get_variables_from_env(env, name);
   n := vars.len();
   cond(
@@ -259,7 +275,7 @@ _bind_some_type :: (
       add_variable_to_env(
         env,
         name,
-        ty,
+        bind_ty,
         Option(EvalValue).Some(val),
         true,
         // is_compile_time_only
@@ -332,7 +348,7 @@ _bind_some_type :: (
         add_variable_to_env(
           env,
           name,
-          ty,
+          bind_ty,
           Option(EvalValue).Some(val),
           true,
           // is_compile_time_only
@@ -346,10 +362,13 @@ _bind_some_type :: (
         );
         return(());
       });
+      // In-place update keeps the EXISTING variable's declared type — TS
+      // `updateExistingVariable(env, variable, {...variable, value: [value]})`
+      // replaces only the value (synthesizer.ts:274-277).
       new_var := Variable(
         id : old_var.id,
         name : old_var.name,
-        ty : ty,
+        ty : old_var.ty,
         is_compile_time_only : old_var.is_compile_time_only,
         frame_level : old_var.frame_level,
         value : value_cell_of(Option(EvalValue).Some(val)),

--- a/yo-self/evaluator/types/synthesizer.yo
+++ b/yo-self/evaluator/types/synthesizer.yo
@@ -30,6 +30,8 @@ open(import("std/string"));
   synthetic_token
 } :: import("../../env.yo");
 { Token } :: import("../../token.yo");
+open(import("std/fmt"));
+_(env : synth_dbg_env) :: import("std/env");
 { in_def_time_trial } :: import("../context.yo");
 { TypeValue } :: import("../../types/definitions.yo");
 { type_of_type } :: import("../../types/hierarchy.yo");
@@ -68,7 +70,7 @@ _is_runtime_numeric :: (fn(t : TypeValue) -> bool)(
 { get_value_of_some_type_from_env }
 :: import("../../types/env_lookup.yo");
 { type_to_string, type_to_string_key } :: import("../../types/string.yo");
-{ EvalValue, lookup_enum_cfid } :: import("../../value.yo");
+{ EvalValue, lookup_enum_cfid, value_to_string } :: import("../../value.yo");
 { get_gadt_type_constructor_args } :: import("./gadt_registry.yo");
 { format_error_message, ErrorKind } :: import("../../error.yo");
 { Exception } :: import("std/error");
@@ -343,6 +345,11 @@ _bind_some_type :: (
       );
       if(identity_mismatch && val_is_self_marker, {
         return(());
+      });
+      if((synth_dbg_env.get(`YO_DEBUG_BIND`).is_some() && (name == "T")) && !(val_is_self_marker), {
+        wrote_lvl := if(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))), env.frames.len() - usize(1), old_var.frame_level);
+        wrote_fid := match(env.frames.get(wrote_lvl), .Some(wf) => wf.id, .None => usize(0));
+        eprintln(`[bind-T] val=${value_to_string(val)} slot_lvl=${old_var.frame_level.to_string()} top=${(env.frames.len() - usize(1)).to_string()} wrote_lvl=${wrote_lvl.to_string()} fid=${wrote_fid.to_string()} inplace=${(!(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))))).to_string()}`);
       });
       if(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))), {
         add_variable_to_env(

--- a/yo-self/evaluator/types/synthesizer.yo
+++ b/yo-self/evaluator/types/synthesizer.yo
@@ -1589,8 +1589,20 @@ _synthesize_types_impl :: (
     // reached specialization/codegen channels and re-broke
     // tests/derive_clone_complex.test.yo (the session's recurring lesson —
     // abstract/looser products must stay out of stamps codegen consumes).
+    // AND scoped to a MISSING nominal identity: the fallback exists to
+    // rescue instantiations minted past the ctor stamp (empty cfid). When
+    // BOTH sides carry known-but-DIFFERENT ctor fids, nominal identity is
+    // decided and the pair must reject — TS synthesizer.ts:662 compares
+    // funcIds directly. Unscoped, two ANONYMOUS same-shaped ctors unified:
+    // HashMapIter(K,V) vs HashMapIterPtr(K,V) (both name="", both fields
+    // `(_map, _index)`) let the Clone-impl trial's `it.next()` bind the
+    // BY-VALUE iterator's `next : -> Option(Bucket(K,V))` for a
+    // HashMapIterPtr receiver, so `bucket_ptr` lost its pointer type and
+    // the trial swallowed "Cannot unify u64 and unit" (hash_map:714,
+    // issues/def-eval-swallow-remaining-roots.md corpus phase).
     (same_shape3 : bool) = false;
-    if(((exp_id3 != giv_id3) && !(same_constructor3)) && in_def_time_trial(), {
+    cfid_unknown3 := ((exp_eff_cfid.len() == usize(0)) || (giv_eff_cfid.len() == usize(0)));
+    if((((exp_id3 != giv_id3) && !(same_constructor3)) && cfid_unknown3) && in_def_time_trial(), {
       exp_snm := match(expected_ty, .Struct({ name : n }) => n, _ => String.from(""));
       giv_snm := match(given_ty, .Struct({ name : n }) => n, _ => String.from(""));
       exp_lbls := match(expected_ty, .Struct({ field_labels : l }) => l, _ => ArrayList(String).new());

--- a/yo-self/evaluator/types/synthesizer.yo
+++ b/yo-self/evaluator/types/synthesizer.yo
@@ -346,7 +346,8 @@ _bind_some_type :: (
       if(identity_mismatch && val_is_self_marker, {
         return(());
       });
-      if((synth_dbg_env.get(`YO_DEBUG_BIND`).is_some() && (name == "T")) && !(val_is_self_marker), {
+      bind_probe_name := match(synth_dbg_env.get(`YO_DEBUG_BIND`), .Some(bpn) => bpn, .None => String.from(""));
+      if(((bind_probe_name.len() > usize(0)) && (name == bind_probe_name)) && !(val_is_self_marker), {
         wrote_lvl := if(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))), env.frames.len() - usize(1), old_var.frame_level);
         wrote_fid := match(env.frames.get(wrote_lvl), .Some(wf) => wf.id, .None => usize(0));
         eprintln(`[bind-T] val=${value_to_string(val)} slot_lvl=${old_var.frame_level.to_string()} top=${(env.frames.len() - usize(1)).to_string()} wrote_lvl=${wrote_lvl.to_string()} fid=${wrote_fid.to_string()} inplace=${(!(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))))).to_string()}`);

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -643,7 +643,13 @@ _bind_forall_from_type_args :: (
     if(is_match, {
       match(
         con_ta.get(j),
-        .Some(ct) => if(!(is_some_type(ct)), {
+        // `Unit` in a type_arguments slot is the NON-TYPE-ARG placeholder
+        // (comptime_fn.yo inst_type_args pads value args with Unit so
+        // positions line up) — never a real binding. Binding a forall to it
+        // specialized `_find_bucket` with `key : unit` under the HashMap
+        // Clone-impl trial and the sibling `set` re-eval swallowed
+        // ("Cannot unify u64 and unit", hash_map:714 of the corpus family).
+        .Some(ct) => if((!(is_some_type(ct))) && !(match(ct, .Unit => true, _ => false)), {
           return(Option(TypeValue).Some(ct));
         }, {
           // Trial-scoped abstract acceptance — same contract as

--- a/yo-self/evaluator/values/impl.yo
+++ b/yo-self/evaluator/values/impl.yo
@@ -779,13 +779,49 @@ try_match_generic_impl :: (
       }
     )
   );
+  if(impl_dbg_env.get(`YO_DEBUG_BIND`).is_some(), {
+    (tmf_ids : String) = String.from("");
+    (tmf_i : usize) = usize(0);
+    while(tmf_i < unify_env.frames.len(), {
+      match(
+        unify_env.frames.get(tmf_i),
+        .Some(tmf_f) => {
+          tmf_ids.push_string(tmf_f.id.to_string());
+          tmf_ids.push_string(String.from(","));
+        },
+        .None => ()
+      );
+      tmf_i = (tmf_i + usize(1));
+    });
+    tmf_lvl := match(
+      entry.forall_some_types.get(usize(0)),
+      .Some(tmf_st) => match(tmf_st, .SomeT({ frame_level : tmf_l }) => tmf_l, _ => usize(9999)),
+      .None => usize(9999)
+    );
+    eprintln(`[tm-frames] pat=${type_to_string(entry.receiver_type_pattern)} fa0_lvl=${tmf_lvl.to_string()} frames=${tmf_ids}`);
+  });
   checked := ArrayList(TypePair).new();
   opts := Option(SynthesizeOptions).None;
+  // Isolate the GIVEN side exactly like the expected side above: TS's
+  // tryMatchGenericImpl runs synthesis in scratch chains it DISCARDS
+  // (impl.ts:2243 pushEnvFrame — persistent chains make every update
+  // invisible to the caller). yo-self passed the caller `env` RAW, so the
+  // synthesizer's given-side shadow-binds landed in the caller env's TOP
+  // frame — during a def-time trial that frame is DURABLE and SHARED, and
+  // one candidate's junk binding (`T := <hash_map struct>` written while
+  // probing a hash_map-family entry against a HashSet receiver) then
+  // poisoned every LATER match's (frame-level, name) resolution: the
+  // blanket pointer impl's `T` resolved to the junk struct, `*(u8)` failed
+  // to unify against it, `.add` dispatch found nothing, and the trial
+  // swallowed ("Failed to evaluate, got ((ctrl_ptr.add)(i).(*))" — the
+  // hash_set corpus family, issues/def-eval-swallow-remaining-roots.md).
+  (given_scratch : Environment) = snapshot_env(env);
+  given_scratch.push_frame(false);
   synth_result := synthesize_types(
     entry.receiver_type_pattern,
     unify_env,
     resolved_concrete,
-    env,
+    given_scratch,
     checked,
     opts,
     exn_match
@@ -1342,6 +1378,9 @@ find_methods_from_generic_impls :: (
         ei = (ei + usize(1));
       }, {
         mb_opt := try_match_generic_impl(resolved, entry, env);
+        if((in_def_time_trial() && impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some()) && (method_name == "add"), {
+          eprintln(`[fmg-try] name=${method_name} recv=${type_to_string(resolved)} pat=${type_to_string(entry.receiver_type_pattern)} matched=${mb_opt.is_some().to_string()}`);
+        });
         if(mb_opt.is_none(), {
           ei = (ei + usize(1));
         }, {


### PR DESCRIPTION
The corpus phase of the swallow campaign (self-compile of yo-self: 3603 trials). The minimal measurement repro reached 0 in #119; the wider import graph exposed a pre-existing family of 5 swallows in std's hash collections — **all 5 fixed here: the full self-compile corpus now shows 0 swallows** (3603 trials, 0 `[swallow]`, 0 transpile-failure markers in the emitted C).

**hash_set ×4 fixed — two stacked roots:**
- `_bind_some_type` bound a type variable with the bound TYPE itself instead of its KIND (TS: `type: value.type` = `typeOfType(...)`, and in-place updates preserve the old variable's type). A where-trait `hash()` dispatch then made the next `T` read stamp `T : (Eq+Hash)` and kind-checking builtins rejected it. Minimal repro in `issues/repros/hashset-where-hash-dispatch-poisons-type-binder.yo`.
- `try_match_generic_impl` passed the caller env RAW as synthesis's given side, so every candidate probe's given-side shadow-binds landed **durably** in the shared trial env (TS discards its match chains, impl.ts:2243). One hash_map-family probe's junk `T := <struct>` binding then broke the blanket pointer impl's `T` resolution for every later `.add` — `[bind-T]` frame-id-verified. Fix: scratch frame on the given side.

**hash_map:714 fixed — a wrong-method dispatch, five probe layers deep:** in the Clone-impl trial, `it.next()` on a `HashMapIterPtr(K,V)` receiver bound the BY-VALUE `HashMapIter`'s `next : -> Option(Bucket(K,V))` — the synthesizer's trial-scoped struct-shape fallback unified two ANONYMOUS same-shaped constructors (both `name=""`, both fields `(_map, _index)`). `bucket_ptr` then typed as a bare `Bucket` struct, the deref stamped nothing, `.key`/`.clone` degraded to unit, and `set`'s synthesis bound `K := unit` — the "Cannot unify u64 and unit" swallow. Fix: the shape fallback now requires a MISSING effective ctor fid on at least one side (its original rescue purpose); when both cfids are known and differ, the pair rejects nominally — TS `synthesizer.ts:662` funcId-compare parity. Two TS-faithful hardening fixes landed en route: `_bind_forall_from_type_args` never binds a forall to the `Unit` placeholder, and trial-scoped callee-env scratch isolation in helper.yo Step 7.

New env-gated debug hooks: `[rm-miss]`, `[fmg-try]`, `[tm-frames]`, `[call-none] callee_ty`, `YO_DEBUG_BIND=<name>`, `[pa-deref-in]`, `[ptr-call]`, `[match-bind]`, `[arg-eval]` (YO_DEBUG_CTFE2), `[ctfe-in] callee=`.

**Battery on the tip (1dce05268):** self-compile 3603 trials / 0 swallows, canaries green (hash_map 61/61, hash_set 63/63, btree_map 25/25, imm_map 21/21, iterator_combinators 19/19, derive_clone_complex 15/15); hollow sweep 188/188 GREEN (SWEEP_GATE_OK), FIXPOINT_HOLDS (stage2 hollow=0), `check ./std` 154/154, `check ./yo-self` 247/247.

This unblocks the endgame: making `_trial_eval_fn_body` fatal (TS parity) in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
