### PR TITLE
ci: gate the doc-site build on PRs, and deploy Pages only after the release publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pages: write
-      id-token: write
       # For the version-bump fallback's `gh pr create` (v0.2.0's silently
       # failed under `|| true` — the branch was pushed but no PR appeared).
       # NOTE: the repo setting "Allow GitHub Actions to create and approve
@@ -283,13 +281,12 @@ jobs:
           yo compile scripts/build_site.yo --release -o /tmp/build-site
           /tmp/build-site --output yo-out/site --version "v${{ steps.version.outputs.version }}" --yo yo
 
+      # Uploaded here, DEPLOYED by the deploy-site job at the bottom of this
+      # file — see the invariant recorded there.
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: yo-out/site
-
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
 
   # Bootstrap seed bundles — plans/SELF_HOSTING_COMPLETION.md Phase 2 (task 2.1)
   # and plans/P2_RETIRE_SRC.md. The TypeScript compiler builds the native
@@ -1062,3 +1059,36 @@ jobs:
             exit 1
           fi
           gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}"             -F draft=false -f make_latest=true --jq .html_url
+
+  # The site deploy waits for publish-release ON PURPOSE.
+  #
+  # It used to sit in the `release` job, firing immediately after the site
+  # build — i.e. while the GitHub Release was still a DRAFT and not one bundle
+  # had been built. Measured live during the v0.2.10 release: the public site
+  # already advertised v0.2.10 while the API reported `draft=true` with a
+  # single asset. A draft's assets 404 on the public download URL, so every
+  # download link that site published pointed at nothing; and had a required
+  # bundle leg then failed, the site would have gone on advertising a version
+  # that never shipped, with no way to notice from the outside.
+  #
+  # publish-release is the moment the release becomes real — it flips the
+  # draft public only once every required bundle leg has uploaded. Deploying
+  # after it means the website and the release always announce the same
+  # thing, which is the same atomicity invariant the draft-until-bundles-land
+  # design already buys on the release side.
+  #
+  # Failure mode is deliberately conservative: if publication does not happen,
+  # the site simply stays on the previous version.
+  deploy-site:
+    name: Deploy the documentation website
+    needs: publish-release
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      # Deploys the `github-pages` artifact uploaded by the `release` job
+      # earlier in this same run — no rebuild, so the bytes published are
+      # exactly the ones the release built.
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,76 @@ jobs:
           packagePath: ./vscode-extension
           registryUrl: https://marketplace.visualstudio.com
 
