### PR TITLE
release: turn zswap on for the seed-driven self-emits — worth 10x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,13 @@ jobs:
     # times out burns a version number, so the budget is sized for the
     # measured cost, not the old one. See
     # issues/seed-v0.2.9-memory-growth-slows-every-self-build.md.
-    timeout-minutes: 180
+    #
+    # 180 -> 360 (2026-08-19): the v0.2.10 attempt was KILLED at 180 with the
+    # candidate build alone taking 159 min, against 18 min for the same step
+    # one release earlier. Root cause was the missing memory treatment below,
+    # not the budget — but the budget is what turned a slow job into a dead
+    # release, so it gets headroom too. The arm64 leg, same steps, took 32 min.
+    timeout-minutes: 360
     permissions:
       contents: write
     # Only the CI-runner platforms (linux-x64, macos-arm64, windows-x64) are
@@ -395,6 +401,47 @@ jobs:
           sudo chmod 600 /mnt/swapfile
           sudo mkswap /mnt/swapfile
           sudo swapon /mnt/swapfile
+
+      # SWAP ALONE IS NOT ENOUGH — the v0.2.10 release proved it expensively.
+      # This job's linux-x64 leg spent 159 minutes on the candidate build and
+      # was killed at the budget, taking the release with it.
+      #
+      # zswap is the knob, and the comparison is unusually well controlled:
+      # test.yml's bootstrap-fixpoint "Stage 1" runs the SAME operation — the
+      # v0.2.9 seed building the compiler — on the same commit, the same
+      # ubuntu-latest runner class, with the same 32 GB swapfile. The only
+      # difference was that it turns zswap on and this job did not.
+      #
+      #     test.yml   Stage 1     zswap ON      16 min
+      #     release.yml            zswap OFF    159 min
+      #
+      # A 10x difference from one sysctl. Once the seed no longer fits in RAM
+      # (v0.2.9 peaks ~28 GB — see the issue below), every reclaimed page goes
+      # to disk; zswap keeps a compressed copy in RAM (~3x) and turns disk
+      # thrash back into memory traffic. The arm64 leg needed only 32 min
+      # without it, which is why this first looked arch-specific rather than
+      # configuration-specific.
+      #
+      # THP off for the reason test.yml sets it on its heavier emit: huge pages
+      # must be split and compacted before they can be swapped at all.
+      #
+      # DELIBERATELY NOT copied from test.yml: its `systemd-run --scope -p
+      # MemoryHigh/MemoryMax` wrapper. It is unmeasured for these steps, it
+      # would newly OOM-kill anything that legitimately exceeds the cap, and
+      # `sudo` resets PATH to secure_path — which does not contain the seed's
+      # bin/ — so wrapping the steps that invoke a bare `yo` would break them
+      # outright. release.yml gets no PR CI, so an untested change here is only
+      # discoverable by burning a release. The measurement says zswap is what
+      # mattered; that is what this applies.
+      #
+      # See issues/seed-v0.2.9-memory-growth-slows-every-self-build.md.
+      - name: Tune the kernel for a swap-heavy self-emit
+        if: runner.os == 'Linux'
+        run: |
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled || true
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/defrag || true
+          echo Y | sudo tee /sys/module/zswap/parameters/enabled || true
+          free -h
 
       - name: Install LLVM/Clang
         if: runner.os == 'Windows'
@@ -601,7 +648,7 @@ jobs:
     name: Cross-emit C (${{ matrix.target }})
     needs: release
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
@@ -636,6 +683,16 @@ jobs:
           sudo mkswap /mnt/swapfile
           sudo swapon /mnt/swapfile
           free -h
+
+      # See the identical step in seed-bundles for why swap alone is not
+      # enough. This job survived the v0.2.10 attempt at 64-69 min, but it runs
+      # the same seed-driven self-emit on the same runner class, so it gets the
+      # same treatment rather than waiting to be the next leg that collapses.
+      - name: Tune the kernel for a swap-heavy self-emit
+        run: |
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled || true
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/defrag || true
+          echo Y | sudo tee /sys/module/zswap/parameters/enabled || true
 
       # The SEED runs on this Linux host, so it needs liburing itself even
       # though the EMITTED C targets macOS (kqueue backend, no liburing).
@@ -893,6 +950,15 @@ jobs:
           sudo mkswap /mnt/swapfile
           sudo swapon /mnt/swapfile
           free -h
+
+      # The swapfile above (added in #166) is what this job was missing
+      # entirely; zswap is what keeps the resulting swap traffic from becoming
+      # thrash. See the identical step in seed-bundles for the measurement.
+      - name: Tune the kernel for a swap-heavy self-emit
+        run: |
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled || true
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/defrag || true
+          echo Y | sudo tee /sys/module/zswap/parameters/enabled || true
 
       - name: Checkout the released commit
         uses: actions/checkout@v4

--- a/issues/seed-v0.2.9-memory-growth-slows-every-self-build.md
+++ b/issues/seed-v0.2.9-memory-growth-slows-every-self-build.md
@@ -154,3 +154,48 @@ website already advertising it — the ordering defect fixed separately in #165.
 needs the 32 GB swapfile, and the check belongs in review of every new such
 job. The demand is ~28 GB peak footprint under the v0.2.9 seed (table above);
 16 GB of RAM is not a question of tuning.
