### PR TITLE
install: link liburing in the source build, and name the Windows SDK

### DIFF
--- a/issues/installer-source-build-never-links-liburing.md
+++ b/issues/installer-source-build-never-links-liburing.md
@@ -1,0 +1,98 @@
+# `install.sh --from-source` never passes `-luring`, and `install.ps1` never checks for the Windows SDK
+
+**Status: FIXED** (found and fixed 2026-08-19, during a fresh-machine audit of
+both installers).
+
+Two independent gaps, found by asking one question of each script: _what does a
+machine that has nothing on it actually need, and does the script provide it?_
+
+## 1. The source build cannot link on any Linux box that has liburing headers
+
+`install_from_source` compiled the published single-file `yo.c` with:
+
+```sh
+"$CC_BIN" -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
+  "$YO_TEMP_DIR/yo.c" -o "$YO_TEMP_DIR/yo" $CFLAGS_OVERRIDE -lpthread -lm
+```
+
+No `-luring`. But the emitted C opens its Linux async runtime with
+
+```c
+#if __has_include(<liburing.h>)
+#define __YO_HAS_LIBURING 1
+#include <liburing.h>
+```
+
+(`yo-self/codegen/async/runtime_io_linux.yo:510`), and the runtime it then
+compiles in calls real liburing symbols — `io_uring_queue_init`,
+`io_uring_submit`, `io_uring_wait_cqe` — not merely the header's `static
+inline` helpers. `__has_include` is evaluated on the INSTALLING machine, so the
+mere presence of the header flips on code that cannot link without the library:
+
+```
+undefined reference to `io_uring_queue_init'
+```
+
+This is exactly the trap `check_liburing_consistency` already warns users
+about ("Yo emits io_uring calls whenever that header exists, but only passes
+-luring when pkg-config succeeds"). The installer's own compile line did not
+obey it.
+
+The reach is wider than it looks:
+
+- `install_dependencies` installs `liburing-dev` BY DEFAULT, immediately before
+  the source build — so the default flow creates the failing condition itself.
+- The script's NixOS advice is `nix-shell -p clang git pkg-config liburing`,
+  which supplies the header too. NixOS is the case `--from-source` exists to
+  serve, and following the printed instructions walked into the failure.
+
+**Why nothing caught it:** `install-scripts.yml` never runs `--from-source` at
+all. Its only mention is a negative assertion that the musl path does _not_
+print the `--from-source` advice.
+
+**Fix.** Decide the flag the same way the compiler itself decides it —
+`pkg-config --exists liburing` — and pass `pkg-config --libs liburing`. When
+liburing is NOT visible, warn loudly, because the silent direction is the
+dangerous one: with no header the file compiles happily and the async runtime is
+replaced by stubs, producing a `yo` that cannot read source files at all.
+`test.yml`'s musl leg asserts against precisely that outcome:
+
+```
+::error::async I/O was compiled OUT — the binary would fail to read sources
+```
+
+## 2. `install.ps1` never mentions the Windows SDK
+
+`clang` on PATH is not a working C toolchain on Windows. Clang targets MSVC
+there: `<stdio.h>` comes from the Windows SDK's UCRT, and the import libraries
+Yo links (`-lws2_32 -lbcrypt -ladvapi32`, `yo-self/main.yo:1652`) are SDK
+libraries. `winget install LLVM.LLVM` installs clang alone, so a fresh Windows
+machine ends up with a clang that cannot build anything.
+
+The repository **already documents this** — `README.md` and
+`docs/zh-CN/README.md` both tell users to install Visual Studio or the Build
+Tools with the "Desktop development with C++" workload. Nothing in the install
+path acted on it: the user got a raw clang error from the hello-world
+verification and no indication of what to install.
+
+**Why nothing caught it:** `install-scripts.yml` runs `install.ps1` on
+`windows-latest`, which ships Visual Studio. CI has always had an SDK and has
+never once run the configuration a new user actually has.
+
+**Fix.** A compile-and-link probe (`Test-CToolchain`) that builds a trivial C
+file and, on failure, names the requirement and the exact `winget` command for
+the Build Tools workload. It is a real compile rather than a registry or path
+check for the same reason `Verify-Install` compiles a hello world: nothing else
+is immune to a partial install.
+
+It deliberately does NOT install the Build Tools. They are a multi-gigabyte
+download, and a script piped from the internet should not start one unasked.
+
+## Lesson
+
+Both gaps share a shape: **CI runners are richer than user machines.** GitHub's
+`windows-latest` has Visual Studio; its Ubuntu images have build tooling
+preinstalled. An installer's job is to work on the machine CI never runs on, so
+"green in install-scripts.yml" says nothing about a fresh box. The same shape
+produced the v0.2.10 release failure, where a job died for want of liburing
+that every other job happened to have.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -98,6 +98,8 @@ function Get-OsArch {
 #     compiler can be selected with --cc).
 #   * git — REQUIRED for `yo fetch` / `yo install`, which resolve dependencies
 #     by shelling out to git. Compiling works without it.
+#   * the Windows SDK — REQUIRED, and NOT installable from here. See
+#     Test-CToolchain below for why this cannot be a package in the list above.
 #
 # There is no liburing on Windows (io_uring is Linux-only), and mimalloc is
 # compiled from the vendored sources shipped in the bundle, so there is no
@@ -144,6 +146,61 @@ git was not found on PATH. 'yo compile' works without it, but 'yo fetch' and
 Install it with: winget install Git.Git
 '@
   }
+  Test-CToolchain
+}
+
+# `clang` on PATH is NOT the same as a working C toolchain on Windows, and this
+# is the one prerequisite the installer cannot satisfy for the user.
+#
+# Clang here targets MSVC. It ships its own compiler headers but NOT the C
+# runtime: <stdio.h> lives in the Windows SDK's UCRT, and the import libraries
+# Yo links against (-lws2_32 -lbcrypt -ladvapi32, see yo-self/main.yo) are SDK
+# libraries too. `winget install LLVM.LLVM` installs clang alone, so a machine
+# with no Visual Studio ends up with a clang that cannot build anything.
+#
+# It is not added to Install-Dependencies because the Build Tools are a
+# multi-gigabyte install; a script piped from the internet should not start one
+# unasked. Naming it precisely is the useful thing.
+#
+# Why this was missed until now: install-scripts.yml exercises install.ps1 on
+# `windows-latest`, which ships Visual Studio — so CI has always had an SDK and
+# has never once run the configuration a new user actually has. The repo README
+# documents the requirement (both languages); nothing in the install path did.
+#
+# The probe is a real compile-and-link rather than a registry or path check,
+# for the same reason Verify-Install compiles a hello world: it is the only
+# check that cannot be fooled by a partial install.
+function Test-CToolchain {
+  if (-not (Has-Cmd 'clang')) { return }   # already reported above
+  # New-TempDir hands back the SHARED script-scoped directory, so this does not
+  # clean up after itself — Verify-Install compiles into the same place for the
+  # same reason, and the single Remove-TempDir at the end of the run covers it.
+  $tmp = New-TempDir
+  $src = Join-Path $tmp 'probe.c'
+  "#include <stdio.h>`nint main(void) { return 0; }" | Set-Content -Path $src -Encoding UTF8
+  $out = Join-Path $tmp 'probe.exe'
+  $log = & clang $src -o $out 2>&1
+  if ($LASTEXITCODE -eq 0) { return }
+  Warn @"
+clang is on PATH but cannot build a C program on this machine, so 'yo compile'
+will fail.
+
+Clang on Windows targets MSVC: the C runtime headers (stdio.h) and the import
+libraries Yo links against (ws2_32, bcrypt, advapi32) come from the WINDOWS SDK,
+which the LLVM package does not include.
+
+Install the "Desktop development with C++" workload — it provides MSVC, the
+Windows SDK and the linker:
+
+    winget install Microsoft.VisualStudio.2022.BuildTools --override "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --quiet"
+
+or download Visual Studio (Community edition is free) from
+https://visualstudio.microsoft.com/downloads/ and select that workload. Then
+reopen your terminal and re-run this installer.
+
+clang reported:
+$(($log | Out-String).Trim())
+"@
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -715,10 +715,36 @@ install_from_source() {
 
   # -w: the emitted C is machine-generated and warns freely; warnings here are
   # noise, not signal, and would bury a real error.
+  # -luring is REQUIRED whenever <liburing.h> is present, and must be decided
+  # here rather than assumed. The emitted C opens its Linux async runtime with
+  # `#if __has_include(<liburing.h>)` — a check made on THIS machine at this
+  # moment — and the runtime it then compiles in calls real liburing symbols
+  # (io_uring_queue_init/_submit/_wait_cqe), not just the header's static
+  # inlines. So the header alone flips on code that cannot link without the
+  # library, which is the exact trap check_liburing_consistency warns about;
+  # this line simply has to obey it.
+  #
+  # Getting it wrong is worse than a link error in one direction: with NO
+  # header the file compiles happily and the async runtime is silently
+  # replaced by stubs, producing a `yo` that cannot read source files at all
+  # (test.yml's musl leg asserts against exactly that outcome).
+  #
+  # pkg-config is the same oracle the compiler itself consults before adding
+  # -luring, so this stays consistent with a bundle-built compiler.
+  uring_libs=""
+  if [ "$OSNAME" = "linux" ] && has_cmd pkg-config && pkg-config --exists liburing 2>/dev/null; then
+    uring_libs="$(pkg-config --libs liburing 2>/dev/null || echo -luring)"
+    info "  liburing: $uring_libs (async I/O compiled in)"
+  elif [ "$OSNAME" = "linux" ]; then
+    warn "liburing is not visible to pkg-config, so async I/O will be compiled OUT"
+    warn "and the resulting compiler cannot read source files. Install it first"
+    warn "(e.g. 'apt-get install pkg-config liburing-dev') and re-run."
+  fi
+
   info "Compiling yo.c (this takes a minute).."
-  # shellcheck disable=SC2086  # CFLAGS_OVERRIDE is intentionally word-split
+  # shellcheck disable=SC2086  # CFLAGS_OVERRIDE and uring_libs are intentionally word-split
   "$CC_BIN" -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
-    "$YO_TEMP_DIR/yo.c" -o "$YO_TEMP_DIR/yo" $CFLAGS_OVERRIDE -lpthread -lm \
+    "$YO_TEMP_DIR/yo.c" -o "$YO_TEMP_DIR/yo" $CFLAGS_OVERRIDE -lpthread -lm $uring_libs \
     || stop "Failed to compile yo.c with $CC_BIN.
   On Linux, install the liburing development headers first (see --help)."
 


### PR DESCRIPTION
Fresh-machine audit of both installers, requested by @shd101wyy. Two independent gaps, invisible to CI for the same reason: **the runners are richer than a user's machine.**

## 1. `install.sh --from-source` never passes `-luring`

It compiled `yo.c` with `-lpthread -lm` and nothing else, while the emitted C opens its Linux async runtime with

```c
#if __has_include(<liburing.h>)     // runtime_io_linux.yo:510
#include <liburing.h>
```

and then calls real liburing symbols — `io_uring_queue_init` / `_submit` / `_wait_cqe`, not just the header's `static inline` helpers. `__has_include` is evaluated on the **installing** machine, so the header alone flips on code that cannot link:

```
undefined reference to `io_uring_queue_init'
```

This is the exact trap `check_liburing_consistency` already warns users about. The installer's own compile line didn't obey it.

The reach is worse than it first looks — **the default flow creates the condition itself**:

- `install_dependencies` installs `liburing-dev` immediately *before* the source build;
- the script's NixOS advice is `nix-shell -p clang git pkg-config liburing`, which supplies the header too — and NixOS is the case `--from-source` exists to serve. Following the printed instructions hit the failure.

Fixed by deciding the flag the way the compiler itself decides it (`pkg-config --exists liburing`), and warning loudly when liburing is absent — because **that** direction is the silent one: with no header the compile *succeeds* and the async runtime is swapped for stubs, yielding a `yo` that cannot read source files at all. test.yml's musl leg asserts against exactly that: `async I/O was compiled OUT — the binary would fail to read sources`.

**Why nothing caught it:** `install-scripts.yml` never runs `--from-source`. Its only mention is a negative assertion that the musl path doesn't *print* the advice.

## 2. `install.ps1` never checked for the Windows SDK

`clang` on PATH is not a working toolchain on Windows. Clang targets MSVC there: `<stdio.h>` comes from the SDK's UCRT, and the import libs Yo links (`-lws2_32 -lbcrypt -ladvapi32`, `yo-self/main.yo:1652`) are SDK libraries. `winget install LLVM.LLVM` gives clang alone.

**The repo already documents this** — `README.md` and `docs/zh-CN/README.md` both say to install the "Desktop development with C++" workload. Nothing in the install path acted on it, so the user got a raw clang error from verification with no idea what to install.

Added `Test-CToolchain`: a real compile-and-link probe that names the requirement and gives the exact `winget` command. A probe rather than a registry check, for the same reason `Verify-Install` compiles a hello world — nothing else is immune to a partial install. It deliberately does **not** install the Build Tools: multi-gigabyte, and a script piped from the internet shouldn't start one unasked.

**Why nothing caught it:** `install-scripts.yml` runs on `windows-latest`, which ships Visual Studio.

## Validation

- `sh -n scripts/install.sh` — clean
- `install.ps1` parses clean under the PowerShell AST parser (`[Parser]::ParseFile`)
- CI here exercises the *unchanged* paths (bundle install on 4 targets, Alpine musl selection, Windows install); neither changed path is covered by it, which is the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)