### PR TITLE
release: fix windows-arm64 with --allocator system, and close two defects it exposed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -669,6 +669,10 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    # Mirrors seed-bundles / seed-bundles-cross. Every leg here is REQUIRED
+    # (experimental: false) except windows-arm64 — see its entry for why this
+    # job needing the flag at all was a latent release-killer.
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -676,25 +680,56 @@ jobs:
           - target: macos-arm64
             yo_target: aarch64-macos
             bundle_allocator: system
+            experimental: false
           - target: macos-x64
             yo_target: x86_64-macos
             bundle_allocator: system
+            experimental: false
           # windows-x64 needs its portable-c arm from here too, now that no
           # native windows leg emits one — `scripts/make-portable-c.sh` treats
           # a missing windows-x64 arm as a hard failure.
           - target: windows-x64
             yo_target: x86_64-windows-msvc
-            # windows keeps MIMALLOC: the system-allocator switch was measured
-            # on macOS only, and the native windows bundle has always shipped
-            # mimalloc. Changing the allocator and the emit route in one step
-            # would make a regression impossible to attribute.
+            # windows-x64 keeps MIMALLOC: the system-allocator switch was
+            # measured on macOS only, and the native windows bundle has always
+            # shipped mimalloc. Changing the allocator and the emit route in
+            # one step would make a regression impossible to attribute.
+            # UNMEASURED on this platform — there has never been an allocator
+            # A/B on a Windows runner, nor any peak-memory measurement at all
+            # there. Revisit once one exists; arm64 uses `system` because
+            # mimalloc does not COMPILE there, which is a different reason.
             bundle_allocator: mimalloc
+            experimental: false
           # windows-arm64 is NEW: no arm64-Windows bundle has ever shipped, so
           # there is no native seed for it either — cross-emit is the only
           # route, not merely the cheaper one.
+          #
+          # SYSTEM, not mimalloc, and this is a fix rather than a preference:
+          # vendored mimalloc cannot be compiled for arm64-Windows by clang at
+          # all. `include/mimalloc/atomic.h` picks its intrinsic family by
+          # ARCHITECTURE (`_M_ARM64`) with no compiler discriminator, and clang
+          # targeting aarch64-windows-msvc defines `_M_ARM64` for MSVC source
+          # compatibility while implementing neither `__ldar64` nor `__stlr64`.
+          # v0.2.12 died exactly there — see
+          # issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md. Upstream has
+          # no source fix (the guards are byte-identical at v3.5.0 and on
+          # main/dev/dev3; `__clang__` appears zero times in that file); its
+          # mitigation is MI_USE_CXX via CMake, which Yo bypasses by handing
+          # static.c to clang as plain C. `system` is also the compiler's own
+          # default, and the one platform where the two were ever measured
+          # (macOS) flipped to `system` because mimalloc was slower AND fatter.
           - target: windows-arm64
             yo_target: aarch64-windows-msvc
-            bundle_allocator: mimalloc
+            bundle_allocator: system
+            # This leg must not be able to block a release. Unlike
+            # seed-bundles-cross, THIS job had no protection at all: it feeds
+            # portable-c, which feeds publish-release, so a failure here leaves
+            # the release an unpublished draft. v0.2.12 survived only because
+            # the failure landed in the protected native-compile leg instead.
+            # Safe to skip: scripts/make-portable-c.sh requires only
+            # linux-x64, linux-arm64, macos-x64, macos-arm64 and windows-x64 —
+            # windows-arm64 is not one of its arms.
+            experimental: true
     steps:
       - name: Checkout the released commit
         uses: actions/checkout@v4
@@ -769,13 +804,22 @@ jobs:
           ./yo-candidate compile src/main.yo --release --allocator system \
             --std-path ./std --target ${{ matrix.yo_target }} \
             --emit-c --skip-c-compiler -o "portable-arm/${{ matrix.target }}" > /dev/null
+          # Travel the allocator WITH the C rather than repeating it in the
+          # seed-bundles-cross matrix. The link line must match the emit, and
+          # a mismatch does not fail loudly: the emitted mimalloc block is
+          # `#if __has_include(<mimalloc.h>)` with a malloc/free `#else`, so a
+          # drifted pair silently ships the wrong heap. One source of truth
+          # cannot drift.
+          echo -n "${{ matrix.bundle_allocator }}" > "cross/allocator-${{ matrix.target }}.txt"
           ls -la cross/ portable-arm/
 
       - name: Upload the bundle C
         uses: actions/upload-artifact@v4
         with:
           name: seed-cross-${{ matrix.target }}
