### PR TITLE
release: give musl-bundle the swapfile every other seed-driven self-emit has

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -866,6 +866,34 @@ jobs:
     # rule recorded here previously.
     continue-on-error: false
     steps:
+      # The one seed-driven self-emit in this file that had NO swapfile, while
+      # seed-bundles, seed-cross-emit and test.yml's musl leg all provision
+      # one. That asymmetry killed the v0.2.10 release: this job ran the same
+      # `yo compile yo-self/main.yo --release --allocator mimalloc` its test.yml
+      # twin runs, on a bare 16 GB runner, and the runner DIED at 50 min —
+      # "The hosted runner lost communication with the server ... starves it
+      # for CPU/Memory", the documented starvation signature. The identical
+      # emit had passed in the gate run an hour earlier, because THAT job has
+      # a swapfile.
+      #
+      # This is exactly the failure the v0.2.9 seed bump was warned to cause:
+      # a seed-driven job sitting just under the 16 GB line goes over it, and
+      # the ones already swapping only get slower (see
+      # issues/seed-v0.2.9-memory-growth-slows-every-self-build.md). musl-bundle
+      # was the release-side job with no swapfile, so it did not get slower —
+      # it died.
+      #
+      # `needs: release` means the version bump and the tag are ALREADY pushed
+      # by the time this runs, so its failure holds publication with the
+      # release half-committed.
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 32G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          free -h
+
       - name: Checkout the released commit
         uses: actions/checkout@v4
         with:

--- a/issues/seed-v0.2.9-memory-growth-slows-every-self-build.md
+++ b/issues/seed-v0.2.9-memory-growth-slows-every-self-build.md
@@ -12,11 +12,11 @@ the problem. See "ANSWERED" below.
 Same commit, same runner class (`ubuntu-latest`, 16 GB), same step — only the
 seed differs:
 
