### PR TITLE
release: revert the burned 0.2.8 bump; Marketplace publish non-fatal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,14 +197,35 @@ jobs:
           npm ci
           npm run package
 
+      # NON-FATAL: a Marketplace outage must not kill the release — the seed
+      # bundles are the release's substance, and the .vsix is uploaded as an
+      # artifact below for a manual `vsce publish --packagePath` when the
+      # service recovers. (The 2026-08-17 v0.2.8 attempt died here on
+      # "TF10216: Azure DevOps services are currently unavailable" AFTER the
+      # version-bump commit was already pushed — every such failure burned a
+      # version number.)
       - name: Publish extension to Visual Studio Marketplace
         id: create_vsix
+        continue-on-error: true
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           dryRun: ${{ github.ref != 'refs/heads/develop' }}
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           packagePath: ./vscode-extension
           registryUrl: https://marketplace.visualstudio.com
+
+      - name: Surface a failed Marketplace publish
+        if: steps.create_vsix.outcome == 'failure'
+        run: |
+          echo "::warning::Marketplace publish FAILED (service outage?). Publish manually when it recovers: cd vscode-extension && vsce publish -p \$VS_MARKETPLACE_TOKEN --packagePath yolang-*.vsix"
+
+      - name: Upload the .vsix as an artifact (manual-publish fallback)
+        uses: actions/upload-artifact@v4
+        with:
+          name: yolang-vsix
+          path: vscode-extension/*.vsix
+          retention-days: 30
+          if-no-files-found: warn
 
       - name: Create GitHub Release (draft — published after the seed bundles land)
         uses: softprops/action-gh-release@v2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shd101wyy/yo",
   "displayName": "Yo",
-  "version": "0.2.8",
+  "version": "0.2.7",
   "main": "./out/cjs/index.cjs",
   "module": "./out/esm/index.mjs",
   "types": "./out/types/src/index.d.ts",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Yo Language",
   "description": "Yo language syntax highlighting",
   "icon": "Yo_logo.png",
-  "version": "0.2.8",
+  "version": "0.2.7",
   "categories": [
     "Programming Languages"
   ],

--- a/yo-self/version.yo
+++ b/yo-self/version.yo
@@ -16,7 +16,7 @@ YO_VERSION_FILE :: ".yo-version";
 /// The current Yo compiler version (must match `package.json`).
 ///
 /// Update this constant when the compiler version changes.
-CURRENT_YO_VERSION :: "0.2.8";
+CURRENT_YO_VERSION :: "0.2.7";
 /// Get the current Yo version string.
 current_yo_version :: (fn() -> str)(CURRENT_YO_VERSION);
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The v0.2.8 dispatch died on Microsoft's TF10216 outage at the Marketplace step, after the bump commit had already pushed (no tag/draft created). This reverts the version fields to 0.2.7 so the next dispatch recomputes 0.2.8, and makes the Marketplace publish non-fatal (continue-on-error + warning + .vsix artifact for manual publish) so store outages can't kill the seed-bundle release or burn version numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)