+  # The release's documentation-website step, rehearsed on every PR.
+  #
+  # scripts/build_site.yo is 24.7 KB of Yo that, until this job existed, was
+  # referenced by exactly ONE place in the repo — release.yml. So it ran for
+  # the first time each release, AFTER the version bump had been pushed to
+  # develop and the tag created. That is precisely how the first v0.2.10
+  # attempt died: the release job installed no liburing, so the seed `yo`
+  # could not even START at this step ("error while loading shared libraries:
+  # liburing.so.2") — and the version number was already spent. Every failure
+  # in a release-only step burns a version; v0.2.8 went the same way on the
+  # Marketplace publish.
+  #
+  # The doc-html / doc-json / doc-markdown cli-cases cover the `yo doc`
+  # SUBCOMMAND. They do not cover build_site.yo, which shells out to `yo doc`
+  # and then does its own git metadata, HTML templating and index assembly —
+  # all of it release-only until now.
+  #
+  # SEED-driven on purpose, mirroring release.yml rather than using a
+  # freshly-built binary: the seed evaluates the CHECKOUT's std, so a std
+  # change the pinned seed cannot evaluate is a break that shows up at the
+  # release and nowhere else. Build only — the Pages deploy stays in
+  # release.yml, gated on the release actually publishing.
+  docs-site:
+    name: Documentation website (build only, no deploy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # The seed links liburing dynamically and cannot start without it.
+      - name: Install liburing
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liburing-dev
+
+      - name: Install the seed compiler (previous release)
+        uses: ./.github/actions/install-seed
+        with:
+          version: ${{ env.SEED_VERSION }}
+
+      # The same two commands release.yml runs, with the version read from the
+      # same source of truth the release computes its bump from.
+      - name: Generate documentation website
+        run: |
+          VERSION=$(perl -ne 'print $1 if /^CURRENT_YO_VERSION :: "([^"]+)";/' yo-self/version.yo)
+          [ -n "$VERSION" ] || { echo "::error::could not read CURRENT_YO_VERSION from yo-self/version.yo"; exit 1; }
+          yo compile scripts/build_site.yo --release -o /tmp/build-site
+          /tmp/build-site --output yo-out/site --version "v$VERSION" --yo yo
+
+      # A site build that emits nothing exits 0 exactly as happily as one that
+      # works, so assert substance rather than exit status — the same lesson
+      # the hollow-batch detection elsewhere in this file encodes.
+      - name: Assert the site has substance
+        run: |
+          test -f yo-out/site/index.html || { echo "::error::build_site produced no index.html"; exit 1; }
+          COUNT=$(find yo-out/site -type f | wc -l)
+          echo "site files: $COUNT"
+          [ "$COUNT" -ge 100 ] || { echo "::error::only $COUNT site files — std alone documents ~160"; exit 1; }
+
+      - name: Upload the site for inspection
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site
+          path: yo-out/site
+          retention-days: 7
+
   # P2.5 step 18 removed `bun test` from the 5-platform matrix — correctly: it
   # ran the same TS unit tests five times to serve one toolchain. But deleting
   # it outright would leave the 23 TS test files (466 tests) unrun by ANY job


### PR DESCRIPTION
Two defects in the documentation-website pipeline, both release-only and therefore invisible until a release was already half-committed. Raised by @shd101wyy.

## 1. `scripts/build_site.yo` was gated by nothing

```
$ grep -rl "build_site" .
scripts/build_site.yo
.github/workflows/release.yml
```

24.7 KB of Yo, referenced by exactly one place in the repo. It ran for the first time each release — **after** the version bump was pushed to develop and the tag created.

That is how the first v0.2.10 attempt died: the release job installed no liburing, so the seed `yo` could not even start at this step, and the version number was already spent. v0.2.8 burned the same way on the Marketplace publish.

The `doc-html` / `doc-json` / `doc-markdown` cli-cases cover the `yo doc` **subcommand**. `build_site.yo` shells out to it (line 715) and then does its own git metadata, HTML templating and index assembly — none of which was gated.

New `docs-site` job runs the release's two commands on every PR. **Seed-driven on purpose**, mirroring release.yml rather than using a freshly-built binary: the seed evaluates the *checkout's* std, so a std change the pinned seed cannot evaluate is a break that surfaces at the release and nowhere else. Build only, no deploy.

It asserts substance, not exit status — a site build that emits nothing exits 0 exactly as happily as one that works, the same lesson the hollow-batch detection encodes.

Rehearsed locally against the real v0.2.9 seed before committing:

```
COMPILE OK / RUN rc=0
index.html      28546 bytes
site files      160          (job floor is >=100, ~60 files of margin)
std docs        154 modules, 1711 items in 31.6s
```

## 2. Pages deployed before the release was published

`Deploy to GitHub Pages` sat in the `release` job, firing right after the site build — while the GitHub Release was still a **draft** and not one bundle had been built. Measured live during the v0.2.10 release:

```
site (public):    v0.2.10
release v0.2.10:  draft=true, assets=1
```

A draft's assets 404 on the public download URL (release.yml's own comments say so), so every download link that live site published pointed at nothing. Had a required bundle leg then failed, the site would have gone on advertising a version that never shipped.

Moved into a `deploy-site` job gated on `publish-release` — the moment the release becomes real, since it flips the draft public only once every required bundle leg has uploaded. The artifact upload stays in `release`, so the deployed bytes are exactly the ones the release built, and `pages: write` / `id-token: write` move with the step that needed them.

Failure mode is deliberately conservative: if publication does not happen, the site stays on the previous version.

## Notes

- Draft until the in-flight v0.2.10 release finishes — merging to develop cancels release-adjacent runs.
- After merge, `docs-site` should join the ruleset's required contexts (currently 14). That has to happen once the job exists on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)