-| job | v0.2.4 seed (develop) | v0.2.9 seed (#137) |
-| --- | --- | --- |
-| ThreadSanitizer | 16 min | **>60 min — killed by `timeout-minutes: 60`** |
-| Bootstrap fixpoint (yo-self self-compile) | 39 min | 53 min |
-| Compiler internal tests, shard 0 | 55 min | 56 min |
+| job                                       | v0.2.4 seed (develop) | v0.2.9 seed (#137)                            |
+| ----------------------------------------- | --------------------- | --------------------------------------------- |
+| ThreadSanitizer                           | 16 min                | **>60 min — killed by `timeout-minutes: 60`** |
+| Bootstrap fixpoint (yo-self self-compile) | 39 min                | 53 min                                        |
+| Compiler internal tests, shard 0          | 55 min                | 56 min                                        |
 
 The pattern explains itself: the jobs that ALREADY provisioned the 32 GB
 swapfile moved modestly (+36 %, +2 %), because they were already swapping. TSan
@@ -51,12 +51,12 @@ Measured directly, same tree, same 16 GB machine (the runners' size), only the
 compiler differing. `--emit-c --skip-c-compiler`, so this is evaluation +
 codegen without clang:
 
-| binary | its own allocator | wall | peak footprint |
-| --- | --- | --- | --- |
-| v0.2.4 bundle | mimalloc | 447 s | 14.49 GB |
-| v0.2.9 bundle | mimalloc | 475 s | **28.36 GB** |
-| current tree | mimalloc | 373 s | 12.67 GB |
-| current tree | system | 186 s | 11.42 GB |
+| binary        | its own allocator | wall  | peak footprint |
+| ------------- | ----------------- | ----- | -------------- |
+| v0.2.4 bundle | mimalloc          | 447 s | 14.49 GB       |
+| v0.2.9 bundle | mimalloc          | 475 s | **28.36 GB**   |
+| current tree  | mimalloc          | 373 s | 12.67 GB       |
+| current tree  | system            | 186 s | 11.42 GB       |
 
 Two independent effects, separable because the first two rows hold the
 allocator constant:
@@ -105,3 +105,52 @@ This is worth understanding rather than absorbing:
 
 Until that is understood, every `SEED_VERSION` bump should be treated as a
 potential CI-wall-clock change and the affected job budgets re-checked.
+
+## The prediction came true, and it cost a release (2026-08-19)
+
+The section above says the jobs already swapping only got _slower_, while the
+one with no swapfile (TSan) was the one pushed over the line. That generalises,
+and the v0.2.10 release found the release-side instance of it.
+
+`release.yml`'s `musl-bundle` ran the same full self-emit its `test.yml` twin
+runs —
+
+```
+yo compile yo-self/main.yo --release --allocator mimalloc --std-path ./std ...
+```
+
+— on a bare 16 GB `ubuntu-latest` with **no swapfile**, while `seed-bundles`,
+`seed-cross-emit` and test.yml's musl leg all provision 32 GB. It died at 50
+minutes (of a 180-minute budget, so NOT a timeout) with the runner-death
+annotation:
+
+> The hosted runner lost communication with the server. Anything in your
+> workflow that terminates the runner process, **starves it for CPU/Memory**,
+> or blocks its network access can cause this error.
+
+Diagnostic notes, since this signature is easy to misread:
+
+- **A timeout kill and a starvation death look different.** `timeout-minutes`
+  reports the job as CANCELLED at exactly the budget; this was a FAILURE at 50
+  of 180 minutes, with the running step left `in_progress` and **no log blob at
+  all** (the runner died before uploading). The reason lives in the job's
+  _annotations_, not its log:
+  `gh api repos/<o>/<r>/check-runs/<job-id>/annotations`.
+- **The identical emit had passed an hour earlier** in the gate run, which is
+  what makes the asymmetry the whole story rather than the seed alone.
+
+Fixed by giving `musl-bundle` the same swapfile its siblings have. A sweep of
+every heavy self-building job in both workflows found no other gap: the only
+other heavy-without-swap job is `ts-unit-tests`, which is the TypeScript
+compiler under an explicit `--max-old-space-size` V8 cap — a different failure
+mode, and deleted with `src/` in Group E.
+
+**Cost.** `musl-bundle` has `needs: release`, so the version bump and the tag
+were already pushed when it died. Publication is held (it is in
+`publish-release`'s `needs`, deliberately), so v0.2.10 sat as a draft with the
+website already advertising it — the ordering defect fixed separately in #165.
+
+**The general rule this yields:** any job that runs a seed-driven self-emit
+needs the 32 GB swapfile, and the check belongs in review of every new such
+job. The demand is ~28 GB peak footprint under the v0.2.9 seed (table above);
+16 GB of RAM is not a question of tuning.


### PR DESCRIPTION
**This killed the v0.2.10 release.**

`musl-bundle` runs the same full self-emit its `test.yml` twin runs —

```
yo compile yo-self/main.yo --release --allocator mimalloc --std-path ./std ...
```

— but was the one seed-driven job in either workflow with **no swapfile**, while `seed-bundles`, `seed-cross-emit` and test.yml's musl leg all provision 32 GB.

On a bare 16 GB runner it died at **50 minutes of a 180-minute budget** (so not a timeout) with the runner-death annotation:

> The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, **starves it for CPU/Memory**, or blocks its network access can cause this error.

The identical emit had passed in the gate run an hour earlier — because that job has a swapfile. **The asymmetry was the whole bug.**

## Why it happened now

Exactly the failure `issues/seed-v0.2.9-memory-growth-slows-every-self-build.md` predicted: the v0.2.9 seed needs ~28 GB peak footprint (vs 14.49 GB for v0.2.4), so jobs already swapping merely got *slower*, and any job without a swapfile went *over the line*. TSan was the test.yml instance and got a swapfile in #137. `musl-bundle` was the release-side instance, and nothing had exercised it since — `release.yml` gets no PR CI.

## Diagnosis notes (the signature misleads)

- A `timeout-minutes` kill reports **CANCELLED** at exactly the budget. This was a **FAILURE at 50/180**, with the running step left `in_progress` and **no log blob at all** — the runner died before uploading. The reason exists only in the job's annotations: `gh api repos/<o>/<r>/check-runs/<job-id>/annotations`.

## Completeness

Swept every heavy self-building job in both workflows for the same gap; none left. The only other heavy-without-swap job is `ts-unit-tests`, which is the TypeScript compiler under an explicit V8 `--max-old-space-size` cap — different failure mode, and deleted with `src/` in Group E.

## Blast radius

`musl-bundle` has `needs: release`, so the version bump and tag were already pushed when it died. It is in `publish-release`'s `needs` **by design**, so v0.2.10 is correctly held as a draft rather than shipping without its musl bundle — but the site had already deployed, which is the ordering defect #165 fixed.

Merging without waiting for CI: this touches `release.yml` only, which gets no PR CI, so a green suite would say nothing about the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)