### PR TITLE
main: a bare `yo` prints the help instead of a one-line scold

### DIFF
--- a/yo-self/main.yo
+++ b/yo-self/main.yo
@@ -3134,8 +3134,18 @@ main :: (fn(io : Io) -> unit)({
     println(`yo ${String.from(CURRENT_YO_VERSION)}`);
     return(());
   });
+  // A bare `yo` prints the FULL help to stderr and exits 1, matching TS
+  // (yargs `.demandCommand()`, src/yo-cli.ts). The one-line "no subcommand
+  // given" error this replaced was a porting gap: it named the subcommands but
+  // taught nothing about them, so the first thing a newly-installed user saw
+  // was a scold rather than the usage text they were about to ask for.
+  //
+  // stderr + rc=1, not stdout + rc=0: no action was performed, so a script
+  // that runs `yo` with no arguments should still see a failure — the same
+  // reasoning as `git`. Explicit `--help` remains stdout + rc=0.
   if(argv.len() < usize(2), {
-    exn.throw(dyn(`no subcommand given. Usage: yo <compile|test|fmt|check|init|build|fetch|install|cache|doc|version|unsafe-report|public-safe-report> ...`));
+    eprintln(_top_level_help_text());
+    unsafe(exit(int(1)));
   });
   subcmd := argv(usize(1));
   // .yo-version PRE-DISPATCH (src/yo-cli.ts:118-195 parity): before any


### PR DESCRIPTION
Reported after installing via `install.sh`: running `yo` with no arguments printed

```
yo: error: no subcommand given. Usage: yo <compile|test|fmt|check|init|build|fetch|install|cache|doc|version|unsafe-report|public-safe-report> ...
```

which names the subcommands and teaches nothing about them. The first thing a newly-installed user saw was a scold rather than the usage text they were about to ask for anyway.

## This is a porting gap, not a design difference

The TypeScript CLI already does the right thing — yargs `.demandCommand()` prints the **full help** for a bare invocation. Measured on `develop`:

```
$ node ./out/cjs/yo-cli.cjs        # TS
rc=1, stdout 0 lines, stderr 96 lines   → the whole help
```

The self-hosted port replaced that with a single error string. Restored to match.

## stderr + rc=1, deliberately

Not stdout + rc=0:

- it's what TS does, so the two agree for the remaining window before `src/` retires;
- no action was performed, so a script running `yo` bare should still see a failure — same reasoning as `git`.

Explicit `yo --help` is unchanged: **stdout, rc=0**.

## Verified on a binary built from this branch

| invocation | rc | stdout | stderr |
|---|---|---|---|
| `yo` | 1 | — | 71-line help |
| `yo --help` | 0 | 71-line help | — |
| `yo --version` | 0 | `yo 0.2.9` | — |

The bare-invocation text and the `--help` text were diffed and are **identical**.