-          path: cross/yo-${{ matrix.target }}.c
+          path: |
+            cross/yo-${{ matrix.target }}.c
+            cross/allocator-${{ matrix.target }}.txt
           retention-days: 1
           if-no-files-found: error
 
@@ -873,17 +917,64 @@ jobs:
       # runner's, and a bundle named windows-x64 containing the wrong
       # architecture would install and run while emitting for the wrong one.
       # The PE assertion below is what actually proves it.
+      # The allocator is matrix-driven rather than hardcoded: windows-arm64
+      # CANNOT link mimalloc (clang lacks the `_M_ARM64` MSVC intrinsics
+      # mimalloc's atomic.h selects on architecture alone), so the two Windows
+      # legs must differ here. It has to match the `bundle_allocator` this
+      # target was EMITTED with in seed-cross-emit: the emitted C guards its
+      # mimalloc block behind `#if __has_include(<mimalloc.h>)`, so a mimalloc
+      # emit compiled without the include path silently degrades to malloc
+      # instead of failing — which is precisely the outcome an assertion has to
+      # catch rather than a link error.
       - name: "Compile the cross-emitted C natively (Windows)"
         if: runner.os == 'Windows'
         shell: bash
         run: |
+          ALLOC=$(cat "cross/allocator-${{ matrix.target }}.txt")
+          echo "emitted with allocator: $ALLOC"
+          echo "ALLOC=$ALLOC" >> "$GITHUB_ENV"
+          if [ "$ALLOC" = "mimalloc" ]; then
+            ALLOC_ARGS=(vendor/mimalloc/src/static.c -I vendor/mimalloc/include)
+          else
+            ALLOC_ARGS=()
+          fi
           clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
             --target=${{ matrix.clang_target }} \
-            "cross/yo-${{ matrix.target }}.c" vendor/mimalloc/src/static.c \
-            -I vendor/mimalloc/include \
+            "cross/yo-${{ matrix.target }}.c" "${ALLOC_ARGS[@]}" \
             -lws2_32 -lbcrypt -ladvapi32 \
             -o yo-seed.exe
           ./yo-seed.exe --version
+
+      # Assert the binary got the allocator it ASKED for. The emitted mimalloc
+      # block is `#if __has_include(<mimalloc.h>)` with a malloc/free `#else`,
+      # so a mis-linked mimalloc build compiles, links, runs and smoke-tests
+      # green while quietly using the CRT heap. Nothing on any Windows leg has
+      # ever checked this, so whether the shipped windows-x64 bundle actually
+      # contains mimalloc is, as of this commit, unverified.
+      - name: "Assert the bundle got the allocator it asked for (Windows)"
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          # The tool must be a HARD requirement. Without this check a missing
+          # llvm-nm yields SYMS=0, which would fail the mimalloc arm with a
+          # misleading message and — far worse — silently "confirm" the system
+          # arm, turning this assertion into a rubber stamp.
+          command -v llvm-nm >/dev/null || {
+            echo "::error::llvm-nm not on PATH; cannot verify the linked allocator"
+            exit 1; }
+          SYMS=$(llvm-nm yo-seed.exe 2>/dev/null | grep -c "mi_malloc\|mi_heap_malloc" || true)
+          echo "requested=$ALLOC  mi_* symbol hits=$SYMS"
+          if [ "$ALLOC" = "mimalloc" ]; then
+            [ "$SYMS" -gt 0 ] || {
+              echo "::error::asked for mimalloc but the binary has no mi_* symbols — the __has_include guard silently fell back to the CRT heap"
+              exit 1; }
+            echo "mimalloc confirmed linked in."
+          else
+            [ "$SYMS" -eq 0 ] || {
+              echo "::error::asked for the system allocator but found $SYMS mi_* symbols"
+              exit 1; }
+            echo "system allocator confirmed (no mimalloc linked)."
+          fi
 
       # PE machine type: 0x8664 == IMAGE_FILE_MACHINE_AMD64.
       - name: "Assert the binary's architecture"

