### PR TITLE
ci: detect the linked allocator by string literals, not symbols (PE has no symtab)

### DIFF
--- a/.github/workflows/ab-windows-allocator.yml
+++ b/.github/workflows/ab-windows-allocator.yml
@@ -153,11 +153,16 @@ jobs:
       - name: Assert the two arms really differ
         shell: bash
         run: |
-          MI=$(llvm-nm yo-mimalloc.exe 2>/dev/null | grep -c "mi_malloc\|mi_heap_malloc" || true)
-          SY=$(llvm-nm yo-system.exe   2>/dev/null | grep -c "mi_malloc\|mi_heap_malloc" || true)
-          echo "mimalloc arm mi_* hits: $MI"
-          echo "system   arm mi_* hits: $SY"
-          [ "$MI" -gt 0 ] || { echo "::error::mimalloc arm has no mi_* symbols — arms are identical, experiment void"; exit 1; }
+          # STRING LITERALS, NOT SYMBOLS — a linked PE has no COFF symbol
+          # table, so llvm-nm reads 0 for BOTH arms and cannot tell "mimalloc
+          # absent" from "symbols unreadable". That is exactly how the first
+          # dispatch of this workflow aborted. mimalloc's unconditional
+          # _mi_fputs literals survive in .rdata in any format.
+          MI=$(grep -a -c "mimalloc: " yo-mimalloc.exe || true)
+          SY=$(grep -a -c "mimalloc: " yo-system.exe   || true)
+          echo "mimalloc arm: $MI literal hits, $(wc -c < yo-mimalloc.exe) bytes"
+          echo "system   arm: $SY literal hits, $(wc -c < yo-system.exe) bytes"
+          [ "$MI" -gt 0 ] || { echo "::error::mimalloc arm carries no mimalloc literals — arms are identical, experiment void"; exit 1; }
           [ "$SY" -eq 0 ] || { echo "::error::system arm picked up mimalloc anyway (a <mimalloc.h> on the default include path?) — experiment void"; exit 1; }
           ./yo-mimalloc.exe --version
           ./yo-system.exe --version
@@ -276,10 +281,9 @@ jobs:
       - name: Verify the C++ route produced a real mimalloc arm64 binary
         shell: bash
         run: |