+
+## The swapfile is only half of it: zswap is worth 10x (2026-08-19)
+
+The same release run failed a second, independent way, and this one is the
+more valuable finding. `release.yml`'s `seed-bundles` linux-x64 leg spent **159
+minutes** on "Build the native yo binary (previous seed)" and was killed at the
+180-minute budget. The same step took 18 minutes one release earlier, and 32
+minutes on the arm64 leg of the same run.
+
+The controlled comparison is unusually clean, because `test.yml` runs the same
+operation on the same commit:
+
+| job                                         | zswap | wall        |
+| ------------------------------------------- | ----- | ----------- |
+| `test.yml` bootstrap-fixpoint, **Stage 1**  | ON    | **16 min**  |
+| `release.yml` seed-bundles, candidate build | OFF   | **159 min** |
+
+Same commit, same `ubuntu-latest` runner class, same v0.2.9 seed, same 32 GB
+swapfile, same `--release --allocator mimalloc` self-build. **The only
+difference is one sysctl**, and it is worth a factor of ten.
+
+The mechanism follows from the measurement above: at ~28 GB peak against 16 GB
+of RAM the seed cannot avoid reclaim, so every reclaimed page is a disk round
+trip. zswap keeps a compressed copy in RAM (~3x), which converts most of that
+disk thrash back into memory traffic. The arm64 leg degraded to only 32 min
+without it, which is why the failure first read as arch-specific rather than
+configuration-specific — a reminder to compare the CONFIGURATION of a fast job
+against a slow one before concluding anything about the hardware.
+
+Fixed by giving every seed-driven Linux job in `release.yml` the zswap + THP-off
+step `test.yml` already had.
+
+**Not adopted:** test.yml's `systemd-run --scope -p MemoryHigh=11G
+-p MemoryMax=14G` wrapper. It is unmeasured for these steps, it would newly
+OOM-kill anything legitimately exceeding the cap, and `sudo` resets PATH to
+`secure_path` — which does not contain the seed's `bin/` — so wrapping a step
+that invokes a bare `yo` breaks it outright. Since `release.yml` gets no PR CI,
+an untested change there is only discoverable by burning a release.
+
+**Method note.** Three failures in one run had three different causes (no
+swapfile; no zswap; a genuinely degraded macOS runner). The macOS one was
+excluded by measuring the same `clang -O2` locally on the exact CI input —
+**68 s, 2.38 GB peak** — and by a re-run that passed in 3 min. Do that before
+"fixing" anything: two of these three symptoms were identical
+("lost communication with the server") and only one of them was our bug.


### PR DESCRIPTION
The **second, independent** way the v0.2.10 release failed, and the more valuable finding. (The first was the missing swapfile, #166.)

`seed-bundles`' linux-x64 leg spent **159 minutes** on the candidate build and was killed at its 180-minute budget. The same step took 18 min one release earlier, and 32 min on the arm64 leg of the same run.

## The measurement

`test.yml` runs the same operation on the same commit, which makes this unusually well controlled:

| job | zswap | wall |
|---|---|---|
| `test.yml` bootstrap-fixpoint **Stage 1** | ON | **16 min** |
| `release.yml` seed-bundles candidate build | OFF | **159 min** |

Same commit, same `ubuntu-latest` runner class, same v0.2.9 seed, same 32 GB swapfile, same `--release --allocator mimalloc` self-build. **The only difference is one sysctl, and it is worth 10x.**

At ~28 GB peak against 16 GB of RAM the seed cannot avoid reclaim, so every reclaimed page becomes a disk round trip; zswap keeps a compressed copy in RAM (~3x) and turns most of that thrash back into memory traffic. The arm64 leg degraded to only 32 min without it — which is why this first read as arch-specific rather than configuration-specific. Worth remembering: **compare the configuration of a fast job against a slow one before concluding anything about the hardware.**

## What this changes

- zswap + THP-off for all three seed-driven Linux jobs (`seed-bundles`, `seed-cross-emit`, `musl-bundle`) — not only the leg that failed. They run the same workload on the same runner class, and the inconsistency between them is what caused the outage.
- `seed-bundles` / `seed-cross-emit` timeouts 180 → 360. The budget was not the cause, but it is what turned a slow job into a dead release.

## What this deliberately does NOT change

test.yml's `systemd-run --scope -p MemoryHigh=11G -p MemoryMax=14G` wrapper. I wrote it, measured, then backed it out:

- unmeasured for these steps — the data says zswap is what mattered;
- it would newly OOM-kill anything legitimately over the cap;
- `sudo` resets PATH to `secure_path`, which does **not** contain the seed's `bin/` (install-seed appends to `$GITHUB_PATH`), so wrapping the steps that invoke a bare `yo` would break them outright.

`release.yml` gets no PR CI, so an untested change here is only discoverable by burning a release.

## The third failure was not ours

The same run also lost `Seed bundle (macos-x64, cross-emitted)` with the **identical** "lost communication with the server" annotation. It was excluded rather than "fixed":

- compiling the exact CI input locally: `clang -O2` → **68 s, 2.38 GB peak**;
- the cross-emitted C is 6,699,976 bytes vs 6,652,250 at v0.2.9 — 0.7% apart;
- a plain re-run passed in **3 min**.

A degraded runner. Two of the three symptoms were the same string and only one was our bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)