### PR TITLE
P3 item 1: unify the installer and version-cache roots

### DIFF
--- a/plans/P3_DISTRIBUTION.md
+++ b/plans/P3_DISTRIBUTION.md
@@ -41,17 +41,49 @@ to the canonical URL and promote `musl-bundle` off `continue-on-error`.
 
 ### Scoreboard after 2026-08-15
 
-| item                  | state                                              |
-| --------------------- | -------------------------------------------------- |
-| 1 — install scripts   | LANDED; **installer/cache unification still open** |
-| 2 — `yo version`      | DONE                                               |
-| 3 — static musl       | DONE, proof release-gated                          |
-| 4 — release hardening | DONE, windows leg release-gated                    |
+| item                  | state                               |
+| --------------------- | ----------------------------------- |
+| 1 — install scripts   | LANDED; unification DONE 2026-08-15 |
+| 2 — `yo version`      | DONE                                |
+| 3 — static musl       | DONE, proof release-gated           |
+| 4 — release hardening | DONE, windows leg release-gated     |
 
-So the ONLY remaining P3 engineering work is the installer/cache unification
-(`install.sh` installs to `<prefix>/lib/yo/<tag>` while `yo version install X`
-uses `~/.cache/yo/versions/<version>`, so `.yo-version` pinning does not see
-script-installed versions). Everything else is waiting on a release.
+**P3 engineering work is complete.** Everything outstanding is waiting on a
+release, not on code.
+
+### Installer/cache unification — DONE 2026-08-15
+
+The gap: `install.sh` lays versions out at `<prefix>/lib/yo/<tag>` while
+`yo version install X` writes `<cache_root>/versions/<version>`. Both are the
+same shape — a plain bundle extraction — but nothing looked in the installer's
+root, so a `.yo-version` pin could not see a script-installed version and
+`yo version list` omitted the very version the user was running.
+
+Resolved by **deriving** the install root rather than configuring it: a
+script-installed compiler runs from `<prefix>/lib/yo/<tag>/bin/yo`, so it
+recovers its own root by walking up from `current_exe()` and checking the
+`lib/yo` shape. Nothing has to be passed in and it works for any `--prefix`.
+`install.sh` needed no change at all, which is the sign the direction was right.
+
+- `get_install_versions_dir()` / `get_install_version_dir()` (`cache.yo`) —
+  `.None` when the layout does not match (bundle run in place, dev build out of
+  `yo-out/`, binary copied to `/tmp`), so callers fall back to exactly the
+  previous cache-only behaviour.
+- `is_version_cached` consults the install root FIRST, then the cache.
+- `resolve_version_dir` (new) returns whichever holds the version, install
+  root winning.
+- `list_cached_versions` unions both roots, de-duplicated.
+
+**Deliberately NOT the other direction** (installing into the version cache).
+A cache is by definition safe to delete — `yo version clean` removes the whole
+versions tree — so installing there would let a routine cache clean delete the
+user's actual installation.
+
+**Also deliberately unchanged:** `yo version install X` still downloads into the
+cache, not the install root. Writing to the install root can require sudo for a
+system prefix (`--prefix=/usr/local`), and a download command that sometimes
+needs privileges is worse than one that never does. Reading from both roots is
+what users needed; writing to both is not.
 
 ## What P2 already delivered that P3 builds on
 
@@ -95,15 +127,15 @@ hide behind a fallback.
 
 That is what shipped: `<prefix>/lib/yo/<tag>/{bin,std,vendor}` with a
 `<prefix>/bin/yo` symlink (a `.cmd` shim on Windows, where symlinks need admin
-or Developer Mode). So the installer and `yo version install X` are still two
-mechanisms, and `.yo-version` pinning does not yet work for script-installed
-versions.
+or Developer Mode).
 