-          command -v llvm-nm >/dev/null || { echo "::error::llvm-nm missing"; exit 1; }
-          MI=$(llvm-nm yo-arm-cxx.exe 2>/dev/null | grep -c "mi_malloc\|mi_heap_malloc" || true)
-          echo "mi_* symbol hits: $MI"
-          [ "$MI" -gt 0 ] || { echo "::error::linked, but no mi_* symbols — the __has_include guard fell back to the CRT heap"; exit 1; }
+          MI=$(grep -a -c "mimalloc: " yo-arm-cxx.exe || true)
+          echo "mimalloc literal hits: $MI, $(wc -c < yo-arm-cxx.exe) bytes"
+          [ "$MI" -gt 0 ] || { echo "::error::linked, but carries no mimalloc literals — the __has_include guard fell back to the CRT heap"; exit 1; }
           MACHINE=$(llvm-readobj --file-headers yo-arm-cxx.exe | grep -i "Machine" | head -1)
           echo "$MACHINE"
           echo "$MACHINE" | grep -qi "ARM64\|AA64" || { echo "::error::not an ARM64 binary"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -964,23 +964,30 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          # The tool must be a HARD requirement. Without this check a missing
-          # llvm-nm yields SYMS=0, which would fail the mimalloc arm with a
-          # misleading message and — far worse — silently "confirm" the system
-          # arm, turning this assertion into a rubber stamp.
-          command -v llvm-nm >/dev/null || {
-            echo "::error::llvm-nm not on PATH; cannot verify the linked allocator"
-            exit 1; }
-          SYMS=$(llvm-nm yo-seed.exe 2>/dev/null | grep -c "mi_malloc\|mi_heap_malloc" || true)
-          echo "requested=$ALLOC  mi_* symbol hits=$SYMS"
+          # DETECT VIA STRING LITERALS, NOT SYMBOLS. A linked PE carries no
+          # COFF symbol table (debug info goes to a PDB), so `llvm-nm` on a
+          # release .exe reports nothing for EITHER allocator — measured, and
+          # it is what made the first A/B dispatch abort: both arms read 0.
+          # A symbol-based check therefore cannot distinguish "mimalloc absent"
+          # from "symbols unreadable", which is the one distinction it exists
+          # to make.
+          #
+          # mimalloc emits unconditional message literals ("mimalloc: ",
+          # "mimalloc: warning: ", "mimalloc: error: ") from its _mi_fputs
+          # path. Those land in .rdata in any object format. Verified locally:
+          # 0 hits for a system-linked binary, 4 for a mimalloc-linked one,
+          # with sizes 33 KB vs 315 KB.
+          HITS=$(grep -a -c "mimalloc: " yo-seed.exe || true)
+          BYTES=$(wc -c < yo-seed.exe)
+          echo "requested=$ALLOC  'mimalloc: ' literal hits=$HITS  size=$BYTES bytes"
           if [ "$ALLOC" = "mimalloc" ]; then
-            [ "$SYMS" -gt 0 ] || {
-              echo "::error::asked for mimalloc but the binary has no mi_* symbols — the __has_include guard silently fell back to the CRT heap"
+            [ "$HITS" -gt 0 ] || {
+              echo "::error::asked for mimalloc but the binary carries no mimalloc literals — the __has_include guard silently fell back to the CRT heap"
               exit 1; }
             echo "mimalloc confirmed linked in."
           else
-            [ "$SYMS" -eq 0 ] || {
-              echo "::error::asked for the system allocator but found $SYMS mi_* symbols"
+            [ "$HITS" -eq 0 ] || {
+              echo "::error::asked for the system allocator but found $HITS mimalloc literals"
               exit 1; }
             echo "system allocator confirmed (no mimalloc linked)."
           fi

--- a/issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md
+++ b/issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md
@@ -1,0 +1,81 @@
+# windows-arm64 emitted C: async state-machine pointer types crossed between temp-file modules
+
+**Status:** OPEN, not yet root-caused. Surfaced 2026-08-20 by
+`.github/workflows/ab-windows-allocator.yml` run 32348332689 (job
+`Q2: can mimalloc build on windows-arm64 via the C++ route?`).
+
+This is a **separate defect** from
+`issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md`. That one is in vendored
+mimalloc. This one is in **Yo's own emitted C**.
+
+## Symptom
+
+Compiling the cross-emitted `aarch64-windows-msvc` C fails with five
+`-Wincompatible-pointer-types` errors, all of the same shape — one async
+state-machine struct pointer assigned from a *different* state-machine struct
+pointer:
+
+```
+cross/yo-windows-arm64.c:2238639:34: error: incompatible pointer types assigning to
+  '_file____home_temp_8543_state_t *'   (aka 'struct _file____home_temp_8543_state_t_struct *')
+  from '_file____home_temp_8574_state_t *'
+cross/yo-windows-arm64.c:2253434:34: error: ... 8543 <- 8574
+cross/yo-windows-arm64.c:2257475:34: error: ... 1354819 <- 1355141
+cross/yo-windows-arm64.c:2257545:38: error: ... 1354819 <- 1354997
+cross/yo-windows-arm64.c:2263953:30: error: ... 7930 <- 7950
+```
+
+Note `-w` is on the command line and does not suppress these: clang promoted
+`-Wincompatible-pointer-types` to a default *error* in recent versions.
+
+## What is and is not implicated
+
+| | |
+| --- | --- |
+| windows-**x64** emitted C | **CLEAN** — both arms of the same run linked with no errors |
+| windows-**arm64** emitted C | 5 errors |
+| v0.2.12's release emit of windows-arm64 | **CLEAN** of this class |
+
+The v0.2.12 point matters and is not an inference from absence: in that run
+(job 96335309059) `cross/yo-windows-arm64.c` was the FIRST input on the clang
+command line, so its diagnostics would have printed before mimalloc's. The log
+shows only the 5 mimalloc/init.c errors. So this C compiled clean there.
+
+## Two candidate causes, not yet discriminated
+
+1. **A regression in `develop` since the v0.2.12 tag.**
+2. **Seed-emit vs candidate-emit.** `release.yml` builds a *candidate* compiler
+   from the released commit and has THAT emit the bundle C; the A/B workflow
+   emits directly with the **seed** binary. Different compiler generations
+   producing different C is exactly the kind of difference this would expose.
+
+Cause 2 is cheap to test and should be tested first: build a candidate the way
+release.yml does, re-emit `aarch64-windows-msvc`, and see whether the errors
+persist.
+
+## The lead worth pulling
+
+The struct names are derived from **temp file paths** — `_file____home_temp_8543_state_t`
+looks like `/home/.../temp/8543`. So each async state machine is keyed by a
+per-file mangled name, and two *different* files' state types are being assigned
+across. Numerically the pairs are adjacent (8543/8574, 1354819/1355141,
+7930/7950), which suggests two modules emitted close together in the same run
+rather than an arbitrary collision.
+
+Compare `issues/module-global-c-names-are-not-namespaced.md` (same family:
+identity derived from a name that is not unique enough) and
+`memory: yo-self-enum-codegen-identity-dedup`.
+
+## Why it was invisible until now
+
+Nothing compiles the windows-arm64 C except the release's own bundle leg, and
+that leg died earlier — at mimalloc — on the only release that ever ran it. The
+A/B workflow compiles the same C by a different route (`-x c++` for mimalloc,
+so the mimalloc errors move out of the way), which let the next error class
+become visible.
+
+## Consequence
+
+`--allocator system` unblocks the mimalloc half of the windows-arm64 bundle but
+**does not** make the leg green: this defect is upstream of the allocator
+choice. The leg must stay `experimental: true` until this is fixed.


### PR DESCRIPTION
## The bug I shipped in #177

The allocator assertion added in #177 **cannot work on Windows**, and would have failed the next release's windows-x64 leg — which is `experimental: false`.

A linked PE carries no COFF symbol table (debug info goes to a PDB), so `llvm-nm` on a release `.exe` reports nothing for **either** allocator. Measured in the first A/B dispatch (run 32348332689):

```
mimalloc arm mi_* hits: 0
system   arm mi_* hits: 0
::error::mimalloc arm has no mi_* symbols — arms are identical, experiment void
```

Both links had succeeded, and one of them definitely compiled `vendor/mimalloc/src/static.c`. So a symbol-based check cannot distinguish *"mimalloc absent"* from *"symbols unreadable"* — exactly the distinction it exists to make.

I flagged in #177 that this assertion might fail windows-x64 and called it "a true positive worth having." It would have been a false positive from my own broken check.

## The fix

Detect mimalloc's unconditional `_mi_fputs` literals — `"mimalloc: "`, `"mimalloc: warning: "`, `"mimalloc: error: "` — which land in `.rdata` in any object format.

Verified locally on a matched pair built from one source:

| arm | `mimalloc: ` hits | size |
| --- | --- | --- |
| system | 0 | 33,480 B |
| mimalloc | 4 | 315,112 B |

Both the count and the binary size are now printed, so an ambiguous future result is diagnosable from the log instead of needing a re-run. Applied to all three call sites: release.yml's bundle assertion and both of the A/B workflow's.

## A second, unrelated defect the run exposed

`issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md`.

The cross-emitted **arm64** C assigns async state-machine struct pointers across different temp-file-derived module types — 5 errors, e.g. `_file____home_temp_8543_state_t *` assigned from `_file____home_temp_8574_state_t *`. This is in **Yo's own emitted C**, not mimalloc.

- windows-**x64** is clean (both arms of the same run linked fine).
- v0.2.12's arm64 emit was clean of this class — and that is not an argument from absence: that C was the *first* clang input in the release job, so its diagnostics would have printed before mimalloc's.

So it is either a regression in `develop` since v0.2.12, or a seed-emit vs candidate-emit difference (release.yml emits with a freshly built *candidate*; the A/B emits with the *seed*). The doc says to test the second first, since it is cheap.

**Consequence:** `--allocator system` unblocks the mimalloc half of that leg but does not make it green. windows-arm64 must stay `experimental: true`.

Dispatch/release-only paths, no CI signal. Admin-merging and re-dispatching the A/B.