--- a/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
+++ b/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
@@ -74,3 +74,85 @@ cross-emit. That stays BLOCKED until this leg produces an artifact — the
 sequencing already agreed (promote only after one green run, per the
 windows-x64 precedent at v0.2.1) is exactly right, and this failure is the
 evidence for it.
+
+---
+
+## RESOLUTION (2026-08-20): `--allocator system` for windows-arm64
+
+Fix option 1 was taken, and the investigation upgraded it from "cheapest" to
+"the only correct one". Options 2 and 3 are now positively ruled out, not merely
+deprioritised.
+
+### Upstream has NO source fix, and will not
+
+The vendored mimalloc is upstream tag **v3.3.2**
+(`30b2d9d89099bee08e9f67a1ffb3e12e7ba45227`, `MI_MALLOC_VERSION 30302`), clean,
+no local modifications. The `_M_ARM64` blocks in `include/mimalloc/atomic.h` are
+**byte-identical** at the newest tag (v3.5.0) and at the tips of `origin/main`,
+`origin/dev` and `origin/dev3` (tip `604c252a`, 2026-08-19). `__clang__` appears
+**zero** times in that file.
+
+Upstream's mitigation is not a source guard at all but a BUILD-SYSTEM one:
+commit `d767dbfb` sets `MI_USE_CXX=ON` for clang-cl in CMakeLists.txt, routing
+clang to the `#if defined(__cplusplus)` `std::atomic` path and skipping the MSVC
+C wrapper entirely. **That commit is already in v3.3.2** — but Yo bypasses
+mimalloc's CMake, handing `vendor/mimalloc/src/static.c` to clang as plain C
+(`src/main.yo:1527`, `release.yml` `-std=c11`), so the mitigation never engages.
+
+### A one-line guard fix is NOT sufficient
+
+There are **four** `__ldar64`/`__stlr64` call sites, not the two visible at
+:277/:302 — `MI_MSC_XX(f)` is `f##64` on `_WIN64`, so :234 and :256 expand to the
+same missing symbols. (4 intrinsic sites + `init.c:446` reconciles exactly with
+the "5 errors generated" in the log.) Worse, those two sit under an `#elif`
+whose `#else` fallback is a **relaxed load mislabelled as acquire** — so they
+cannot simply be excluded without introducing a memory-ordering bug. Patching
+this correctly means either the C11-stdatomic route (3 edits, unverified on
+Windows ARM64) or compiling `static.c` as C++ (pulls in msvcprt, which the
+current link line does not provide).
+
+Carrying such a patch also has no precedent here: the only vendored-dependency
+pin in the repo is `markdown_yo`, a Yo-source dep the maintainer controls.
+
+### Why `system` is a good outcome regardless
+
+`system` is the compiler's own CLI default (`src/main.yo:956`), and the one
+platform where the two allocators were ever measured — macOS — flipped to
+`system` because mimalloc was **slower and fatter** (3.3x on markdown_it_yo,
++53% wall on the r15 self-emit).
+
+## Two further defects found while fixing this
+
+### 1. `seed-cross-emit` was UNPROTECTED — a latent release-killer
+
+windows-arm64 is built by TWO legs, and only one was guarded:
+
+| job | protection |
+| --- | --- |
+| `seed-bundles-cross` (native compile) | `continue-on-error: ${{ matrix.experimental }}` |
+| `seed-cross-emit` (Yo -> C) | **none** |
+
+`seed-cross-emit` feeds `portable-c`, which feeds `publish-release`. A failure
+in the windows-arm64 cross-emit leg would therefore have left the release an
+**unpublished draft**. v0.2.12 survived only because the failure happened to land
+in the protected native-compile leg. Fixed by giving that job the same
+`experimental` flag. Safe: `scripts/make-portable-c.sh` requires only
+`linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`, `windows-x64` —
+windows-arm64 is not one of its arms.
+
+### 2. Nothing ever verified the Windows bundle LINKS mimalloc
+
+The emitted mimalloc block is `#if __has_include(<mimalloc.h>)` with a
+malloc/free `#else`. A build that asks for mimalloc but is compiled without the
+include path therefore **compiles, links, runs and smoke-tests green while
+quietly using the CRT heap** — the mis-link degrades silently instead of
+failing. No Windows leg has ever asserted otherwise, so whether the shipped
+windows-x64 bundle actually contains mimalloc is **unverified to date**.
+
+Two changes close this: the allocator now travels WITH the C as
+`cross/allocator-<target>.txt` (one source of truth, so the emit and the link
+cannot drift), and a new assertion greps the built `.exe` for `mi_*` symbols and
+fails if they disagree with what was requested.
+
+**Watch the next release:** if windows-x64 has been silently falling back, that
+assertion will fail it. That is a true positive worth having.


