### PR TITLE
build: delete the `libc` allocator alias now that the migration window has closed

### DIFF
--- a/.github/skills/yo-project-workflow/workflow-cheatsheet.md
+++ b/.github/skills/yo-project-workflow/workflow-cheatsheet.md
@@ -178,7 +178,7 @@ wasm_api :: build.executable({
   root: "./src/wasm_api.yo",
   target: build.CompilationTarget.Wasm32_Emscripten,
   optimize: build.Optimize.ReleaseSmall,
-  allocator: build.Allocator.Libc
+  allocator: build.Allocator.System
 });
 wasm_api.add_c_flags("-O3 -flto -mbulk-memory -sALLOW_MEMORY_GROWTH -sENVIRONMENT=web,node -sMODULARIZE=1 -sEXPORT_NAME=createModule -sEXPORTED_FUNCTIONS=_my_func,_wasm_alloc,_wasm_free -sEXPORTED_RUNTIME_METHODS=HEAPU8");
 

--- a/.github/skills/yo-wasm-integration/wasm-integration-cheatsheet.md
+++ b/.github/skills/yo-wasm-integration/wasm-integration-cheatsheet.md
@@ -96,7 +96,7 @@ wasm_api :: build.executable({
   root: "./src/wasm_api.yo",
   target: build.CompilationTarget.Wasm32_Emscripten,
   optimize: build.Optimize.ReleaseSmall,
-  allocator: build.Allocator.Libc
+  allocator: build.Allocator.System
 });
 wasm_api.add_c_flags("-O3 -flto -mbulk-memory -sALLOW_MEMORY_GROWTH -sENVIRONMENT=web,node -sMODULARIZE=1 -sEXPORT_NAME=createModule -sEXPORTED_FUNCTIONS=_wasm_alloc,_wasm_free,_render -sEXPORTED_RUNTIME_METHODS=HEAPU8");
 
@@ -106,7 +106,7 @@ install.depend_on(wasm_api);
 
 Available targets: `Wasm32_Emscripten`, `Wasm32_Wasi`, `X86_64_Linux_Gnu`, `Aarch64_Macos`, etc.
 Available optimizations: `Debug`, `ReleaseSafe`, `ReleaseFast`, `ReleaseSmall`.
-Available allocators: `Mimalloc` (default), `Libc`.
+Available allocators: `Mimalloc` (default), `System`.
 
 ## npm package structure
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,7 +567,7 @@ jobs:
           YO_MAIN_STACK_MB: "4096"
         run: |
           mkdir -p portable-arm
-          yo compile src/main.yo --release --allocator libc \
+          yo compile src/main.yo --release --allocator system \
             --std-path ./std --emit-c --skip-c-compiler \
             -o "portable-arm/${{ matrix.target }}" > /dev/null
           ls -la "portable-arm/${{ matrix.target }}.c"
@@ -704,7 +704,7 @@ jobs:
           ./yo-candidate compile src/main.yo --release --allocator ${{ matrix.bundle_allocator }} \
             --std-path ./std --target ${{ matrix.yo_target }} \
             --emit-c --skip-c-compiler -o "cross/yo-${{ matrix.target }}" > /dev/null
-          ./yo-candidate compile src/main.yo --release --allocator libc \
+          ./yo-candidate compile src/main.yo --release --allocator system \
             --std-path ./std --target ${{ matrix.yo_target }} \
             --emit-c --skip-c-compiler -o "portable-arm/${{ matrix.target }}" > /dev/null
           ls -la cross/ portable-arm/