-The rework is smaller than feared: the layout IS per-version and IS a plain
-bundle extraction — the same shape item 2 specifies — so unification is a
-**re-rooting** (point the installer at the version-cache root, or teach the
-cache about the install root), not a rewrite. Do it as part of item 2, which
-has to touch both sides anyway.
+**RESOLVED 2026-08-15** — see "Installer/cache unification" above. The
+prediction here held exactly: the layout IS per-version and IS a plain bundle
+extraction, so it was a re-rooting rather than a rewrite. Of the two options
+floated, "teach the cache about the install root" was taken; installing into
+the cache was rejected because `yo version clean` may delete a cache and must
+never be able to delete an installation. The root is DERIVED from
+`current_exe()`, so `install.sh` did not change.
 
 ### Dependencies — measured against the shipped compiler, not assumed
 

--- a/yo-self/cache.yo
+++ b/yo-self/cache.yo
@@ -16,7 +16,7 @@
 //! This mirrors `src/cache.ts`.
 open(import("std/string"));
 { Path } :: import("std/path");
-{ env } :: import("std/env");
+{ env, current_exe } :: import("std/env");
 { platform, Platform } :: import("std/process");
 { home_dir } :: import("std/os/env");
 { create_dir_all } :: import("std/fs/dir");
@@ -84,10 +84,60 @@ get_global_versions_cache_dir :: (fn() -> String)(
 get_version_cache_dir :: (fn(version : String) -> String)(
   get_global_versions_cache_dir().concat(String.from("/")).concat(version)
 );
+/// Return the INSTALL root that `scripts/install.sh` lays versions out under —
+/// `<prefix>/lib/yo` — or `.None` when this binary was not script-installed.
+///
+/// Why this exists (P3 item 1's "installer/cache unification"): the installer
+/// writes `<prefix>/lib/yo/<tag>/{bin,std,vendor}` while `yo version install`
+/// writes `<cache_root>/versions/<version>/`. Both are the SAME shape — a plain
+/// bundle extraction — but nothing looked in the installer's root, so a
+/// `.yo-version` pin could not see a script-installed version and would offer
+/// to re-download a version already on disk.
+///
+/// The re-rooting is derived, not configured: a script-installed compiler runs
+/// from `<prefix>/lib/yo/<tag>/bin/yo`, so the binary can recover its own root
+/// by walking up from `current_exe()`. Nothing has to be passed in, and it
+/// works for any `--prefix` the user chose.
+///
+/// DELIBERATELY NOT the other direction (installing INTO the version cache).
+/// A cache is by definition safe to delete — `yo version clean` removes the
+/// whole versions tree — so installing there would let a routine cache clean
+/// delete the user's actual installation.
+///
+/// Returns `.None` rather than guessing when the layout does not match (a
+/// bundle run in place, a dev build out of `yo-out/`, a binary copied to
+/// `/tmp`), so callers fall back to cache-only behaviour exactly as before.
+get_install_versions_dir :: (fn() -> Option(String))({
+  exe := match(current_exe(), .Ok(p) => p, .Err(_) => return(Option(String).None));
+  // <prefix>/lib/yo/<tag>/bin/yo  ->  walk up bin and <tag>, then require the
+  // grandparent to be `yo` sitting directly inside `lib`. Both names are
+  // checked: `<x>/yo/<tag>/bin/yo` alone is a shape a dev tree could hit.
+  bin_dir := match(exe.parent(), .Some(p) => p, .None => return(Option(String).None));
+  tag_dir := match(bin_dir.parent(), .Some(p) => p, .None => return(Option(String).None));
+  yo_dir := match(tag_dir.parent(), .Some(p) => p, .None => return(Option(String).None));
+  lib_dir := match(yo_dir.parent(), .Some(p) => p, .None => return(Option(String).None));
+  yo_name := match(yo_dir.file_name(), .Some(n) => n, .None => return(Option(String).None));
+  lib_name := match(lib_dir.file_name(), .Some(n) => n, .None => return(Option(String).None));
+  if((yo_name != "yo") || (lib_name != "lib"), {
+    return(Option(String).None);
+  });
+  Option(String).Some(yo_dir.to_string())
+});
+/// Return the install directory for a specific version, when this binary was
+/// script-installed. `.None` otherwise.
+get_install_version_dir :: (fn(version : String) -> Option(String))(
+  match(
+    get_install_versions_dir(),
+    .Some(root) => Option(String).Some(root.concat(String.from("/")).concat(version)),
+    .None => Option(String).None
+  )
+);
 export(
   get_global_cache_dir,
   get_global_deps_cache_dir,
   ensure_global_deps_cache_dir,
   get_global_versions_cache_dir,
-  get_version_cache_dir
+  get_version_cache_dir,
+  get_install_versions_dir,
+  get_install_version_dir
 );

--- a/yo-self/version_cache.yo
+++ b/yo-self/version_cache.yo
@@ -44,7 +44,9 @@ open(import("std/fmt"));
 } :: import("./target.yo");
 {
   get_global_versions_cache_dir,
-  get_version_cache_dir
+  get_version_cache_dir,
+  get_install_versions_dir,
+  get_install_version_dir
 } :: import("./cache.yo");
 // ---------------------------------------------------------------------------
 // Constants