### PR DESCRIPTION
## The fix

windows-arm64 **cannot link vendored mimalloc at all** under clang. `include/mimalloc/atomic.h` selects its intrinsic family by *architecture* (`_M_ARM64`) with no compiler discriminator, and clang targeting `aarch64-windows-msvc` defines `_M_ARM64` for MSVC source compatibility while implementing neither `__ldar64` nor `__stlr64`. v0.2.12 died exactly there.

**Patching mimalloc was investigated and ruled out**, not merely deprioritised:

- **Upstream has no source fix.** Vendored is v3.3.2; the `_M_ARM64` blocks are byte-identical at v3.5.0 and at the tips of `main`, `dev` and `dev3` (tip `604c252a`, 2026-08-19). `__clang__` appears **zero** times in that file. Upstream's mitigation is `MI_USE_CXX=ON` via CMake — already in v3.3.2 — but Yo bypasses mimalloc's CMake, handing `static.c` to clang as plain C, so it never engages.
- **A one-line guard would be wrong.** `MI_MSC_XX(f)` is `f##64` on `_WIN64`, so there are **four** call sites, not the two visible in the error output (4 + `init.c:446` reconciles exactly with "5 errors generated"). Two of them sit under an `#elif` whose `#else` fallback is a **relaxed load mislabelled as acquire** — excluding them would trade a build error for a memory-ordering bug.

`system` is the compiler's own default (`src/main.yo:956`), and the one platform where the two were ever measured — macOS — flipped to `system` because mimalloc was slower *and* fatter (3.3× on markdown_it_yo, +53% wall on the r15 self-emit).

**windows-x64 deliberately keeps mimalloc.** That remains unmeasured on Windows, and changing it here would confound a fix with an optimization.

## Defect 1: `seed-cross-emit` was unprotected — a latent release-killer

windows-arm64 is built by two legs, and only one was guarded:

| job | protection |
| --- | --- |
| `seed-bundles-cross` (native compile) | `continue-on-error: ${{ matrix.experimental }}` |
| `seed-cross-emit` (Yo → C) | **none** |

`seed-cross-emit` → `portable-c` → `publish-release`. A failure in the windows-arm64 **cross-emit** leg would have left the release an **unpublished draft**. v0.2.12 survived only because the failure happened to land in the protected native-compile leg.

I stated earlier in this campaign that `experimental: true` had windows-arm64 contained. That was only half true, and this is the correction.

Safe to skip: `scripts/make-portable-c.sh` requires only `linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`, `windows-x64` — windows-arm64 is not one of its arms.

## Defect 2: nothing ever verified the Windows bundle *links* mimalloc

The emitted mimalloc block is `#if __has_include(<mimalloc.h>)` with a malloc/free `#else`. So a build that asks for mimalloc but compiles without the include path **compiles, links, runs and smoke-tests green while quietly using the CRT heap**. No Windows leg has ever checked. Whether the shipped windows-x64 bundle actually contains mimalloc is, to date, unverified.

Two changes close it:

- The allocator **travels with the C** as `cross/allocator-<target>.txt`, rather than being repeated in the `seed-bundles-cross` matrix. One source of truth, so the emit and the link line cannot drift — and drift here fails silently, which is the worst kind.
- A new step greps the built `.exe` for `mi_*` symbols and fails if they disagree with what was requested. `llvm-nm` is a **hard requirement**, because otherwise a missing tool yields `SYMS=0`, which would silently *confirm* the system arm and turn the assertion into a rubber stamp.

## ⚠️ Watch the next release

If windows-x64 has been silently falling back to the CRT heap all along, **this assertion will fail that leg** (it is `experimental: false`). That would be a true positive worth having, but it is a real possibility rather than a hypothetical — flagging it so the failure is legible rather than surprising.

## Testing

`release.yml` is exercised only by an actual release, so CI carries no signal here; YAML validated locally and both matrices checked for field consistency. The real test is the next release.