### PR TITLE
Promote the musl bundle (root cause closed), seed-drive its emit, and record the seed-bundles memory blocker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ on:
           - patch
           - minor
 
+env:
+  # The previous-release seed used by the seed-driven steps below (the musl
+  # bundle's Yo->C emit). Same trust-chain root as test.yml's SEED_VERSION;
+  # bump to the latest PUBLISHED release whose bundle matrix covers the
+  # needed targets.
+  SEED_VERSION: v0.2.7
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -435,22 +442,17 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: write
-    # EXPERIMENTAL on arrival, exactly as windows-x64 was. The pipeline is
-    # proven end-to-end in PR CI (test.yml's musl leg: static link + io_uring
-    # genuinely compiled in, asserted under seccomp=unconfined), but it has
-    # never produced a PUBLISHED bundle, and a new leg must not be able to
-    # block a release. Promote to `continue-on-error: false` after one green
-    # release run, the same rule the seed-bundle matrix uses.
-    continue-on-error: true
-    # DELIBERATELY ABSENT from publish-release's `needs`, unlike portable-c.
-    # `continue-on-error: true` stops a failure from failing the WORKFLOW, but
-    # the job's result is still `failure`, and a dependent job whose `needs`
-    # resolves to failure is SKIPPED — so listing it there would let a broken
-    # musl leg block publication entirely, the exact opposite of experimental.
-    # The trade is that publication may land shortly before this asset does;
-    # that is safe because install.sh falls back to the glibc bundle, and the
-    # asset attaches to the already-published release when it finishes.
-    # Add it to `needs` in the same commit that flips continue-on-error off.
+    # PROMOTED 2026-08-17 per this job's own rule ("after one green release
+    # run"): v0.2.7 (run 31925643271) built, smoked and shipped the bundle.
+    # The earlier failures are root-caused, not mysterious — every red run's
+    # musl log dies on `duplicate 'static'` in the emitted C, the GCC
+    # comptime-prototype blocker (issues/fixed/comptime-only-prototype-breaks-
+    # gcc.md): Alpine's cc is GCC, making this job the second GCC-family
+    # consumer after portable-c, and PR #130 (the only substantive commit
+    # between the last red run 31909103188 and the first green) fixed it.
+    # `needs` on publish-release added in this same commit, per the pairing
+    # rule recorded here previously.
+    continue-on-error: false
     steps:
       - name: Checkout the released commit
         uses: actions/checkout@v4
@@ -458,30 +460,37 @@ jobs:
           ref: ${{ needs.release.outputs.sha }}
           submodules: recursive
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-
-      - name: Build the TS compiler
+      # The SEED needs liburing to RUN even though this job only uses it to
+      # emit C — the published Linux bundle is dynamically linked against
+      # liburing.so.2, so without this the seed dies with exit 127 before
+      # doing any work (same note as test.yml's musl leg, which proved this
+      # exact seed-driven pipeline in PR CI).
+      - name: Install liburing (needed to run the seed)
         run: |
-          bun install
-          bun run build
+          sudo apt-get update
+          sudo apt-get install -y liburing-dev
 
-      # Phase 1 — emit C on the glibc host. Yo cannot cross-compile gnu->musl,
-      # which is exactly why this is split at the C boundary: C is the portable
-      # intermediate. No liburing needed on the host, since only the LINKED
-      # binary uses it and the link happens in Alpine below.
-      - name: "Yo -> C (glibc host)"
+      - name: Install the seed compiler (previous release)
+        uses: ./.github/actions/install-seed
+        with:
+          version: ${{ env.SEED_VERSION }}
+
+      # Phase 1 — emit C on the glibc host, with the SEED (P2.5 step 24:
+      # previous release builds the current compiler; this retires bun/node
+      # from this job). Yo cannot cross-compile gnu->musl, which is exactly
+      # why this is split at the C boundary: C is the portable intermediate.
+      # SEED-ERA FLAGS ONLY: `--emit-c-to` may postdate the seed, so use
+      # `--emit-c --skip-c-compiler -o <base>` (the `<base>.c` sidecar), the
+      # flag set test.yml's musl leg already proves against the seed. stdout
+      # is discarded because `--emit-c` PRINTS the C (140 MB of it); the
+      # sidecar is the artifact. `--std-path ./std` is load-bearing — the
+      # seed would otherwise emit against its OWN bundled std.
+      - name: "Yo -> C (glibc host, seed compiler)"
+        env:
+          YO_MAIN_STACK_MB: "4096"
         run: |
-          node --expose-gc --max-old-space-size=4096 ./out/cjs/yo-cli.cjs compile \
-            yo-self/main.yo --release --allocator mimalloc \
-            --emit-c-to yo-musl.c --skip-c-compiler
+          yo compile yo-self/main.yo --release --allocator mimalloc \
+            --std-path ./std --emit-c --skip-c-compiler -o yo-musl > /dev/null
           ls -la yo-musl.c
 
       - name: "C -> static binary, inside Alpine (musl + static liburing)"