@@ -247,10 +249,67 @@ is_version_cached :: (
   ) -> Impl(Future(bool, IoExn))
 )(
   io.async((e : IoExn) => {
+    // Look in the INSTALL root first, then the download cache. P3 item 1's
+    // "installer/cache unification": scripts/install.sh lays versions out at
+    // <prefix>/lib/yo/<tag> in exactly the same bundle shape the cache uses,
+    // but nothing looked there — so a `.yo-version` pin could not see a
+    // script-installed version and would offer to re-download it.
+    // Install root wins because it is the version the user deliberately
+    // installed; the cache is a download side-effect.
+    installed := match(
+      get_install_version_dir(version.clone()),
+      .Some(d) => e.io.await(exists(Path.new(cached_binary_path(d)), e.io), e.io),
+      .None => false
+    );
+    if(installed, {
+      return(true);
+    });
     version_dir := get_version_cache_dir(version);
     e.io.await(exists(Path.new(cached_binary_path(version_dir)), e.io), e.io)
   })
 );
+/// Resolve the directory holding `version`, preferring a script-installed copy
+/// over a downloaded one. `.None` when neither exists.
+resolve_version_dir :: (
+  fn(
+    version : String,
+    io : Io,
+    exn : Exception
+  ) -> Impl(Future(Option(String), IoExn))
+)(
+  io.async((e : IoExn) => {
+    match(
+      get_install_version_dir(version.clone()),
+      .Some(d) => {
+        if(e.io.await(exists(Path.new(cached_binary_path(d.clone())), e.io), e.io), {
+          return(Option(String).Some(d));
+        });
+      },
+      .None => ()
+    );
+    cached := get_version_cache_dir(version);
+    if(e.io.await(exists(Path.new(cached_binary_path(cached.clone())), e.io), e.io), {
+      return(Option(String).Some(cached));
+    });
+    Option(String).None
+  })
+);
+/// Is `name` already in `xs`? Used to de-duplicate a version that exists in
+/// both the install root and the download cache.
+_contains_version :: (fn(xs : ArrayList(String), name : String) -> bool)({
+  i := usize(0);
+  while(i < xs.len(), {
+    match(
+      xs.get(i),
+      .Some(v) => if(v == name, {
+        return(true);
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  false
+});
 /// List all locally cached Yo versions (directories holding a `bin/yo`).
 /// Returns an ArrayList sorted by semver (ascending). Old npm-shaped cache
 /// entries (package.json + node_modules) are ignored — that channel is dead.
@@ -261,29 +320,50 @@ list_cached_versions :: (
   ) -> Impl(Future(ArrayList(String), IoExn))
 )(
   io.async((e : IoExn) => {
-    versions_dir := get_global_versions_cache_dir();
-    dir_exists := e.io.await(exists(Path.new(versions_dir), e.io), e.io);
-    if(!(dir_exists), {
-      return(ArrayList(String).new());
-    });
-    entries := e.io.await(read_dir(Path.new(versions_dir), e.io), e);
     versions := ArrayList(String).new();
-    i := usize(0);
-    while(i < entries.len(), {
+    // Scan BOTH roots: the download cache and — when this binary was
+    // script-installed — <prefix>/lib/yo. Without the second, `yo version list`
+    // omits the very version the user is running, which reads as "not
+    // installed" (P3 item 1's installer/cache unification).
+    roots := ArrayList(String).new();
+    match(
+      get_install_versions_dir(),
+      .Some(d) => {
+        roots.push(d);
+      },
+      .None => ()
+    );
+    roots.push(get_global_versions_cache_dir());
+    r := usize(0);
+    while(r < roots.len(), {
       match(
-        entries.get(i),
+        roots.get(r),
         .None => (),
-        .Some(entry) => {
-          if(match(entry.file_type, .Directory => true, _ => false), {
-            entry_path := `${versions_dir}/${entry.name}`;
-            bin_exists := e.io.await(exists(Path.new(cached_binary_path(entry_path)), e.io), e.io);
-            if(bin_exists, {
-              versions.push(entry.name);
+        .Some(versions_dir) => {
+          if(e.io.await(exists(Path.new(versions_dir.clone()), e.io), e.io), {
+            entries := e.io.await(read_dir(Path.new(versions_dir.clone()), e.io), e);
+            i := usize(0);
+            while(i < entries.len(), {
+              match(
+                entries.get(i),
+                .None => (),
+                .Some(entry) => {
+                  if(match(entry.file_type, .Directory => true, _ => false), {
+                    entry_path := `${versions_dir}/${entry.name}`;
+                    bin_exists := e.io.await(exists(Path.new(cached_binary_path(entry_path)), e.io), e.io);
+                    // A version present in BOTH roots must appear once.
+                    if(bin_exists && !(_contains_version(versions, entry.name.clone())), {
+                      versions.push(entry.name);
+                    });
+                  });
+                }
+              );
+              i = (i + usize(1));
             });
           });
         }
       );
-      i = (i + usize(1));
+      r = (r + usize(1));
     });
     _sort_by_semver(versions)
   })
@@ -642,6 +722,7 @@ export(
   cached_binary_path,
   host_bundle_name,
   is_version_cached,
+  resolve_version_dir,
   list_cached_versions,
   clean_version_cache,
   download_version,


### PR DESCRIPTION
The last piece of P3 **engineering** work. After this, everything outstanding in P3 is waiting on a release, not on code.

## The gap

`install.sh` lays versions out at `<prefix>/lib/yo/<tag>` while `yo version install X` writes `<cache_root>/versions/<version>`. Both are the same shape — a plain bundle extraction — but nothing looked in the installer's root, so a `.yo-version` pin could not see a script-installed version, and `yo version list` omitted the very version the user was running.

## The fix

The install root is **derived, not configured**: a script-installed compiler runs from `<prefix>/lib/yo/<tag>/bin/yo`, so it recovers its own root by walking up from `current_exe()` and checking the `lib/yo` shape. Nothing is passed in, and it works for whatever `--prefix` the user chose. **`install.sh` needed no change at all**, which is the sign the direction was right.

- `get_install_versions_dir` / `get_install_version_dir` (`cache.yo`)
- `is_version_cached` consults the install root first, then the cache
- `resolve_version_dir` (new) returns whichever holds it, install root winning
- `list_cached_versions` unions both roots, de-duplicated

Both helpers return `.None` when the layout does not match — a bundle run in place, a dev build out of `yo-out/`, a binary copied to `/tmp` — so callers fall back to exactly the previous cache-only behaviour rather than guessing.

## Two directions deliberately not taken

**Installing into the version cache** (the alternative the plan floated). A cache is by definition safe to delete and `yo version clean` removes the whole versions tree, so that would let a routine cache clean delete the user's actual installation.

**Making `yo version install X` write to the install root.** That can require sudo for a system prefix (`--prefix=/usr/local`), and a download command that sometimes needs privileges is worse than one that never does. Reading from both roots is what users needed; writing to both is not.

`check ./yo-self` 248/248.

Stacked on #126; retarget or rebase after that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)