### PR TITLE
release: flip the draft public by release ID (drafts are invisible to get-by-tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -949,7 +949,18 @@ jobs:
         with:
           ref: ${{ needs.release.outputs.sha }}
 
+      # Flip by RELEASE ID, not tag: `gh release edit <tag>` resolves through
+      # the get-release-by-tag API, which returns 404 for DRAFTS (their tag
+      # ref does not exist until publication) — v0.2.9's first flip attempt
+      # died on exactly that ("release not found" with a complete draft
+      # sitting right there; it was published by hand via the PATCH below).
       - name: Publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "v${{ needs.release.outputs.version }}" --draft=false
+        run: |
+          release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases"             --jq '.[] | select(.tag_name == "v${{ needs.release.outputs.version }}" and .draft) | .id')
+          if [ -z "$release_id" ]; then
+            echo "::error::no draft release found for v${{ needs.release.outputs.version }}"
+            exit 1
+          fi
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}"             -F draft=false -f make_latest=true --jq .html_url


### PR DESCRIPTION
v0.2.9's publish job — the atomic draft→public flip's first real exercise — failed with `release not found` while a complete draft sat right there. `gh release edit <tag>` resolves through the get-release-by-tag API, which returns 404 for **drafts**: their tag ref doesn't exist until publication. (v0.2.9 itself was published by hand with the PATCH-by-ID call this PR now encodes.)

The step now finds the draft's release ID from the releases list and PATCHes `draft=false, make_latest=true`, failing loudly if no draft exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)