@@ -621,7 +630,11 @@ jobs:
     # portable-c is in `needs` so the draft never flips public without the
     # single-file artifact — the same atomicity invariant the seed bundles
     # rely on, and the one install.sh's source fallback will depend on.
-    needs: [release, seed-bundles, portable-c]
+    # musl-bundle joined `needs` 2026-08-17 in the same commit that flipped
+    # its continue-on-error off (the pairing rule its comment recorded): a
+    # promoted leg's failure must hold publication, or a red musl run ships a
+    # release whose install.sh advertises a bundle that never arrives.
+    needs: [release, seed-bundles, portable-c, musl-bundle]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/issues/fixed/comptime-only-prototype-breaks-gcc.md
+++ b/issues/fixed/comptime-only-prototype-breaks-gcc.md
@@ -1,8 +1,13 @@
 # A comptime-only return type emits `// Unknown type:` as the return type, and GCC rejects the file
 
-**Status: OPEN. Blocks the v0.2.6 release** (release run 31909103188: the
-`portable-c` job failed, so `publish-release` was skipped and the draft never
-went public).
+**Status: FIXED by PR #130 (233b774dd), verified 2026-08-17.** The
+`_func_result_is_comptime_only` skip was ported to the TS declaration
+emitter and the fallback hardened; a fresh emit of `yo-self/main.yo` now has
+ZERO `static inline // Unknown type` prototypes (was 2), and both GCC-family
+consumers are green — the portable-c job AND the musl bundle (whose
+`duplicate 'static'` failures were this same bug: Alpine's `cc` is GCC; the
+v0.2.7 release run 31925643271 passed both, and #130 is the only substantive
+commit between the last red release run 31909103188 and that green).
 
 Not a regression — this has been latent for a long time. It is invisible under
 clang and fatal under GCC, and the portable-`yo.c` job is the first thing in the

--- a/plans/P2_5_RETIRE_EXECUTION.md
+++ b/plans/P2_5_RETIRE_EXECUTION.md
@@ -252,6 +252,30 @@ Each step is independently landable and gated by `tests/internal` or a new cli-c
     stage-2-builds-stage-1 pre-release gate, and the Pages step, which stays a
     documented bun island until B7 decides on a Yo rewrite of
     `scripts/build-site.ts`. → **verify:** a `workflow_dispatch` release producing all five bundles, each smoke-tested from outside the checkout. **[CI-only]**
