### PR TITLE
ci: trigger on `merge_group` so the merge queue can be enabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,13 @@ on:
   # alone still run nothing (the push trigger stays develop-only); a PR's
   # synchronize event covers its branch pushes.
   pull_request:
+  # Merge queue. EVERY workflow that provides a REQUIRED status check must
+  # trigger on `merge_group`, or the queue waits forever on checks that never
+  # run — all 14 required contexts come from this file, so this line is the
+  # whole requirement. It is inert until the queue is enabled on the ruleset,
+  # which is why it lands first: enabling the queue against a workflow that
+  # cannot see `merge_group` hangs every queued PR.
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
**Step 1 of 2** for turning on a merge queue. This one line is inert on its own — it must land *before* the queue is enabled.

### Why the ordering matters

Enabling a merge queue against workflows that don't listen for `merge_group` **hangs every queued PR forever**: the queue builds the PR merged onto the current `develop` on a temporary ref, then waits for the required checks to report *there* — and they never run.

All 14 required status contexts come from `test.yml` (`fixpoint-arm64.yml`'s only job is `Bootstrap fixpoint (linux-arm64, byte-identity)`, which is neither required nor PR-triggered), so this single trigger is the whole requirement.

### Why a queue at all

The ruleset has `strict_required_status_checks_policy: true` — "require branches to be up to date". That rule is **correct and should stay**: two individually-green PRs can be broken together, which isn't hypothetical here — #147 was green on its own and broke every macOS/Windows seed leg once combined with the seed-driven jobs on develop.

But `strict` currently means a human re-updates every open PR after each merge, and with this suite (four internal-test shards, hollow sweep, both fixpoint gates) that's slow and easy to forget. A queue keeps the guarantee and removes the human.

### Rejected alternative

An Action that auto-updates every open PR on each merge is a thundering herd — six open PRs means six full suites restarted per merge, five wasted, since only one can merge next anyway. The queue does the same work serially, for the PR actually landing.

### Note

`concurrency` is keyed on `github.ref`, and each merge group gets its own `refs/gh-readonly-queue/...` ref, so `cancel-in-progress` can't cancel a queue entry on behalf of another.

### Step 2 (after this merges)

Enable the `merge_queue` rule on ruleset 13548862. Once the queue is on, `strict` can be turned off — the queue guarantees freshness by construction.