### PR TITLE
release: skip the Marketplace publish when the extension is unchanged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,9 +134,59 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "$CURRENT -> $NEW_VERSION"
 
+      # Republishing a byte-identical extension burns a Marketplace version for
+      # no diff — v0.2.12 did exactly that, shipping an extension whose diff
+      # against v0.2.11 was EMPTY.
+      #
+      # MUST RUN BEFORE the version bump below, and that ordering is what makes
+      # the check need no normalization: the previous release's tag captured
+      # `package.json` at the previous version and pre-bump HEAD still holds
+      # that same version, so the one field that changes every release cancels
+      # out. Move this step after the bump and it reports "changed" forever.
+      #
+      # The baseline is the MARKETPLACE's own current version, not the last git
+      # tag, and that choice is load-bearing. The publish step below is
+      # `continue-on-error` (a service outage must not kill a release), so the
+      # Marketplace can legitimately sit behind the newest tag. Baselining on
+      # the tag would then see "no change since the last release" and skip
+      # forever, stranding the extension. Asking the Marketplace what it
+      # actually has makes the check self-healing: whatever the reason it is
+      # behind, the diff reappears and we publish.
+      - name: Decide whether the extension needs publishing
+        id: ext
+        run: |
+          set -o pipefail
+          LIVE=$(npx --yes @vscode/vsce show shd101wyy.yolang --json 2>/dev/null \
+                 | jq -r '.versions[0].version' 2>/dev/null || true)
+          if [ -z "$LIVE" ] || [ "$LIVE" = "null" ]; then
+            echo "::warning::Could not read the Marketplace version — publishing unconditionally."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Marketplace currently has $LIVE"
+          if ! git rev-parse -q --verify "v$LIVE^{commit}" >/dev/null; then
+            echo "::warning::No local tag v$LIVE to diff against — publishing unconditionally."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "v$LIVE" HEAD -- vscode-extension/)
+          if [ -z "$CHANGED" ]; then
+            echo "Extension is byte-identical to v$LIVE — SKIPPING the Marketplace publish."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Extension changed since v$LIVE:"
+            printf '%s\n' "$CHANGED" | sed 's/^/  /'
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # The extension keeps its own package.json (npm-only island, §2.3), so it
       # is SET to the computed version rather than bumped independently — two
       # independent bumpers is how they drift apart.
+      #
+      # Bumped even when the publish is skipped, so the repo's two version
+      # fields never disagree. The Marketplace then simply skips that number,
+      # which is why the step above baselines on the Marketplace rather than on
+      # `package.json`.
       - name: Set version in vscode-extension package.json
         run: |
           cd vscode-extension
@@ -220,6 +270,7 @@ jobs:
       # version number.)
       - name: Publish extension to Visual Studio Marketplace
         id: create_vsix
+        if: steps.ext.outputs.changed == 'true'
         continue-on-error: true
         uses: HaaLeo/publish-vscode-extension@v2
         with:
@@ -227,6 +278,11 @@ jobs:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           packagePath: ./vscode-extension
           registryUrl: https://marketplace.visualstudio.com
+
+      - name: Note the skipped Marketplace publish
+        if: steps.ext.outputs.changed != 'true'
+        run: |
+          echo "::notice::Marketplace publish SKIPPED — the extension is unchanged since the version already live there. The .vsix is still built and attached to this release."
 
       - name: Surface a failed Marketplace publish
         if: steps.create_vsix.outcome == 'failure'
@@ -268,7 +324,13 @@ jobs:
             (`bin/yo` + `std/` + `vendor/mimalloc/` + LICENSE). See
             `plans/SELF_HOSTING_COMPLETION.md` Phase 2 for the trust chain.
           prerelease: false
