### PR TITLE
RC header split: 16 B small header for cycle-incapable types (−0.7 GB, both compilers)

### DIFF
--- a/plans/backlog/RC_HEADER_SPLIT.md
+++ b/plans/backlog/RC_HEADER_SPLIT.md
@@ -49,10 +49,19 @@ are inflated ~2x by the instrument — compare only tracked numbers.)
 | 64 B class                                 | 18.1M       | 1.08 GB     | 6.1%  |
 | 112 B (Environment) + 80 B (tracked lists) | 15.8M       | 1.39 GB     | 7.8%  |
 
-**Revised lever ranking:** (1) the ≥4 KB buffer pool is the new #1 — 5.11 GB
-that no object-layout work touches; needs call-site attribution
-(`__builtin_return_address` in the shims + atos) to see whether it is HashMap
-tables, ArrayList data arrays, or something else. (2) The 40 B ArrayList army
+**Revised lever ranking:** (1) ~~the ≥4 KB buffer pool~~ **LANDED same day:
+the pool was `_inject_forall_captures`** — ra1 attribution (shims record
+`__builtin_return_address(1)`; arm64 keeps frame pointers) put 3.87 GB /
+167k live copies on that one function; a 150k-call probe measured 99.2%
+duplicate (func_id, bindings) keys (1,259 distinct); memoizing the injection
+erased it: tracked live **19.07 → 14.94 GB (−4.1 GB)**, wall **227 →
+148.5 s (−35%)**, FIXPOINT_HOLDS, gates_fast failures=0 (PR
+perf/inject-forall-captures-memo). Metric reminders re-proven during the
+A/B: footprint is compressor-noise across runs (same memoized binary read
+16.48 GB libc / 18.39 GB mimalloc footprint while tracked live FELL 4.1 GB);
+and a `--allocator mimalloc` build in a tree whose `vendor/mimalloc`
+submodule is uninitialized SILENTLY falls back to libc ("Bundled mimalloc
+not found" on stderr; verify with `nm <bin> | grep -c mi_malloc`). (2) The 40 B ArrayList army
 is now 60% BODY (24 B) — the remaining lever is deleting objects (Variable.value
 inline single-slot), not shrinking headers. (3) ExprInfo diet unchanged
 (~−1.2 GB). Raw dumps: /tmp/peak_hist.txt (libc), /tmp/peak_hist_mi.txt

--- a/plans/backlog/RC_HEADER_SPLIT.md
+++ b/plans/backlog/RC_HEADER_SPLIT.md
@@ -1,6 +1,23 @@
 # RC-header split: the measured path from 12.2 GB to sub-7 GB self-emit
 
-**Status: PLANNED, deliberately sequenced AFTER `src/` retirement (P2 Group E).**
+**Status: PHASE 1 LANDED 2026-08-17** (branch `perf/rc-header-split`,
+user-directed to start before retirement — implemented in BOTH compilers).
+**Measured result: −0.7 GB (12.21 → 11.53 GB), wall 227 s** — real but far
+short of the −3.31 GB projection, because the census below OVERCOUNTS
+liveness: its −1 counters live in dispose FUNCTIONS, but inline RC drops
+(the dup/drop optimizer's inline generators) free objects without calling
+the mapped dispose, so hot-path types' "live at exit" is inflated (that is
+also why "live" appeared to exceed peak, which is impossible for true
+liveness). True peak composition still unknown — next instrument is a
+malloc/free size-class histogram snapshotted at the high-water mark
+(allocator-boundary accounting, immune to the inline-drop blind spot).
+Validation: smoke + ASan clean, 10 canary files green, FIXPOINT_HOLDS
+(also proves both compilers emit identical C), gates_fast T1 failures=0,
+317 of ~396 ref types small in the self-emit.
+
+Original plan (with the now-known-flawed census projection) follows.
+
+**Original status: PLANNED, deliberately sequenced AFTER `src/` retirement (P2 Group E).**
 The change rewrites every emitted object's layout; under the strict-1:1 rule it
 would have to land in BOTH compilers and re-prove fixpoint across both, then
 one copy is deleted. Post-retirement it is a single-codebase change. Nothing

--- a/plans/backlog/RC_HEADER_SPLIT.md
+++ b/plans/backlog/RC_HEADER_SPLIT.md
@@ -2,18 +2,61 @@
 
 **Status: PHASE 1 LANDED 2026-08-17** (branch `perf/rc-header-split`,
 user-directed to start before retirement — implemented in BOTH compilers).
-**Measured result: −0.7 GB (12.21 → 11.53 GB), wall 227 s** — real but far
-short of the −3.31 GB projection, because the census below OVERCOUNTS
-liveness: its −1 counters live in dispose FUNCTIONS, but inline RC drops
-(the dup/drop optimizer's inline generators) free objects without calling
-the mapped dispose, so hot-path types' "live at exit" is inflated (that is
-also why "live" appeared to exceed peak, which is impossible for true
-liveness). True peak composition still unknown — next instrument is a
-malloc/free size-class histogram snapshotted at the high-water mark
-(allocator-boundary accounting, immune to the inline-drop blind spot).
+**Measured result: −0.7 GB footprint (12.21 → 11.53 GB), wall 227 s** — which
+looked far short of the −3.31 GB projection, but the post-mortem below shows
+the projection was RIGHT in live bytes and the FOOTPRINT METRIC hid the win
+(macOS compression accounting). The census still overcounts per-type liveness
+(its −1 counters live in dispose FUNCTIONS; inline RC drops bypass them),
+so per-type rows are ceilings — the histogram below is the trustworthy total.
 Validation: smoke + ASan clean, 10 canary files green, FIXPOINT_HOLDS
 (also proves both compilers emit identical C), gates_fast T1 failures=0,
 317 of ~396 ref types small in the self-emit.
+
+## POST-MORTEM 2026-08-17: the peak-composition histogram (allocator-boundary)
+
+The promised follow-up instrument ran the same day and REVERSED the "−0.7 GB"
+verdict. Method: retarget the emitted `#define __yo_malloc/calloc/realloc/free`
+macros at accounting shims (`malloc_size`/`mi_usable_size` per block), keep a
+per-16B-size-class histogram (bytes + counts), snapshot at every >1/128
+high-water growth. Shims unit-tested exact (delta=0 on a 1M-block mixed
+pattern); every runtime free (RC, GC sweep, async) goes through the macros, so
+there is no asymmetry. Scripts: scratchpad `peak_histogram.py` (libc) /
+`peak_histogram_mi.py` (mimalloc); NOTE `__yo_malloc` is a MACRO — instrument
+by retargeting the defines, never by renaming functions.
+
+**Finding 1 — the footprint metric was lying, not the census math.** Tracked
+live at peak is **~19 GB and allocator-independent** (libc 19.1–20.5 GB,
+mimalloc 19.07 GB; gap = bin rounding), yet the uninstrumented mimalloc run
+reports 11.53 GB "peak memory footprint". macOS charges compressed pages at
+COMPRESSED size in phys_footprint, and this heap is zero-heavy. The header
+split really did delete its ~2.6 GB of live bytes — but they were mostly NULL
+pointer fields the compressor already stored at near-zero cost, so footprint
+only moved −0.7 GB. Consequences: (a) A/B memory levers in TRACKED LIVE BYTES
+(this instrument), not footprint; (b) footprint remains the right number only
+for "does it fit runner RAM"; (c) zero-heavy savings are still real wins on
+Linux CI and under real memory pressure. (The instrumented runs' own footprints
+are inflated ~2x by the instrument — compare only tracked numbers.)
+
+**Finding 2 — true peak composition (mimalloc bins, 17.76 GB snapshot /
+19.07 GB peak, 217M live blocks):**
+
+| pool                                       | live blocks | live bytes  | share |
+| ------------------------------------------ | ----------- | ----------- | ----- |
+| 40 B class (small-header ArrayLists)       | 114.3M      | 4.01 GB     | 22.6% |
+| **buffers ≥4 KB (16 KB + 8 KB classes)**   | ~0.4M       | **5.11 GB** | 29%   |
+| 448 B class (ExprInfo)                     | 5.65M       | 2.40 GB     | 13.5% |
+| 176+192 B classes (Variable et al.)        | 15.2M       | 2.61 GB     | 14.7% |
+| 64 B class                                 | 18.1M       | 1.08 GB     | 6.1%  |
+| 112 B (Environment) + 80 B (tracked lists) | 15.8M       | 1.39 GB     | 7.8%  |
+
+**Revised lever ranking:** (1) the ≥4 KB buffer pool is the new #1 — 5.11 GB
+that no object-layout work touches; needs call-site attribution
+(`__builtin_return_address` in the shims + atos) to see whether it is HashMap
+tables, ArrayList data arrays, or something else. (2) The 40 B ArrayList army
+is now 60% BODY (24 B) — the remaining lever is deleting objects (Variable.value
+inline single-slot), not shrinking headers. (3) ExprInfo diet unchanged
+(~−1.2 GB). Raw dumps: /tmp/peak_hist.txt (libc), /tmp/peak_hist_mi.txt
+(mimalloc) — regenerate with the scratchpad pipeline scripts.
 
 Original plan (with the now-known-flawed census projection) follows.
 

--- a/src/codegen/functions/generation.ts
+++ b/src/codegen/functions/generation.ts
@@ -31,6 +31,7 @@ import {
 } from "../../types/guards";
 import {
   canTypeFormRcCycle,
+  typeUsesSmallRcHeader,
   typeCanFormCyclicRcReference,
   typeContainsRcType,
   typeContainsSomeType,
@@ -3084,10 +3085,19 @@ export function generateRefStructConstructorFunctions(
         `  obj->header.borrow_count = 0;  // Law-of-Exclusivity: no live interior borrows yet`
       );
       if (context.needsCycleGC && !type.isAtomicRc) {
+        // gc_flags/gc_mark live in the shared packed word and MUST be
+        // initialized for every layout: GC visitors read a CHILD's gc_flags
+        // before deciding to skip it, and small-header objects are visited
+        // as children of tracked parents. The GC list pointers exist only in
+        // the big header.
         emitter.emitLine(`  obj->header.gc_flags = 0;`);
         emitter.emitLine(`  obj->header.gc_mark = __YO_GC_UNMARKED;`);
-        emitter.emitLine(`  obj->header.gc_next = NULL;`);
-        emitter.emitLine(`  obj->header.gc_prev = NULL;`);
+        if (
+          !typeUsesSmallRcHeader(type, context.needsCycleGC ?? false, type.env)
+        ) {
+          emitter.emitLine(`  obj->header.gc_next = NULL;`);
+          emitter.emitLine(`  obj->header.gc_prev = NULL;`);
+        }
       }
       // Set dispose function pointer to ___dispose, which handles both user cleanup and field dropping.
       // ___dispose will call user's dispose() if it exists, then drop all GC-containing fields.
@@ -3138,7 +3148,11 @@ export function generateRefStructConstructorFunctions(
 
       // Set traversal function pointer for GC (only when cycle detection is needed)
       // Atomic objects never participate in cycle GC
-      if (context.needsCycleGC && !type.isAtomicRc) {
+      if (
+        context.needsCycleGC &&
+        !type.isAtomicRc &&
+        !typeUsesSmallRcHeader(type, context.needsCycleGC ?? false, type.env)
+      ) {
         const traversalFunctionName = `__yo_traverse_${cName}`;
         emitter.emitLine(
           `  obj->header.traverse_fn = ${traversalFunctionName};`
@@ -3331,10 +3345,19 @@ export function generateRefEnumConstructorFunctions(
       emitter.emitLine(`  obj->header.ref_count = 1;`);
       emitter.emitLine(`  obj->header.borrow_count = 0;`);
       if (context.needsCycleGC && !type.isAtomicRc) {
+        // gc_flags/gc_mark live in the shared packed word and MUST be
+        // initialized for every layout: GC visitors read a CHILD's gc_flags
+        // before deciding to skip it, and small-header objects are visited
+        // as children of tracked parents. The GC list pointers exist only in
+        // the big header.
         emitter.emitLine(`  obj->header.gc_flags = 0;`);
         emitter.emitLine(`  obj->header.gc_mark = __YO_GC_UNMARKED;`);
-        emitter.emitLine(`  obj->header.gc_next = NULL;`);
-        emitter.emitLine(`  obj->header.gc_prev = NULL;`);
+        if (
+          !typeUsesSmallRcHeader(type, context.needsCycleGC ?? false, type.env)
+        ) {
+          emitter.emitLine(`  obj->header.gc_next = NULL;`);
+          emitter.emitLine(`  obj->header.gc_prev = NULL;`);
+        }
       }
       if (disposeFunctionCName) {
         if (context.needsCycleGC) {
@@ -3351,7 +3374,11 @@ export function generateRefEnumConstructorFunctions(
           emitter.emitLine(`  obj->header.type_id = 0;`);
         }
       }
-      if (context.needsCycleGC && !type.isAtomicRc) {
+      if (
+        context.needsCycleGC &&
+        !type.isAtomicRc &&
+        !typeUsesSmallRcHeader(type, context.needsCycleGC ?? false, type.env)
+      ) {
         emitter.emitLine(`  obj->header.traverse_fn = __yo_traverse_${cName};`);
       }
       emitter.emitLine(

--- a/src/codegen/types/generation.ts
+++ b/src/codegen/types/generation.ts
@@ -22,7 +22,11 @@ import {
   isUnionType,
   isUnitType,
 } from "../../types/guards";
-import { typeContainsSomeType, typeToString } from "../../types/utils";
+import {
+  typeContainsSomeType,
+  typeToString,
+  typeUsesSmallRcHeader,
+} from "../../types/utils";
 
 /**
  * Local helper: struct whose only SomeType content lives inside function-typed
@@ -418,13 +422,32 @@ typedef struct __yo_ref_header_t {
   uint8_t gc_flags;
   uint8_t gc_mark;
   uint16_t borrow_count;  // Law-of-Exclusivity flag: # of live interior refs into this object
+  // dispose_fn sits IMMEDIATELY after the packed word so the small header
+  // below is a strict PREFIX of this one: __yo_decr_rc reads flags and
+  // dispose_fn at the same offsets for both layouts, branch-free.
+  void (*dispose_fn)(void*);
+  void (*traverse_fn)(void*, void (*visit)(void*));
   struct __yo_ref_header_t* gc_next;
   struct __yo_ref_header_t* gc_prev;
   struct __yo_ref_header_t* roots_next;  // Bacon-Rajan possible-roots intrusive list (O(1) unlink at free)
   struct __yo_ref_header_t* roots_prev;
-  void (*dispose_fn)(void*);
-  void (*traverse_fn)(void*, void (*visit)(void*));
 } __yo_ref_header_t;
+
+// Small RC header (16 B) for cycle-INCAPABLE, non-atomic types — the ones
+// whose constructors never __yo_gc_register. Every GC visitor early-returns
+// on !(gc_flags & __YO_GC_TRACKED), so these objects' traverse_fn and GC
+// list pointers were never read; this drops them (56 -> 16 B on the
+// majority class — see plans/backlog/RC_HEADER_SPLIT.md). A strict prefix
+// of __yo_ref_header_t: generic code (__yo_incr_rc/__yo_decr_rc, borrow
+// checks, visitor flag reads) casts every object to __yo_ref_header_t* and
+// touches only the shared prefix on untracked objects.
+typedef struct __yo_ref_header_small_t {
+  uint32_t ref_count;
+  uint8_t gc_flags;
+  uint8_t gc_mark;
+  uint16_t borrow_count;
+  void (*dispose_fn)(void*);
+} __yo_ref_header_small_t;
 
 // Per-thread GC state
 struct __yo_thread_gc_state {
@@ -1327,9 +1350,21 @@ export function generateStructDeclaration(
     emitter.emitDeclarationLine(
       `struct ${cName}_struct { // ${structType.typeName} : ${typeToString(structType)} (${atomicTag ? "atomic " : ""}reference counted)`
     );
-    emitter.emitDeclarationLine(
-      `  __yo_ref_header_t header; // ${atomicTag ? "Atomic r" : "R"}eference count header`
-    );
+    if (
+      typeUsesSmallRcHeader(
+        structType,
+        context.needsCycleGC ?? false,
+        structType.env
+      )
+    ) {
+      emitter.emitDeclarationLine(
+        `  __yo_ref_header_small_t header; // Small RC header (cycle-incapable type)`
+      );
+    } else {
+      emitter.emitDeclarationLine(
+        `  __yo_ref_header_t header; // ${atomicTag ? "Atomic r" : "R"}eference count header`
+      );
+    }
 
     for (const field of runtimeFields) {
       const fieldTypeStr = getTypeString(field.type, context);
@@ -1518,9 +1553,21 @@ export function generateEnumDeclaration(
     emitter.emitDeclarationLine(
       `struct ${cName}_struct { // ${enumType.typeName} : ${typeToString(enumType)} (${atomicTag}reference counted)`
     );
-    emitter.emitDeclarationLine(
-      `  __yo_ref_header_t header; // ${enumType.isAtomicRc ? "Atomic r" : "R"}eference count header`
-    );
+    if (
+      typeUsesSmallRcHeader(
+        enumType,
+        context.needsCycleGC ?? false,
+        enumType.env
+      )
+    ) {
+      emitter.emitDeclarationLine(
+        `  __yo_ref_header_small_t header; // Small RC header (cycle-incapable type)`
+      );
+    } else {
+      emitter.emitDeclarationLine(
+        `  __yo_ref_header_t header; // ${enumType.isAtomicRc ? "Atomic r" : "R"}eference count header`
+      );
+    }
     emitter.emitDeclarationLine(`  ${tagEnumName} tag;`);
     emitter.emitDeclarationLine(`  ${variantUnionName} data;`);
     emitter.emitDeclarationLine(`};`);

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1946,6 +1946,36 @@ export function bufferElementType(fieldType: Type): Type | undefined {
   return undefined;
 }
 
+/**
+ * Whether a reference-semantics type uses the SMALL RC header
+ * (`__yo_ref_header_small_t`, 16 B: the packed count word + `dispose_fn`)
+ * instead of the full 56 B header. Eligible: cycle-INCAPABLE, non-atomic
+ * types in a cycle-GC program — exactly the types whose constructors never
+ * call `__yo_gc_register`. Every GC visitor early-returns on
+ * `!(gc_flags & __YO_GC_TRACKED)`, so an untracked object's `traverse_fn`
+ * and GC list pointers are never read; the small header drops them (40 B on
+ * 88.8M of 120M live objects in a self-emit — the measured −3.31 GB of
+ * plans/backlog/RC_HEADER_SPLIT.md). The small header is a strict PREFIX of
+ * the big one (the big header puts dispose_fn immediately after the packed
+ * word), so `__yo_incr_rc`/`__yo_decr_rc`/borrow checks are layout-agnostic.
+ * Atomic-RC types keep the big header in phase 1 (their ctors skip the
+ * gc_flags init, so nothing may ever read past their packed word — but the
+ * atomic paths were not audited for prefix-safety; they are rare).
+ * In a no-cycle-GC program the header is already the 8 B type_id form.
+ */
+export function typeUsesSmallRcHeader(
+  type: Type,
+  needsCycleGC: boolean,
+  env: Environment
+): boolean {
+  if (!needsCycleGC) return false;
+  const isRefStruct = isReferenceStructType(type);
+  const isRefEnumRoot = isEnumType(type) && type.isReferenceSemantics;
+  if (!isRefStruct && !isRefEnumRoot) return false;
+  if ((type as StructType | EnumType).isAtomicRc) return false;
+  return !canTypeFormRcCycle(type, new Set(), env);
+}
+
 export function canTypeFormRcCycle(
   type: Type,
   visitedTypes: Set<string>,

--- a/yo-self/codegen/functions/constructors.yo
+++ b/yo-self/codegen/functions/constructors.yo
@@ -19,7 +19,7 @@ open(import("std/string"));
 { ArrayList } :: import("std/collections/array_list");
 { TypeValue } :: import("../../types/definitions.yo");
 { is_reference_struct_type, is_atomic_reference_struct_type, is_reference_enum_type, is_atomic_reference_enum_type, is_enum_type, is_struct_type, is_newtype_type, is_tuple_type, is_array_type, is_unit_type } :: import("../../types/guards.yo");
-{ type_contains_some_type, type_contains_rc_type, can_type_form_rc_cycle, _type_refs_back_to_cyclic } :: import("../../types/utils.yo");
+{ type_contains_some_type, type_contains_rc_type, can_type_form_rc_cycle, type_uses_small_rc_header, _type_refs_back_to_cyclic } :: import("../../types/utils.yo");
 { get_type_string, get_runtime_struct_fields, sanitize_for_c_identifier, get_enum_variant_c_name, can_optimize_as_nullable_pointer, can_optimize_as_simple_enum, RuntimeStructField } :: import("../utils/index.yo");
 { FunctionGenerationContext } :: import("./context.yo");
 { get_dispose_function_for_type, get_trace_function_for_type } :: import("../exprs/drop_dup.yo");
@@ -89,11 +89,19 @@ _generate_one_constructor :: (fn(type : TypeValue, c_name : String, context : Fu
   em.emit_string_line(String.from("  obj->header.ref_count = 1;  // Start with one reference"));
   em.emit_string_line(String.from("  obj->header.borrow_count = 0;  // Law-of-Exclusivity: no live interior borrows yet"));
   is_atomic := is_atomic_reference_struct_type(type);
+  small_header := type_uses_small_rc_header(type, context.base.needs_cycle_gc, is_atomic);
   if(context.base.needs_cycle_gc && !(is_atomic), {
+    // gc_flags/gc_mark live in the shared packed word and MUST be
+    // initialized for every layout: GC visitors read a CHILD's gc_flags
+    // before deciding to skip it, and small-header objects are visited
+    // as children of tracked parents. The GC list pointers exist only in
+    // the big header.
     em.emit_string_line(String.from("  obj->header.gc_flags = 0;"));
     em.emit_string_line(String.from("  obj->header.gc_mark = __YO_GC_UNMARKED;"));
-    em.emit_string_line(String.from("  obj->header.gc_next = NULL;"));
-    em.emit_string_line(String.from("  obj->header.gc_prev = NULL;"));
+    if(!(small_header), {
+      em.emit_string_line(String.from("  obj->header.gc_next = NULL;"));
+      em.emit_string_line(String.from("  obj->header.gc_prev = NULL;"));
+    });
   });
   // Dispose function pointer / type-tag.
   match(
@@ -116,8 +124,10 @@ _generate_one_constructor :: (fn(type : TypeValue, c_name : String, context : Fu
       em.emit_string_line(String.from("  obj->header.type_id = 0;"));
     })
   );
-  // Traversal function pointer (cyclic GC only; atomic never participates).
-  if(context.base.needs_cycle_gc && !(is_atomic), {
+  // Traversal function pointer (cyclic GC only; atomic never participates;
+  // the small header has no traverse_fn — nothing ever reads it on
+  // untracked objects).
+  if((context.base.needs_cycle_gc && !(is_atomic)) && !(small_header), {
     line := String.from("  obj->header.traverse_fn = __yo_traverse_");
     line.push_string(c_name.clone());
     line.push_str(";");
@@ -508,6 +518,7 @@ _generate_one_ref_enum_constructor_set :: (fn(type : TypeValue, c_name : String,
   dispose_opt := get_dispose_function_for_type(type, context);
   is_atomic := is_atomic_reference_enum_type(type);
   registers_with_gc := ((context.base.needs_cycle_gc && !(is_atomic)) && can_type_form_rc_cycle(type));
+  enum_small_header := type_uses_small_rc_header(type, context.base.needs_cycle_gc, is_atomic);
   match(
     type,
     .EnumT({ id : enum_id, variant_names, variant_fields, variant_field_labels }) => {
@@ -566,10 +577,14 @@ _generate_one_ref_enum_constructor_set :: (fn(type : TypeValue, c_name : String,
         em.emit_string_line(`  obj->header.ref_count = 1;  // Start with one reference`);
         em.emit_string_line(`  obj->header.borrow_count = 0;  // Law-of-Exclusivity: no live interior borrows yet`);
         if(context.base.needs_cycle_gc && !(is_atomic), {
+          // Shared packed word always initialized; GC list pointers exist
+          // only in the big header (see the struct ctor's comment).
           em.emit_string_line(`  obj->header.gc_flags = 0;`);
           em.emit_string_line(`  obj->header.gc_mark = __YO_GC_UNMARKED;`);
-          em.emit_string_line(`  obj->header.gc_next = NULL;`);
-          em.emit_string_line(`  obj->header.gc_prev = NULL;`);
+          if(!(enum_small_header), {
+            em.emit_string_line(`  obj->header.gc_next = NULL;`);
+            em.emit_string_line(`  obj->header.gc_prev = NULL;`);
+          });
         });
         // Dispose function pointer (cyclic GC) / type-tag (lightweight path).
         match(
@@ -586,8 +601,9 @@ _generate_one_ref_enum_constructor_set :: (fn(type : TypeValue, c_name : String,
             em.emit_string_line(`  obj->header.type_id = 0;`);
           })
         );
-        // Traversal function pointer (cyclic GC only; atomic never participates).
-        if(context.base.needs_cycle_gc && !(is_atomic), {
+        // Traversal function pointer (cyclic GC only; atomic never
+        // participates; small header has no traverse_fn).
+        if((context.base.needs_cycle_gc && !(is_atomic)) && !(enum_small_header), {
           em.emit_string_line(`  obj->header.traverse_fn = __yo_traverse_${c_name};`);
         });
         // Tag + active variant's non-unit field assignments.

--- a/yo-self/codegen/types/generation.yo
+++ b/yo-self/codegen/types/generation.yo
@@ -13,7 +13,7 @@ open(import("std/string"));
 { HashMap } :: import("std/collections/hash_map");
 { TypeValue } :: import("../../types/definitions.yo");
 { is_unit_type, is_struct_type, is_enum_type, is_tuple_type, is_reference_struct_type, is_newtype_type, is_dyn_type, is_union_type, is_future_trait_type, is_function_type, is_fn_trait_type, is_some_type } :: import("../../types/guards.yo");
-{ type_contains_some_type } :: import("../../types/utils.yo");
+{ type_contains_some_type, type_uses_small_rc_header } :: import("../../types/utils.yo");
 { lookup_some_resolved_concrete } :: import("../../expr_info.yo");
 { type_to_string } :: import("../../types/string.yo");
 { is_target_windows, is_target_macos } :: import("../../target.yo");
@@ -150,7 +150,11 @@ generate_struct_declaration :: (fn(struct_type : TypeValue, c_name : String, con
           atomic_word := if(is_atomic_rc, "atomic ", "");
           header_word := if(is_atomic_rc, "Atomic r", "R");
           context.emitter.emit_declaration_string_line(`struct ${c_name}_struct { // ${name} : ${type_to_string(struct_type)} (${atomic_word}reference counted)`);
-          context.emitter.emit_declaration_string_line(`  __yo_ref_header_t header; // ${header_word}eference count header`);
+          if(type_uses_small_rc_header(struct_type, context.needs_cycle_gc, is_atomic_rc), {
+            context.emitter.emit_declaration_line("  __yo_ref_header_small_t header; // Small RC header (cycle-incapable type)");
+          }, {
+            context.emitter.emit_declaration_string_line(`  __yo_ref_header_t header; // ${header_word}eference count header`);
+          });
           _emit_runtime_fields(runtime_fields, context);
           context.emitter.emit_declaration_line("};");
         },
@@ -337,7 +341,11 @@ generate_enum_declaration :: (fn(enum_type : TypeValue, c_name : String, context
         atomic_tag := if(is_atomic_rc, String.from("atomic "), String.from(""));
         header_tag := if(is_atomic_rc, String.from("Atomic r"), String.from("R"));
         context.emitter.emit_declaration_string_line(`struct ${c_name}_struct { // ${name} : ${type_to_string(enum_type)} (${atomic_tag}reference counted)`);
-        context.emitter.emit_declaration_string_line(`  __yo_ref_header_t header; // ${header_tag}eference count header`);
+        if(type_uses_small_rc_header(enum_type, context.needs_cycle_gc, is_atomic_rc), {
+          context.emitter.emit_declaration_line("  __yo_ref_header_small_t header; // Small RC header (cycle-incapable type)");
+        }, {
+          context.emitter.emit_declaration_string_line(`  __yo_ref_header_t header; // ${header_tag}eference count header`);
+        });
         context.emitter.emit_declaration_string_line(`  ${tag_enum_name} tag;`);
         context.emitter.emit_declaration_string_line(`  ${variant_union_name} data;`);
         context.emitter.emit_declaration_line("};");
@@ -662,13 +670,32 @@ typedef struct __yo_ref_header_t {
   uint8_t gc_flags;
   uint8_t gc_mark;
   uint16_t borrow_count;
+  // dispose_fn sits IMMEDIATELY after the packed word so the small header
+  // below is a strict PREFIX of this one: __yo_decr_rc reads flags and
+  // dispose_fn at the same offsets for both layouts, branch-free.
+  void (*dispose_fn)(void*);
+  void (*traverse_fn)(void*, void (*visit)(void*));
   struct __yo_ref_header_t* gc_next;
   struct __yo_ref_header_t* gc_prev;
   struct __yo_ref_header_t* roots_next;  // Bacon-Rajan possible-roots intrusive list (O(1) unlink at free)
   struct __yo_ref_header_t* roots_prev;
-  void (*dispose_fn)(void*);
-  void (*traverse_fn)(void*, void (*visit)(void*));
 } __yo_ref_header_t;
+
+// Small RC header (16 B) for cycle-INCAPABLE, non-atomic types — the ones
+// whose constructors never __yo_gc_register. Every GC visitor early-returns
+// on !(gc_flags & __YO_GC_TRACKED), so these objects' traverse_fn and GC
+// list pointers were never read; this drops them (56 -> 16 B on the
+// majority class — see plans/backlog/RC_HEADER_SPLIT.md). A strict prefix
+// of __yo_ref_header_t: generic code (__yo_incr_rc/__yo_decr_rc, borrow
+// checks, visitor flag reads) casts every object to __yo_ref_header_t* and
+// touches only the shared prefix on untracked objects.
+typedef struct __yo_ref_header_small_t {
+  uint32_t ref_count;
+  uint8_t gc_flags;
+  uint8_t gc_mark;
+  uint16_t borrow_count;
+  void (*dispose_fn)(void*);
+} __yo_ref_header_small_t;
 
 // Per-thread GC state
 struct __yo_thread_gc_state {

--- a/yo-self/types/utils.yo
+++ b/yo-self/types/utils.yo
@@ -914,6 +914,22 @@ can_type_form_rc_cycle :: (fn(ty : TypeValue) -> bool)(
     true => false
   )
 );
+/// Whether a reference-semantics type uses the SMALL RC header
+/// (`__yo_ref_header_small_t`, 16 B) instead of the full 56 B one. Mirrors
+/// TS `typeUsesSmallRcHeader` (types/utils.ts): cycle-INCAPABLE, non-atomic
+/// types in a cycle-GC program — exactly the ones whose constructors never
+/// `__yo_gc_register`. Call sites are already inside reference-semantics
+/// branches and pass their own atomicity, so this reduces to the predicate
+/// core. See plans/backlog/RC_HEADER_SPLIT.md.
+type_uses_small_rc_header :: (
+  fn(ty : TypeValue, needs_cycle_gc : bool, is_atomic : bool) -> bool
+)(
+  cond(
+    !(needs_cycle_gc) => false,
+    is_atomic => false,
+    true => !(can_type_form_rc_cycle(ty))
+  )
+);
 /// Return `true` if the type needs type-inference to resolve fully
 /// — specifically when an `Array(T, length)` carries an unknown
 /// `length` that the evaluator must compute. Mirrors
@@ -1802,7 +1818,7 @@ export(type_requires_comptime_modifier, type_prohibits_comptime_modifier);
 export(type_implements_runtime_builtin, type_implements_runtime, type_is_comptime_only);
 export(type_contains_rc_type);
 export(type_is_control_bound);
-export(can_type_form_rc_cycle, buffer_element_type, _type_refs_back_to_cyclic);
+export(can_type_form_rc_cycle, type_uses_small_rc_header, buffer_element_type, _type_refs_back_to_cyclic);
 export(type_requires_inference);
 export(type_contains_some_type);
 export(get_all_some_types);


### PR DESCRIPTION
## What

Phase 1 of `plans/backlog/RC_HEADER_SPLIT.md` (user-directed): reference-semantics types that can never form RC cycles — exactly the ones whose constructors never `__yo_gc_register` — get a 16-byte RC header instead of 56.

Two findings made this branch-free and registry-free:
1. **Every GC visitor early-returns on `!(gc_flags & __YO_GC_TRACKED)`** — an untracked object's `traverse_fn` and 32 B of GC list-pointers were never read by anything.
2. The big header is **reordered so `dispose_fn` sits directly after the packed count word**, making the small header a strict prefix: `__yo_incr_rc`/`__yo_decr_rc`/borrow checks/visitor flag-reads are layout-agnostic — zero new branches in the hot path.

`typeUsesSmallRcHeader` (both compilers' `types/utils`) drives the per-type choice at the struct/enum member sites and ctor inits. Enum registration stays per-variant; header choice is per-type. Atomic-RC types conservatively keep the big header in phase 1.

## Measured

Self-emit (`compile yo-self/main.yo --emit-c`): **12.21 → 11.53 GB peak (−0.7 GB), 227 s wall**; 317 of ~396 ref types go small (the whole ArrayList army: 80→40 B each).

The plan's −3.31 GB projection was based on a flawed census: its −1 counters lived in dispose *functions*, but inline RC drops free objects without calling the mapped dispose, inflating "live" counts for hot-path types (the tell: "live at exit" exceeded peak footprint, impossible for true liveness). The plan doc records the correction; the follow-up instrument is an allocator-boundary size-class histogram at the high-water mark.

## Verification

- FIXPOINT_HOLDS (stage-2 C compiles, stage-3 byte-identical — this also proves the TS and yo-self implementations emit identical C).
- gates_fast T1 **failures=0**: `check ./yo-self` 248/248, CLI differential 40 PASS / 0 DIFF, goldens clean, fmt idempotent.
- 10 canary test files green under the split compiler (rc, arc, gc, hash_map, string, closure, async_await, algebraic_effects, iterator_combinators, path); smoke binary + ASan clean.
- Full-corpus hollow sweep running; result will be posted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)