### PR TITLE
Fix the GCC blocker (comptime prototypes), close the TS/yo-self divergence gap, and file the nested-await-loop holes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,27 @@ jobs:
       # `--skip-c-compiler` stops after emitting C — 187s locally, versus a full
       # clang build. Dies with src/ in Group E, along with this whole job.
       - name: TS compiler compiles yo-self (release-divergence gate)
-        run: node --expose-gc --max-old-space-size=4096 ./out/cjs/yo-cli.cjs compile yo-self/main.yo --skip-c-compiler -o /tmp/ts-yoself-gate
+        run: |
+          node --expose-gc --max-old-space-size=4096 ./out/cjs/yo-cli.cjs \
+            compile yo-self/main.yo --skip-c-compiler -o /tmp/ts-yoself-gate
+
+          # `getTypeString` falls back to a LINE comment, `// Unknown type: …`.
+          # Mid-declaration that swallows the rest of the line and merges the
+          # NEXT declaration into it. clang accepts the resulting duplicate
+          # storage-class specifiers silently, so this stayed invisible until
+          # the release job's `gcc -fsyntax-only` on the portable yo.c — GCC
+          # rejects it ("duplicate 'static'"), which blocked v0.2.6 and breaks
+          # `--cc gcc` for users. See issues/comptime-only-prototype-breaks-gcc.md.
+          #
+          # Catch it here instead of at release time.
+          # The marker is fine at the START of a line (the whole line is an
+          # intentionally omitted field) and inside a string literal (yo-self's
+          # own source text, compiled in). Only an appearance after real tokens,
+          # outside quotes, eats a declaration — hence the no-quote-before rule.
+          if grep -nE '^[^"]*[^/"[:space:]][^"]*// Unknown type:' /tmp/ts-yoself-gate.c; then
+            echo "::error::emitted C has a '// Unknown type:' comment mid-declaration — it will eat the following declaration and GCC will reject the file"
+            exit 1
+          fi
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,6 +133,24 @@ jobs:
       - name: Run TS unit tests
         run: bun test --timeout 600000
 
+      # The TS compiler must be able to compile the yo-self sources. Until now
+      # `release.yml`'s seed-bundles job was the ONLY place that did, so a
+      # divergence — code the self-hosted compiler accepts and the TS one
+      # rejects — passed every PR check and detonated at release. That is
+      # exactly how `io.await` in a cond condition
+      # (issues/yoself-accepts-await-in-cond-that-ts-rejects.md) landed green in
+      # #128 and then broke every seed-driven job of the v0.2.5 attempt.
+      #
+      # It must be `compile`, NOT `check`: verified red-first, `check ./yo-self`
+      # returns rc=0 with the offending shape reintroduced, because the
+      # restriction is enforced during async state-machine codegen. `compile`
+      # with the same shape fails rc=1 on "must BE the first condition".
+      #
+      # `--skip-c-compiler` stops after emitting C — 187s locally, versus a full
+      # clang build. Dies with src/ in Group E, along with this whole job.
+      - name: TS compiler compiles yo-self (release-divergence gate)
+        run: node --expose-gc --max-old-space-size=4096 ./out/cjs/yo-cli.cjs compile yo-self/main.yo --skip-c-compiler -o /tmp/ts-yoself-gate
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 360

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,8 +148,14 @@ bun test src/tests/build-system.test.ts --timeout 10000
 ./yo-cli test ./tests --exclude tests/internal --bail
 
 # Self-hosted gate battery (needs a built yo-self binary in $S1). GATE 4 is
-# `check ./yo-self` — the ONLY thing that type-checks build_runner.yo and
-# version_cache.yo, which sit outside main.yo's import closure.
+# `check ./yo-self`, which type-checks the whole tree rather than one import
+# closure. (It USED to be the only thing covering build_runner.yo and
+# version_cache.yo — no longer true as of 2026-08-16: main.yo imports both.)
+# NOTE `check` is evaluator-only. The async state-machine restrictions — e.g.
+# "`io.await` in a cond condition must BE the first condition" — are enforced in
+# CODEGEN, so `check` passes over them. Use `compile yo-self/main.yo
+# --skip-c-compiler` (~3 min) to catch that class; test.yml's ts-unit-tests job
+# now runs it as the TS/yo-self release-divergence gate.
 S1=/tmp/yo-s1 P=local bash scripts/bootstrap/gates_fast.sh
 S1=/tmp/yo-s1 P=local bash scripts/bootstrap/fixpoint_only.sh
 

