### PR TITLE
release: fail loudly if a version-bump path moved, instead of silently not bumping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,10 +170,22 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          # Group E deletes root package.json; `git add` of a missing path is a
-          # hard error, so stage only what exists.
-          for f in package.json vscode-extension/package.json vscode-extension/package-lock.json yo-self/version.yo; do
+          # OPTIONAL — Group E deletes root package.json, and `git add` of a
+          # missing path is a hard error, so this one is skipped when absent.
+          for f in package.json; do
             [ -f "$f" ] && git add "$f"
+          done
+          # REQUIRED. These must exist, and a blanket `[ -f ] &&` over them is
+          # a silent-failure trap: if a path MOVES (e.g. yo-self/ -> src/ in
+          # P2.5 Group F), the guard quietly skips it and the release commits
+          # WITHOUT the version bump — no error, after the release is already
+          # tagged and the extension published. Fail loudly instead.
+          for f in vscode-extension/package.json vscode-extension/package-lock.json yo-self/version.yo; do
+            if [ ! -f "$f" ]; then
+              echo "::error::$f is missing, so the version bump would not land. Did a path move? Update this list in the same change."
+              exit 1
+            fi
+            git add "$f"
           done
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
           # The checkout used RELEASE_PAT (repository-admin ruleset bypass),


### PR DESCRIPTION
**Draft deliberately — must not merge until v0.2.10 is out**, because merging to develop cancels the in-flight release gate (that is how the last gate run got cancelled).

## The trap

```bash
for f in package.json vscode-extension/package.json vscode-extension/package-lock.json yo-self/version.yo; do
  [ -f "$f" ] && git add "$f"
done
```

The `[ -f ]` guard exists for one reason — Group E deletes root `package.json` and `git add` of a missing path is fatal. But applying it to the whole list makes **every** entry optional, including the one that matters.

`yo-self/version.yo` is the version **source of truth**, and P2.5 Group F renames `yo-self/` → `src/`. The moment that lands, this loop stops staging it, the commit records a bump containing no bump, and the release continues — **no error, after the release is tagged and the extension published**. A release would ship claiming a version that never landed on develop.

That is strictly worse than what just happened with v0.2.10, which at least failed loudly.

## Consistency argument

The push step immediately below already fails loudly *on purpose*, with a comment saying why: *"fail LOUDLY rather than releasing a tree whose version never landed on develop."* This applies the same principle one step earlier.

## The change

Root `package.json` stays optional (Group E removes it). The three that must always exist now fail with a named error identifying the moved path.

Found while mapping the Group F rename, which flagged it as that task's worst silent failure — but it is a latent trap independent of when the rename happens.