### PR TITLE
release: install liburing before the site build, and reset the burned bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,18 @@ jobs:
       # is scripts/build_site.yo, compiled and run by the SEED compiler — no
       # bun/node in this step. Verified byte-identical to the TS original
       # (160 files, homepage md5 equal) before the swap.
+      # The seed is a dynamically linked Linux binary and the async runtime
+      # links liburing, so it cannot even START without it — `yo: error while
+      # loading shared libraries: liburing.so.2`. Every other Linux job in this
+      # file installs it; this job did not, because until the docs site moved
+      # off bun (#151) it never RAN a Yo compiler. That is what failed v0.2.10:
+      # exit 127 at the site build, AFTER the version bump had been committed
+      # and the extension published.
+      - name: Install liburing
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liburing-dev
+
       - name: Install the seed compiler (for the site build)
         uses: ./.github/actions/install-seed
         with:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shd101wyy/yo",
   "displayName": "Yo",
-  "version": "0.2.10",
+  "version": "0.2.9",
   "main": "./out/cjs/index.cjs",
   "module": "./out/esm/index.mjs",
   "types": "./out/types/src/index.d.ts",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yolang",
-  "version": "0.2.10",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yolang",
-      "version": "0.2.10",
+      "version": "0.2.9",
       "license": "NCSA",
       "devDependencies": {
         "@vscode/vsce": "^3.2.0"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Yo Language",
   "description": "Yo language syntax highlighting",
   "icon": "Yo_logo.png",
-  "version": "0.2.10",
+  "version": "0.2.9",
   "categories": [
     "Programming Languages"
   ],

--- a/yo-self/version.yo
+++ b/yo-self/version.yo
@@ -16,7 +16,7 @@ YO_VERSION_FILE :: ".yo-version";
 /// The current Yo compiler version (must match `package.json`).
 ///
 /// Update this constant when the compiler version changes.
-CURRENT_YO_VERSION :: "0.2.10";
+CURRENT_YO_VERSION :: "0.2.9";
 /// Get the current Yo version string.
 current_yo_version :: (fn() -> str)(CURRENT_YO_VERSION);
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**v0.2.10 failed. This fixes the cause and makes the version recoverable rather than burned.**

## What happened

```
yo: error while loading shared libraries: liburing.so.2: cannot open shared object file
##[error]Process completed with exit code 127
```

The `release` job has **no `Install liburing` step**, while every other Linux job in this file does. It never needed one: until #151 moved the docs site off bun, this job ran no Yo compiler at all. #151 added a seed invocation and inherited the gap — the seed is a dynamically linked Linux binary whose async runtime links liburing, so it cannot even start.

## Why it hurt

The failure landed **after** the irreversible steps:

| step | outcome |
|---|---|
| Commit version bump (0.2.9 → 0.2.10) | ✅ pushed to develop |
| Publish extension to Marketplace @ 0.2.10 | ✅ published |
| Create GitHub Release (draft) | ✅ created |
| **Generate documentation website** | ❌ **exit 127** |
| every bundle job, portable-c, publish-release | ⏭ skipped |

So v0.2.10 sat as a **draft with no bundles** — the same shape as the v0.2.8 burn this file's own comments warn about.

## Why this reverts the bump too

The workflow computes the next version from `yo-self/version.yo`. Re-running against the bumped tree would produce **0.2.11** and leave the Marketplace extension at **0.2.10** — exactly the compiler/extension drift the *"two independent bumpers is how they drift apart"* comment exists to prevent.

Reverting to 0.2.9 makes the re-run reproduce **0.2.10**, matching what is already published. Re-publishing the same extension version is safe: that step is `continue-on-error: true` (`:185`), so a duplicate warns instead of failing.

## Recovery sequence after this merges

1. delete the draft `v0.2.10` release (so the re-run recreates it)
2. re-run the release workflow → computes 0.2.10 again
3. resume: `src-attic-final` tag → merge #158

Reverts `530f5c7f9`.