--- a/build.yo
+++ b/build.yo
@@ -28,7 +28,7 @@ yo_exe :: build.executable({
   optimize : build.Optimize.ReleaseSmall,
   // The canonical CI/release builds pass `--allocator mimalloc`
   // (test.yml native probes, release.yml seed build); without this the
-  // `yo build` route silently shipped a libc-allocator compiler —
+  // `yo build` route silently shipped a system-allocator compiler —
   // plans/P2_5_RETIRE_EXECUTION.md step 24b (make `yo build` the canonical
   // yo-self builder everywhere).
   allocator : build.Allocator.Mimalloc

--- a/docs/en-US/BUILD_SYSTEM.md
+++ b/docs/en-US/BUILD_SYSTEM.md
@@ -155,7 +155,6 @@ Shared libraries compile with `-shared -fPIC` and produce `.so` (Linux), `.dylib
 | -------------------- | ----------------------------------------- |
 | `Allocator.Mimalloc` | High-performance allocator (mimalloc)     |
 | `Allocator.System`   | The platform's system allocator (default) |
-| `Allocator.Libc`     | Deprecated alias of `Allocator.System`    |
 
 ### Sanitizers
 

--- a/docs/zh-CN/BUILD_SYSTEM.md
+++ b/docs/zh-CN/BUILD_SYSTEM.md
@@ -155,7 +155,6 @@ test_step.depend_on(tests);
 | -------------------- | ----------------------------- |
 | `Allocator.Mimalloc` | 高性能分配器（mimalloc）      |
 | `Allocator.System`   | 平台系统分配器（默认）        |
-| `Allocator.Libc`     | `Allocator.System` 的废弃别名 |
 
 ### 检测器
 

--- a/src/main.yo
+++ b/src/main.yo
@@ -1193,15 +1193,8 @@ run_compile :: (
   if(((cc != "") && (((cc != "cc") && (cc != "gcc")) && ((cc != "clang") && (cc != "zig")))) && (cc != "emcc"), {
     exn.throw(dyn(`compile: invalid --c-compiler "${cc}". Choices: cc, gcc, clang, zig, emcc`));
   });
-  if(((allocator != "mimalloc") && (allocator != "system")) && (allocator != "libc"), {
-    exn.throw(dyn(`compile: invalid --allocator "${allocator}". Choices: mimalloc, system (deprecated alias: libc)`));
-  });
-  // Collapse the deprecated "libc" alias to the canonical name (TS parity:
-  // codegen/index.ts resolves anything non-mimalloc to "system"). The alias
-  // is REMOVED once the migration window closes (rename release ships +
-  // SEED_VERSION moves past it).
-  if(allocator == "libc", {
-    allocator = String.from("system");
+  if((allocator != "mimalloc") && (allocator != "system"), {
+    exn.throw(dyn(`compile: invalid --allocator "${allocator}". Choices: mimalloc, system`));
   });
   if((optimize != "") && (((optimize != "0") && (optimize != "1")) && ((optimize != "2") && (optimize != "3"))), {
     exn.throw(dyn(`compile: invalid --optimize "${optimize}". Choices: 0, 1, 2, 3`));

--- a/std/build.yo
+++ b/std/build.yo
@@ -37,11 +37,7 @@ Allocator :: enum(
   Mimalloc,
   /// The platform's system allocator (macOS malloc zones, Windows CRT heap,
   /// glibc/musl malloc on Linux).
-  System,
-  /// Deprecated alias of `System`, TO BE REMOVED once the migration window
-  /// closes (first release with the rename ships + SEED_VERSION moves past
-  /// it). The system allocator is not libc's on macOS or Windows.
-  Libc
+  System
 );
 export(Allocator);
 // ── Sanitizers ───────────────────────────────────────────────────────
@@ -287,17 +283,16 @@ executable :: (fn(comptime(config) : Executable) -> comptime(Step))({
     .ReleaseFast => "release-fast",
     .ReleaseSmall => "release-small"
   );
-  // MIGRATION WINDOW (seed-era flags): `.System` must SPELL itself "libc"
-  // until SEED_VERSION reaches a release that accepts "system" — this string
-  // is handed to whichever compiler binary runs the build, and the seeds
-  // (v0.2.9 and older) reject "system" ("invalid --allocator"). "libc" is
-  // the permanent-until-deletion alias, so NEW compilers treat it as system.
-  // Flip both arms to "system" in the alias-deletion change, not before.
+  // This string is handed to whichever compiler binary runs the build. It
+  // spelled itself "libc" through the migration window, because seeds v0.2.9
+  // and older rejected "system" ("invalid --allocator"). SEED_VERSION reached
+  // v0.2.11 in #169 and v0.2.11 accepts "system", so the window is closed and
+  // the alias is gone. A pre-v0.2.10 `yo` can no longer build this tree — that
+  // is the intended consequence, and CI already requires v0.2.11.
   alloc_str :: match(
     config.allocator,
     .Mimalloc => "mimalloc",
-    .System => "libc",
-    .Libc => "libc"
+    .System => "system"
   );
   san_str :: match(
     config.sanitize,


### PR DESCRIPTION
`std/build.yo` spelled `.System` as `"libc"` deliberately, and its comment recorded the exact condition for undoing it:

> `.System` must SPELL itself "libc" **until `SEED_VERSION` reaches a release that accepts "system"** … Flip both arms in the alias-deletion change, not before.

Both halves now hold. **#169 moved all three `SEED_VERSION` pins to v0.2.11**, and v0.2.11 accepts `--allocator system` — verified by running it, rc=0. That string is handed to whichever compiler binary runs the build, and every binary CI uses now understands the canonical name.

## Removed, in one change because they are one contract

| file | what |
|---|---|
| `std/build.yo` | the `Libc` enum variant, the migration-window comment, both `"libc"` arms of `alloc_str` (`.System` now emits `"system"`) |
| `src/main.yo` | `libc` drops out of `--allocator` validation, out of the error message's choices, and the collapse block is gone |
| `.github/workflows/release.yml` | the two portable-c arms pass `--allocator system` |
| `docs/{en-US,zh-CN}/BUILD_SYSTEM.md` | the `Allocator.Libc` row |
| 2 skill cheatsheets | `build.Allocator.Libc` → `.System`, and the "Available allocators" line |
| `build.yo` | a comment still calling the fallback "a libc-allocator compiler" — it is the *system* allocator, which was the entire point of the rename |

## Consequence, stated rather than discovered later

**A pre-v0.2.10 `yo` can no longer build this tree** — `std/build.yo` hands it `"system"` and it rejects the flag. That is intended: CI already requires v0.2.11, and CONTRIBUTING points at the install script.

## Not touched

`src/public_safe_report.yo:150` keeps its `"libc"` — that's a path segment for `std/sys/libc`, nothing to do with allocators.

## Verified

- `yo check ./std` → **154/154**
- `yo build --list-steps` still evaluates the config through `executable()` with the `.Libc` arm gone
- **no test depends on the alias** — `tests/internal/build_runner.test.yo:23` passes an empty string
- `yo check ./src` running locally; CI's GATE 4 covers it too

🤖 Generated with [Claude Code](https://claude.com/claude-code)