### PR TITLE
release: the candidate, not the seed, does the macOS cross-emits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -563,7 +563,7 @@ jobs:
     name: Cross-emit macOS C (${{ matrix.target }})
     needs: release
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -599,20 +599,36 @@ jobs:
         with:
           version: ${{ env.SEED_VERSION }}
 
-      # SEED-ERA FLAGS ONLY (same rule as the musl job). Two emits: the
-      # mimalloc-flavored C for the bundle binary, and the libc-flavored
-      # portable arm (published as `portable-c-<target>` directly, so the
-      # portable-c assembly job needs nothing from the macOS runners).
+      # The CANDIDATE (this release's compiler) must do the cross-emits, not
+      # the seed. v0.2.7 predates f7b5cc460 ("fold comptime platform/arch
+      # from the TARGET"), so a v0.2.7 cross-emit bakes the LINUX host's
+      # platform constants into the macOS binary, which then emits Linux C
+      # on macOS — v0.2.8 attempt 3's smoke test died on
+      # `#include <sys/sendfile.h>` in hello.c. Building the candidate
+      # natively is safe (host == target, seed-era flags), and the
+      # candidate's cross-emits fold from the target. This extra stage also
+      # future-proofs the legs against any seed-era codegen bug: released
+      # bundles are always emitted by the release's own compiler.
+      - name: Build the candidate compiler (previous seed, native)
+        shell: bash
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: yo compile yo-self/main.yo --release --allocator mimalloc --std-path ./std -o yo-candidate
+
+      # Two emits by the candidate: the mimalloc-flavored C for the bundle
+      # binary, and the libc-flavored portable arm (published as
+      # `portable-c-<target>` directly, so the portable-c assembly job needs
+      # nothing from the macOS runners).
       - name: "Cross-emit the bundle C (mimalloc) and the portable arm (libc)"
         shell: bash
         env:
           YO_MAIN_STACK_MB: "4096"
         run: |
           mkdir -p cross portable-arm
-          yo compile yo-self/main.yo --release --allocator mimalloc \
+          ./yo-candidate compile yo-self/main.yo --release --allocator mimalloc \
             --std-path ./std --target ${{ matrix.yo_target }} \
             --emit-c --skip-c-compiler -o "cross/yo-${{ matrix.target }}" > /dev/null
-          yo compile yo-self/main.yo --release --allocator libc \
+          ./yo-candidate compile yo-self/main.yo --release --allocator libc \
             --std-path ./std --target ${{ matrix.yo_target }} \
             --emit-c --skip-c-compiler -o "portable-arm/${{ matrix.target }}" > /dev/null
           ls -la cross/ portable-arm/


### PR DESCRIPTION
Follow-up to #143 (this commit was pushed to that branch seconds after it merged, so it needs its own PR). Fixes the remaining attempt-3 failure class:

Both cross-emitted macOS legs failed their smoke test: the bundle binary ran on macOS but emitted **Linux C** (`hello.c:507: fatal error: 'sys/sendfile.h' file not found`). Root cause: the target-folding fix f7b5cc460 (comptime platform/arch fold from the TARGET, not the host) landed **five minutes after v0.2.7 was tagged**, so the v0.2.7 seed bakes its Linux host's platform constants into any cross-emit — the resulting macOS binary defaults its own codegen target to Linux.

Fix: `seed-cross-emit` builds the candidate natively first (host == target — correct with any seed) and the **candidate** does both cross-emits. Timeout 60 → 90 for the extra build. This also hardens the design permanently: released bundles are always emitted by the release's own compiler, never the previous one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)