+
+    **PARTIAL 2026-08-17: the musl bundle's Yo->C emit is seed-driven**
+    (bun/node retired from that job), the leg is promoted
+    (`continue-on-error: false` + `publish-release` needs — the "unexplained
+    green" was the GCC comptime-prototype blocker, see
+    `issues/fixed/comptime-only-prototype-breaks-gcc.md`), and release.yml
+    gained the `SEED_VERSION` env. **The seed-bundles matrix flip is BLOCKED
+    on memory, and the step as written cannot land**: a yo-self self-emit
+    holds ~9-11.5 GB (test.yml's Linux-only note, settled run 31856743929),
+    macOS runners have ~7 GB, so a naive flip OOMs 3 of the 5 legs. Options,
+    for a decision before building:
+    (A) **C-boundary fan-out** — the seed emits per-target C on Linux runners
+        (`--target <triple>`, with the 32 GB swapfile), each native runner
+        only compiles the C and smoke-tests. Retires node from seed-bundles
+        entirely; cross-emit is target-deterministic and the per-target smoke
+        gates contain the risk; the cost is that Yo->C no longer runs
+        natively on macOS/Windows (the C->binary compile + smoke still do).
+    (B) keep TS on the macOS/Windows legs — contradicts Group E (deleting
+        `src/` breaks them); recorded for completeness, not a path.
+    (C) paid larger macOS/Windows runners — a money decision.
+    (D) wait for plans/backlog/YO_SELF_ENV_SHARING.md (def-time envs COPY
+        what TS SHARES) to bring the emit under 7 GB.
+    The stage-2-builds-stage-1 pre-release gate is Linux-viable regardless
+    and should ride whichever variant lands.
     24b. **`yo build` becomes the canonical yo-self builder everywhere** (user directive, 2026-08-13; completes what 2.2's root `build.yo` started). Inventory of the raw `compile yo-self/main.yo` builders to convert: - `.github/workflows/test.yml:144` (TS native probe — dies with the job in step 18 anyway), `:240`, `:428`, `:623`-area, `:836`-area (the per-job stage-1 builds) → `yo build` + take the binary from `yo-out/` (or `build.yo` grows an output-path option). Note the CI builds pass `--allocator mimalloc` while root `build.yo`'s `executable` set no allocator (defaulting Libc) — `std/build.yo` already supports `allocator` (`:86-87`, threaded at `build_runner.yo:486`), so this was a one-line `build.yo` fix (landed with this plan edit); without it the conversion would have silently changed the shipped allocator. - `.github/workflows/release.yml:310` (the seed build) → same conversion at step 24. - `scripts/bootstrap/fixpoint_only.sh:7`, `:12` — **keep as `compile --emit-c --skip-c-compiler`**: these are emit-only C byte-comparisons with explicit output paths, not builds; `yo build` has no emit-only mode and imposing one would complicate the build API for a diagnostic script. Record this as the deliberate carve-out. - Local guidance (AGENTS.md build commands, plans/, skills) — sweep in 2.6 to present `yo build` as the way to build the compiler, keeping `yo compile` for one-off artifacts.
     → **verify:** `yo build` from the repo root produces a runnable compiler byte-comparable (same flags) to the `compile --release --allocator mimalloc` build; converted CI legs green; grep shows the fixpoint carve-out is the only surviving raw self-build. **[CI-only]** for the legs, **[local-slow]** for the flag-parity check.
 

--- a/plans/P3_DISTRIBUTION.md
+++ b/plans/P3_DISTRIBUTION.md
@@ -219,6 +219,20 @@ Redesign:
 
 ## Item 3 — static-musl Linux bundles
 
+**The "unexplained green" at v0.2.7 is EXPLAINED (2026-08-17), and the leg is
+promoted.** Every prior red release run's musl log dies on `duplicate
+'static'` in the emitted C — the GCC comptime-prototype blocker
+(`issues/fixed/comptime-only-prototype-breaks-gcc.md`): Alpine's `cc` is GCC,
+which made this job the SECOND GCC-family consumer after portable-c, and the
+musl job's Yo->C step runs the compiler built from the RELEASED commit (not
+the seed), so PR #130's fix — the only substantive commit between the last
+red run 31909103188 and the first green 31925643271 — took effect at v0.2.7.
+Confirmed by a fresh emit with zero `static inline // Unknown type`
+prototypes and by the PR-side musl leg's consecutive greens. Accordingly the
+release job is `continue-on-error: false` and in `publish-release`'s `needs`
+(the pairing its comment required), and its emit is now SEED-driven (bun/node
+retired from the job).
+
 **Priority raised 2026-08-12: there are now two distinct distros where the
 shipped Linux bundle cannot run, not one.** Measured on the published
 `yo-v0.2.3-linux-x64.tar.gz`:

--- a/src/codegen/functions/declarations.ts
+++ b/src/codegen/functions/declarations.ts
@@ -195,7 +195,7 @@ export function generateFunctionDeclarations(
       // storage-class specifiers silently; GCC rejects the file outright
       // ("duplicate 'static'"), so `--cc gcc` and the portable yo.c both break.
       // The prototype is useless anyway — nothing calls these at runtime.
-      // See issues/comptime-only-prototype-breaks-gcc.md; yo-self has carried
+      // See issues/fixed/comptime-only-prototype-breaks-gcc.md; yo-self has carried
       // the equivalent guard (`_func_result_is_comptime_only` in its `skip1`).
       (isComptimeFunction(value) ||
         (!isConcreteSpecialization &&


### PR DESCRIPTION
## What

Closes the "unexplained musl green" investigation (P3 item 3 / prior session's task #18) and lands the well-understood slice of P2.5 step 24:

1. **Root cause on record**: every red release run's musl job died on `duplicate 'static'` in the emitted C — the GCC comptime-prototype blocker (`issues/fixed/comptime-only-prototype-breaks-gcc.md`). Alpine's `cc` is GCC, which made the musl job the second GCC-family consumer after portable-c, and the job's Yo→C step runs the compiler built from the released commit — so PR #130 (the only substantive commit between red run 31909103188 and green run 31925643271) is what fixed it at v0.2.7. Verified today with a fresh emit: zero `static inline // Unknown type` prototypes (was 2). The issue doc moves to `issues/fixed/`.
2. **Promotion per the job's own rule** ("after one green release run"): `continue-on-error: false`, and `musl-bundle` joins `publish-release`'s `needs` in the same commit — the pairing the job's comment required.
3. **Seed-driven emit** (step 24 increment): the musl job's Yo→C step now uses the previous-release seed (`install-seed` + seed-era flags, byte-for-byte the pipeline test.yml's musl leg proves in PR CI), retiring bun/node from the job. `release.yml` gains `SEED_VERSION: v0.2.7`.
4. **The remaining seed-bundles flip is documented as memory-blocked** in `plans/P2_5_RETIRE_EXECUTION.md` step 24, with the four options (C-boundary fan-out / keep-TS / paid runners / env-sharing) laid out for a decision before building — a self-emit holds ~9–11.5 GB and macOS runners have ~7 GB, so the step as written would OOM 3 of 5 legs.

## Verify

- YAML parses; the workflow change is release-dispatch-only (no PR-CI behavior change).
- The real verification is the next `workflow_dispatch` release: the musl leg must build+smoke with the seed emit, and publication must wait for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)