-          files: ${{ steps.create_vsix.outputs.vsixPath }}
+          # The freshly packaged .vsix, NOT the publish step's output. That
+          # output is empty whenever the publish did not run — which was
+          # already true for a `continue-on-error` Marketplace outage, silently
+          # dropping the .vsix from the GitHub release, and would now also be
+          # true for a deliberate skip. `*.vsix` is gitignored, so a fresh
+          # checkout holds exactly the one file `npm run package` just built.
+          files: vscode-extension/*.vsix
 
       # Yo-native as of P2.5 B7 (user decision 2026-08-18): the site builder
       # is scripts/build_site.yo, compiled and run by the SEED compiler — no

--- a/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
+++ b/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
@@ -1,0 +1,76 @@
+# windows-arm64 bundle fails: vendored mimalloc uses MSVC-only ARM64 intrinsics under clang
+
+**Status:** OPEN. Found by the first release that exercised the leg (v0.2.12,
+run 32336959494, job 96335309059). The leg is `experimental: true`, so the
+release still concluded `success` and published — this is why that flag exists.
+
+## What failed, and what did NOT
+
+`Cross-emit C (windows-arm64)` **succeeded**. The compiler emits
+`aarch64-windows-msvc` C correctly, and every one of the 5 errors is in
+`vendor/mimalloc`, none in Yo's emitted C. This is a vendored-dependency
+portability bug, not a codegen bug.
+
+`Compile the cross-emitted C natively (Windows)` (step 6) failed:
+
+```
+vendor/mimalloc/include\mimalloc\atomic.h:277:14: error: call to undeclared
+  function '__ldar64'; ISO C99 and later do not support implicit function
+  declarations [-Wimplicit-function-declaration]
+vendor/mimalloc/include\mimalloc\atomic.h:302:7: error: call to undeclared
+  function '__stlr64'
+vendor/mimalloc/src\init.c:446:47: error: incompatible pointer types passing
+  'mi_heap_t **' to parameter of type 'const uintptr_t *'
+5 errors generated.
+```
+
+The third error is downstream noise: with `mi_atomic_load_explicit` failing to
+resolve, the macro expansion loses its type.
+
+## Root cause
+
+`vendor/mimalloc/include/mimalloc/atomic.h` selects the intrinsic family by
+ARCHITECTURE with no COMPILER discriminator:
+
+```c
+#elif defined(_M_ARM) || defined(_M_ARM64)
+    if (mo == mi_memory_order_relaxed) { ... }
+    #if defined(_M_ARM64)
+    else if (mo <= mi_memory_order_acquire) {
+      return __ldar64((volatile const uintptr_t*)p);   // MSVC-only
+    }
+    #endif
+```
+
+`__ldar64` / `__stlr64` are `cl.exe` intrinsics. Clang targeting
+`aarch64-windows-msvc` defines `_M_ARM64` **for MSVC source compatibility**
+while providing neither intrinsic, so the guard steers clang into the MSVC path.
+Note an outer `_MSC_VER` guard would NOT help — clang also defines `_MSC_VER`
+in MSVC-ABI mode. The correct discriminator is `defined(__clang__)`.
+
+**Why windows-x64 is unaffected:** it takes the `_M_IX86 || _M_X64` branch,
+whose `_Interlocked*` intrinsics clang DOES implement in MSVC-compat mode. So
+this is specific to ARM64 + clang, and could only ever have surfaced once a
+windows-arm64 leg existed.
+
+## Fix options, in order of preference
+
+1. **Build this leg with `--allocator system`.** Sidesteps mimalloc entirely and
+   unblocks the leg today. Cheap on merit too: `issues/fixed/mimalloc-performance-regression.md`
+   and the r15/r16 allocator A/B both measured mimalloc SLOWER AND FATTER than
+   the libc default for this workload, so dropping it here may be a small win.
+   (`--allocator system` is the spelling as of the `libc`-alias deletion, #173.)
+2. **Fix the guard** — `#if defined(_M_ARM64) && !defined(__clang__)`, or bump
+   the vendored mimalloc to a release that already handles clang-on-ARM64.
+   Correct upstream-wards, but this is a submodule, so it needs a fork or a
+   patch step.
+3. **Use `cl.exe` for this leg.** Rejected for now: the whole bundle pipeline
+   assumes clang, and this would make one leg structurally different.
+
+## Consequence for queued work
+
+`plans/` has a queued item to run the language suite on windows-arm64 via
+cross-emit. That stays BLOCKED until this leg produces an artifact — the
+sequencing already agreed (promote only after one green run, per the
+windows-x64 precedent at v0.2.1) is exactly right, and this failure is the
+evidence for it.


### PR DESCRIPTION
## The problem, demonstrated by the release that just shipped

v0.2.12 published extension **0.2.12** to the Marketplace. Its diff against v0.2.11:

```
$ git diff --name-only v0.2.11 HEAD -- vscode-extension/
(empty)
```

Every release burned a Marketplace version for no diff.

## The gate

A new **`Decide whether the extension needs publishing`** step. Two things about it are load-bearing and easy to get wrong:

**It runs BEFORE the version bump**, and that ordering is what makes it need no normalization at all. The previous release's tag captured `package.json` at the previous version, and pre-bump `HEAD` still holds that same version — so the one field that changes every release cancels out. Move this step after the bump and it reports "changed" forever.

**The baseline is the Marketplace's live version, not the last git tag.** The publish step is `continue-on-error` so an outage cannot kill a release (v0.2.8 died there on an Azure DevOps outage). That means the Marketplace can legitimately sit behind the newest tag. Baselining on the tag would then see "nothing changed since the last release" and skip *forever*, stranding the extension. Asking the Marketplace what it actually has makes the check self-healing: whatever the reason it is behind, the diff reappears and we publish.

## Verified both directions on real history

| baseline | verdict | correct? |
| --- | --- | --- |
| `v0.2.11` | `changed=false` (skip) | yes — the diff is empty |
| `v0.2.9` | `changed=true`, listing `.vscodeignore`, `build.js`, `src/extension.ts`, `tsconfig.json`, … | yes — the P2.5 B2 syntax-only teardown |

A real positive and a real negative, not just a smoke test.

## Also fixes a pre-existing bug

The release attached `files: ${{ steps.create_vsix.outputs.vsixPath }}` — empty whenever the publish step doesn't run. So a `continue-on-error` Marketplace outage **already** dropped the `.vsix` from the GitHub release, silently; skipping would have done the same. Now `files: vscode-extension/*.vsix`, decoupled from publishing, so the `.vsix` is built and attached either way. `*.vsix` is gitignored, so a fresh checkout holds exactly the one file `npm run package` just built.

The version bump stays unconditional, so the repo's two version fields never disagree; the Marketplace simply skips a number.

## Second commit contents

`issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md` documents the one failure in the v0.2.12 run. `Cross-emit C (windows-arm64)` **succeeded** — all 5 errors are in vendored mimalloc, which selects intrinsics by architecture with no compiler check and so steers clang into `cl.exe`-only `__ldar64`/`__stlr64`. windows-x64 escapes because clang implements the x64 branch. Contained by `experimental: true`: the run still concluded `success` and the release published.

## CI

Nothing in the test suite exercises `release.yml` — it is only ever exercised by an actual release — so CI on this PR carries no signal. Merging by admin per instruction.