### PR TITLE
release: fix all three attempt-3 leg failures (swap, node heap was #142, cross-emit host-constants)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y liburing-dev
 
+      # Same provisioning as seed-cross-emit and every self-building job in
+      # test.yml: the stage-2 gate below is a full self-emit, which does not
+      # fit a swapless 16 GB runner (v0.2.8 attempt 3's linux-x64 leg took the
+      # whole VM down mid-emit — "runner received a shutdown signal").
+      - name: Add swap space
+        if: runner.os == 'Linux'
+        run: |
+          sudo fallocate -l 32G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+
       - name: Install LLVM/Clang
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
Two commits fixing the remaining v0.2.8 attempt-3 failures (the windows node-heap OOM was #142):

## 1. Swap for the seed-bundles Linux legs
`Seed bundle (linux-x64)` and `(linux-arm64)` both killed their runner VMs mid stage-2 self-emit (`The runner has received a shutdown signal`). `seed-bundles` was the only self-building job with no swap step — test.yml's comment records the self-emit fits 16 GB runners *because* ~10 GB of swap is provisioned. Added the same 32 GB swap block, Linux-only.

## 2. The candidate, not the seed, does the macOS cross-emits
Both cross-emitted macOS legs failed their smoke test: the bundle binary ran on macOS but emitted **Linux C** (`hello.c:507: fatal error: 'sys/sendfile.h' file not found`). Root cause: the target-folding fix f7b5cc460 (comptime platform/arch fold from the TARGET, not the host) landed **five minutes after v0.2.7 was tagged**, so the v0.2.7 seed bakes its Linux host's platform constants into any cross-emit. `seed-cross-emit` now builds the candidate natively first (host == target — safe with any seed) and the candidate does both cross-emits. Timeout 60 → 90 for the extra build.

This also hardens the design permanently: released bundles are always emitted by the release's own compiler.

Rehearsal positives from attempt 3: seed install + seed build passed on all three seed legs, and the musl bundle went green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)