### PR TITLE
ci: Windows peak-memory sampler + mimalloc-vs-system A/B, and correct the arm64 claim

### DIFF
--- a/.github/workflows/ab-windows-allocator.yml
+++ b/.github/workflows/ab-windows-allocator.yml
@@ -1,0 +1,287 @@
+name: A/B — Windows allocator (mimalloc vs system)
+
+# Answers two questions the tree has never had evidence for.
+#
+# Q1 (windows-x64): is mimalloc actually better than the system allocator
+#     THERE? windows-x64 ships mimalloc purely because the system-allocator
+#     switch "was measured on macOS only" — never because Windows was measured.
+#     On macOS mimalloc lost on BOTH axes (3.3x on markdown_it_yo, +53% wall on
+#     the r15 self-emit), which is why macOS flipped.
+#
+# Q2 (windows-arm64): mimalloc DOES support Windows ARM64 upstream. What fails
+#     is narrower — clang compiling static.c as plain C11 for
+#     aarch64-windows-msvc, because atomic.h picks intrinsics on _M_ARM64 alone
+#     and clang defines that for MSVC compat without providing __ldar64 /
+#     __stlr64. Upstream's own mitigation is MI_USE_CXX (the C++ std::atomic
+#     path) via CMake, which Yo bypasses. So: does compiling static.c as C++
+#     make mimalloc work on arm64? Untested assertion until this job runs.
+#
+# WHY THE MEASUREMENT IS CHEAP: the allocator changes only a preprocessor block
+# in the emitted C, and that block is `#if __has_include(<mimalloc.h>)` with a
+# malloc/free `#else`. So ONE mimalloc-flavored emit links BOTH ways — with the
+# include path for the mimalloc arm, without it for the system arm — and the two
+# translation units are byte-identical after preprocessing (verified by md5).
+# The arms therefore differ in the allocator and nothing else.
+
+on:
+  workflow_dispatch:
+    inputs:
+      workload:
+        description: "Workload for the timed arms"
+        required: true
+        default: "check-std"
+        type: choice
+        options:
+          - check-std
+          - check-src
+      reps:
+        description: "Repetitions per arm (min is reported; n=1 is not a measurement)"
+        required: true
+        default: "3"
+
+env:
+  SEED_VERSION: v0.2.12
+  APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"
+
+jobs:
+  emit:
+    name: Cross-emit Windows C (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows-x64
+            yo_target: x86_64-windows-msvc
+          - target: windows-arm64
+            yo_target: aarch64-windows-msvc
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 32G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+
+      - name: Tune the kernel for a swap-heavy emit
+        run: |
+          sudo modprobe zswap 2>/dev/null || true
+          echo 1 | sudo tee /sys/module/zswap/parameters/enabled >/dev/null 2>&1 || true
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null 2>&1 || true
+
+      - name: Install liburing
+        run: sudo apt-get $APT_OPTS update && sudo apt-get $APT_OPTS install -y liburing-dev
+
+      - name: Install the seed compiler
+        uses: ./.github/actions/install-seed
+        with:
+          version: ${{ env.SEED_VERSION }}
+
+      # ALWAYS mimalloc-flavored, for BOTH arms. The `__has_include` guard is
+      # what lets the system arm fall out of the same file: compiled without
+      # -I vendor/mimalloc/include, this C preprocesses identically to an
+      # `--allocator system` emit. Emitting twice would introduce a second
+      # variable (two compiler runs) into a one-variable experiment.
+      - name: Cross-emit the C (mimalloc-flavored)
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: |
+          mkdir -p cross
+          yo compile src/main.yo --release --allocator mimalloc \
+            --std-path ./std --target ${{ matrix.yo_target }} \
+            --emit-c --skip-c-compiler -o "cross/yo-${{ matrix.target }}" > /dev/null
+          ls -la cross/
+
+      - name: Upload the C
+        uses: actions/upload-artifact@v4
+        with:
+          name: ab-c-${{ matrix.target }}
+          path: cross/yo-${{ matrix.target }}.c
+          retention-days: 1
+          if-no-files-found: error
+
+  measure-x64:
+    name: "Q1: measure mimalloc vs system (windows-x64)"
+    needs: emit
+    runs-on: windows-latest
+    timeout-minutes: 240
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install LLVM/Clang
+        run: |
+          choco install llvm -y
+          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ab-c-windows-x64
+          path: cross
+
+      # ONE source, TWO links. The only difference is whether mimalloc is on
+      # the include path and in the TU list.
+      - name: Link both arms
+        shell: bash
+        run: |
+          set -x
+          clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
+            --target=x86_64-pc-windows-msvc \
+            cross/yo-windows-x64.c vendor/mimalloc/src/static.c \
+            -I vendor/mimalloc/include \
+            -lws2_32 -lbcrypt -ladvapi32 -o yo-mimalloc.exe
+          clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
+            --target=x86_64-pc-windows-msvc \
+            cross/yo-windows-x64.c \
+            -lws2_32 -lbcrypt -ladvapi32 -o yo-system.exe
+
+      # Prove the arms are what they claim BEFORE timing them. Without this the
+      # experiment silently degenerates: if the mimalloc arm failed to pick up
+      # the include path it would run on the CRT heap too, and the A/B would
+      # confidently report "no difference" — which is also the result a real
+      # null would produce. Indistinguishable failure and success is the worst
+      # property a measurement can have.
+      - name: Assert the two arms really differ
+        shell: bash
+        run: |
+          MI=$(llvm-nm yo-mimalloc.exe 2>/dev/null | grep -c "mi_malloc\|mi_heap_malloc" || true)
+          SY=$(llvm-nm yo-system.exe   2>/dev/null | grep -c "mi_malloc\|mi_heap_malloc" || true)
+          echo "mimalloc arm mi_* hits: $MI"
+          echo "system   arm mi_* hits: $SY"
+          [ "$MI" -gt 0 ] || { echo "::error::mimalloc arm has no mi_* symbols — arms are identical, experiment void"; exit 1; }
+          [ "$SY" -eq 0 ] || { echo "::error::system arm picked up mimalloc anyway (a <mimalloc.h> on the default include path?) — experiment void"; exit 1; }
+          ./yo-mimalloc.exe --version
+          ./yo-system.exe --version
+
+      - name: Measure both arms
+        shell: pwsh
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: |
+          $target = if ('${{ inputs.workload }}' -eq 'check-src') { './src' } else { './std' }
+          $reps = [int]'${{ inputs.reps }}'
+          $env:YO_STD = "$PWD/std"
+
+          # Warm the filesystem cache once with each binary so the FIRST timed
+          # rep of arm A is not paying for cold I/O that arm B then benefits
+          # from. Ordering effects are the classic way a two-arm CI benchmark
+          # invents a winner.
+          Write-Host "warming..."
+          & ./yo-mimalloc.exe check $target *> $null
+          & ./yo-system.exe   check $target *> $null
+
+          Write-Host "`n=== mimalloc ==="
+          ./scripts/bootstrap/measure-windows.ps1 -Exe ./yo-mimalloc.exe `
+            -Arguments check,$target -Reps $reps -Label mimalloc -JsonOut mimalloc.json
+          Write-Host "`n=== system ==="
+          ./scripts/bootstrap/measure-windows.ps1 -Exe ./yo-system.exe `
+            -Arguments check,$target -Reps $reps -Label system -JsonOut system.json
+
+      - name: Compare
+        shell: pwsh
+        run: |
+          $m = Get-Content mimalloc.json | ConvertFrom-Json
+          $s = Get-Content system.json   | ConvertFrom-Json
+          $wallPct = (($m.wallMinSec - $s.wallMinSec) / $s.wallMinSec) * 100
+          $peakPct = (($m.peakMinB   - $s.peakMinB)   / $s.peakMinB)   * 100
+
+          Write-Host ""
+          Write-Host ("{0,-10} {1,12} {2,14}" -f 'arm', 'min wall (s)', 'min peak (MB)')
+          Write-Host ("{0,-10} {1,12:N2} {2,14:N0}" -f 'mimalloc', $m.wallMinSec, ($m.peakMinB/1MB))
+          Write-Host ("{0,-10} {1,12:N2} {2,14:N0}" -f 'system',   $s.wallMinSec, ($s.peakMinB/1MB))
+          Write-Host ("mimalloc vs system: wall {0:+0.0;-0.0}%  peak {1:+0.0;-0.0}%" -f $wallPct, $peakPct)
+
+          # Refuse to call a winner inside the noise. The musl A/B in this repo
+          # produced +2.9% then -4.5% on consecutive single runs — it could not
+          # agree on the SIGN — and that number was quoted as fact for a while.
+          # The guard: a wall delta smaller than the larger arm's own
+          # run-to-run spread is not a result.
+          $noise = [Math]::Max($m.wallSpread, $s.wallSpread)
+          $delta = [Math]::Abs($m.wallMinSec - $s.wallMinSec)
+          Write-Host ("wall delta {0:N2}s vs within-arm spread {1:N2}s" -f $delta, $noise)
+          if ($delta -lt $noise) {
+            Write-Host "::warning::wall-clock difference is INSIDE run-to-run noise — do not quote a wall winner from this run. Peak memory may still be conclusive; it is far less noisy."
+          }
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ab-windows-x64-results
+          path: "*.json"
+
+  probe-arm64-cxx:
+    name: "Q2: can mimalloc build on windows-arm64 via the C++ route?"
+    needs: emit
+    runs-on: windows-11-arm
+    timeout-minutes: 120
+    # Exploratory: a NO here is a valid, useful answer and must not read as a
+    # broken workflow.
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install LLVM/Clang
+        run: |
+          choco install llvm -y
+          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ab-c-windows-arm64
+          path: cross
+
+      - name: "Route A (baseline): static.c as plain C11 — expected to FAIL"
+        shell: bash
+        continue-on-error: true
+        run: |
+          clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
+            --target=aarch64-pc-windows-msvc \
+            cross/yo-windows-arm64.c vendor/mimalloc/src/static.c \
+            -I vendor/mimalloc/include \
+            -lws2_32 -lbcrypt -ladvapi32 -o yo-arm-c.exe 2>&1 | tail -30
+          echo "route A rc=${PIPESTATUS[0]}"
+
+      # THE QUESTION. Upstream's own mitigation for clang on ARM64 is
+      # MI_USE_CXX=ON, which routes to the `#if defined(__cplusplus)`
+      # std::atomic path and skips the MSVC-C intrinsic wrapper entirely. Yo
+      # bypasses mimalloc's CMake, so this does by hand what that flag does.
+      # The open risk is the link, not the compile: C++ pulls in the MSVC C++
+      # runtime, which the current link line does not provide.
+      - name: "Route B: compile static.c as C++ (upstream's MI_USE_CXX, by hand)"
+        id: route_b
+        shell: bash
+        run: |
+          clang -w -O2 --target=aarch64-pc-windows-msvc \
+            -c -x c++ vendor/mimalloc/src/static.c \
+            -I vendor/mimalloc/include -o mimalloc_cxx.o 2>&1 | tail -30
+          echo "--- compiled; now linking ---"
+          clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
+            --target=aarch64-pc-windows-msvc \
+            cross/yo-windows-arm64.c mimalloc_cxx.o \
+            -I vendor/mimalloc/include \
+            -lws2_32 -lbcrypt -ladvapi32 -o yo-arm-cxx.exe 2>&1 | tail -30
+
+      - name: Verify the C++ route produced a real mimalloc arm64 binary
+        shell: bash
+        run: |
+          command -v llvm-nm >/dev/null || { echo "::error::llvm-nm missing"; exit 1; }
+          MI=$(llvm-nm yo-arm-cxx.exe 2>/dev/null | grep -c "mi_malloc\|mi_heap_malloc" || true)
+          echo "mi_* symbol hits: $MI"
+          [ "$MI" -gt 0 ] || { echo "::error::linked, but no mi_* symbols — the __has_include guard fell back to the CRT heap"; exit 1; }
+          MACHINE=$(llvm-readobj --file-headers yo-arm-cxx.exe | grep -i "Machine" | head -1)
+          echo "$MACHINE"
+          echo "$MACHINE" | grep -qi "ARM64\|AA64" || { echo "::error::not an ARM64 binary"; exit 1; }
+          ./yo-arm-cxx.exe --version
+          echo "ROUTE B WORKS: mimalloc builds, links and runs on windows-arm64 via the C++ route."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -704,20 +704,29 @@ jobs:
           # there is no native seed for it either — cross-emit is the only
           # route, not merely the cheaper one.
           #
-          # SYSTEM, not mimalloc, and this is a fix rather than a preference:
-          # vendored mimalloc cannot be compiled for arm64-Windows by clang at
-          # all. `include/mimalloc/atomic.h` picks its intrinsic family by
+          # SYSTEM, not mimalloc — but NOT because "mimalloc does not work on
+          # arm64-Windows". It does; upstream supports that platform. The
+          # failure is narrower: clang compiling `static.c` as PLAIN C11 for
+          # aarch64-windows-msvc. `include/mimalloc/atomic.h` picks its
+          # intrinsic family by
           # ARCHITECTURE (`_M_ARM64`) with no compiler discriminator, and clang
           # targeting aarch64-windows-msvc defines `_M_ARM64` for MSVC source
           # compatibility while implementing neither `__ldar64` nor `__stlr64`.
           # v0.2.12 died exactly there — see
           # issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md. Upstream has
-          # no source fix (the guards are byte-identical at v3.5.0 and on
+          # no SOURCE fix (the guards are byte-identical at v3.5.0 and on
           # main/dev/dev3; `__clang__` appears zero times in that file); its
-          # mitigation is MI_USE_CXX via CMake, which Yo bypasses by handing
-          # static.c to clang as plain C. `system` is also the compiler's own
-          # default, and the one platform where the two were ever measured
-          # (macOS) flipped to `system` because mimalloc was slower AND fatter.
+          # mitigation is MI_USE_CXX via CMake — i.e. compile it as C++ — which
+          # Yo bypasses by handing static.c to clang as plain C.
+          #
+          # So a C++ route (`-x c++`) plausibly WOULD work here and is not ruled
+          # out; it is merely untested, the open risk being the link rather than
+          # the compile (C++ pulls in the MSVC C++ runtime that this link line
+          # does not provide). `.github/workflows/ab-windows-allocator.yml`
+          # probes exactly that. Until it reports, `system` is the only route
+          # PROVEN to build — and it is also the compiler's own default, and
+          # what the one platform where the two were ever measured (macOS)
+          # flipped to, mimalloc having been slower AND fatter there.
           - target: windows-arm64
             yo_target: aarch64-windows-msvc
             bundle_allocator: system

--- a/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
+++ b/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
@@ -83,7 +83,30 @@ Fix option 1 was taken, and the investigation upgraded it from "cheapest" to
 "the only correct one". Options 2 and 3 are now positively ruled out, not merely
 deprioritised.
 
-### Upstream has NO source fix, and will not
+### IMPORTANT correction: mimalloc DOES support Windows ARM64
+
+An earlier revision of this doc and of the release.yml comment said mimalloc
+"cannot be compiled for arm64-Windows by clang at all". That is **wrong** and is
+corrected here. Upstream supports the platform. The failure is narrower:
+
+| route | works? |
+| --- | --- |
+| MSVC (`cl.exe`) | YES — the `__ldar64`/`__stlr64` intrinsics exist there |
+| clang-cl with `MI_USE_CXX=ON` | YES — upstream's own mitigation |
+| clang, `static.c` as C++ (`-x c++`) | PLAUSIBLE, untested — the same thing by hand |
+| **clang, `static.c` as plain C11** | **NO — this is Yo's route, and what broke** |
+
+The open risk on the C++ route is the LINK, not the compile: C++ pulls in the
+MSVC C++ runtime, which the current `-lws2_32 -lbcrypt -ladvapi32` line does not
+provide. `.github/workflows/ab-windows-allocator.yml` probes it directly
+(job `probe-arm64-cxx`, Route B).
+
+`system` remains the right immediate choice because it is the only route PROVEN
+to build today, it is the compiler's own default, and macOS measured mimalloc
+slower and fatter. But it is an unblock pending evidence, not a verdict that
+mimalloc is impossible here.
+
+### Upstream has no source fix (but has a BUILD-SYSTEM one)
 
 The vendored mimalloc is upstream tag **v3.3.2**
 (`30b2d9d89099bee08e9f67a1ffb3e12e7ba45227`, `MI_MALLOC_VERSION 30302`), clean,

--- a/scripts/bootstrap/measure-windows.ps1
+++ b/scripts/bootstrap/measure-windows.ps1
@@ -1,0 +1,136 @@
+<#
+.SYNOPSIS
+  Measure wall-clock and PEAK memory of a command on Windows.
+
+.DESCRIPTION
+  The Windows analogue of `/usr/bin/time -v` (Linux) and `/usr/bin/time -l`
+  (macOS). Until this script, the repo had NO peak-memory measurement of any
+  kind on a Windows runner: the sampler's Windows arm in test.yml is empty
+  (`Windows) : ;;`) and sits inside a step gated `if: runner.os == 'Linux'`, so
+  it never ran either way. Every allocator A/B to date has therefore been
+  macOS-only, which is exactly why windows-x64 still ships mimalloc "because the
+  switch was measured on macOS only".
+
+  THE GOTCHA THIS SCRIPT EXISTS TO ENCODE: .NET can only report
+  PeakWorkingSet64 after a process exits if its native handle was cached WHILE
+  IT WAS ALIVE. Touching `$p.Handle` once before waiting is what caches it.
+  Without that line the property throws InvalidOperationException ("Process has
+  exited") or silently reads 0 — and a peak of 0 compares equal across arms, so
+  the bug presents as "the allocators are identical" rather than as an error.
+
+  Reports the MIN across repetitions, not the mean. Min is the right estimator
+  for "how fast can this go": a shared CI runner only ever adds noise, so the
+  fastest observed run is the closest to the true cost, while the mean tracks
+  whatever else the runner was doing. This also follows the repo's established
+  A/B method (plans/ + issues/fixed/mimalloc-performance-regression.md).
+
+.PARAMETER Exe
+  The executable to run.
+
+.PARAMETER Arguments
+  Arguments passed to it, as an array.
+
+.PARAMETER Reps
+  How many times to run. Default 3. n=1 is NOT a measurement — the musl A/B in
+  this repo produced +2.9% and -4.5% on consecutive single runs, i.e. it could
+  not even agree on the SIGN.
+
+.PARAMETER Label
+  A name for this arm, printed with the results.
+
+.PARAMETER JsonOut
+  Optional path to write machine-readable results for a comparison step.
+
+.EXAMPLE
+  ./measure-windows.ps1 -Exe .\yo-mimalloc.exe -Arguments check,./std -Reps 3 -Label mimalloc
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$Exe,
+  [string[]]$Arguments = @(),
+  [int]$Reps = 3,
+  [string]$Label = 'run',
+  [string]$JsonOut = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $Exe)) { throw "no such executable: $Exe" }
+$exePath = (Resolve-Path $Exe).Path
+
+$wall = @()
+$peak = @()
+$codes = @()
+
+for ($i = 1; $i -le $Reps; $i++) {
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName = $exePath
+  # ArgumentList keeps the args as an argv array rather than re-parsing a
+  # command line, so paths with spaces survive.
+  foreach ($a in $Arguments) { $psi.ArgumentList.Add($a) }
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  $p = [System.Diagnostics.Process]::Start($psi)
+
+  # LOAD-BEARING — see THE GOTCHA above. Caches the native handle while the
+  # process is alive so PeakWorkingSet64 survives its exit. Do not "clean up"
+  # this apparently unused expression.
+  $null = $p.Handle
+
+  # Drain both pipes BEFORE waiting. A child that fills a redirected pipe
+  # blocks forever if nobody reads it, and this workload is chatty enough to
+  # do that — the deadlock would look like a hung runner, not a bug here.
+  $stdout = $p.StandardOutput.ReadToEndAsync()
+  $stderr = $p.StandardError.ReadToEndAsync()
+  $p.WaitForExit()
+  $sw.Stop()
+  $null = $stdout.Result
+  $errText = $stderr.Result
+
+  $p.Refresh()
+  $peakBytes = $p.PeakWorkingSet64
+  $code = $p.ExitCode
+
+  if ($peakBytes -le 0) {
+    throw "peak working set read back as $peakBytes — the handle was not cached, so this measurement is void"
+  }
+  if ($code -ne 0) {
+    Write-Host "  rep ${i}: EXIT $code"
+    if ($errText) { Write-Host ($errText -split "`n" | Select-Object -Last 20 | Out-String) }
+    throw "$Label rep $i exited $code — a failed run cannot be compared"
+  }
+
+  $wall += $sw.Elapsed.TotalSeconds
+  $peak += $peakBytes
+  $codes += $code
+  Write-Host ("  rep {0}: {1,8:N2}s  peak {2,8:N0} MB" -f $i, $sw.Elapsed.TotalSeconds, ($peakBytes / 1MB))
+}
+
+$minWall = ($wall | Measure-Object -Minimum).Minimum
+$minPeak = ($peak | Measure-Object -Minimum).Minimum
+$maxWall = ($wall | Measure-Object -Maximum).Maximum
+
+Write-Host ""
+Write-Host ("{0}: min wall {1:N2}s (spread {2:N2}s), min peak {3:N0} MB" -f `
+  $Label, $minWall, ($maxWall - $minWall), ($minPeak / 1MB))
+
+if ($JsonOut) {
+  $result = [ordered]@{
+    label      = $Label
+    exe        = $exePath
+    args       = $Arguments
+    reps       = $Reps
+    wallAll    = $wall
+    peakAll    = $peak
+    wallMinSec = $minWall
+    peakMinB   = $minPeak
+    # The spread is reported so a comparison can refuse to call a winner when
+    # the difference between arms is inside one arm's own run-to-run noise.
+    wallSpread = $maxWall - $minWall
+  }
+  $result | ConvertTo-Json -Depth 4 | Set-Content -Path $JsonOut -Encoding utf8
+  Write-Host "wrote $JsonOut"
+}


### PR DESCRIPTION
## Correction first

#177 said vendored mimalloc "cannot be compiled for arm64-Windows by clang at all." **That is wrong**, and this PR corrects the comment and the issue doc. mimalloc supports Windows ARM64 upstream. The failure is narrower:

| route | works? |
| --- | --- |
| MSVC (`cl.exe`) | YES — the `__ldar64`/`__stlr64` intrinsics exist there |
| clang-cl with `MI_USE_CXX=ON` | YES — upstream's own mitigation |
| clang, `static.c` as C++ (`-x c++`) | PLAUSIBLE, untested — the same thing by hand |
| **clang, `static.c` as plain C11** | **NO — Yo's route, and what broke** |

`system` remains the right immediate choice: it is the only route *proven* to build today, it is the compiler's own default, and macOS measured mimalloc slower and fatter. But that is an unblock pending evidence, not a verdict that mimalloc is impossible there — so this PR goes and gets the evidence.

## The sampler: `scripts/bootstrap/measure-windows.ps1`

The Windows analogue of `/usr/bin/time -v`. The repo had **no peak-memory measurement of any kind on a Windows runner** — the sampler's Windows arm in `test.yml` is literally `Windows) : ;;`, inside a step gated `if: runner.os == 'Linux'` so it never ran anyway. That absence is precisely why windows-x64 still ships mimalloc "because the switch was measured on macOS only."

**The gotcha it encodes:** .NET can only report `PeakWorkingSet64` after a process exits if its native handle was cached *while the process was alive*. Touching `$p.Handle` once before waiting is what does that. Without it the property throws or reads **0** — and a peak of 0 compares **equal** across arms, so the bug would present as "the allocators are identical" rather than as an error. That is the single most dangerous failure mode for this measurement, so it is a hard throw.

It also drains both pipes before waiting (a chatty child filling a redirected pipe otherwise deadlocks, which looks like a hung runner) and reports the **min** across reps.

## Q1 — windows-x64: mimalloc vs system, measured

Cheap, because the allocator only changes a `#if __has_include(<mimalloc.h>)` block: **one mimalloc-flavored emit links both ways** — with the include path for the mimalloc arm, without it for the system arm — and the two TUs are byte-identical after preprocessing. The arms differ in the allocator and nothing else.

