### PR TITLE
compilers: stop offering `--cc cl` (it never produced MSVC-compilable C)

### DIFF
--- a/.github/skills/yo-project-workflow/workflow-cheatsheet.md
+++ b/.github/skills/yo-project-workflow/workflow-cheatsheet.md
@@ -162,7 +162,7 @@ yo compile main.yo --cc emcc --release -o app
 yo test ./tests/main.test.yo --target wasm-wasi
 ```
 
-- Common C compilers: `clang`, `gcc`, `zig`, `cl`, `emcc`
+- Common C compilers: `clang`, `gcc`, `zig`, `emcc`
 - `--cc emcc` targets Emscripten-based WebAssembly
 - `--target wasm-wasi` targets standalone WASI
 - Prefer the host target for routine development unless the task is explicitly cross-platform

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ export(main);
 The `Yo` compiler is written in [TypeScript](https://www.typescriptlang.org/) and uses [Bun](https://bun.sh/) as the runtime.
 
 Yo is primarily developed on the Steam Deck LCD (Linux). The compiler currently transpiles Yo to C; to produce
-machine code you must have a C compiler (for example `gcc`, `clang`, `zig`, `cl`, `emcc`, etc).
+machine code you must have a C compiler (for example `gcc`, `clang`, `zig`, `emcc`, etc).
 
 Please install [nix](https://nixos.org/download.html) and [direnv](https://direnv.net/) before proceeding.
 

--- a/docs/en-US/BUILD_SYSTEM.md
+++ b/docs/en-US/BUILD_SYSTEM.md
@@ -666,7 +666,7 @@ Options:
   --build-file <path>    Path to build file (default: ./build.yo)
   --target <triple>      Override target for all artifacts
   --sysroot <path>       Sysroot directory for cross-compilation
-  --cc <compiler>        C compiler: clang, gcc, zig, cc, cl
+  --cc <compiler>        C compiler: clang, gcc, zig, cc, emcc
   --verbose, -v          Verbose build output
   --dry-run              Show what would be built
   --list-steps           List available build steps

--- a/docs/zh-CN/BUILD_SYSTEM.md
+++ b/docs/zh-CN/BUILD_SYSTEM.md
@@ -664,7 +664,7 @@ Options:
   --build-file <path>    构建文件路径（默认：./build.yo）
   --target <triple>      为所有产物覆盖目标
   --sysroot <path>       交叉编译的 sysroot 目录
-  --cc <compiler>        C 编译器：clang, gcc, zig, cc, cl
+  --cc <compiler>        C 编译器：clang, gcc, zig, cc, emcc
   --verbose, -v          详细构建输出
   --dry-run              显示将要构建的内容
   --list-steps           列出可用的构建步骤

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -336,7 +336,7 @@ export(main);
 
 `Yo` 编译器用 [TypeScript](https://www.typescriptlang.org/) 编写，使用 [Bun](https://bun.sh/) 作为运行时。
 
-Yo 主要在 Steam Deck LCD（Linux）上开发。编译器目前将 Yo 转换为 C；要生成机器码，你必须有一个 C 编译器（例如 `gcc`、`clang`、`zig`、`cl`、`emcc` 等）。
+Yo 主要在 Steam Deck LCD（Linux）上开发。编译器目前将 Yo 转换为 C；要生成机器码，你必须有一个 C 编译器（例如 `gcc`、`clang`、`zig`、`emcc` 等）。
 
 请继续之前安装 [nix](https://nixos.org/download.html) 和 [direnv](https://direnv.net/)。
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -131,7 +131,7 @@ function Install-Dependencies {
 }
 
 function Check-Dependencies {
-  if (-not (Has-Cmd 'clang') -and -not (Has-Cmd 'gcc') -and -not (Has-Cmd 'cl')) {
+  if (-not (Has-Cmd 'clang') -and -not (Has-Cmd 'gcc')) {
     Warn @'
 No C compiler found on PATH. Yo compiles to C, so 'yo compile' will fail.
 Install LLVM (winget install LLVM.LLVM) and reopen your terminal.

--- a/src/compiler-utils.ts
+++ b/src/compiler-utils.ts
@@ -77,7 +77,7 @@ export function checkCompilerAvailable(compiler: string): boolean {
  * @returns
  */
 export function findAvailableCompiler(): string | null {
-  const compilers = ["clang", "cc", "gcc", "zig", "cl"];
+  const compilers = ["clang", "cc", "gcc", "zig"];
   for (const compiler of compilers) {
     if (checkCompilerAvailable(compiler)) {
       return compiler;

--- a/src/yo-cli.ts
+++ b/src/yo-cli.ts
@@ -305,7 +305,7 @@ yo --version                     Show version number
               "C Compiler to use: 'cc', 'gcc', 'clang', 'zig', 'cl' (MSVC), or 'emcc' (Emscripten/WASM)",
             type: "string",
             demandOption: false,
-            choices: ["cc", "gcc", "clang", "zig", "cl", "emcc"],
+            choices: ["cc", "gcc", "clang", "zig", "emcc"],
           })
           .option("t", {
             alias: "target",
@@ -715,7 +715,7 @@ yo --version                     Show version number
             describe:
               "C Compiler to use: 'cc', 'gcc', 'clang', 'zig', 'cl' (MSVC), or 'emcc' (Emscripten/WASM)",
             type: "string",
-            choices: ["cc", "gcc", "clang", "zig", "cl", "emcc"],
+            choices: ["cc", "gcc", "clang", "zig", "emcc"],
           })
           .option("target", {
             describe:
@@ -959,7 +959,7 @@ yo --version                     Show version number
             describe:
               "C Compiler to use: 'cc', 'gcc', 'clang', 'zig', 'cl' (MSVC), or 'emcc' (Emscripten/WASM)",
             type: "string",
-            choices: ["cc", "gcc", "clang", "zig", "cl", "emcc"],
+            choices: ["cc", "gcc", "clang", "zig", "emcc"],
           })
           .option("t", {
             alias: "target",

--- a/tests/internal/target.test.yo
+++ b/tests/internal/target.test.yo
@@ -20,7 +20,6 @@ open(import("std/string"));
   is_target_windows,
   is_target_linux,
   is_target_macos,
-  is_target_msvc,
   is_target_wasm,
   is_target_emscripten,
   is_target_standalone_wasi,

--- a/yo-self/main.yo
+++ b/yo-self/main.yo
@@ -747,7 +747,6 @@ _find_available_compiler :: (fn(io : Io) -> Option(String))({
   candidates.push(String.from("cc"));
   candidates.push(String.from("gcc"));
   candidates.push(String.from("zig"));
-  candidates.push(String.from("cl"));
   (fci : usize) = usize(0);
   while(fci < candidates.len(), {
     c := match(candidates.get(fci), .Some(x) => x, .None => String.from(""));
@@ -1183,8 +1182,8 @@ run_compile :: (
     );
   });
   // ----- choices validation (yargs `choices:` parity, src/yo-cli.ts) -------
-  if(((cc != "") && (((cc != "cc") && (cc != "gcc")) && ((cc != "clang") && (cc != "zig")))) && ((cc != "cl") && (cc != "emcc")), {
-    exn.throw(dyn(`compile: invalid --c-compiler "${cc}". Choices: cc, gcc, clang, zig, cl, emcc`));
+  if(((cc != "") && (((cc != "cc") && (cc != "gcc")) && ((cc != "clang") && (cc != "zig")))) && (cc != "emcc"), {
+    exn.throw(dyn(`compile: invalid --c-compiler "${cc}". Choices: cc, gcc, clang, zig, emcc`));
   });
   if(((allocator != "mimalloc") && (allocator != "system")) && (allocator != "libc"), {
     exn.throw(dyn(`compile: invalid --allocator "${allocator}". Choices: mimalloc, system (deprecated alias: libc)`));
@@ -1218,7 +1217,7 @@ run_compile :: (
         cc = found_cc;
       },
       .None => {
-        exn.throw(dyn(String.from("Error: No C compiler found. Please install a C compiler (cc, gcc, clang, zig, or cl) or specify one using the -cc/--c-compiler flag.")));
+        exn.throw(dyn(String.from("Error: No C compiler found. Please install a C compiler (cc, gcc, clang, or zig) or specify one using the -cc/--c-compiler flag.")));
       }
     );
   });
@@ -2079,7 +2078,7 @@ run_test :: (
         // and never sets `--c-compiler`, so `test_cc` is "" and this gate used
         // to hand `-fsanitize=address` to emcc. TS never does, because it
         // resolves the cc first and reads `isEmcc` off the RESULT.
-        if((!(no_sanitize)) && (((test_cc != "cl") && (test_cc != "emcc")) && !(run_is_wasi)), {
+        if((!(no_sanitize)) && ((test_cc != "emcc") && !(run_is_wasi)), {
           ccmd.arg(String.from("--sanitize"));
           ccmd.arg(san_choice.clone());
         });
@@ -2097,7 +2096,7 @@ run_test :: (
         // Same `run_is_wasi` correction as the --sanitize gate above: without
         // it the WASI leg built an lsan suppression file and applied a
         // LeakSanitizer verdict to an emcc artifact that carries no ASan.
-        use_asan := ((!(no_sanitize)) && ((san_choice == "address") && (((test_cc != "cl") && (test_cc != "emcc")) && !(run_is_wasi))));
+        use_asan := ((!(no_sanitize)) && ((san_choice == "address") && ((test_cc != "emcc") && !(run_is_wasi))));
         // YO_TEST_LEAK_VERDICT=0 stages leak checking off entirely: LSan's
         // OWN nonzero exit fails a leaking child regardless of the runner's
         // verdict, so `detect_leaks` itself must follow the flag — ASan's

--- a/yo-self/target.yo
+++ b/yo-self/target.yo
@@ -336,9 +336,6 @@ is_target_linux :: (fn(target : TargetInfo) -> bool)(
 is_target_macos :: (fn(target : TargetInfo) -> bool)(
   target.os == Os.Macos
 );
-is_target_msvc :: (fn(target : TargetInfo) -> bool)(
-  (target.os == Os.Windows) && (target.abi == Option(Abi).Some(Abi.Msvc))
-);
 is_target_wasm :: (fn(target : TargetInfo) -> bool)(
   (target.arch == Arch.Wasm32) || ((target.os == Os.Wasi) || (target.os == Os.Emscripten))
 );
@@ -379,7 +376,6 @@ export(
   is_target_windows,
   is_target_linux,
   is_target_macos,
-  is_target_msvc,
   is_target_wasm,
   is_target_emscripten,
   is_target_standalone_wasi,


### PR DESCRIPTION
**Pre-deletion prerequisite for P2.5 Group E** (1 of 2).

`cl` was not merely an advertised choice — it was **auto-selectable**. Both compilers pushed it onto the end of the C-compiler probe list (`yo-self/main.yo:750`, `src/compiler-utils.ts:80`), so on a machine with no clang/cc/gcc/zig the compiler picked `cl` unasked and then handed it a clang command line (`-std=c11 -fno-strict-aliasing -fwrapv … -o`). The user got a generic `compile: C compiler failed (exit N)` with nothing pointing at the cause.

### Nothing working is lost

TS had an MSVC flag dialect (`src/compiler-utils.ts:28` `isMSVC`), but the **emitted C was never MSVC-compilable regardless**: there is not one `_MSC_VER` guard in the tree, and the RC helpers emit unguarded `__attribute__((always_inline))`. yo-self never had the dialect at all. So `--cc cl` could only ever fail — the only question was whether it failed clearly.

This lands **before** the `src/` deletion deliberately: after it, TS's dialect is gone and the advertised choice would be a guaranteed failure with no implementation behind it anywhere.

### Not touched: the MSVC **ABI**

`Abi.Msvc`, `parse_abi("msvc")`, and `clang_triple`'s `-pc-windows-msvc` are how the **shipping clang-built Windows target** works. `x86_64-windows-msvc` is unaffected.

### Verified

- `check ./yo-self` — 248/248
- `tests/internal/target.test.yo` — 22/22 (it imported `is_target_msvc`, so it had to change with the removal)
- `bun run build` — clean
- `cl` is exercised by no test, script, or CI leg