### PR TITLE
plans: ExprInfo diet refuted as implemented (binary×input matrix); silent assignment-to-call issue

### DIFF
--- a/issues/assignment-to-call-expression-silently-accepted.md
+++ b/issues/assignment-to-call-expression-silently-accepted.md
@@ -1,0 +1,52 @@
+# Assignment to a call expression is silently accepted (check AND runtime)
+
+**Found 2026-08-18** during the ExprInfo diet refactor (perf/exprinfo-diet).
+
+## Symptom
+
+```rust
+expr_info_runtime_arg_exprs_in_order(out_info) =
+  Option(ArrayList(AstExpr)).Some(call_result.runtime_arg_exprs_in_order);
+```
+
+The LHS is a **function call**, not a place. Both compilers accepted this:
+
+- `check ./yo-self` passed 248/248 with this line present
+  (yo-self/evaluator/exprs/recur.yo:221 at the time).
+- The compiled compiler ran it silently as a no-op — the RHS value was
+  discarded, `runtime_arg_exprs_in_order` never stored, and the failure
+  surfaced only much later as `yo: error: No arguments for recur call`
+  during a self-emit, plus FIXPOINT_BROKEN and 7 gates_fast failures.
+
+## Expected
+
+`<call-expr> = <value>` where the callee is not an Index-trait place or
+another recognized lvalue form should be a hard evaluator error ("cannot
+assign to a function call"), at check time.
+
+## Why it matters
+
+The failure mode is maximally silent: no diagnostic at check, no diagnostic
+at runtime, wrong behavior arbitrarily far downstream. A mechanical refactor
+(field write → accessor call) can manufacture exactly this shape, which is
+how it was found.
+
+## Repro sketch
+
+```rust
+f :: (fn(x : i32) -> i32)(x);
+main :: (fn() -> unit)({
+  f(1) = 2; // should be a check error; today it is silently evaluated
+});
+export(main);
+```
+
+(Verify the minimal shape — the found instance had a unit-returning callee
+on the LHS; the discard behavior may depend on the `=` dispatch path.)
+
+## Next steps
+
+- Add a `comptime_expect_error` test for the minimal repro.
+- Fix in the `=` evaluation path (both compilers): reject call-expression
+  LHS unless it resolves to an Index-trait place (`arr(0) = v`) or another
+  sanctioned lvalue form.

--- a/plans/backlog/RC_HEADER_SPLIT.md
+++ b/plans/backlog/RC_HEADER_SPLIT.md
@@ -49,6 +49,32 @@ are inflated ~2x by the instrument — compare only tracked numbers.)
 | 64 B class                                 | 18.1M       | 1.08 GB     | 6.1%  |
 | 112 B (Environment) + 80 B (tracked lists) | 15.8M       | 1.39 GB     | 7.8%  |
 
+**ExprInfo diet: REFUTED AS IMPLEMENTED (2026-08-18, branch
+`perf/exprinfo-diet`, kept parked).** The accessor-based diet (15 read/write-cold
+fields into `ExprInfoRare`, write-hot four kept inline per the origin_type
+rule, skip-None setters) produced a compiler that is genuinely better — the
+binary×input matrix (tracked live, mi_usable_size):
+
+| tracked live (GB) | memo tree input | diet tree input |
+| ----------------- | --------------- | --------------- |
+| memo binary       | 14.94           | 18.87           |
+| diet binary       | —               | 17.06           |
+
+— the diet BINARY saves 1.8 GB / ~10% wall on identical input, but the diet
+SOURCE costs +3.9 GB to compile: ~370 field accesses became function calls in
+the hottest evaluator/codegen code, and each call site adds ~10 MB of retained
+evaluation state to a self-compile. Net on the bootstrap loop: +2.1 GB. The
+~10 MB/site figure smells like ONE pathological per-call mechanism
+(specialization/capture machinery), not honest linear cost — finding and
+fixing it would flip the diet to a double win; that investigation is the
+reopening condition. Salvage: the YO_EI_CENSUS occupancy + write-rate probe
+(on the branch), the occupancy data (19/24 fields ≤2.5% at exit), the
+write-rate rule (rare membership requires BOTH read-cold AND write-cold —
+deferred_drop 1.84M writes, runtime_args 1.83M despite ≤2.5% occupancy), and
+issues/assignment-to-call-expression-silently-accepted.md (a half-converted
+write was silently swallowed by check AND runtime). FIXPOINT_HOLDS and
+gates failures=0 on the branch — the refutation is purely the memory matrix.
+
 **Revised lever ranking:** (1) ~~the ≥4 KB buffer pool~~ **LANDED same day:
 the pool was `_inject_forall_captures`** — ra1 attribution (shims record
 `__builtin_return_address(1)`; arm64 keeps frame pointers) put 3.87 GB /


### PR DESCRIPTION
Docs + issue only. The ExprInfo diet (branch `perf/exprinfo-diet`, kept parked with FIXPOINT_HOLDS and gates green) was built, measured, and refuted by the binary×input matrix — the diet binary saves 1.8 GB / ~10% wall, but the accessor-heavy source costs +3.9 GB to self-compile; net +2.1 GB on the bootstrap loop. Table, salvage, and the reopening condition (find the ~10 MB/call-site mechanism) in the plan post-mortem. Also files `issues/assignment-to-call-expression-silently-accepted.md`: check AND runtime silently swallow `f(x) = v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)