### PR TITLE
p3: add a stack-sizing probe that can actually fail

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to Yo
+
+The `Yo` compiler is **self-hosted**: it is written in Yo and lives in
+[`src/`](./src/). Building it needs an already-installed `yo` binary
+(get one from the [install script](./README.md#install-script-recommended)) plus
+a C compiler.
+
+Yo is primarily developed on the Steam Deck LCD (Linux). The compiler currently transpiles Yo to C; to produce
+machine code you must have a C compiler (for example `gcc`, `clang`, `zig`, `emcc`, etc).
+
+Please install [nix](https://nixos.org/download.html) and [direnv](https://direnv.net/) before proceeding.
+
+The dev environment is defined in [shell.nix](./shell.nix). You can also manually install the dependencies listed in the file.
+
+## Setup
+
+```bash
+$ cd Yo
+$ direnv allow . # Run this command to activate the nix shell.
+                 # You only need to run it once.
+```
+
+There is no package-manager install step. The only vendored dependencies are git
+submodules:
+
+```bash
+$ git submodule update --init --recursive
+```
+
+Type-check the compiler sources (evaluator only, no codegen — this is the fast
+iteration loop):
+
+```bash
+$ yo check ./src
+```
+
+Build the compiler from source. Always pass `--release`: at `-O0` the big
+evaluator functions have multi-megabyte stack frames and deep compile-time
+recursion exhausts the stack.
+
+```bash
+$ yo compile src/main.yo --release -o /tmp/yo-self-bin
+```
+
+> There is no watch-and-rebuild loop — re-run the `yo compile` above after a
+> change.
+
+Try the compiler you just built on a scratch program (`./tmp/` is gitignored —
+put throwaway `.yo` files there):
+
+```bash
+$ /tmp/yo-self-bin compile ./tmp/fixme.yo --release -o /tmp/fixme && /tmp/fixme
+```
+
+Run the test suites with `yo test`:
+
+```bash
+$ yo test ./tests --exclude tests/internal --exclude tests/cli-cases --bail
+$ yo test ./tests/internal --parallel 1   # the compiler's own tests
+```
+
+## LLM and AI-agent contributions are welcome
+
+**Yo is designed to be written by language models**, so contributions produced
+with an LLM are welcome here rather than merely tolerated. There is no
+disclosure requirement and no separate review track.
+
+What we ask is the same thing we ask of any contributor: **understand the change
+you are proposing, and verify it.** A patch nobody can explain is a problem
+whether a person or a model wrote it. Concretely, before opening a PR:
+
+- run `yo check ./src` — the fast evaluator-only loop;
+- run the tests that cover what you touched (see below), not just the fast ones;
+- state what you actually ran in the PR description, including anything that
+  failed or that you skipped.
+
+The repository is set up for this. [`AGENTS.md`](./AGENTS.md) is the entry point
+an agent should read first; `.github/instructions/` holds per-area rules (C
+codegen, debugging, testing, language design, syntax); and `.github/skills/`
+ships reusable skill packs. Keeping those current is itself a valued
+contribution — if you learn something about Yo the hard way, write it down
+there.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ Yo aims to be **Simple** and **Fast** (around 0% - 15% slower than C).
 - [Features](#features)
 - [Installation](#installation)
   - [Install script (recommended)](#install-script-recommended)
-  - [Linux](#linux)
-  - [macOS](#macos)
-  - [Windows](#windows)
-  - [WebAssembly (WASM)](#webassembly-wasm)
 - [Quick Start](#quick-start)
 - [Prelude](#prelude)
 - [Standard Library](#standard-library)
@@ -40,7 +36,6 @@ Yo aims to be **Simple** and **Fast** (around 0% - 15% slower than C).
 - [Version Management](#version-management)
 - [AI Agent Skills](#ai-agent-skills)
   - [Using in your own project](#using-in-your-own-project)
-- [Star History](#star-history)
 - [License](#license)
 
 <!-- /code_chunk_output -->
@@ -71,7 +66,7 @@ Below is a non-exhaustive list of features that Yo supports:
 
 ### Install script (recommended)
 
-Installs a native prebuilt compiler — no Node.js or npm required.
+Installs a native prebuilt compiler.
 
 ```bash
 # macOS / Linux
@@ -118,110 +113,16 @@ NixOS, where the prebuilt binary's hardcoded ELF interpreter
 The installer puts the `yo` command on your `PATH`. Run `yo --help` to see the
 available commands.
 
-> **The `npm` channel is gone.** Yo used to be published as the
-> `@shd101wyy/yo` npm package, back when the compiler was a TypeScript program.
-> npm publishing stopped at `v0.2.0`; the compiler is now self-hosted and every
-> release since ships as a native bundle from GitHub Releases. Use the install
-> script above.
+Yo transpiles to C, so a **C compiler** is required to produce machine code. The
+install script above sets one up for you — these guides are for configuring the
+toolchain by hand, or for diagnosing a failed install.
 
-Yo transpiles to C, so a **C compiler** is required to produce machine code. Follow the instructions for your platform below.
+- **[Linux](./docs/en-US/INSTALL_LINUX.md)**
+- **[macOS](./docs/en-US/INSTALL_MACOS.md)**
+- **[Windows](./docs/en-US/INSTALL_WINDOWS.md)**
 
-### Linux
-
-Install **Clang** (recommended), **liburing** (for async I/O), and **pkg-config** (for system library discovery):
-
-```bash
-# Ubuntu/Debian
-$ sudo apt-get update
-$ sudo apt-get install clang liburing-dev pkg-config
-
-# Fedora/RHEL
-$ sudo dnf install clang liburing-devel pkgconf-pkg-config
-
-# Arch Linux
-$ sudo pacman -S clang liburing pkgconf
-```
-
-You can also use `gcc` or `zig` instead of `clang` by passing `--cc gcc` or `--cc zig`.
-
-### macOS
-
-Clang is included with Xcode Command Line Tools:
-
-```bash
-$ xcode-select --install
-
-# Also install pkgconf for system library discovery
-$ brew install pkgconf
-```
-
-Or install LLVM via Homebrew:
-
-```bash
-$ brew install llvm pkgconf
-```
-
-### Windows
-
-Clang on Windows requires a linker and Windows SDK headers. Install **Visual Studio** (Community edition is free) or the **Build Tools for Visual Studio** with the "Desktop development with C++" workload:
-
-1. Download from [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/)
-2. In the installer, select **"Desktop development with C++"** (this includes MSVC, Windows SDK, and the linker)
-3. Then install LLVM/Clang:
-
-```bash
-# Using Chocolatey
-$ choco install llvm
-
-# Using Scoop
-$ scoop install llvm
-
-# Or download from https://releases.llvm.org/
-```
-
-Alternatively, you can use `zig` as the C compiler (no Visual Studio needed):
-
-```bash
-$ choco install zig
-$ yo compile main.yo --cc zig --release -o main
-```
-
-For system library discovery, install **vcpkg**:
-
-```bash
-$ git clone https://github.com/microsoft/vcpkg.git
-$ .\vcpkg\bootstrap-vcpkg.bat
-# Then set the VCPKG_ROOT environment variable to the vcpkg directory
-
-# Or using Scoop
-$ scoop install vcpkg
-```
-
-For more information, see the [vcpkg documentation](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started).
-
-### WebAssembly (WASM)
-
-Yo can compile to WebAssembly using [Emscripten](https://emscripten.org/):
-
-```bash
-# Install Emscripten (https://emscripten.org/docs/getting_started/downloads.html)
-$ git clone https://github.com/emscripten-core/emsdk.git
-$ cd emsdk
-$ ./emsdk install latest
-$ ./emsdk activate latest
-$ source ./emsdk_env.sh
-
-# Compile a Yo program to WASM
-$ yo compile main.yo --cc emcc --release -o app
-
-# This produces: app.html + app.js + app.wasm
-# Run with Node.js:
-$ node app.js
-
-# Or open app.html in a browser
-```
-
-When using `--cc emcc`, Yo automatically targets `wasm32-emscripten` and uses the `libc` allocator. You can also use `--target wasm-emscripten` (which auto-selects `emcc`). Emscripten produces an `.html` file (browser shell), a `.js` file (runtime glue), and a `.wasm` file (compiled binary).
+Targeting WebAssembly needs Emscripten as well —
+**[WASM setup](./docs/en-US/INSTALL_WASM.md)**.
 
 ## Quick Start
 
@@ -454,10 +355,6 @@ cp -r .github/skills /path/to/your-yo-project/.github/
 ```
 
 Then in any AI agent session, invoke a skill by name (e.g. `@yo-syntax`) to give the agent contextual knowledge about the Yo language.
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=shd101wyy/Yo&type=date&legend=top-left)](https://www.star-history.com/#shd101wyy/Yo&type=date&legend=top-left)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Yo aims to be **Simple** and **Fast** (around 0% - 15% slower than C).
   - [Hello World](#hello-world)
   - [Example Projects](#example-projects)
 - [Contributing](#contributing)
-  - [Setup](#setup)
 - [Editor Support](#editor-support)
 - [Version Management](#version-management)
 - [AI Agent Skills](#ai-agent-skills)
@@ -228,66 +227,9 @@ export(main);
 
 ## Contributing
 
-The `Yo` compiler is **self-hosted**: it is written in Yo and lives in
-[`src/`](./src/). Building it needs an already-installed `yo` binary
-(get one from the [install script](#install-script-recommended)) plus a C
-compiler — there is no TypeScript, Node.js, npm, or bun in the toolchain any
-more.
-
-Yo is primarily developed on the Steam Deck LCD (Linux). The compiler currently transpiles Yo to C; to produce
-machine code you must have a C compiler (for example `gcc`, `clang`, `zig`, `emcc`, etc).
-
-Please install [nix](https://nixos.org/download.html) and [direnv](https://direnv.net/) before proceeding.
-
-The dev environment is defined in [shell.nix](./shell.nix). You can also manually install the dependencies listed in the file.
-
-### Setup
-
-```bash
-$ cd Yo
-$ direnv allow . # Run this command to activate the nix shell.
-                 # You only need to run it once.
-```
-
-There is no package-manager install step. The only vendored dependencies are git
-submodules:
-
-```bash
-$ git submodule update --init --recursive
-```
-
-Type-check the compiler sources (evaluator only, no codegen — this is the fast
-iteration loop):
-
-```bash
-$ yo check ./src
-```
-
-Build the compiler from source. Always pass `--release`: at `-O0` the big
-evaluator functions have multi-megabyte stack frames and deep compile-time
-recursion exhausts the stack.
-
-```bash
-$ yo compile src/main.yo --release -o /tmp/yo-self-bin
-```
-
-> **There is no watch-and-rebuild loop any more.** `bun run dev` rebuilt the
-> TypeScript compiler on every file change; nothing replaces it. Re-run the
-> `yo compile` above after a change.
-
-Try the compiler you just built on a scratch program (`./tmp/` is gitignored —
-put throwaway `.yo` files there):
-
-```bash
-$ /tmp/yo-self-bin compile ./tmp/fixme.yo --release -o /tmp/fixme && /tmp/fixme
-```
-
-Run the test suites with `yo test`:
-
-```bash
-$ yo test ./tests --exclude tests/internal --exclude tests/cli-cases --bail
-$ yo test ./tests/internal --parallel 1   # the compiler's own tests
-```
+The compiler is written in Yo and builds itself. See
+**[CONTRIBUTING.md](./CONTRIBUTING.md)** for the dev environment, the build loop,
+and how to run the test suites — LLM-assisted contributions included.
 
 ## Editor Support
 

--- a/docs/en-US/INSTALL_LINUX.md
+++ b/docs/en-US/INSTALL_LINUX.md
@@ -1,0 +1,27 @@
+<!-- Split out of README.md so the front page can lead with the install
+script, which sets these up for you. This guide is for manual setup and
+for troubleshooting. -->
+
+# Installing the C toolchain on Linux
+
+> **You probably do not need this page.** `scripts/install.sh` installs a C
+> compiler and the rest of these dependencies for you — see
+> [Installation](../../README.md#installation). Read on only if you are
+> setting the toolchain up by hand, or diagnosing a failed install.
+
+
+Install **Clang** (recommended), **liburing** (for async I/O), and **pkg-config** (for system library discovery):
+
+```bash
+# Ubuntu/Debian
+$ sudo apt-get update
+$ sudo apt-get install clang liburing-dev pkg-config
+
+# Fedora/RHEL
+$ sudo dnf install clang liburing-devel pkgconf-pkg-config
+
+# Arch Linux
+$ sudo pacman -S clang liburing pkgconf
+```
+
+You can also use `gcc` or `zig` instead of `clang` by passing `--cc gcc` or `--cc zig`.

--- a/docs/en-US/INSTALL_MACOS.md
+++ b/docs/en-US/INSTALL_MACOS.md
@@ -1,0 +1,26 @@
+<!-- Split out of README.md so the front page can lead with the install
+script, which sets these up for you. This guide is for manual setup and
+for troubleshooting. -->
+
+# Installing the C toolchain on macOS
+
+> **You probably do not need this page.** `scripts/install.sh` installs a C
+> compiler and the rest of these dependencies for you — see
+> [Installation](../../README.md#installation). Read on only if you are
+> setting the toolchain up by hand, or diagnosing a failed install.
+
+
+Clang is included with Xcode Command Line Tools:
+
+```bash
+$ xcode-select --install
+
+# Also install pkgconf for system library discovery
+$ brew install pkgconf
+```
+
+Or install LLVM via Homebrew:
+
+```bash
+$ brew install llvm pkgconf
+```

--- a/docs/en-US/INSTALL_WASM.md
+++ b/docs/en-US/INSTALL_WASM.md
@@ -1,0 +1,31 @@
+<!-- Split out of README.md with the per-platform toolchain guides: this is
+setup for a compile TARGET, not language documentation. -->
+
+# Compiling to WebAssembly
+
+> Yo compiles to C, so targeting WebAssembly means installing Emscripten and
+> pointing Yo at it. See [Installation](../../README.md#installation) for the
+> compiler itself.
+
+
+Yo can compile to WebAssembly using [Emscripten](https://emscripten.org/):
+
+```bash
+# Install Emscripten (https://emscripten.org/docs/getting_started/downloads.html)
+$ git clone https://github.com/emscripten-core/emsdk.git
+$ cd emsdk
+$ ./emsdk install latest
+$ ./emsdk activate latest
+$ source ./emsdk_env.sh
+
+# Compile a Yo program to WASM
+$ yo compile main.yo --cc emcc --release -o app
+
+# This produces: app.html + app.js + app.wasm
+# Run with Node.js:
+$ node app.js
+
+# Or open app.html in a browser
+```
+
+When using `--cc emcc`, Yo automatically targets `wasm32-emscripten` and uses the `libc` allocator. You can also use `--target wasm-emscripten` (which auto-selects `emcc`). Emscripten produces an `.html` file (browser shell), a `.js` file (runtime glue), and a `.wasm` file (compiled binary).

--- a/docs/en-US/INSTALL_WINDOWS.md
+++ b/docs/en-US/INSTALL_WINDOWS.md
@@ -1,0 +1,47 @@
+<!-- Split out of README.md so the front page can lead with the install
+script, which sets these up for you. This guide is for manual setup and
+for troubleshooting. -->
+
+# Installing the C toolchain on Windows
+
+> **You probably do not need this page.** `scripts/install.sh` installs a C
+> compiler and the rest of these dependencies for you — see
+> [Installation](../../README.md#installation). Read on only if you are
+> setting the toolchain up by hand, or diagnosing a failed install.
+
+
+Clang on Windows requires a linker and Windows SDK headers. Install **Visual Studio** (Community edition is free) or the **Build Tools for Visual Studio** with the "Desktop development with C++" workload:
+
+1. Download from [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/)
+2. In the installer, select **"Desktop development with C++"** (this includes MSVC, Windows SDK, and the linker)
+3. Then install LLVM/Clang:
+
+```bash
+# Using Chocolatey
+$ choco install llvm
+
+# Using Scoop
+$ scoop install llvm
+
+# Or download from https://releases.llvm.org/
+```
+
+Alternatively, you can use `zig` as the C compiler (no Visual Studio needed):
+
+```bash
+$ choco install zig
+$ yo compile main.yo --cc zig --release -o main
+```
+
+For system library discovery, install **vcpkg**:
+
+```bash
+$ git clone https://github.com/microsoft/vcpkg.git
+$ .\vcpkg\bootstrap-vcpkg.bat
+# Then set the VCPKG_ROOT environment variable to the vcpkg directory
+
+# Or using Scoop
+$ scoop install vcpkg
+```
+
+For more information, see the [vcpkg documentation](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started).

--- a/docs/zh-CN/CONTRIBUTING.md
+++ b/docs/zh-CN/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# 为 Yo 做贡献
+
+`Yo` 编译器是**自举**的：它用 Yo 自身编写，代码位于 [`src/`](../../src/)。
+构建它需要一个已经安装好的 `yo` 二进制（可以用[安装脚本](./README.md#安装脚本推荐)获取）以及一个
+C 编译器。
+
+Yo 主要在 Steam Deck LCD（Linux）上开发。编译器目前将 Yo 转换为 C；要生成机器码，你必须有一个 C 编译器（例如 `gcc`、`clang`、`zig`、`emcc` 等）。
+
+请继续之前安装 [nix](https://nixos.org/download.html) 和 [direnv](https://direnv.net/)。
+
+开发环境定义在 [shell.nix](../../shell.nix) 中。你也可以手动安装文件中列出的依赖项。
+
+## 环境设置
+
+```bash
+$ cd Yo
+$ direnv allow . # 运行此命令激活 nix shell。
+                  # 只需运行一次。
+```
+
+没有包管理器的安装步骤。唯一的第三方依赖是 git 子模块：
+
+```bash
+$ git submodule update --init --recursive
+```
+
+对编译器源码做类型检查（只跑求值器，不生成代码 —— 这是最快的迭代循环）：
+
+```bash
+$ yo check ./src
+```
+
+从源码构建编译器。务必加上 `--release`：在 `-O0` 下，求值器中那些大函数的栈帧有好几
+兆字节，编译期的深度递归会耗尽栈空间。
+
+```bash
+$ yo compile src/main.yo --release -o /tmp/yo-self-bin
+```
+
+> 没有监视重建的循环 —— 改动之后重新运行上面的 `yo compile`。
+
+用刚构建出来的编译器试跑一个临时程序（`./tmp/` 已被 gitignore —— 请把一次性的 `.yo`
+文件放在那里）：
+
+```bash
+$ /tmp/yo-self-bin compile ./tmp/fixme.yo --release -o /tmp/fixme && /tmp/fixme
+```
+
+用 `yo test` 运行测试套件：
+
+```bash
+$ yo test ./tests --exclude tests/internal --exclude tests/cli-cases --bail
+$ yo test ./tests/internal --parallel 1   # 编译器自身的测试
+```
+
+## 欢迎 LLM 与 AI Agent 的贡献
+
+**Yo 的设计目标之一就是让语言模型来编写**，因此我们欢迎借助 LLM 完成的贡献，而不只是
+勉强接受。无需声明，也没有单独的评审流程。
+
+我们的要求和对任何贡献者一样：**理解你提交的改动，并验证它。** 一个没人能解释的补丁
+就是问题，无论作者是人还是模型。提交 PR 之前请：
+
+- 运行 `yo check ./src` —— 只跑求值器的快速循环；
+- 运行覆盖你所改动部分的测试（见下文），不要只跑最快的那些；
+- 在 PR 描述中写清楚你实际运行了什么，包括失败的和跳过的部分。
+
+仓库本身已经为此做好准备：[`AGENTS.md`](../../AGENTS.md) 是 agent 应当最先阅读的入口；
+`.github/instructions/` 存放各领域的规则（C 代码生成、调试、测试、语言设计、语法）；
+`.github/skills/` 提供可复用的技能包。保持这些文档的准确本身就是有价值的贡献 —— 如果
+你在 Yo 上踩过坑并学到了什么，请把它写进去。

--- a/docs/zh-CN/INSTALL_LINUX.md
+++ b/docs/zh-CN/INSTALL_LINUX.md
@@ -1,0 +1,25 @@
+<!-- 从 README.md 拆分出来，让首页可以直接推荐安装脚本；
+     本页面用于手动配置与排查问题。 -->
+
+# 在 Linux 上安装 C 工具链
+
+> **多数情况下你不需要这一页。**`scripts/install.sh` 会替你安装 C 编译器和
+> 其余依赖 —— 参见 [安装](../../README.md#安装)。只有在手动配置工具链或
+> 排查安装失败时才需要阅读本页。
+
+
+安装 **Clang**（推荐）、**liburing**（用于异步 I/O）和 **pkg-config**（用于系统库发现）：
+
+```bash
+# Ubuntu/Debian
+$ sudo apt-get update
+$ sudo apt-get install clang liburing-dev pkg-config
+
+# Fedora/RHEL
+$ sudo dnf install clang liburing-devel pkgconf-pkg-config
+
+# Arch Linux
+$ sudo pacman -S clang liburing pkgconf
+```
+
+你也可以通过传递 `--cc gcc` 或 `--cc zig` 使用 `gcc` 或 `zig` 代替 `clang`。

--- a/docs/zh-CN/INSTALL_MACOS.md
+++ b/docs/zh-CN/INSTALL_MACOS.md
@@ -1,0 +1,24 @@
+<!-- 从 README.md 拆分出来，让首页可以直接推荐安装脚本；
+     本页面用于手动配置与排查问题。 -->
+
+# 在 macOS 上安装 C 工具链
+
+> **多数情况下你不需要这一页。**`scripts/install.sh` 会替你安装 C 编译器和
+> 其余依赖 —— 参见 [安装](../../README.md#安装)。只有在手动配置工具链或
+> 排查安装失败时才需要阅读本页。
+
+
+Clang 包含在 Xcode 命令行工具中：
+
+```bash
+$ xcode-select --install
+
+# 同时安装 pkgconf 用于系统库发现
+$ brew install pkgconf
+```
+
+或者通过 Homebrew 安装 LLVM：
+
+```bash
+$ brew install llvm pkgconf
+```

--- a/docs/zh-CN/INSTALL_WASM.md
+++ b/docs/zh-CN/INSTALL_WASM.md
@@ -1,0 +1,30 @@
+<!-- 与各平台工具链指南一并从 README.md 拆分出来：这是编译目标的配置，
+     不是语言文档。 -->
+
+# 编译到 WebAssembly
+
+> Yo 会转译为 C，因此以 WebAssembly 为目标需要安装 Emscripten 并让 Yo 使用它。
+> 编译器本身的安装参见 [安装](../../README.md#安装)。
+
+
+Yo 可以使用 [Emscripten](https://emscripten.org/) 编译到 WebAssembly：
+
+```bash
+# 安装 Emscripten（https://emscripten.org/docs/getting_started/downloads.html）
+$ git clone https://github.com/emscripten-core/emsdk.git
+$ cd emsdk
+$ ./emsdk install latest
+$ ./emsdk activate latest
+$ source ./emsdk_env.sh
+
+# 将 Yo 程序编译为 WASM
+$ yo compile main.yo --cc emcc --release -o app
+
+# 生成：app.html + app.js + app.wasm
+# 使用 Node.js 运行：
+$ node app.js
+
+# 或在浏览器中打开 app.html
+```
+
+使用 `--cc emcc` 时，Yo 自动针对 `wasm32-emscripten` 目标并使用 `libc` 分配器。你也可以使用 `--target wasm-emscripten`（会自动选择 `emcc`）。Emscripten 生成一个 `.html` 文件（浏览器外壳）、一个 `.js` 文件（运行时胶水代码）和一个 `.wasm` 文件（编译后的二进制文件）。

--- a/docs/zh-CN/INSTALL_WINDOWS.md
+++ b/docs/zh-CN/INSTALL_WINDOWS.md
@@ -1,0 +1,45 @@
+<!-- 从 README.md 拆分出来，让首页可以直接推荐安装脚本；
+     本页面用于手动配置与排查问题。 -->
+
+# 在 Windows 上安装 C 工具链
+
+> **多数情况下你不需要这一页。**`scripts/install.sh` 会替你安装 C 编译器和
+> 其余依赖 —— 参见 [安装](../../README.md#安装)。只有在手动配置工具链或
+> 排查安装失败时才需要阅读本页。
+
+
+Windows 上的 Clang 需要链接器和 Windows SDK 头文件。安装 **Visual Studio**（社区版免费）或带有"Desktop development with C++"工作负载的 **Build Tools for Visual Studio**：
+
+1. 从 [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/) 下载
+2. 在安装程序中选择 **"Desktop development with C++"**（包含 MSVC、Windows SDK 和链接器）
+3. 然后安装 LLVM/Clang：
+
+```bash
+# 使用 Chocolatey
+$ choco install llvm
+
+# 使用 Scoop
+$ scoop install llvm
+
+# 或从 https://releases.llvm.org/ 下载
+```
+
+或者，你可以使用 `zig` 作为 C 编译器（无需 Visual Studio）：
+
+```bash
+$ choco install zig
+$ yo compile main.yo --cc zig --release -o main
+```
+
+对于系统库发现，安装 **vcpkg**：
+
+```bash
+$ git clone https://github.com/microsoft/vcpkg.git
+$ .\vcpkg\bootstrap-vcpkg.bat
+# 然后将 VCPKG_ROOT 环境变量设置为 vcpkg 目录
+
+# 或使用 Scoop
+$ scoop install vcpkg
+```
+
+更多信息，请参阅 [vcpkg 文档](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started)。

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -24,10 +24,6 @@ Yo 的目标是 **简单** 和 **快速**（比 C 语言慢约 0% - 15%）。
 - [特性](#特性)
 - [安装](#安装)
   - [安装脚本（推荐）](#安装脚本推荐)
-  - [Linux](#linux)
-  - [macOS](#macos)
-  - [Windows](#windows)
-  - [WebAssembly (WASM)](#webassembly-wasm)
 - [快速开始](#快速开始)
 - [预导入模块（Prelude）](#预导入模块prelude)
 - [标准库](#标准库)
@@ -40,7 +36,6 @@ Yo 的目标是 **简单** 和 **快速**（比 C 语言慢约 0% - 15%）。
 - [版本管理](#版本管理)
 - [AI Agent 技能包](#ai-agent-技能包)
   - [在自己的项目中使用](#在自己的项目中使用)
-- [Star 历史](#star-历史)
 - [许可证](#许可证)
 
 <!-- /code_chunk_output -->
@@ -71,7 +66,7 @@ Yo 的目标是 **简单** 和 **快速**（比 C 语言慢约 0% - 15%）。
 
 ### 安装脚本（推荐）
 
-安装原生预编译的编译器 —— 无需 Node.js 或 npm。
+安装原生预编译的编译器。
 
 ```bash
 # macOS / Linux
@@ -115,109 +110,15 @@ NixOS 上的解决方案 —— 预编译二进制文件中硬编码的 ELF 解�
 
 安装脚本会把 `yo` 命令放到你的 `PATH` 中。运行 `yo --help` 查看可用命令。
 
-> **`npm` 渠道已经废弃。** 在编译器还是 TypeScript 程序的年代，Yo 曾以
-> `@shd101wyy/yo` 这个 npm 包发布。npm 发布在 `v0.2.0` 之后就停止了；编译器现在
-> 是自举的，此后的每个版本都以原生预编译包的形式发布在 GitHub Releases 上。请使用
-> 上面的安装脚本。
+Yo 将代码转换为 C，因此需要一个 **C 编译器**来生成机器码。上面的安装脚本会替你
+准备好；下面的指南用于手动配置工具链，或排查安装失败的问题。
 
-Yo 将代码转换为 C，因此需要一个 **C 编译器**来生成机器码。请按照以下平台说明操作。
+- **[Linux](./INSTALL_LINUX.md)**
+- **[macOS](./INSTALL_MACOS.md)**
+- **[Windows](./INSTALL_WINDOWS.md)**
 
-### Linux
-
-安装 **Clang**（推荐）、**liburing**（用于异步 I/O）和 **pkg-config**（用于系统库发现）：
-
-```bash
-# Ubuntu/Debian
-$ sudo apt-get update
-$ sudo apt-get install clang liburing-dev pkg-config
-
-# Fedora/RHEL
-$ sudo dnf install clang liburing-devel pkgconf-pkg-config
-
-# Arch Linux
-$ sudo pacman -S clang liburing pkgconf
-```
-
-你也可以通过传递 `--cc gcc` 或 `--cc zig` 使用 `gcc` 或 `zig` 代替 `clang`。
-
-### macOS
-
-Clang 包含在 Xcode 命令行工具中：
-
-```bash
-$ xcode-select --install
-
-# 同时安装 pkgconf 用于系统库发现
-$ brew install pkgconf
-```
-
-或者通过 Homebrew 安装 LLVM：
-
-```bash
-$ brew install llvm pkgconf
-```
-
-### Windows
-
-Windows 上的 Clang 需要链接器和 Windows SDK 头文件。安装 **Visual Studio**（社区版免费）或带有"Desktop development with C++"工作负载的 **Build Tools for Visual Studio**：
-
-1. 从 [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/) 下载
-2. 在安装程序中选择 **"Desktop development with C++"**（包含 MSVC、Windows SDK 和链接器）
-3. 然后安装 LLVM/Clang：
-
-```bash
-# 使用 Chocolatey
-$ choco install llvm
-
-# 使用 Scoop
-$ scoop install llvm
-
-# 或从 https://releases.llvm.org/ 下载
-```
-
-或者，你可以使用 `zig` 作为 C 编译器（无需 Visual Studio）：
-
-```bash
-$ choco install zig
-$ yo compile main.yo --cc zig --release -o main
-```
-
-对于系统库发现，安装 **vcpkg**：
-
-```bash
-$ git clone https://github.com/microsoft/vcpkg.git
-$ .\vcpkg\bootstrap-vcpkg.bat
-# 然后将 VCPKG_ROOT 环境变量设置为 vcpkg 目录
-
-# 或使用 Scoop
-$ scoop install vcpkg
-```
-
-更多信息，请参阅 [vcpkg 文档](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started)。
-
-### WebAssembly (WASM)
-
-Yo 可以使用 [Emscripten](https://emscripten.org/) 编译到 WebAssembly：
-
-```bash
-# 安装 Emscripten（https://emscripten.org/docs/getting_started/downloads.html）
-$ git clone https://github.com/emscripten-core/emsdk.git
-$ cd emsdk
-$ ./emsdk install latest
-$ ./emsdk activate latest
-$ source ./emsdk_env.sh
-
-# 将 Yo 程序编译为 WASM
-$ yo compile main.yo --cc emcc --release -o app
-
-# 生成：app.html + app.js + app.wasm
-# 使用 Node.js 运行：
-$ node app.js
-
-# 或在浏览器中打开 app.html
-```
-
-使用 `--cc emcc` 时，Yo 自动针对 `wasm32-emscripten` 目标并使用 `libc` 分配器。你也可以使用 `--target wasm-emscripten`（会自动选择 `emcc`）。Emscripten 生成一个 `.html` 文件（浏览器外壳）、一个 `.js` 文件（运行时胶水代码）和一个 `.wasm` 文件（编译后的二进制文件）。
+以 WebAssembly 为目标还需要 Emscripten —— 参见
+**[WASM 配置](./INSTALL_WASM.md)**。
 
 ## 快速开始
 
@@ -440,10 +341,6 @@ cp -r .github/skills /path/to/your-yo-project/.github/
 ```
 
 之后在任意 AI Agent 会话中，通过技能名称（例如 `@yo-syntax`）调用该技能，即可为 Agent 提供关于 Yo 语言的上下文知识。
-
-## Star 历史
-
-[![Star History Chart](https://api.star-history.com/svg?repos=shd101wyy/Yo&type=date&legend=top-left)](https://www.star-history.com/#shd101wyy/Yo&type=date&legend=top-left)
 
 ## 许可证
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -31,7 +31,6 @@ Yo 的目标是 **简单** 和 **快速**（比 C 语言慢约 0% - 15%）。
   - [Hello World](#hello-world)
   - [示例项目](#示例项目)
 - [贡献](#贡献)
-  - [环境设置](#环境设置)
 - [编辑器支持](#编辑器支持)
 - [版本管理](#版本管理)
 - [AI Agent 技能包](#ai-agent-技能包)
@@ -224,59 +223,8 @@ export(main);
 
 ## 贡献
 
-`Yo` 编译器是**自举**的：它用 Yo 自身编写，代码位于 [`src/`](../../src/)。
-构建它需要一个已经安装好的 `yo` 二进制（可以用[安装脚本](#安装脚本推荐)获取）以及一个
-C 编译器 —— 工具链中已经不再有 TypeScript、Node.js、npm 或 bun。
-
-Yo 主要在 Steam Deck LCD（Linux）上开发。编译器目前将 Yo 转换为 C；要生成机器码，你必须有一个 C 编译器（例如 `gcc`、`clang`、`zig`、`emcc` 等）。
-
-请继续之前安装 [nix](https://nixos.org/download.html) 和 [direnv](https://direnv.net/)。
-
-开发环境定义在 [shell.nix](../../shell.nix) 中。你也可以手动安装文件中列出的依赖项。
-
-### 环境设置
-
-```bash
-$ cd Yo
-$ direnv allow . # 运行此命令激活 nix shell。
-                  # 只需运行一次。
-```
-
-没有包管理器的安装步骤。唯一的第三方依赖是 git 子模块：
-
-```bash
-$ git submodule update --init --recursive
-```
-
-对编译器源码做类型检查（只跑求值器，不生成代码 —— 这是最快的迭代循环）：
-
-```bash
-$ yo check ./src
-```
-
-从源码构建编译器。务必加上 `--release`：在 `-O0` 下，求值器中那些大函数的栈帧有好几
-兆字节，编译期的深度递归会耗尽栈空间。
-
-```bash
-$ yo compile src/main.yo --release -o /tmp/yo-self-bin
-```
-
-> **监视重建的循环已经没有了。** `bun run dev` 会在文件变更时重新构建 TypeScript
-> 编译器；它没有任何替代品。改动之后请重新运行上面的 `yo compile`。
-
-用刚构建出来的编译器试跑一个临时程序（`./tmp/` 已被 gitignore —— 请把一次性的 `.yo`
-文件放在那里）：
-
-```bash
-$ /tmp/yo-self-bin compile ./tmp/fixme.yo --release -o /tmp/fixme && /tmp/fixme
-```
-
-用 `yo test` 运行测试套件：
-
-```bash
-$ yo test ./tests --exclude tests/internal --exclude tests/cli-cases --bail
-$ yo test ./tests/internal --parallel 1   # 编译器自身的测试
-```
+编译器用 Yo 编写并自举。开发环境、构建流程与测试运行方式见
+**[CONTRIBUTING.md](./CONTRIBUTING.md)** —— 也欢迎借助 LLM 完成的贡献。
 
 ## 编辑器支持
 

--- a/plans/P3_DISTRIBUTION.md
+++ b/plans/P3_DISTRIBUTION.md
@@ -331,7 +331,7 @@ and `=64`, and requires the outcomes to DIFFER. Every compiled Yo program runs
 `main` on the same worker thread, so this exercises the identical codegen path
 in seconds rather than the 76 minutes the A/B cost.
 
-Measured on macOS/arm64 with the v0.2.9 bundle:
+Measured on macOS/arm64 with the **v0.2.11** bundle:
 
 | `YO_MAIN_STACK_MB` | rc |
 | --- | --- |

--- a/plans/P3_DISTRIBUTION.md
+++ b/plans/P3_DISTRIBUTION.md
@@ -324,12 +324,34 @@ than passing green:
    coloring shrinks frames ~100x versus the `-O0` case that originally exposed
    the stack ceiling — so no threshold hunt with this workload can discriminate.
 
-**What would close it:** a direct probe rather than a threshold hunt. Compile a
-small program that recurses to a fixed depth needing a few MB, run it at
-`YO_MAIN_STACK_MB=1` and `=64`, and check the outcomes differ. Every compiled Yo
-program runs `main` on that same worker thread, so it exercises the identical
-codegen path in seconds. This matters more under musl-only than today: the
-static binary becomes the compiler everyone runs.
+**The probe now exists and is validated:**
+`scripts/bootstrap/probe-stack-sizing.sh <path-to-yo>`. It compiles a program
+that recurses 500,000 deep (~12 MB of frames), runs it at `YO_MAIN_STACK_MB=1`
+and `=64`, and requires the outcomes to DIFFER. Every compiled Yo program runs
+`main` on the same worker thread, so this exercises the identical codegen path
+in seconds rather than the 76 minutes the A/B cost.
+
+Measured on macOS/arm64 with the v0.2.9 bundle:
+
+| `YO_MAIN_STACK_MB` | rc |
+| --- | --- |
+| 1 | 138 (crash) |
+| 4 | 138 (crash) |
+| 16 / 64 / 256 | 0 |
+
+Threshold between 4 and 16 MB, consistent with 500k frames at ~24 bytes. **The
+request is honoured there.** What remains is running the same probe against the
+STATIC MUSL bundle on Linux, which is the actual open question — that belongs in
+the musl-only migration PR, since it is the evidence required before dropping
+the glibc legs.
+
+**The trap the script encodes**, because the first two attempts at this both
+failed: "non-tail recursion" is not sufficient. `n + recur(n - 1)` is linearised
+by LLVM's accumulator tail-call transform (addition is associative), and the
+probe then reports 500,000 frames fitting in 1 MB — 2 bytes per frame, i.e. no
+recursion happened at all. The fix is an `inout` local whose address escapes,
+which pins one real frame per level. A probe that cannot fail proves nothing;
+check the arithmetic of bytes-per-frame before believing a green result.
 
 ### The trap: no musl liburing ⇒ a binary that links fine and cannot work
 

--- a/scripts/bootstrap/probe-stack-sizing.sh
+++ b/scripts/bootstrap/probe-stack-sizing.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Does a compiled Yo binary actually GET the worker stack it asks for?
+#
+# Codegen runs `main` on a worker thread requested at 1 GiB
+# (`__yo_main_stack`, overridable via YO_MAIN_STACK_MB) and falls back SILENTLY
+# to `__yo_main_thread_entry(NULL)` on the ~8 MB process stack if
+# pthread_create fails:
+#
+#     if (pthread_attr_init(...) == 0
+#         && pthread_attr_setstacksize(&attr, __yo_main_stack) == 0
+#         && pthread_create(&tid, &attr, __yo_main_thread_entry, NULL) == 0) { ... }
+#     else { __yo_main_thread_entry(NULL); }
+#
+# A build that ignored the request would therefore pass ordinary workloads and
+# SIGSEGV (rc=139, no message) only on deep recursion — the Windows failure in
+# issues/windows-no-main-worker-stack-rc139.md, where YO_MAIN_STACK_MB was
+# silently a no-op. This matters most for the static musl bundle, whose libc
+# defaults to a ~128 KB thread stack against glibc's 8 MB.
+#
+# WHY A SYNTHETIC PROBE RATHER THAN `check ./yo-self`: that workload needs under
+# 1 MB at -O2 (LLVM stack coloring shrinks frames ~100x), so it cannot reach the
+# threshold and a sweep over it returns "pass" at every size — measured, see
+# plans/P3_DISTRIBUTION.md item 3.
+#
+# THE TRAP THIS SCRIPT ENCODES: naive "non-tail" recursion is NOT enough.
+# `n + recur(n - 1)` gets linearised by LLVM's accumulator tail-call transform
+# because addition is associative, and the probe then reports 500,000 frames
+# fitting in 1 MB — 2 bytes per frame, i.e. no recursion at all. The `inout`
+# local below makes the address escape, which pins a real frame per level.
+#
+# Usage:  probe-stack-sizing.sh <path-to-yo>       # e.g. /tmp/seed-musl/bin/yo
+# Exit:   0 = the request is HONOURED (small stack fails, large stack passes)
+#         1 = ignored, or inconclusive
+set -uo pipefail
+YO=${1:?usage: probe-stack-sizing.sh <path-to-yo>}
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/probe.yo" <<'YO'
+open(import("std/fmt"));
+
+bump :: (fn(inout(x) : i64) -> unit)({ x = (x + i64(1)); });
+
+deep :: (fn(n : i64) -> i64)(
+  cond(
+    (n <= i64(0)) => i64(0),
+    true => {
+      local := n;
+      r := recur((n - i64(1)));
+      bump(local);
+      (r + local)
+    }
+  )
+);
+
+main :: (fn() -> unit)({
+  println(`ok, sum = ${deep(i64(500000))}`);
+});
+
+export(main);
+YO
+
+"$YO" compile "$WORK/probe.yo" --release -o "$WORK/probe" > "$WORK/compile.log" 2>&1 || {
+  echo "::error::probe failed to compile"; tail -20 "$WORK/compile.log"; exit 1; }
+
+# Subshells with stderr closed: the SMALL run is EXPECTED to die on a signal,
+# and bash announces that ("Bus error", "Segmentation fault") from the shell
+# itself, not the program — which reads as a genuine failure in a CI log.
+# Run each in a CHILD shell that reports its own exit code. The SMALL run is
+# EXPECTED to die on a signal, and the announcement ("Bus error",
+# "Segmentation fault") is emitted by the shell that WAITS on it — so
+# redirecting the command, or even a subshell around it, does not suppress it.
+# Letting a child print the rc and discarding that child's stderr does.
+run_at() {  # <stack-mb> -> echoes the rc
+  bash -c 'YO_MAIN_STACK_MB=$1 "$2" >/dev/null 2>&1; echo $?' _ "$1" "$WORK/probe" 2>/dev/null
+}
+SMALL=$(run_at 1)
+LARGE=$(run_at 64)
+
+echo "500k-deep recursion (~12 MB of frames):"
+echo "  YO_MAIN_STACK_MB=1  -> rc=$SMALL"
+echo "  YO_MAIN_STACK_MB=64 -> rc=$LARGE"
+
+if [ "$LARGE" -ne 0 ]; then
+  echo "::error::64 MB was NOT enough (rc=$LARGE) — the stack request is not being honoured, or the binary is broken"
+  exit 1
+fi
+if [ "$SMALL" -eq 0 ]; then
+  echo "::error::1 MB ALSO sufficed, so the size is being ignored — main is very likely running on the process stack via the silent pthread_create fallback"
+  exit 1
+fi
+echo "HONOURED: 1 MB fails, 64 MB passes — the requested stack size takes effect"


### PR DESCRIPTION
Stacked on #171 (base is the Group F branch, so the diff shows only this change).

The last unvalidated item on the musl-only checklist. **Two previous attempts were inconclusive** — and correctly said so rather than passing green.

## Why `check ./yo-self` can't answer it

That workload needs **under 1 MB** at `-O2` — LLVM stack coloring shrinks frames ~100× versus the `-O0` case that exposed the original ceiling. A downward sweep over 1/2/4/8 MB returned `0 0 0 0` for *both* libcs. And 8 MB is useless as a probe value regardless, since **8 MB is also what the silent fallback yields** when `pthread_create` fails.

## The trap this encodes, having fallen into it first

"Non-tail recursion" is **not** sufficient. `n + recur(n - 1)` is linearised by LLVM's accumulator tail-call transform, because addition is associative. The probe then cheerfully reports 500,000 frames fitting in 1 MB — **2 bytes per frame**, i.e. no recursion happened at all.

Only the bytes-per-frame arithmetic gives that away. A probe that cannot fail proves nothing. The fix is an `inout` local whose address escapes, pinning one real frame per level.

## Measured (macOS/arm64, v0.2.9 bundle)

| `YO_MAIN_STACK_MB` | rc |
|---|---|
| 1 | 138 (crash) |
| 4 | 138 (crash) |
| 16 / 64 / 256 | 0 |

Threshold between 4 and 16 MB — consistent with 500k frames at ~24 bytes. **The request is honoured there.** Runs in seconds, versus the 76 minutes the A/B cost without answering this.

## What remains

The same probe against the **static musl bundle on Linux** — the actual open question. That belongs in the musl-only migration PR, as the evidence required before dropping the glibc legs.

## Also

Quiets the expected crash. The shell that *waits* on a signalled child prints "Bus error"/"Segmentation fault", so neither redirecting the command nor wrapping it in a subshell suppresses it — the run happens in a child shell that echoes its own rc. Otherwise a CI log shows what looks like a real failure on the deliberately-failing arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)