--- a/issues/comptime-only-prototype-breaks-gcc.md
+++ b/issues/comptime-only-prototype-breaks-gcc.md
@@ -1,0 +1,115 @@
+# A comptime-only return type emits `// Unknown type:` as the return type, and GCC rejects the file
+
+**Status: OPEN. Blocks the v0.2.6 release** (release run 31909103188: the
+`portable-c` job failed, so `publish-release` was skipped and the draft never
+went public).
+
+Not a regression — this has been latent for a long time. It is invisible under
+clang and fatal under GCC, and the portable-`yo.c` job is the first thing in the
+pipeline that ever runs real GNU GCC over generated C.
+
+## Symptom
+
+```
+yo.c:5593783: error: duplicate ‘static’
+5593783 | static inline // Unknown type: ComptimeList(Expr) fn_yocd6da6f3_id_19331_cdr_specialized_T_Expr_Self_ComptimeList_u40_Expr_u41__(
+##[error]assembled yo.c does not even parse on linux-x64
+```
+
+## Mechanism
+
+`getTypeString` (`src/codegen/utils/index.ts:840`) ends with
+
+```ts
+return `// Unknown type: ${typeToString(type)}`; // fallback
+```
+
+a **line** comment, returned where a C **type** is expected. The declaration
+emitter drops it into the return-type slot, so the `//` swallows the rest of
+that line and the declaration continues onto the next one:
+
+```c
+static inline // Unknown type: Expr           fn_..._car_...();   // line eaten
+static inline // Unknown type: ComptimeList(Expr) fn_..._cdr_...();   // line eaten
+static inline __yo_str fn_..._int_suffix(...);                       // survives
+```
+
+After preprocessing that is a single declaration reading
+`static inline static inline static inline __yo_str fn_..._int_suffix(...);`.
+
+- **clang accepts it** (duplicate storage-class specifiers, silent under `-w`),
+  so every bundle build has always passed. The two comptime prototypes are
+  simply lost, which is harmless — nothing calls them at runtime.
+- **GCC rejects it**: `duplicate ‘static’`.
+
+Verified locally: the preprocessed output really is the merged declaration, and
+`clang -std=c11 -fsyntax-only` returns 0 on a reduced case. (macOS `gcc` is a
+clang shim — `gcc --version` reports clang 21 — so GCC itself cannot be
+reproduced on this box; the CI log is the evidence.)
+
+## Severity beyond the release
+
+`--cc gcc` is an advertised choice in the CLI. So **any user compiling with GCC
+hits this** whenever the program emits a prototype for a function whose return
+type has no C representation. That is a supported-configuration bug, not just a
+release-pipeline one.
+
+## The types involved
+
+`ComptimeList(Expr)`'s `car` / `cdr` specializations. Their return types
+(`Expr`, `ComptimeList(Expr)`) are comptime-only — there is no C representation
+by design, and the functions are never called at runtime.
+
+## Fix: yo-self already does this; TS does not
+
+Reverse parity — the self-hosted compiler has the guard and the TypeScript one
+is missing it. `yo-self/codegen/functions/declarations.yo:511` includes
+
+```
+_func_result_is_comptime_only(function_type)
+```
+
+in its `skip1` condition, and `:513-515` documents the same failure mode in
+another guise:
+
+> Array with an UNRESOLVED length variable (`Array(i32, n)`) has no C rendering
+> (`// Unknown type:` ate the prototype line — array.test batch clang errors);
+> treat it as a generic return like a SomeT one.
+
+`src/codegen/functions/declarations.ts:185-199` skips on
+`isComptimeFunction(value)` — a property of the function VALUE — but never
+checks whether the RESULT TYPE is comptime-only, which is the case here.
+
+So: port `_func_result_is_comptime_only` to the TS skip.
+
+Do it as well as, not instead of, hardening the fallback: returning a line
+comment from a function whose contract is "give me a C type" can only ever
+produce broken C. A block comment (`/* Unknown type: … */`) at least cannot eat
+the following declarations. Note a block comment alone is NOT sufficient — it
+leaves `static inline fn_x();`, an implicit-int declaration that is invalid C99+
+— which is why the skip is the actual fix.
+
+## Verify
+
+Locally, without GCC:
+
+```
+node --expose-gc --max-old-space-size=4096 ./out/cjs/yo-cli.cjs \
+  compile yo-self/main.yo --skip-c-compiler -o /tmp/gate
+grep -c "static inline // Unknown type" /tmp/gate.c    # must be 0; is 2 today
+```
+
+`grep -c "Unknown type" /tmp/gate.c` is 7 today: 2 are the broken prototypes
+above, 2 are inside `__yo_str` literals (yo-self's own source text, harmless),
+and 3 are in already-commented positions.
+
+In CI, the real gate is the `portable-c` job's
+`gcc -std=c11 -fsyntax-only -w yo.c`.
+
+## Note on where the arms come from
+
+The portable-`yo.c` arms are emitted by the **TypeScript** compiler
+(`release.yml`'s "Emit this platform's arm of the portable yo.c" step runs
+`node ./out/cjs/yo-cli.cjs … --emit-c-to`), NOT by the seed. So a fix in `src/`
+does take effect on the very next release — unlike a seed-side bug, which
+cannot be fixed retroactively.

--- a/issues/fixed/nested-await-loop-emits-undefined-label.md
+++ b/issues/fixed/nested-await-loop-emits-undefined-label.md
@@ -160,11 +160,22 @@ cannot coincide with the right answer.
 
 ## Verify
 
+The stable check is the two regression tests, which await `yield` rather than
+real I/O:
+
 ```
-./yo-cli compile issues/repros/nested-await-loop-undefined-label.yo -o /tmp/probe && /tmp/probe
+./yo-cli test ./tests/async_await.test.yo --test-name-pattern "nested awaiting while" --parallel 1
 ```
 
-Expected: `probe=6`. Before the fix this failed at the C compiler.
+Expected: 2 passed (confirmed stable over 5 consecutive runs).
+
+The `exists`-based repro now COMPILES where it previously failed at the C
+compiler, and prints the correct `probe=6` — but only intermittently: the same
+binary SIGBUS/SIGTRAPs on most runs. **That is a separate, still-open defect in
+the nested-loop + real-I/O-future path**, filed as
+`issues/nested-await-loop-remaining-holes.md` (Hole 2) along with a second
+shape this fix does not cover (Hole 1). Do not use the repro's exit code as a
+pass/fail gate for THIS issue until Hole 2 is closed.
 
 ## Note on the earlier diagnosis
 

--- a/issues/nested-await-loop-remaining-holes.md
+++ b/issues/nested-await-loop-remaining-holes.md
@@ -1,0 +1,138 @@
+# Nested await-loops: two holes remaining after the back-edge fix
+
+**Status: OPEN.** Found 2026-08-16 while verifying
+`issues/fixed/nested-await-loop-emits-undefined-label.md`. Both are in the
+shapes that fix newly makes compilable — neither is a regression of code that
+worked before, because **both shapes failed to compile at all** on the pre-fix
+compiler.
+
+Read the fixed issue first; it explains the lowering and the vocabulary
+(`while_loop_N_continue`, `after_while_loop_N`, `outerWhileLoop`,
+`condBranchPostWhileExprs`).
+
+## Hole 1 — outer loop with NO await of its own: the inner loop truncates
+
+Repro: an outer `while` whose body has no `io.await` outside the nested loop,
+with the inner await-loop inside a `match` arm.
+
+```rust
+while(runtime(r < outer.len()), {
+  match(outer.get(r), .None => (), .Some(d) => {
+    inner := ArrayList(usize).new();
+    inner.push(d); inner.push(d);
+    i := usize(0);
+    while(runtime(i < inner.len()), {
+      match(inner.get(i), .None => (), .Some(f) => {
+        aio.await(yield(aio), aio); count = (count + f);
+      });
+      i = (i + usize(1));
+    });
+  });
+  r = (r + usize(1));
+});
+```
+
+With `outer = [1, 10, 100]` and two inner entries per outer element, `count`
+should be 222.
+
+| compiler                 | result                                              |
+| ------------------------ | --------------------------------------------------- |
+| before the back-edge fix | `error: redefinition of label 'while_loop_0_start'` |
+| after                    | compiles, `count == 111`                            |
+
+111 is 1+10+100: the OUTER loop iterates correctly all three times, the INNER
+loop runs once per outer iteration.
+
+### Diagnosis
+
+The emitted labels are all structurally correct — both loops get
+`_start`/`_end`/`_continue`/`after_`, via the original `outerWhileLoop` path.
+The defect is drop placement, the same family as Bug B in the fixed issue but a
+THIRD emission site: `processChainedBranch`'s "no more awaits" branch
+(`src/codegen/async/state-machine.ts`, the `else` that emits
+`chainedBranch.deferredDropExpressions` inline at indent 6). It emits the
+enclosing match arm's scope-end drop of `inner` at the top of the inner loop's
+resume state, so `inner` is freed during the first iteration and the loop
+condition then re-reads freed memory:
+
+```c
+      switch (sm->cond_branch_0) { case 4: { count += f; break; } }
+      fn_..._drop(sm->var_..._inner);          // <-- arm scope drop, every iteration
+      }
+      // Execute remaining code from while loop body and continue loop
+      if (sm->while_loop_0_active) {
+        i = i + 1;
+      while_loop_0_continue:
+        ... fn_..._len(sm->var_..._inner) ...   // <-- reads freed memory
+```
+
+### Attempted fix, and why it was reverted
+
+Routing those drops into the enclosing loop's `condBranchPostWhileExprs` slot
+made this shape correct (222) **but broke the nested repro** — that slot is
+already claimed by `generateCondWithAwait` for the `if(...)` layer in shapes
+that have one, and the two uses collide. Reverted.
+
+The direction that should work is a DEDICATED field on the while-loop info
+(e.g. `postLoopDrops`) emitted immediately after `after_while_loop_N:`, so it
+cannot contend with `condBranchPostWhileExprs`. Not attempted — see the note on
+verification cost below.
+
+## Hole 2 — nested await-loops over REAL I/O futures crash intermittently
+
+`issues/repros/nested-await-loop-undefined-label.yo` (which awaits
+`exists(Path, io)` rather than `yield`) compiles and prints `probe=6`, but only
+sometimes:
+
+```
+run1: rc=0   probe=6
+run2: rc=138          # SIGBUS
+run3: rc=133          # SIGTRAP
+run4: rc=133
+run5: rc=133
+```
+
+Roughly 5 failures in 6, with and without `MallocScribble`. It is memory
+corruption, not a wrong answer.
+
+### What is and isn't implicated
+
+- A **single, non-nested** `exists` loop is stable (5/5 correct) — so this is
+  not the async-I/O path on its own.
+- The **same nested shape over `yield`** is stable (5/5, and the two regression
+  tests in `tests/async_await.test.yo` pass 5/5) — so it is not the nested
+  lowering on its own.
+- It is the combination: nesting plus a future that can complete
+  asynchronously. The timing dependence is consistent with the inline
+  fast-path (`__yo_inline_budget`) vs. real suspension taking different routes
+  through the states.
+- **Not** the state-machine dispose double-dropping: dispose is gated on
+  `state == -2` (abort), and the normal path's drop of `inner` sits in the
+  post-while block, which runs once per outer iteration as it should.
+
+Undiagnosed beyond that. The next step is to find which value is freed while
+still live — the per-inner-iteration temps (`Path.new(f.clone())`) and the
+outer continue block's drop of the match scrutinee temp are the two candidates
+visible in the emitted C.
+
+## Why these are filed rather than fixed
+
+The async state-machine emitter miscompiles silently when it is wrong, and this
+session already produced one such attempt (the `condBranchPostWhileExprs`
+collision above) that turned a green repro into a SIGBUS. Each candidate needs
+the full battery to say anything, and the two fixes already landed are worth
+getting through CI on their own before more is stacked on them.
+
+## Verify
+
+Hole 1 (expect 222, currently 111) — the shape is in this repo's history as
+`shapes/a.yo` in the session scratchpad; reconstruct from the snippet above.
+
+Hole 2:
+
+```
+./yo-cli compile issues/repros/nested-await-loop-undefined-label.yo --release -o /tmp/probe
+for i in 1 2 3 4 5 6; do /tmp/probe; echo "rc=$?"; done
+```
+
+Expected once fixed: `probe=6`, rc=0, six times out of six.

--- a/issues/nested-await-loop-remaining-holes.md
+++ b/issues/nested-await-loop-remaining-holes.md
@@ -163,16 +163,30 @@ state. One slot, two legitimate clients.
 
 ### The fix
 
-Give the slot room for both layers, in source order: either make
-`condBranchPostWhileExprs` a LIST that clients append to, or add the dedicated
-`postLoopDrops` field (see Hole 1) and route the second client there. A list is
-the more principled of the two — there is nothing special about "two", and the
-consumer already iterates `exprs`.
+Give the slot room for both layers, in source order — but note that the obvious
+shape is wrong.
 
-Do NOT simply overwrite or merge under the existing entry's guard: the two
-layers dispatch on DIFFERENT `cond_branch_N` fields (`cond_branch_0 == 2` here
-versus the inner layer's own), so a merge is only sound when the surviving entry
-is unconditional (`skipCondBranchCheck`). Relying on that is fragile.
+**A list of ENTRIES, looped over, does not work.** The consumer's body is a
+single pass that stops at the first expression containing an await
+(`foundPostWhileAwait`), hands the rest to the next state via
+`asyncCondBranchInfo`, and only emits `deferredDropExpressions` when it did NOT
+chain. Run that per entry and the ordering breaks the moment entry 1 chains:
+entry 2 (the OUTER arm) would be emitted in THIS state while entry 1's tail runs
+in the next one — outer code before inner code.
+
+**Concatenate instead.** Merge the layers into ONE expression sequence, inner
+layer first then the enclosing arm, and let the existing single pass run over
+the concatenation. Ordering and the chaining semantics then both fall out for
+free — the pass splits at whichever await comes first in the merged sequence,
+which is the correct split point. Merge `deferredDropExpressions` the same way.
+
+The one thing that genuinely needs care is the guard. Layers can carry different
+`branchIndex` / `condBranchFieldIndex` (`cond_branch_0 == 2` here versus the
+inner layer's own field), and one emission cannot test two fields. Set
+`skipCondBranchCheck` whenever the merged layers disagree — which is sound for
+the same reason the existing code already gives for that flag: `after_while_loop_N`
+is reachable only from the branch that ran the loop. Do NOT silently keep one
+layer's guard and drop the other's.
 
 Both compilers need it; `yo-self/codegen/functions/context.yo`'s
 `CondBranchPostWhileExprs` is a `ref(struct(...))` in the same single-slot shape.

--- a/issues/nested-await-loop-remaining-holes.md
+++ b/issues/nested-await-loop-remaining-holes.md
@@ -126,10 +126,56 @@ corruption, not a wrong answer.
   `state == -2` (abort), and the normal path's drop of `inner` sits in the
   post-while block, which runs once per outer iteration as it should.
 
-Undiagnosed beyond that. The next step is to find which value is freed while
-still live — the per-inner-iteration temps (`Path.new(f.clone())`) and the
-outer continue block's drop of the match scrutinee temp are the two candidates
-visible in the emitted C.
+### Root cause: ONE post-loop slot, TWO clients
+
+Localised with Guard Malloc (`DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib`
+under lldb, against the emitted C rebuilt `clang -g -O0`), which traps at the
+offending access instead of downstream in `mfm_alloc`:
+
+```
+frame #0: __yo_decr_rc(ptr=0x340147fe0) at h2crash.c:4957
+frame #1: fn_yodb917980_id_44___drop  (Path)  at h2crash.c:11945 [inlined]
+frame #2: _yo38915498_temp_46221_resume       at h2crash.c:13812
+```
+
+`h2crash.c:13809-13814` is:
+
+```c
+      // Outer cond branch 2 remaining code (chained)
+      if (sm->cond_branch_0 == 2) {
+      if (sm->await_future_0 != NULL) { __yo_decr_rc((void*)sm->await_future_0); };
+      fn_..._drop(sm->var_..._temp_46112);   // the OUTER arm's Path.new(d.clone())
+      fn_..._drop(sm->var_..._temp_46111);   // and its String
+      }
+```
+
+That is the OUTER match arm's scope-end code, emitted inside the INNER loop's
+resume state — so a `Path` built once per OUTER iteration is dropped on every
+INNER iteration. A double-free, hence the timing dependence and the corrupted
+heap.
+
+It is the same defect as Bug B in the fixed issue, reaching the same place by a
+different route: the fix routes a branch's post-loop code into the nested loop's
+`condBranchPostWhileExprs`, but **declines when that slot is already occupied**
+— and here `generateCondWithAwait` has already claimed it for the `if(got, …)`
+layer. Declining falls back to chaining, which emits at the top of the resume
+state. One slot, two legitimate clients.
+
+### The fix
+
+Give the slot room for both layers, in source order: either make
+`condBranchPostWhileExprs` a LIST that clients append to, or add the dedicated
+`postLoopDrops` field (see Hole 1) and route the second client there. A list is
+the more principled of the two — there is nothing special about "two", and the
+consumer already iterates `exprs`.
+
+Do NOT simply overwrite or merge under the existing entry's guard: the two
+layers dispatch on DIFFERENT `cond_branch_N` fields (`cond_branch_0 == 2` here
+versus the inner layer's own), so a merge is only sound when the surviving entry
+is unconditional (`skipCondBranchCheck`). Relying on that is fragile.
+
+Both compilers need it; `yo-self/codegen/functions/context.yo`'s
+`CondBranchPostWhileExprs` is a `ref(struct(...))` in the same single-slot shape.
 
 ## Why these are filed rather than fixed
 

--- a/issues/nested-await-loop-remaining-holes.md
+++ b/issues/nested-await-loop-remaining-holes.md
@@ -125,8 +125,11 @@ getting through CI on their own before more is stacked on them.
 
 ## Verify
 
-Hole 1 (expect 222, currently 111) — the shape is in this repo's history as
-`shapes/a.yo` in the session scratchpad; reconstruct from the snippet above.
+Hole 1 (expect `A=222`, currently `A=111`):
+
+```
+./yo-cli compile issues/repros/nested-await-loop-outer-no-own-await.yo --release -o /tmp/holeA && /tmp/holeA
+```
 
 Hole 2:
 

--- a/issues/nested-await-loop-remaining-holes.md
+++ b/issues/nested-await-loop-remaining-holes.md
@@ -177,6 +177,23 @@ is unconditional (`skipCondBranchCheck`). Relying on that is fragile.
 Both compilers need it; `yo-self/codegen/functions/context.yo`'s
 `CondBranchPostWhileExprs` is a `ref(struct(...))` in the same single-slot shape.
 
+## Blast radius: nothing shipped is affected
+
+Emit-diff gate, run to decide whether the compiler we ship is itself exposed:
+`compile yo-self/main.yo --skip-c-compiler` under the pre-fix and post-fix
+TypeScript compilers, then diff the two ~120 MB C files.
+
+After normalising the two nondeterministic name families — gensym'd labels
+(`continue_<rand>`, `loop_<rand>`, `_yo_async_return_<rand>`) and
+millisecond-timestamped capture structs
+(`__capture_fn_..._1786819606464_59`) — the outputs are **identical**, and the
+normalised files are byte-for-byte the same size.
+
+So `yo-self` contains no nested await-loop anywhere: the fix changes nothing
+about the compiler's own emission, and neither hole can affect the shipped
+binary. It also means the two holes are reachable only by user code that writes
+a shape which, before this fix, did not compile at all.
+
 ## Why these are filed rather than fixed
 
 The async state-machine emitter miscompiles silently when it is wrong, and this

--- a/issues/nested-await-loop-remaining-holes.md
+++ b/issues/nested-await-loop-remaining-holes.md
@@ -47,13 +47,9 @@ loop runs once per outer iteration.
 
 The emitted labels are all structurally correct — both loops get
 `_start`/`_end`/`_continue`/`after_`, via the original `outerWhileLoop` path.
-The defect is drop placement, the same family as Bug B in the fixed issue but a
-THIRD emission site: `processChainedBranch`'s "no more awaits" branch
-(`src/codegen/async/state-machine.ts`, the `else` that emits
-`chainedBranch.deferredDropExpressions` inline at indent 6). It emits the
-enclosing match arm's scope-end drop of `inner` at the top of the inner loop's
-resume state, so `inner` is freed during the first iteration and the loop
-condition then re-reads freed memory:
+The defect is drop placement: the enclosing match arm's scope-end drop of
+`inner` lands at the top of the inner loop's resume state, so `inner` is freed
+during the first iteration and the loop condition then re-reads freed memory:
 
 ```c
       switch (sm->cond_branch_0) { case 4: { count += f; break; } }
@@ -66,17 +62,37 @@ condition then re-reads freed memory:
         ... fn_..._len(sm->var_..._inner) ...   // <-- reads freed memory
 ```
 
-### Attempted fix, and why it was reverted
+### Which emitter produces that drop is still UNKNOWN
 
-Routing those drops into the enclosing loop's `condBranchPostWhileExprs` slot
-made this shape correct (222) **but broke the nested repro** — that slot is
-already claimed by `generateCondWithAwait` for the `if(...)` layer in shapes
-that have one, and the two uses collide. Reverted.
+An earlier revision of this file blamed `processChainedBranch`'s "no more
+awaits" path in `state-machine.ts`. **That was wrong.** Tagging every
+`${dropCode}` emitter in `src/codegen/async/state-machine.ts` and
+`state-code-gen.ts` with a distinct `/*DROPSITE_*/` marker and recompiling this
+repro shows only ONE of them firing in that region — `SM1158`, and it emits the
+`__yo_decr_rc(await_future_0)` line, not the `inner` drop. So the drop comes
+from outside the async emitters: the generic scope-exit drop machinery
+(`src/codegen/exprs/begin.ts`, `atom.ts`, `other-fn-call.ts` all emit
+`${indent}${dropCode};`) is the place to tag next.
 
-The direction that should work is a DEDICATED field on the while-loop info
-(e.g. `postLoopDrops`) emitted immediately after `after_while_loop_N:`, so it
-cannot contend with `condBranchPostWhileExprs`. Not attempted — see the note on
-verification cost below.
+That matters for the fix, because a deferral only works if it is applied where
+the drop is actually produced.
+
+### Two attempts, both reverted
+
+1. Routing the drops into the enclosing loop's `condBranchPostWhileExprs` made
+   this shape correct (222) but **broke the nested repro into a SIGBUS** — that
+   slot is already claimed by `generateCondWithAwait` for the `if(...)` layer,
+   and the two uses collide.
+2. A DEDICATED `postLoopDrops` field on the while-loop info, emitted right after
+   `after_while_loop_N:`, avoids that collision and does emit correctly (the
+   drop code must be generated where it is COLLECTED, not where it is emitted —
+   the state-machine variable mapping is only set up at the collection point, so
+   deferring an `Expr` yields a bare `inner` and a C compile error; defer the
+   generated string instead). But it changed nothing here, because the drop is
+   not produced by the site it hooks. Reverted.
+
+The `postLoopDrops` design is still the right shape for the eventual fix; it
+just needs to be wired to the emitter that actually produces this drop.
 
 ## Hole 2 — nested await-loops over REAL I/O futures crash intermittently
 

--- a/issues/repros/nested-await-loop-outer-no-own-await.yo
+++ b/issues/repros/nested-await-loop-outer-no-own-await.yo
@@ -1,0 +1,51 @@
+open(import("std/string"));
+open(import("std/fmt"));
+{ yield } :: import("std/async");
+{ ArrayList } :: import("std/collections/array_list");
+/// Hole 1 of issues/nested-await-loop-remaining-holes.md: the outer loop has NO
+/// await of its own — the only suspension is inside the nested loop, which sits
+/// in a `match` arm. Before the back-edge fix this failed to compile
+/// (`redefinition of label 'while_loop_0_start'`). It now compiles, but the
+/// enclosing arm's scope-end drop of `inner` is emitted at the top of the inner
+/// loop's resume state, so `inner` is freed during the first iteration and the
+/// condition re-reads freed memory: the inner loop runs once per outer
+/// iteration and the total is 111 instead of 222.
+drive :: (fn(rio : Io) -> Impl(Future(usize, Io)))(
+  rio.async((aio : Io) => {
+    (count : usize) = usize(0);
+    outer := ArrayList(usize).new();
+    outer.push(usize(1));
+    outer.push(usize(10));
+    outer.push(usize(100));
+    r := usize(0);
+    while(runtime(r < outer.len()), {
+      match(
+        outer.get(r),
+        .None => (),
+        .Some(d) => {
+          inner := ArrayList(usize).new();
+          inner.push(d);
+          inner.push(d);
+          i := usize(0);
+          while(runtime(i < inner.len()), {
+            match(
+              inner.get(i),
+              .None => (),
+              .Some(f) => {
+                aio.await(yield(aio), aio);
+                count = (count + f);
+              }
+            );
+            i = (i + usize(1));
+          });
+        }
+      );
+      r = (r + usize(1));
+    });
+    count
+  })
+);
+main :: (fn(io : Io) -> unit)({
+  println(`A=${io.await(drive(io), io).to_string()} want=222`);
+});
+export(main);

--- a/issues/yoself-accepts-await-in-cond-that-ts-rejects.md
+++ b/issues/yoself-accepts-await-in-cond-that-ts-rejects.md
@@ -41,8 +41,8 @@ compiler pair that disagrees about what compiles is its own problem.
 
 ## Why no PR check catches it
 
-**`node out/cjs/yo-cli.cjs compile yo-self/main.yo` appears ONLY in
-`release.yml`'s seed-bundles job.** In PR CI the `test` matrix uses the SEED,
+**`node out/cjs/yo-cli.cjs compile yo-self/main.yo` appeared ONLY in
+`release.yml`'s seed-bundles job** (until the gate below). In PR CI the `test` matrix uses the SEED,
 bootstrap-fixpoint goes seed → stage-1, and the differential uses stage-1 — so
 the TypeScript compiler never compiles `yo-self/main.yo`.
 
@@ -52,8 +52,26 @@ detonates at release time. That is exactly what happened: the code landed in
 
 **This gap is worth closing regardless of which compiler turns out to be
 right** — it is the reason a whole class of divergence is invisible until a
-release. Cheapest form: add a PR job that runs the TS compiler over
-`yo-self/main.yo` with `--skip-c-compiler`. Locally that is a few minutes.
+release.
+
+**CLOSED 2026-08-16**: `test.yml`'s `ts-unit-tests` job now runs
+`compile yo-self/main.yo --skip-c-compiler` (187 s locally, and that job already
+builds the TS compiler, so it costs nothing else). It dies with `src/` in Group
+E, which is correct — the gate only means anything while both compilers exist.
+
+Two things found while verifying it red-first, both worth knowing:
+
+- **It must be `compile`, not `check`.** `check ./yo-self` returns **rc=0** with
+  the offending shape reintroduced: the restriction lives in async
+  state-machine CODEGEN, which `check` never reaches. Only `compile` fails
+  (rc=1, "must BE the first condition"). A `check`-based gate would have been
+  pure false confidence.
+- **The restriction is narrower than this issue's title suggests.** An await
+  that IS the sole/first condition is accepted by TS — `if(e.io.await(f, e.io),
+{...})` on its own compiles fine. What TS rejects is an await _nested inside a
+  larger expression_ (`if(!(e.io.await(...)), ...)`) or in a _later_ branch. The
+  first red probe here used the legal form and passed, which is what exposed the
+  distinction.
 
 ## Encountered as
 

--- a/src/codegen/functions/declarations.ts
+++ b/src/codegen/functions/declarations.ts
@@ -187,13 +187,23 @@ export function generateFunctionDeclarations(
       !isEffectfulFunction &&
       !hasEvidenceParams &&
       !value.isEffectRecordMember &&
-      !isConcreteSpecialization &&
-      ((isFunctionTypeHardGeneric(value.type) && !value.type.isClosure) ||
-        (value.specializedFunctionCaches?.length > 0 &&
-          !value.type.isClosure) ||
-        isComptimeFunction(value) ||
-        isFunctionValueWithOnlyBuiltinYoInlineFunctionCall(value) ||
-        value.isIoAsyncStateMachineClosure)
+      // A comptime function is skipped even when it IS a concrete
+      // specialization. Its return type is comptime-only, so getTypeString
+      // renders it as the `// Unknown type: …` fallback — a LINE comment in the
+      // return-type slot, which swallows the rest of the declaration and merges
+      // the next one into it. clang accepts the resulting duplicate
+      // storage-class specifiers silently; GCC rejects the file outright
+      // ("duplicate 'static'"), so `--cc gcc` and the portable yo.c both break.
+      // The prototype is useless anyway — nothing calls these at runtime.
+      // See issues/comptime-only-prototype-breaks-gcc.md; yo-self has carried
+      // the equivalent guard (`_func_result_is_comptime_only` in its `skip1`).
+      (isComptimeFunction(value) ||
+        (!isConcreteSpecialization &&
+          ((isFunctionTypeHardGeneric(value.type) && !value.type.isClosure) ||
+            (value.specializedFunctionCaches?.length > 0 &&
+              !value.type.isClosure) ||
+            isFunctionValueWithOnlyBuiltinYoInlineFunctionCall(value) ||
+            value.isIoAsyncStateMachineClosure)))
     ) {
       continue;
     }


### PR DESCRIPTION
Follow-up to #129. **Carries the fix that blocked the v0.2.6 release.**

## 1. The release blocker: emitted C does not parse under GCC

Release run 31909103188 got all five seed bundles green — then `portable-c` failed and `publish-release` was skipped, so the draft never went public (no tag; `latest` is still v0.2.4).

```
yo.c:5593783: error: duplicate 'static'
static inline // Unknown type: ComptimeList(Expr) fn_..._cdr_specialized_...(
```

`getTypeString` falls back to a **line** comment, `// Unknown type: <t>`, and returns it where a C **type** is expected. In the return-type slot the `//` swallows the rest of the declaration and the next one merges in — after preprocessing, `static inline static inline static inline __yo_str fn_...(...)`. **clang accepts** the duplicate storage-class specifiers silently under `-w`, which is why every bundle build has always passed; **GCC rejects the file**. Since `--cc gcc` is an advertised choice, this broke real users too, not just the release — the portable-`yo.c` job is simply the first thing in the pipeline that ever runs real GNU GCC over generated C.

`declarations.ts` *did* list `isComptimeFunction(value)` among its skip conditions, but the whole disjunction sits behind `!isConcreteSpecialization` — a carve-out added so concrete specializations keep their declarations. `ComptimeList(Expr)`'s `car`/`cdr` *are* specializations, so the carve-out un-skipped them. Hoisted `isComptimeFunction` out of that disjunction: a comptime function is skipped whether or not it is a specialization. Its return type has no C representation and nothing calls it at runtime, so the prototype could only ever be broken C.

**Reverse parity again** — yo-self has carried the equivalent guard all along (`_func_result_is_comptime_only` in `declarations.yo`'s `skip1`, with a neighbouring comment describing this exact "`// Unknown type:` ate the prototype line" failure in another guise).

Verified: marker-in-declaration count **2 → 0** in the emitted yo-self C; `clang -fsyntax-only` over all 120 MB returns **0 errors**, so no needed prototype was dropped; **189 language test files green**, with the same 4 `tests/cli-cases` fixtures failing by design as before.

## 2. The CI gate for TS/yo-self divergence

`release.yml`'s seed-bundles job was the only place TS ever compiled `yo-self`, so a construct yo-self accepts and TS rejects passed every PR check and detonated at release — exactly how the `io.await`-in-cond divergence landed green in #128 and broke v0.2.5. `test.yml`'s `ts-unit-tests` job now runs `compile yo-self/main.yo --skip-c-compiler` (8.3 min in CI, inside a 30-min budget that was using 5m27s), and additionally greps for the `// Unknown type:` marker appearing mid-declaration so **class 1 above cannot reach a release again**.

Both checks verified **red-first**, and both probes corrected a belief:

- It must be `compile`, not `check` — `check ./yo-self` returns **rc=0** with the offending shape reintroduced, because the restriction is enforced in async state-machine *codegen*. A check-based gate would have been pure false confidence.
- The marker grep needs a no-quote-before rule: a first attempt false-positived on yo-self's own source text compiled in as string literals.

Also corrects `AGENTS.md`, which claimed `build_runner.yo` and `version_cache.yo` sit outside `main.yo`'s import closure — `main.yo` imports both, and that stale note is what pointed me at `check`.

## 3. The two remaining nested-await-loop holes (docs only)

Found while verifying #129; **neither regresses working code** — both shapes failed to compile before that fix. Repros committed. Hole 2 is root-caused to slot contention on `condBranchPostWhileExprs` (one slot, two legitimate clients) via Guard Malloc under lldb, with the fix direction recorded — including why the obvious shape is wrong. **Blast radius is nil**: an emit-diff of yo-self's ~120 MB of C, pre- and post-#129, is identical once gensyms and timestamped capture structs are normalised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)