Three guards against the ways a two-arm CI benchmark lies:

- **Assert the arms really differ** before timing (`mi_*` symbols present in one, absent in the other). A mis-linked mimalloc arm would run on the CRT heap too, and the A/B would confidently report "no difference" — *indistinguishable from a real null*. Both arms are checked, because a stray system `<mimalloc.h>` would silently contaminate the system arm instead.
- **Warm the cache with both binaries** before timing, so the first arm doesn't pay cold I/O the second benefits from.
- **Refuse to call a wall winner inside the noise.** The musl A/B here produced +2.9% then −4.5% on consecutive single runs — it couldn't agree on the *sign* — and that figure got quoted as fact for a while. The job compares the delta against each arm's own run-to-run spread and warns when it's smaller. Peak memory is far less noisy and is where mimalloc actually lost on macOS.

## Q2 — windows-arm64: does the C++ route work?

Route A (plain C11) is the expected-failure baseline; Route B does upstream's `MI_USE_CXX` by hand via `-x c++`, then verifies the output is a real ARM64 binary containing `mi_*` symbols that actually runs. The open risk is the **link**, not the compile — C++ pulls in the MSVC C++ runtime that `-lws2_32 -lbcrypt -ladvapi32` doesn't provide.

`continue-on-error: true` — a NO is a valid, useful answer here, not a broken workflow.

## Cost and testing

Dispatch-only. The expensive part is the Linux cross-emit (two targets, parallel). YAML validated; the PowerShell parsed clean through `[Parser]::ParseFile`. The real test is dispatching it, which I'll do once this lands.