### PR TITLE
release: Windows uses the system allocator on both targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -690,15 +690,28 @@ jobs:
           # a missing windows-x64 arm as a hard failure.
           - target: windows-x64
             yo_target: x86_64-windows-msvc
-            # windows-x64 keeps MIMALLOC: the system-allocator switch was
-            # measured on macOS only, and the native windows bundle has always
-            # shipped mimalloc. Changing the allocator and the emit route in
-            # one step would make a regression impossible to attribute.
-            # UNMEASURED on this platform — there has never been an allocator
-            # A/B on a Windows runner, nor any peak-memory measurement at all
-            # there. Revisit once one exists; arm64 uses `system` because
-            # mimalloc does not COMPILE there, which is a different reason.
-            bundle_allocator: mimalloc
+            # SYSTEM as of 2026-08-20 (user decision): Windows drops mimalloc
+            # entirely, on BOTH targets.
+            #
+            # Yo compiles mimalloc as plain C11, and mimalloc's MSVC-C path —
+            # which clang takes, because it defines _MSC_VER and _M_ARM64 for
+            # MSVC compatibility — is not one upstream exercises under clang;
+            # its own CMake builds mimalloc as C++ for clang (MI_USE_CXX). The
+            # C++ route is REJECTED here: it would pull in the MSVC C++ runtime
+            # and break the portable single-file yo.c, whose entire purpose is
+            # bootstrapping with nothing but a C compiler.
+            #
+            # That mismatch has cost repeatedly and is getting worse, not
+            # better:
+            #   v3.3.2  x64 builds, arm64 FAILS (__ldar64/__stlr64)
+            #   v3.5.0  x64 ALSO FAILS (internal.h:792 page->self)
+            # so it already blocks arm64 AND blocks upgrading mimalloc at all.
+            # `system` removes Windows from that dependency's blast radius.
+            #
+            # Cost is unmeasured on Windows and knowingly accepted. The one
+            # platform where the two WERE compared, macOS, measured mimalloc
+            # slower AND fatter and flipped to `system` for that reason.
+            bundle_allocator: system
             experimental: false
           # windows-arm64 is NEW: no arm64-Windows bundle has ever shipped, so
           # there is no native seed for it either — cross-emit is the only

--- a/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
+++ b/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
@@ -1,6 +1,6 @@
 # windows-arm64 bundle fails: vendored mimalloc uses MSVC-only ARM64 intrinsics under clang
 
-**Status:** OPEN. Found by the first release that exercised the leg (v0.2.12,
+**Status:** RESOLVED BY DECISION 2026-08-20 — Windows drops mimalloc on BOTH targets and uses the system allocator. See the closing section. Originally filed as: Found by the first release that exercised the leg (v0.2.12,
 run 32336959494, job 96335309059). The leg is `experimental: true`, so the
 release still concluded `success` and published — this is why that flag exists.
 
@@ -179,3 +179,52 @@ fails if they disagree with what was requested.
 
 **Watch the next release:** if windows-x64 has been silently falling back, that
 assertion will fail it. That is a true positive worth having.
+
+
+---
+
+## CLOSED 2026-08-20: Windows uses the system allocator on both targets
+
+**User decision.** Rather than fix mimalloc for arm64, Windows stops using
+mimalloc at all — `bundle_allocator: system` for windows-x64 and windows-arm64.
+
+### Why fixing it was the worse option
+
+Every available fix was blocked or rejected:
+
+| option | verdict |
+| --- | --- |
+| patch `atomic.h`'s guard | 4 call sites, and 2 sit under an `#elif` whose `#else` is a relaxed load mislabelled acquire — trades a build error for a memory-ordering bug |
+| upgrade mimalloc | **makes it worse**: v3.5.0 breaks windows-**x64** too (`internal.h:792` `page->self`), which v3.3.2 does not |
+| compile `static.c` as C++ (upstream's `MI_USE_CXX`) | WORKS — measured: it removes the `__ldar64`/`__stlr64` errors — but **rejected by policy**. It pulls in the MSVC C++ runtime and would break the portable single-file `yo.c`, whose whole purpose is bootstrapping with only a C compiler. C11 stays the only build route. |
+| use `cl.exe` | rejected: the bundle pipeline is clang end to end |
+
+### The underlying mismatch, stated plainly
+
+Yo compiles mimalloc as plain C11. Clang defines `_MSC_VER` and `_M_ARM64` for
+MSVC source compatibility, so it takes mimalloc's **MSVC-C** path — which
+upstream does not exercise under clang, because upstream's CMake compiles
+mimalloc as C++ for clang. We are using a route upstream does not support, and
+the evidence is that the route is decaying rather than stabilising: v3.3.2 broke
+arm64, v3.5.0 broke x64 as well.
+
+`system` removes Windows from that dependency's blast radius entirely: no arm64
+patch, no version pin, no C++ toolchain, and mimalloc upgrades stop being
+Windows-blocked.
+
+### Accepted cost
+
+Unmeasured on Windows, knowingly. The only platform where the two were ever
+compared is macOS, where mimalloc measured **slower and fatter** and macOS
+flipped to `system` for that reason. A Windows A/B exists
+(`.github/workflows/ab-windows-allocator.yml`) and can quantify what was given
+up, but it is no longer a blocker.
+
+**Linux is unaffected** and keeps mimalloc — glibc malloc inflates the emit's
+RSS ~72%, which is a measured, platform-specific reason that does not transfer.
+
+### Still open, and NOT fixed by this
+
+`issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md`. The arm64
+leg has a second, unrelated defect in Yo's OWN emitted C. Switching allocator
+does not touch it, so windows-arm64 stays `experimental: true`.


### PR DESCRIPTION
Windows stops using mimalloc. `bundle_allocator: system` for **windows-x64** as well as windows-arm64 (which #177 already moved).

## Why not fix mimalloc instead

Every alternative is blocked or rejected:

| option | verdict |
| --- | --- |
| patch `atomic.h`'s guard | 4 call sites, and 2 sit under an `#elif` whose `#else` is a **relaxed load mislabelled acquire** — trades a build error for a memory-ordering bug |
| upgrade mimalloc | **makes it worse**: v3.5.0 breaks windows-**x64** too (`internal.h:792` `page->self`), which v3.3.2 does not |
| compile `static.c` as C++ | **works** — measured, it removes the `__ldar64`/`__stlr64` errors — but rejected: pulls in the MSVC C++ runtime and breaks the portable single-file `yo.c`, whose whole purpose is bootstrapping with only a C compiler |
| `cl.exe` | rejected: the bundle pipeline is clang end to end |

## The mismatch, stated plainly

Yo compiles mimalloc as **plain C11**. Clang defines `_MSC_VER` and `_M_ARM64` for MSVC source compatibility, so it takes mimalloc's **MSVC-C** path — which upstream does not exercise under clang, because upstream's own CMake compiles mimalloc as C++ there.

We are using a route upstream does not support, and the evidence is that it is **decaying rather than stabilising**: v3.3.2 broke arm64, v3.5.0 broke x64 as well. Staying on this path means pinning mimalloc forever and absorbing each new break.

`system` removes Windows from that dependency's blast radius entirely: no arm64 patch, no version pin, no C++ toolchain, and mimalloc upgrades stop being Windows-blocked.

## Accepted cost

**Unmeasured on Windows, and knowingly so.** The only platform where the two were ever compared is macOS, where mimalloc measured *slower and fatter* — which is why macOS already flipped to `system`. The Windows A/B still exists and can quantify what was given up, but it is no longer a blocker for anything.

**Linux is unaffected** and keeps mimalloc: glibc malloc inflates the emit's RSS ~72%, a measured platform-specific reason that does not transfer to Windows.

## What this does not fix

`issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md` — that leg has a second, unrelated defect in **Yo's own emitted C**. Switching allocator does not touch it, so windows-arm64 stays `experimental: true`.

## Diff hygiene

Two files, both intended. I verified `git diff HEAD -- vendor/mimalloc` is empty and staged files by name rather than `git add -A` — the specific failure that caused #182/#183.