### PR TITLE
fix(async): cond/match shared await points model every branch, not just the representative

### DIFF
--- a/.github/instructions/c-codegen.instructions.md
+++ b/.github/instructions/c-codegen.instructions.md
@@ -26,6 +26,33 @@ Each OS thread has its own **single-threaded event loop**. Within a single threa
 - Process-global state (signal handlers, WSA init, TTY/console settings, umask) stays `static` — it is shared across all threads.
 - The **parallelism** runtime (`src/codegen/parallelism/`) is a separate concern with actual multi-threading — do not confuse it with async/await.
 
+## Shared cond/match await points — consult the dispatch predicate
+
+A `cond`/`match` whose branches await shares ONE await point (one suspension
+state — only one branch runs). Branches can await futures of DIFFERENT C
+types, mix named and anonymous futures, or mix io/state-machine kinds, so any
+emission touching that point's future (slot declaration, branch stores,
+readiness/registration, result extraction, branch continuation) MUST route
+through `cond_await_point_needs_dispatch` (`src/codegen/async/state_code_gen.yo`):
+
+- **uniform-anonymous** (all awaiting branches anonymous, same future C name):
+  the classic single-slot emission, unchanged.
+- **dispatch** (any named-future branch, or any type mismatch): the slot is a
+  type-erased `void*`; registration and extraction are emitted inside
+  `switch (sm->cond_branch_N)`, each case accessing the future through ITS
+  branch's exact type (`cond_branch_future_access`).
+
+Mixing the two modes at different sites emits ill-typed C. Full defect history
+(eight shapes, two silently wrong at runtime in released compilers):
+`issues/async-cond-shared-await-point-only-models-representative-branch.md`.
+
+Related CI trap: `-Wincompatible-pointer-types` is a **default error in clang
+22+ that `-w` does not downgrade**, and the two Windows runners carry different
+clang majors (`windows-latest` pre-installs LLVM 20 so `choco install llvm`
+no-ops; `windows-11-arm` gets the latest from choco). An "arm64-only" C failure
+may be a clang VERSION difference, not an architecture one — check the
+versions in the job logs first.
+
 ## Compilation commands
 
 - Emit C only: `yo compile tmp/fixme.yo --emit-c --skip-c-compiler --release`

--- a/issues/async-cond-shared-await-point-only-models-representative-branch.md
+++ b/issues/async-cond-shared-await-point-only-models-representative-branch.md
@@ -1,10 +1,22 @@
 # async cond/match shared await point only models its REPRESENTATIVE branch
 
 **Status:** FIX IMPLEMENTED 2026-08-20 (branch
-`fix/async-cond-heterogeneous-await-slots`) — all eight shapes verified fixed
-at runtime, 178/178 `tests/async_await.test.yo` green (10 new regression
-tests), emitted C clean of the incompatible-pointer class. Awaiting full-suite
-+ fixpoint validation before moving to `issues/fixed/`.
+`fix/async-cond-heterogeneous-await-slots`, commit 41592a403) — all shapes
+verified fixed at runtime, 181/181 `tests/async_await.test.yo` green (15 new
+regression tests incl. heterogeneous MATCH arms, NESTED cond arms, and the
+reverse named/anonymous mix), 74/74 effects, emitted C clean of the
+incompatible-pointer class (native strict-clang: 0). Awaiting full-suite +
+fixpoint validation before moving to `issues/fixed/`.
+
+Two more members surfaced while validating (same root, now also fixed):
+- a MATCH arm whose value IS the await recorded no branch info at all
+  (`remaining.len() > 0` gate), so even uniform tail-await match arms lost
+  their value;
+- NESTED cond/match arms: the outer `_store_cond_branch_info` overwrote the
+  nested arms' records, leaving their (globally unique) dispatch codes caseless
+  — the switch's `default:` then skipped the await entirely. Dispatch points
+  now UNION branch records, and anonymous cases carry a NULL-slot guard so
+  dead/outer codes and never-stored paths skip cleanly.
 Supersedes `issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md`
 (the Windows-arm64 sighting was one symptom of this; the defect is in the
 emitter and affects EVERY target).

--- a/issues/async-cond-shared-await-point-only-models-representative-branch.md
+++ b/issues/async-cond-shared-await-point-only-models-representative-branch.md
@@ -1,0 +1,120 @@
+# async cond/match shared await point only models its REPRESENTATIVE branch
+
+**Status:** FIX IMPLEMENTED 2026-08-20 (branch
+`fix/async-cond-heterogeneous-await-slots`) — all eight shapes verified fixed
+at runtime, 178/178 `tests/async_await.test.yo` green (10 new regression
+tests), emitted C clean of the incompatible-pointer class. Awaiting full-suite
++ fixpoint validation before moving to `issues/fixed/`.
+Supersedes `issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md`
+(the Windows-arm64 sighting was one symptom of this; the defect is in the
+emitter and affects EVERY target).
+
+## Root cause
+
+A `cond`/`match` whose branches await shares **one await point** across all
+awaiting branches (one suspension state suffices — only one branch runs). But
+everything hung off that await point — the `await_future_N` slot's C type, the
+registration/extraction access path, the result type, the future-variable-ness,
+the target binding — is taken from a single **representative branch** (the
+first one the analysis saw). Every other awaiting branch is emitted through the
+representative's model:
+
+- `src/evaluator/shared/suspension_analysis.yo` (~line 540): branch suspension
+  points are merged by depth position; one representative per position survives.
+- `src/codegen/exprs/async.yo:755`: the slot is declared with the
+  representative's future type (or not at all, if the representative awaited a
+  named variable).
+- `src/codegen/async/state_code_gen.yo` (`generate_cond_branch_with_await`):
+  every branch stores its own future into the one slot.
+- `src/codegen/async/state_machine.yo` (`_emit_await_suspension`,
+  `_emit_prev_await_result_extraction`): readiness check, cold-start,
+  continuation registration, abort check and result extraction all go through
+  the representative's field and type.
+
+The retired TS compiler has the identical structure (attic
+`state-code-gen.ts:2527,2542`) — this is inherited, not a porting regression.
+
+## The eight defect shapes (all reproduced 2026-08-20, `--release`, macOS)
+
+Reproducers: `issues/repros/async-cond-branch-await-shapes.yo` (shapes 1–6)
+plus the shape 7/8 regression tests in `tests/async_await.test.yo`. "anon" = the branch awaits a call
+expression; "var" = it awaits a named local Future.
+
+| # | branches | today's behavior |
+| - | -------- | ---------------- |
+| 1 | anon+anon, same result type, both tail awaits | **wrong value** (cond result stays 0) + ill-typed C |
+| 2 | anon+anon, `String` vs `unit` results | ill-typed C; registration/extraction read WRONG OFFSETS for the non-representative branch — deadlock or RC-on-garbage once that branch's future actually suspends |
+| 3 | anon+anon, representative result is `unit`, other branch binds | extraction skipped entirely (`is_prev_unit`); the bound variable reads a zeroed field |
+| 4 | anon+anon, single awaiting branch whose VALUE IS the await | **wrong value** (0) — `r := cond(flag => io.await(f, io), true => i32(7))`; the branch has no remaining exprs, so nothing ever assigns the registered target |
+| 5 | var+var (branches await different named futures) | **C compile fails** (`no member named 'await_future_N'`) — declaration took the var path, stores took the anon path; and registration polls the representative's variable, i.e. the WRONG future for the other branch |
+| 6 | var+anon, same future type | **C compile fails**, same missing-field class |
+| 7 | SINGLE awaiting branch, `x := io.await(named_var, io)` | **C compile fails** — the `:=`-await branch store always writes the slot, but the declaration site skipped it (`future_variable_id`); a var-await that BINDS inside a cond has never compiled |
+| 8 | SINGLE awaiting branch, standalone `io.await(named_var, io)`; the OTHER branch taken | compiles, but the not-taken branch's **lazy future is cold-started and awaited anyway**: the "was the await branch taken" guard is `sm->var_X != NULL`, and a bound variable is never NULL. Side effects the program chose not to run, run (measured: marker incremented). A never-completing future would deadlock the state machine |
+
+Shape 4 needs no heterogeneity at all and silently miscompiles in the current
+release on every platform. Shapes 1–3 are live in the compiler tree itself:
+the windows cross-emit shows five `-Wincompatible-pointer-types` sites, one of
+which (`_7930`/`_7950`) pairs a `__yo_t2*` result with a `uint8_t` result —
+shape 2. It has not misfired only because those futures complete synchronously
+and the misread offset lands on a calloc'd-NULL `continuation_fn`
+(`__yo_incr_rc(NULL)` no-ops).
+
+## Why Windows arm64 exposed it first
+
+The store `sm->await_future_N = <other branch's future>` is
+`-Wincompatible-pointer-types`. On the x64 release leg that is a suppressed
+warning; on the arm64 leg it is a hard error. **Not an architecture difference
+— a clang version skew**: `windows-latest` pre-installs LLVM 20.1.8 (so
+`choco install llvm` no-ops), while `windows-11-arm` has no pre-installed LLVM
+and choco installs 22.1.7, where the diagnostic is a default ERROR that `-w`
+does not downgrade. The moment GitHub's x64 image ships LLVM 22+, every leg
+fails. The v0.2.12 arm64 emit was NOT clean either — its log died at mimalloc
+first, and the earlier "CLEAN" reading of that log was wrong: this class was
+present in that C too (same emitter, same tree).
+
+## Fix design (implemented)
+
+One authority for "is this await point branch-uniform?": the suspension
+analysis records every branch's await expr per merged position
+(`cond_branch_suspension_exprs` on `SuspensionPoint`). Codegen attaches each
+branch's own await exprs to its `CondBranch` record.
+
+- **Uniform-anonymous points** (all awaiting branches anonymous, same future C
+  type, same io-ness — the overwhelming majority): emission unchanged,
+  byte-identical C. Shapes 7/8 prove var-await points are broken even when
+  "uniform", so ANY named-future branch routes to the dispatch path.
+- **Dispatch points** (heterogeneous types, mixed io-ness, or any named-future
+  branch): the slot is declared `void*` (stores are implicit
+  `T*`→`void*`, no casts); suspension registration and result extraction are
+  emitted inside the existing `switch (sm->cond_branch_M)`, each case accessing
+  the future through ITS OWN exact type (cast from the erased slot, or the
+  branch's `sm->var_X`), extracting per the branch's own result type directly
+  into the branch's own destination (bound var field, or the cond's registered
+  target). No cross-type field access survives anywhere.
+- Shape 4 (uniform case): an awaiting branch with EMPTY remaining exprs whose
+  value is the await itself gets `<target> = sm->await_result_N;` in its
+  dispatch case.
+
+## Implementation map (2026-08-20)
+
+| piece | where |
+| --- | --- |
+| per-branch suspension exprs recorded on the merged representative | `src/evaluator/shared/suspension_analysis.yo` (merge loop), `cond_branch_suspension_exprs` on `SuspensionPoint` |
+| the ONE dispatch/uniform predicate | `cond_await_point_needs_dispatch` (`src/codegen/async/state_code_gen.yo`) — consulted by declaration, stores, suspension, extraction, continuation. Uniform = all awaiting branches ANONYMOUS + same future C name; any named-future branch or type mismatch → dispatch |
+| per-branch future access (cast/var-field/io-ness/result type) | `cond_branch_future_access` + `resolve_future_var_field` (same file); `CondBranch.await_exprs` carries each branch's awaits in order (depth = `ap.index - cond_branch_source_index`) |
+| erased `void*` slot declaration | `src/codegen/exprs/async.yo` (`emit_async_block_struct_definition`) |
+| per-branch stores (named branches don't store) | `generate_cond_branch_with_await`, `generate_remaining_expr_future` |
+| per-branch registration switch (replaces the NULL guard) | `_emit_await_suspension_dispatch` + `_emit_await_suspension_core` (`state_machine.yo`) |
+| per-branch extraction switch | `_emit_prev_await_result_extraction_dispatch` (`state_machine.yo`) |
+| shape-4 target handover (uniform path) | `_emit_cond_branch_continuation` — empty-remaining await-value branch emits `<target> = sm->await_result_N;` in its case |
+
+Uniform-anonymous points emit byte-identical C to before (the suspension core
+is the same text, parameterized).
+
+## Known open corner (documented, loud if hit)
+
+A dispatch-mode point where one branch's await is a `while` CONDITION (reads
+`sm->await_result_N` to decide the next iteration) is not given a per-branch
+`await_result_N` write; if the shapes ever combine that way the emitted C
+fails to compile (loudly) rather than corrupting. No such shape exists in the
+tree, std, or tests.

--- a/issues/repros/async-cond-branch-await-shapes.yo
+++ b/issues/repros/async-cond-branch-await-shapes.yo
@@ -1,0 +1,150 @@
+// Reproducers for issues/async-cond-shared-await-point-only-models-representative-branch.md
+// Six shapes of "a cond whose branches await differently", all sharing one
+// await point. Expected output (post-fix): every line prints its wanted value.
+// Pre-fix (2026-08-20): shape1/shape4 print 0, shape2 corrupts or deadlocks,
+// shape3 prints 0 for the bound branch, shape5/shape6 fail to C-compile.
+open(import("std/string"));
+open(import("std/fmt"));
+{ yield } :: import("std/async");
+
+mk_ten :: (fn(io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    return(i32(10))
+  })
+);
+mk_twenty :: (fn(io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    io.await(yield(io), io);
+    return(i32(20))
+  })
+);
+mk_str :: (fn(io : Io) -> Impl(Future(String, Io)))(
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    return(`hello`)
+  })
+);
+mk_unit :: (fn(io : Io) -> Impl(Future(unit, Io)))(
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    return(())
+  })
+);
+mk_val :: (fn(v : i32, io : Io) -> Impl(Future(i32, Io)))({
+  b := Box(i32)(v);
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    return(b.*)
+  })
+});
+
+// Shape 1: same result type, heterogeneous future types, tail awaits.
+shape1 :: (fn(flag : bool, io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    r := cond(
+      flag => io.await(mk_ten(io), io),
+      true => io.await(mk_twenty(io), io)
+    );
+    return(r)
+  })
+);
+
+// Shape 2: String-result representative, unit-result other branch.
+shape2 :: (fn(flag : bool, io : Io) -> Impl(Future(usize, Io)))(
+  io.async((io : Io) => {
+    r := cond(
+      flag => {
+        s := io.await(mk_str(io), io);
+        s.len()
+      },
+      true => {
+        io.await(mk_unit(io), io);
+        usize(0)
+      }
+    );
+    return(r)
+  })
+);
+
+// Shape 3: unit representative; the OTHER branch binds a non-unit result.
+shape3 :: (fn(flag : bool, io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    r := cond(
+      flag => {
+        io.await(mk_unit(io), io);
+        i32(0)
+      },
+      true => {
+        x := io.await(mk_ten(io), io);
+        x + i32(1)
+      }
+    );
+    return(r)
+  })
+);
+
+// Shape 4: single awaiting branch whose VALUE IS the await. No heterogeneity.
+shape4 :: (fn(flag : bool, io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    r := cond(
+      flag => io.await(mk_ten(io), io),
+      true => i32(7)
+    );
+    return(r)
+  })
+);
+
+// Shape 5: branches await DIFFERENT named future variables.
+shape5 :: (fn(flag : bool, io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    f1 := mk_val(i32(100), io);
+    f2 := mk_val(i32(200), io);
+    r := cond(
+      flag => {
+        x := io.await(f1, io);
+        x + i32(1)
+      },
+      true => {
+        y := io.await(f2, io);
+        y + i32(2)
+      }
+    );
+    return(r)
+  })
+);
+
+// Shape 6: one branch awaits a NAMED future, the other an anonymous call.
+shape6 :: (fn(flag : bool, io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    f1 := mk_val(i32(100), io);
+    r := cond(
+      flag => {
+        x := io.await(f1, io);
+        x + i32(1)
+      },
+      true => {
+        y := io.await(mk_val(i32(200), io), io);
+        y + i32(2)
+      }
+    );
+    return(r)
+  })
+);
+
+main :: (fn(io : Io) -> unit)({
+  println(`shape1(true)  = ${io.await(shape1(true, io), io).to_string()} (want 10)`);
+  println(`shape1(false) = ${io.await(shape1(false, io), io).to_string()} (want 20)`);
+  println(`shape2(true)  = ${io.await(shape2(true, io), io).to_string()} (want 5)`);
+  println(`shape2(false) = ${io.await(shape2(false, io), io).to_string()} (want 0)`);
+  println(`shape3(true)  = ${io.await(shape3(true, io), io).to_string()} (want 0)`);
+  println(`shape3(false) = ${io.await(shape3(false, io), io).to_string()} (want 11)`);
+  println(`shape4(true)  = ${io.await(shape4(true, io), io).to_string()} (want 10)`);
+  println(`shape4(false) = ${io.await(shape4(false, io), io).to_string()} (want 7)`);
+  println(`shape5(true)  = ${io.await(shape5(true, io), io).to_string()} (want 101)`);
+  println(`shape5(false) = ${io.await(shape5(false, io), io).to_string()} (want 202)`);
+  println(`shape6(true)  = ${io.await(shape6(true, io), io).to_string()} (want 101)`);
+  println(`shape6(false) = ${io.await(shape6(false, io), io).to_string()} (want 202)`);
+});
+export(main);

--- a/issues/retired/windows-arm64-emitted-c-state-machine-pointer-mismatch.md
+++ b/issues/retired/windows-arm64-emitted-c-state-machine-pointer-mismatch.md
@@ -1,3 +1,10 @@
+> **RETIRED 2026-08-20.** Root-caused and superseded by
+> `issues/async-cond-shared-await-point-only-models-representative-branch.md`.
+> Two claims below did not survive: the defect is NOT arm64-specific (the x64
+> emit carries the byte-identical class — arm64 merely compiles with clang 22,
+> where the diagnostic is a default error), and v0.2.12's arm64 emit was NOT
+> clean of it (its log died at mimalloc before reaching these sites).
+
 # windows-arm64 emitted C: async state-machine pointer types crossed between temp-file modules
 
 **Status:** OPEN, not yet root-caused. Surfaced 2026-08-20 by

--- a/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
+++ b/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
@@ -231,6 +231,6 @@ RSS ~72%, which is a measured, platform-specific reason that does not transfer.
 
 ### Still open, and NOT fixed by this
 
-`issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md`. The arm64
+`issues/async-cond-shared-await-point-only-models-representative-branch.md`. The arm64
 leg has a second, unrelated defect in Yo's OWN emitted C. Switching allocator
 does not touch it, so windows-arm64 stays `experimental: true`.

--- a/plans/WINDOWS_ALLOCATOR_DECISION.md
+++ b/plans/WINDOWS_ALLOCATOR_DECISION.md
@@ -82,18 +82,26 @@ decaying rather than stabilising: v3.3.2 broke arm64, v3.5.0 broke x64 as well.
 Keeping mimalloc on Windows therefore meant pinning it indefinitely and
 absorbing each new break.
 
-## The cost, stated honestly
+## The cost: measured, and it is not a cost
 
-**Unmeasured on Windows, and knowingly accepted.** There has never been an
-allocator A/B on a Windows runner, and until 2026-08-20 there was no
-peak-memory measurement of any kind there — the sampler's Windows arm in
-`test.yml` was literally `Windows) : ;;`, inside a step gated
-`if: runner.os == 'Linux'`.
+The A/B finally ran clean on 2026-08-20 (run 32355228818, `windows-latest`,
+`check ./std`, 3 reps per arm, min-of-reps):
 
-`.github/workflows/ab-windows-allocator.yml` and
-`scripts/bootstrap/measure-windows.ps1` now exist and can quantify what was
-given up. That measurement is no longer a blocker for anything — it is
-informational.
+| arm | min wall | spread | min peak |
+| --- | --- | --- | --- |
+| mimalloc | 31.96 s | 0.26 s | 1,657 MB |
+| system | 32.74 s | 2.78 s | 1,566 MB |
+
+Wall: −2.4% for mimalloc, but the 0.78 s delta sits INSIDE the system arm's
+own 2.78 s run-to-run spread — the workflow's own guard refuses to call a wall
+winner. Peak: mimalloc is **+5.8% fatter** (91 MB). So on Windows the switch
+to the system allocator gave up nothing measurable and saved memory — nothing
+like Linux glibc's 72% peak inflation, which remains the only platform where
+mimalloc pays its way.
+
+(Before this run there had NEVER been a peak-memory measurement on a Windows
+runner — the sampler's Windows arm in `test.yml` was literally `Windows) : ;;`
+inside a step gated `if: runner.os == 'Linux'`.)
 
 The other cost of the alternative is worth restating: keeping mimalloc on x64
 would have pinned the submodule to v3.3.2, since v3.5.0 does not compile there.
@@ -117,7 +125,7 @@ Reopen this if any of the following changes:
 ## Related
 
 - `issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md` — the original arm64 break
-- `issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md` — a SEPARATE
+- `issues/async-cond-shared-await-point-only-models-representative-branch.md` — a SEPARATE
   defect in Yo's own emitted C. windows-arm64 stays `experimental: true` because
   of it; the allocator change does not touch it.
 - `issues/fixed/mimalloc-performance-regression.md` — the macOS measurements

--- a/plans/backlog/INCREMENTAL_COMPILATION.md
+++ b/plans/backlog/INCREMENTAL_COMPILATION.md
@@ -1,0 +1,41 @@
+# Incremental compilation — deferred to the P4 (LSP) era
+
+**Status: BACKLOG (decision 2026-08-20).** Asked during the P3 campaign:
+should the compiler cache per-module work to speed up `yo build` / `yo check`?
+Decision: not now — design it once, driven by the LSP's requirements, as the
+opening work of P4.
+
+## Why deferred
+
+1. **P4 needs it regardless.** An LSP that re-evaluates the full import
+   closure per keystroke is unusable, so incremental evaluation must be
+   designed for P4 anyway. Doing a build-oriented cache first means designing
+   invalidation twice.
+2. **It is a deep cut, not a lever.** A compilation cache needs module-level
+   dependency hashing, serializable evaluated exports, and invalidation. The
+   evaluated-export state is exactly the structure the memory campaign
+   measured: a heavily shared env graph (7.4 M live `Variable`s at peak,
+   `plans/backlog/YO_SELF_ENV_SHARING.md`) — snapshotting it is a project, not
+   a patch. Codegen additionally assumes a process-lifetime shared
+   `ExprInfoTable` (`src/module_manager.yo`).
+3. **Risk timing.** The bootstrap fixpoint gates BYTE-IDENTITY of the emit; a
+   cache introduces staleness/nondeterminism bug classes into exactly that
+   story while the release machinery (musl-only migration, per-target yo.c
+   split, Windows legs) is mid-flight.
+4. **The pain is partially mitigated.** `_inject_forall_captures` memoization
+   already cut the self-emit 227→148.5 s wall / 19.07→14.94 GB live (#145),
+   and `yo check <file>` remains the fast iteration loop.
+
+## The cheap win available WITHOUT touching the evaluator
+
+Build-runner-level artifact caching: `src/build_runner.yo` already schedules a
+build DAG; skipping recompilation of an artifact whose input closure hash is
+unchanged needs no evaluator state to be serialized at all — hash source files
+(+ compiler version + flags), keep the emitted C/object keyed by hash. Worth
+scoping as its own small plan if build times become the bottleneck before P4.
+
+## When this reopens
+
+At P4 kickoff (`plans/P4_LSP.md`): the LSP's incremental evaluation design
+should subsume the build-cache question — a module whose evaluated exports can
+be reused across LSP edits can be reused across builds.

--- a/src/codegen/async/state_code_gen.yo
+++ b/src/codegen/async/state_code_gen.yo
@@ -15,22 +15,333 @@ open(import("std/string"));
 { AwaitPoint, CapturedVariable } :: import("../../evaluator/async/await_analysis_types.yo");
 { SuspensionPoint } :: import("../../evaluator/shared/suspension_analysis_types.yo");
 { split_body_at_suspension_points, contains_suspension_expr } :: import("../shared/suspension_codegen.yo");
-{ is_io_async_call, is_io_await_call } :: import("../../evaluator/async/await_analysis.yo");
+{ is_io_async_call, is_io_await_call, extract_future_trait_from_type, get_future_variable_id_ } :: import("../../evaluator/async/await_analysis.yo");
 { extract_target_variable_id } :: import("../../evaluator/shared/suspension_analysis.yo");
 { expr_contains_await, expr_contains_while_with_await } :: import("../../expr_traversal.yo");
-{ expr_info_primitive_pattern_values, expr_info_is_primitive_match, lookup_macro_expansion } :: import("../../expr_info.yo");
+{ expr_info_primitive_pattern_values, expr_info_is_primitive_match, lookup_macro_expansion, lookup_some_resolved_concrete } :: import("../../expr_info.yo");
 { FunctionGenerationContext, SmWhileBreakInfo, SmWhileContinueInfo, WhileLoopInfo, OuterWhileLoop, CondBranchPostWhileExprs, CondBranch, ChainedCondBranches, AsyncCondBranchInfo, merge_cond_branch_post_while_exprs } :: import("../functions/context.yo");
 { _call_generate_expr } :: import("../exprs/_expr.yo");
 { _call_generate_cond_with_await, _call_generate_match_with_await, _call_generate_while_with_await, register_fsm_emitters } :: import("./_fsm.yo");
 { get_variables_from_env } :: import("../../env.yo");
 { is_temp_variable_name } :: import("../../utils.yo");
 { emit_async_future_completion } :: import("../exprs/async_completion.yo");
-{ is_unit_type, is_enum_type } :: import("../../types/guards.yo");
+{ is_unit_type, is_enum_type, is_some_type, is_concrete_trait_type, is_extern_type_name } :: import("../../types/guards.yo");
 { EvalValue, type_of_eval_value } :: import("../../value.yo");
 { get_type_string, sanitize_for_c_identifier, can_optimize_as_nullable_pointer, can_optimize_as_simple_enum, get_enum_variant_c_name, type_key } :: import("../utils/index.yo");
 { get_state_machine_field_name } :: import("./state_machine_naming.yo");
 { generate_comptime_value } :: import("../exprs/comptime_value.yo");
 { TypeValue } :: import("../../types/definitions.yo");
+/// True when `ty` is an io.async/io.await Future SomeType (vs an extern
+/// `__yo_io_future_t`). Mirrors `isIoFutureType` (state-machine.ts:496).
+///
+/// TS has TWO signals:
+///   (1) `resolvedConcreteType` is itself an EXTERN SomeType — an extern C type
+///       like `__yo_io_future_t` (so NOT a state-machine Future).
+///   (2) any required trait is a `Concrete(...)` trait.
+/// Branch (2) is ported faithfully. Branch (1) is a DOCUMENTED GAP: yo-self's
+/// `SomeT` has no `is_extern` field, so although the resolved concrete type is
+/// available via `g_some_resolved_concrete`, its extern-ness is unrepresentable
+/// (a second SomeT model gap alongside resolved-concrete; see
+/// plans/archive/BOOTSTRAPPING_CODEGEN.md Phase 5 #3 — needs a `g_some_is_extern`
+/// side-table or a SomeT field). The `lookup_some_resolved_concrete` read is kept
+/// to mark the wiring point. Inert until the FSM emitters call this.
+is_io_future_type :: (fn(ty : TypeValue) -> bool)({
+  if(!(is_some_type(ty)), {
+    return(false);
+  });
+  // Branch (1): resolved concrete is an extern SomeType (TS
+  // state-machine.ts:521-527, `resolvedConcreteType.isExtern`). No longer a
+  // model gap: an extern opaque type IS a SomeT whose NAME is registered in
+  // the extern-type-name set, so extern-ness is `is_extern_type_name(name)`.
+  // This branch became LOAD-BEARING once Impl's `Concrete(T)` support landed:
+  // the marker now moves into the resolved-concrete cell (as in TS) instead
+  // of sitting in required_trait_types, so branch (2) alone no longer fires
+  // for `IoFuture` — and misclassifying an io future as a lazy sync future
+  // emits a `->__yo_resume_fn` cold-start on `__yo_io_future_t`, which has no
+  // such member (the fs/gc batch C errors).
+  some_id := match(ty, .SomeT({ id }) => id, _ => String.from(""));
+  rc_cell := match(ty, .SomeT({ resolved_concrete : io_src }) => io_src.get(usize(0)), _ => Option(TypeValue).None);
+  rc_final := match(
+    rc_cell,
+    .Some(io_r) => Option(TypeValue).Some(io_r),
+    .None => lookup_some_resolved_concrete(some_id)
+  );
+  match(
+    rc_final,
+    .Some(io_rcv) => match(
+      io_rcv,
+      .SomeT({ name : io_enm }) => if(is_extern_type_name(io_enm), {
+        return(true);
+      }),
+      _ => ()
+    ),
+    .None => ()
+  );
+  // Branch (2): any required trait is a `Concrete(...)` trait.
+  rts := match(ty, .SomeT({ required_trait_types }) => required_trait_types, _ => ArrayList(TypeValue).new());
+  (i : usize) = usize(0);
+  while(i < rts.len(), {
+    rt := match(rts.get(i), .Some(t) => t, .None => TypeValue.Unit);
+    if(is_concrete_trait_type(rt), {
+      return(true);
+    });
+    i = (i + usize(1));
+  });
+  false
+});
+/// Collect every `io.await` call expr inside a cond/match branch VALUE, in
+/// source order. Does not descend into nested `io.async` bodies (their awaits
+/// belong to that block's own state machine) or into a found await's own
+/// arguments (nested awaits are rejected upstream). Companion walker to
+/// `_find_branch_await_target_variable_id`.
+collect_branch_await_exprs :: (
+  fn(expr : AstExpr, out : ArrayList(AstExpr)) -> unit
+)({
+  if(!(ast_expr_is_fn_call(expr)), {
+    return(());
+  });
+  if(is_io_async_call(expr.clone()), {
+    return(());
+  });
+  if(is_io_await_call(expr.clone()), {
+    out.push(expr);
+    return(());
+  });
+  // A macro call (`if`, ...) keeps its macro head in the AST; the exprs the
+  // evaluator ANNOTATED live in the expansion. Walking the raw args here
+  // collects await exprs with no ExprInfo, which the access builder cannot
+  // type. Every tree walk in this family follows the expansion.
+  match(
+    lookup_macro_expansion(ast_expr_id(expr)),
+    .Some(me) => {
+      recur(me, out);
+      return(());
+    },
+    .None => ()
+  );
+  match(
+    expr,
+    .Atom(_, _) => (),
+    .FnCall(_, f, args, _, _) => {
+      recur(f, out);
+      (i : usize) = usize(0);
+      while(i < args.len(), {
+        match(
+          args.get(i),
+          .Some(a) => recur(a, out),
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+    }
+  );
+});
+/// The future argument (arg 0) of an `io.await(...)` call expr.
+await_call_future_arg :: (fn(await_expr : AstExpr) -> Option(AstExpr))(
+  match(
+    await_expr,
+    .FnCall(_, _, a, _, _) => a.get(usize(0)),
+    .Atom(_, _) => Option(AstExpr).None
+  )
+);
+/// DISPATCH-mode decision for a shared cond/match await point.
+///
+/// A cond/match whose branches await shares ONE await point; the slot type,
+/// registration and extraction historically came from the point's
+/// REPRESENTATIVE branch only, which miscompiles every branch shaped
+/// differently from it (eight shapes catalogued in
+/// issues/async-cond-shared-await-point-only-models-representative-branch.md).
+///
+/// Returns true when the branches do NOT all await a same-typed ANONYMOUS
+/// future — any named-future branch (shapes 5-8: the "was the await branch
+/// taken" NULL guard is meaningless for a bound variable, and `:=`-await of a
+/// var stored into an undeclared slot) or any future-type mismatch (shapes
+/// 1-3). Every site that touches the point's future (slot declaration, branch
+/// stores, suspension registration, result extraction, branch continuation)
+/// MUST consult this one predicate — mixing modes emits ill-typed C.
+cond_await_point_needs_dispatch :: (
+  fn(await_point : AwaitPoint, context : FunctionGenerationContext) -> bool
+)({
+  exprs := match(
+    await_point.base.cond_branch_suspension_exprs,
+    .Some(e) => e,
+    .None => {
+      return(false);
+    }
+  );
+  // NOTE a single awaiting branch is not automatically uniform: it still
+  // needs dispatch when it awaits a NAMED future (shapes 7/8), so fall
+  // through to the per-expr checks whenever any entry exists.
+  if(exprs.len() == usize(0), {
+    return(false);
+  });
+  (first_type : Option(String)) = Option(String).None;
+  (i : usize) = usize(0);
+  n := exprs.len();
+  while(i < n, {
+    e := match(
+      exprs.get(i),
+      .Some(x) => x,
+      // Unreachable (i < n) — classify conservatively as uniform.
+      .None => {
+        return(false);
+      }
+    );
+    // Effects share SuspensionPoint; only io.await exprs are classified here.
+    if(ast_expr_is_fn_call(e) && is_io_await_call(e.clone()), {
+      match(
+        await_call_future_arg(e),
+        .Some(fa) => {
+          // A named future: an identifier atom. The dispatch path accesses it
+          // through its own state-machine field instead of the shared slot.
+          if(ast_expr_is_atom(fa) && (ast_expr_token(fa).kind == TokenKind.Identifier), {
+            return(true);
+          });
+          // Compare the exact C name the slot declaration derives
+          // (get_type_string of the ARG's type — exprs/async.yo:753).
+          match(
+            context.base.get_expr_info(fa),
+            .Some(ei) => {
+              tname := get_type_string(ei.ty, context.base);
+              match(
+                first_type,
+                .Some(ft0) => if(!(ft0 == tname), {
+                  return(true);
+                }),
+                .None => {
+                  first_type = Option(String).Some(tname);
+                }
+              );
+            },
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+    });
+    i = (i + usize(1));
+  });
+  false
+});
+/// Per-branch future access for a dispatch-mode await point: how the resume
+/// function reaches THIS branch's future. `access` is a C expression valid
+/// wherever `sm` is; `is_named` marks a named-future branch (no slot store, no
+/// slot decref — the future's lifetime belongs to its binding).
+CondBranchFutureAccess :: ref(
+  struct(
+    access : String,
+    is_named : bool,
+    is_io_future : bool,
+    /// The branch future's result type (the T of Future(T, ...)).
+    result_type : Option(TypeValue)
+  )
+);
+/// Resolve a named awaited future to the C field the resume function reads it
+/// through: outer capture -> `__capture.<id>`, Phase-1b alias wins, local ->
+/// `var_<id>`. Returns None when the id is not a state-machine variable and has
+/// no alias (the caller falls back to the shared slot).
+resolve_future_var_field :: (
+  fn(fvid : String, context : FunctionGenerationContext) -> Option(String)
+)({
+  kind_hint := match(
+    context.state_machine_variables,
+    .Some(m) => match(
+      m.get(fvid),
+      .Some(cv) => match(
+        cv.kind,
+        .Outer => Option(String).Some(String.from("outer")),
+        .Local => Option(String).Some(String.from("local"))
+      ),
+      .None => Option(String).None
+    ),
+    .None => Option(String).None
+  );
+  match(
+    kind_hint,
+    .Some(k) => Option(String).Some(get_state_machine_field_name(fvid, Option(String).Some(k), context.state_machine_field_aliases)),
+    .None => match(
+      context.state_machine_field_aliases,
+      .Some(a) => match(
+        a.get(fvid),
+        .Some(al) => Option(String).Some(al.clone()),
+        .None => Option(String).None
+      ),
+      .None => Option(String).None
+    )
+  )
+});
+/// Build the future access for one awaiting branch of a dispatch-mode point.
+/// `await_expr` is the branch's own `io.await` call at this point's depth.
+cond_branch_future_access :: (
+  fn(await_expr : AstExpr, await_point : AwaitPoint, context : FunctionGenerationContext) -> Option(CondBranchFutureAccess)
+)({
+  fa := match(
+    await_call_future_arg(await_expr.clone()),
+    .Some(x) => x,
+    .None => {
+      return(Option(CondBranchFutureAccess).None);
+    }
+  );
+  fa_ty := match(
+    context.base.get_expr_info(fa),
+    .Some(ei) => Option(TypeValue).Some(ei.ty),
+    .None => Option(TypeValue).None
+  );
+  result_type := match(
+    fa_ty,
+    .Some(t) => match(
+      extract_future_trait_from_type(t.clone()),
+      .Some(ft) => match(ft, .FutureTraitT(output : ob) => Option(TypeValue).Some(ob), _ => Option(TypeValue).None),
+      .None => Option(TypeValue).None
+    ),
+    .None => Option(TypeValue).None
+  );
+  // Named future — access via its own field.
+  if(ast_expr_is_atom(fa) && (ast_expr_token(fa).kind == TokenKind.Identifier), {
+    match(
+      get_future_variable_id_(fa.clone(), (e : AstExpr) => context.base.get_expr_info(e)),
+      .Some(fvid) => match(
+        resolve_future_var_field(fvid, context),
+        .Some(field) => if(!(field == `await_future_${await_point.base.index.to_string()}`), {
+          return(
+            Option(CondBranchFutureAccess).Some(
+              CondBranchFutureAccess(
+                access : `sm->${field}`,
+                is_named : true,
+                is_io_future : match(fa_ty, .Some(t) => is_io_future_type(t), .None => false),
+                result_type : result_type
+              )
+            )
+          );
+        }),
+        // Not captured into the struct — fall through to the slot access below.
+        // (A Phase-1b temp aliased to the slot itself resolves to the slot's
+        // own name and is likewise treated as anonymous: the slot is `void*`
+        // in dispatch mode, so it must be accessed through the branch cast.)
+        .None => ()
+      ),
+      .None => ()
+    );
+  });
+  // Anonymous future — the branch stored it into the shared `void*` slot;
+  // access through a cast to this branch's exact state type (the same C name
+  // the non-dispatch slot declaration would use: get_type_string of the ARG).
+  c_type := match(
+    fa_ty,
+    .Some(t) => get_type_string(t, context.base),
+    .None => {
+      return(Option(CondBranchFutureAccess).None);
+    }
+  );
+  Option(CondBranchFutureAccess).Some(
+    CondBranchFutureAccess(
+      access : `((${c_type})sm->await_future_${await_point.base.index.to_string()})`,
+      is_named : false,
+      is_io_future : match(fa_ty, .Some(t) => is_io_future_type(t), .None => false),
+      result_type : result_type
+    )
+  )
+});
 /// A contiguous run of body expressions that execute in one FSM state, ending
 /// at an await (or the final segment). Mirrors `StateSegment`
 /// (state-code-gen.ts:47). yo-self's `split_body_at_suspension_points` collapses
@@ -1341,6 +1652,18 @@ generate_while_with_await :: (
   });
   context.async_while_loop_info = Option(HashMap(usize, WhileLoopInfo)).Some(info_map);
 });
+/// Whether THIS branch's await reads a named future through its own field
+/// (dispatch mode only). Must agree with `cond_branch_future_access` — the
+/// store decision and the access decision are two halves of one contract.
+_branch_future_is_named :: (
+  fn(await_expr : AstExpr, await_point : AwaitPoint, context : FunctionGenerationContext) -> bool
+)(
+  match(
+    cond_branch_future_access(await_expr, await_point, context),
+    .Some(a) => a.is_named,
+    .None => false
+  )
+);
 /// Emit a single cond/match branch body (a `begin` block) up to its first await:
 /// pre-await expressions emit normally, the await stores its Future (or delegates
 /// to a nested cond/match/while), and post-await expressions are returned for the
@@ -1351,6 +1674,10 @@ generate_cond_branch_with_await :: (
   em := context.base.emitter;
   remaining_exprs := ArrayList(AstExpr).new();
   idx_s := await_point.base.index.to_string();
+  // Dispatch-mode points access each branch's future through its own shape:
+  // a NAMED branch future is read via its own field (no slot store), an
+  // anonymous one is stored into the shared `void*` slot.
+  dispatch_mode := cond_await_point_needs_dispatch(await_point, context);
   // A branch body that is NOT a `begin` block — e.g. `.Some(v) => cond(...)`,
   // where the arm body is a bare `cond` with the await inside it.
   //
@@ -1388,11 +1715,16 @@ generate_cond_branch_with_await :: (
                 v_args := match(value_expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
                 match(
                   v_args.get(usize(0)),
-                  .Some(future_expr) => {
+                  .Some(future_expr) => if(dispatch_mode && _branch_future_is_named(value_expr, await_point, context), {
+                    // Named future: the branch's own field holds it — storing
+                    // it into the slot would hand the slot an unowned
+                    // reference (the extraction decref would over-release it).
+                    em.emit_string_line(`${indent}// Await will use this branch's named Future (dispatch)`);
+                  }, {
                     future_code := _call_generate_expr(future_expr, indent, context);
                     em.emit_string_line(`${indent}// Store Future for await ${idx_s} (cond branch)`);
                     em.emit_string_line(`${indent}sm->await_future_${idx_s} = ${future_code};`);
-                  },
+                  }),
                   .None => ()
                 );
               }),
@@ -1402,19 +1734,27 @@ generate_cond_branch_with_await :: (
             // Standalone await.
             if(ast_expr_is_fn_call(expr) && is_io_await_call(expr), {
               s_args := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
+              // In dispatch mode the named/anonymous decision is PER BRANCH —
+              // the representative's future_variable_id says nothing about
+              // this branch (issues/async-cond-shared-await-point-only-models-representative-branch.md).
+              branch_named := (dispatch_mode && _branch_future_is_named(expr, await_point, context));
               match(
                 s_args.get(usize(0)),
-                .Some(future_expr) => match(
-                  await_point.future_variable_id,
-                  .None => {
-                    future_code := _call_generate_expr(future_expr, indent, context);
-                    em.emit_string_line(`${indent}// Store Future for await ${idx_s} (cond branch)`);
-                    em.emit_string_line(`${indent}sm->await_future_${idx_s} = ${future_code};`);
-                  },
-                  .Some(fv) => {
-                    em.emit_string_line(`${indent}// Await will use Future from sm->var_${fv}`);
-                  }
-                ),
+                .Some(future_expr) => if(branch_named, {
+                  em.emit_string_line(`${indent}// Await will use this branch's named Future (dispatch)`);
+                }, {
+                  match(
+                    cond(dispatch_mode => Option(String).None, true => await_point.future_variable_id),
+                    .None => {
+                      future_code := _call_generate_expr(future_expr, indent, context);
+                      em.emit_string_line(`${indent}// Store Future for await ${idx_s} (cond branch)`);
+                      em.emit_string_line(`${indent}sm->await_future_${idx_s} = ${future_code};`);
+                    },
+                    .Some(fv) => {
+                      em.emit_string_line(`${indent}// Await will use Future from sm->var_${fv}`);
+                    }
+                  );
+                }),
                 .None => ()
               );
             }, {
@@ -1829,7 +2169,11 @@ _find_branch_await_target_variable_id :: (
 });
 _make_cond_branch :: (
   fn(index : usize, value : AstExpr, has_await : bool, remaining : Option(ArrayList(AstExpr)), context : FunctionGenerationContext) -> CondBranch
-)(
+)({
+  branch_awaits := ArrayList(AstExpr).new();
+  if(has_await, {
+    collect_branch_await_exprs(value.clone(), branch_awaits);
+  });
   CondBranch(
     index : index,
     value : value,
@@ -1839,9 +2183,13 @@ _make_cond_branch :: (
     await_target_variable_id : cond(
       has_await => _find_branch_await_target_variable_id(value.clone(), context),
       true => Option(String).None
+    ),
+    await_exprs : cond(
+      has_await => Option(ArrayList(AstExpr)).Some(branch_awaits),
+      true => Option(ArrayList(AstExpr)).None
     )
   )
-);
+});
 /// The destination the await-branch registration names for the branch's LAST
 /// remaining expression. The value an await-carrying arm computes AFTER its
 /// await never leaves the resume segment unless the registration names one:
@@ -1912,11 +2260,78 @@ _store_cond_branch_info :: (
     idx : usize,
     branches : ArrayList(CondBranch),
     target_variable_id : Option(String),
-    target_assignment_code : Option(String)
+    target_assignment_code : Option(String),
+    /// Dispatch-mode points UNION branch records instead of overwriting:
+    /// dispatch codes are per-function unique, and the registration/extraction
+    /// switches need a case for EVERY awaiting arm at any nesting level —
+    /// overwriting the nested cond's records left its live codes caseless
+    /// (the `default:` skipped the await entirely). Uniform points keep the
+    /// overwrite: their nested remaining code rides `chained_branches`, and a
+    /// union would double-emit it.
+    merge_branches : bool
   ) -> unit
 )({
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
+  });
+  if(merge_branches, {
+    cmap0 := match(context.async_cond_branch_info, .Some(m) => m, .None => HashMap(usize, AsyncCondBranchInfo).new());
+    match(
+      cmap0.get(idx),
+      .Some(existing) => {
+        // Union by dispatch code; entry-level fields (targets) take the
+        // OUTER store's values — it runs last and owns the value flow.
+        (bi : usize) = usize(0);
+        while(bi < existing.branches.len(), {
+          match(
+            existing.branches.get(bi),
+            .Some(eb) => {
+              (dup : bool) = false;
+              (ni : usize) = usize(0);
+              while((ni < branches.len()) && !(dup), {
+                match(
+                  branches.get(ni),
+                  .Some(nb) => if(nb.index == eb.index, {
+                    dup = true;
+                  }),
+                  .None => ()
+                );
+                ni = (ni + usize(1));
+              });
+              if(!(dup), {
+                branches.push(eb);
+              });
+            },
+            .None => ()
+          );
+          bi = (bi + usize(1));
+        });
+        cmap0.set(
+          idx,
+          AsyncCondBranchInfo(
+            branches : branches,
+            target_variable_id : target_variable_id,
+            target_assignment_code : target_assignment_code,
+            cond_branch_field_index : existing.cond_branch_field_index,
+            chained_branches : existing.chained_branches
+          )
+        );
+      },
+      .None => {
+        cmap0.set(
+          idx,
+          AsyncCondBranchInfo(
+            branches : branches,
+            target_variable_id : target_variable_id,
+            target_assignment_code : target_assignment_code,
+            cond_branch_field_index : Option(usize).None,
+            chained_branches : Option(ArrayList(ChainedCondBranches)).None
+          )
+        );
+      }
+    );
+    context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(cmap0);
+    return(());
   });
   if(!(_cond_inner_has_remaining_code(context, idx)), {
     cmap := match(context.async_cond_branch_info, .Some(m) => m, .None => HashMap(usize, AsyncCondBranchInfo).new());
@@ -2085,7 +2500,7 @@ generate_cond_with_await :: (
       },
       .None => ()
     );
-    _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(cond_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
+    _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(cond_expr, context, target_variable_id.clone(), target_assignment_code.clone()), cond_await_point_needs_dispatch(await_point, context));
     return();
   });
   // General if-else chain.
@@ -2167,7 +2582,7 @@ generate_cond_with_await :: (
     em.emit_string_line(`${current_indent}}`);
     cd = (cd + usize(1));
   });
-  _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(cond_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
+  _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(cond_expr, context, target_variable_id.clone(), target_assignment_code.clone()), cond_await_point_needs_dispatch(await_point, context));
 });
 /// Index of the variant named `variant_name` in the enum's parallel arrays, or
 /// `.None`. Replaces TS `enumType.variants.find(v => v.name === ...)`.
@@ -2336,6 +2751,11 @@ generate_primitive_match_with_await :: (
   });
   em.emit_string_line(`${indent}}`);
   // Primitive match always stores branch info (TS sets unconditionally).
+  // Dispatch-mode points merge instead — nested arm records must survive.
+  if(cond_await_point_needs_dispatch(await_point, context), {
+    _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()), true);
+    return(());
+  });
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
   });
@@ -2515,13 +2935,16 @@ _push_chained_match_arm :: (
       chained_branches : Option(ArrayList(ChainedCondBranches)).None
     )
   );
+  chained_awaits := ArrayList(AstExpr).new();
+  collect_branch_await_exprs(case_body.clone(), chained_awaits);
   cb := CondBranch(
     index : case_index,
     value : case_body,
     has_await : true,
     remaining_exprs : Option(ArrayList(AstExpr)).Some(remaining),
     deferred_drop_expressions : match(context.base.get_expr_info(case_body), .Some(ei) => ei.deferred_drop_expressions, .None => Option(ArrayList(AstExpr)).None),
-    await_target_variable_id : Option(String).None
+    await_target_variable_id : Option(String).None,
+    await_exprs : Option(ArrayList(AstExpr)).Some(chained_awaits)
   );
   chained := match(entry.chained_branches, .Some(c) => c, .None => ArrayList(ChainedCondBranches).new());
   bl := ArrayList(CondBranch).new();
@@ -2552,6 +2975,18 @@ _emit_match_case_await_or_value :: (
   if(branch_has_await(case_body), {
     branch_count_before := _cond_entry_branch_count(context, await_point.base.index);
     remaining := generate_cond_branch_with_await(case_body, await_point, indent, context);
+    if(remaining.len() == usize(0), {
+      // Tail-await arm (the await IS the arm's value): record it anyway —
+      // dispatch-mode registration/extraction and the uniform target handover
+      // key off this record; without it the arm has no case and its value is
+      // silently dropped. Skip only when a NESTED cond/match claimed the
+      // dispatch slot during the recursion above (its arm records are the
+      // live ones).
+      if(!(_cond_entry_branch_count(context, await_point.base.index) > branch_count_before), {
+        _push_cond_branch(context, await_point.base.index, _make_cond_branch(case_index, case_body, true, Option(ArrayList(AstExpr)).Some(remaining), context));
+      });
+      _set_cond_branch_target(context, await_point.base.index, _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
+    });
     if(remaining.len() > usize(0), {
       // A NESTED match inside this arm claims the dispatch slot: its
       // `sm->cond_branch_N = …` assignment overwrites this arm's, so a `case`
@@ -2930,5 +3365,12 @@ export(
   generate_cond_with_await,
   generate_primitive_match_with_await,
   generate_match_with_await,
-  register_fsm_emitters_impl
+  register_fsm_emitters_impl,
+  is_io_future_type,
+  collect_branch_await_exprs,
+  await_call_future_arg,
+  cond_await_point_needs_dispatch,
+  CondBranchFutureAccess,
+  resolve_future_var_field,
+  cond_branch_future_access
 );

--- a/src/codegen/async/state_machine.yo
+++ b/src/codegen/async/state_machine.yo
@@ -10,12 +10,12 @@ open(import("std/string"));
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
 { TypeValue } :: import("../../types/definitions.yo");
-{ is_some_type, is_concrete_trait_type, is_struct_type, is_function_type, is_dyn_type, is_unit_type, is_extern_type_name } :: import("../../types/guards.yo");
+{ is_some_type, is_struct_type, is_function_type, is_dyn_type, is_unit_type } :: import("../../types/guards.yo");
 { type_implements_future, extract_future_trait_from_type } :: import("../../evaluator/trait_checking.yo");
 { lookup_macro_expansion, lookup_some_resolved_concrete } :: import("../../expr_info.yo");
 { AwaitAnalysisResult, AwaitPoint, CapturedVariable, CapturedVariableKind } :: import("../../evaluator/async/await_analysis_types.yo");
 { SuspensionCapturedVariable } :: import("../../evaluator/shared/suspension_analysis_types.yo");
-{ StateSegment, split_into_state_segments, generate_await_expression, generate_state_segment_code, hoist_non_splittable_awaits, await_is_while_condition } :: import("./state_code_gen.yo");
+{ StateSegment, split_into_state_segments, generate_await_expression, generate_state_segment_code, hoist_non_splittable_awaits, await_is_while_condition, is_io_future_type, cond_await_point_needs_dispatch, cond_branch_future_access, CondBranchFutureAccess, collect_branch_await_exprs } :: import("./state_code_gen.yo");
 { is_io_async_call, is_io_await_call } :: import("../../evaluator/async/await_analysis.yo");
 { AstExpr, ast_expr_id, ast_expr_is_atom, ast_expr_is_atom_of, ast_expr_is_fn_call, ast_expr_is_fn_call_of, ast_expr_token, BK_COND, BK_MATCH, BK_WHILE, BK_BEGIN } :: import("../../expr.yo");
 { _call_generate_expr } :: import("../exprs/_expr.yo");
@@ -28,69 +28,12 @@ open(import("std/string"));
 { FunctionGenerationContext, EvidenceParameter, WhileLoopInfo, CondBranch, ChainedCondBranches, AsyncCondBranchInfo, InAsyncStateMachine, CondBranchPostWhileExprs, OuterWhileLoop, SmWhileBreakInfo, SmWhileContinueInfo, merge_cond_branch_post_while_exprs } :: import("../functions/context.yo");
 { expr_contains_await, expr_contains_while_with_await } :: import("../../expr_traversal.yo");
 { is_temp_variable_name } :: import("../../utils.yo");
+{ codegen_fatal } :: import("../constants.yo");
 { get_type_string } :: import("../utils/index.yo");
 { get_state_machine_field_name } :: import("./state_machine_naming.yo");
 { Emitter } :: import("../../emitter.yo");
 { emit_async_future_completion, emit_async_future_escape } :: import("../exprs/async_completion.yo");
 { get_dup_function_for_type, generate_dup_code_for_value } :: import("../exprs/drop_dup.yo");
-/// True when `ty` is an io.async/io.await Future SomeType (vs an extern
-/// `__yo_io_future_t`). Mirrors `isIoFutureType` (state-machine.ts:496).
-///
-/// TS has TWO signals:
-///   (1) `resolvedConcreteType` is itself an EXTERN SomeType — an extern C type
-///       like `__yo_io_future_t` (so NOT a state-machine Future).
-///   (2) any required trait is a `Concrete(...)` trait.
-/// Branch (2) is ported faithfully. Branch (1) is a DOCUMENTED GAP: yo-self's
-/// `SomeT` has no `is_extern` field, so although the resolved concrete type is
-/// available via `g_some_resolved_concrete`, its extern-ness is unrepresentable
-/// (a second SomeT model gap alongside resolved-concrete; see
-/// plans/archive/BOOTSTRAPPING_CODEGEN.md Phase 5 #3 — needs a `g_some_is_extern`
-/// side-table or a SomeT field). The `lookup_some_resolved_concrete` read is kept
-/// to mark the wiring point. Inert until the FSM emitters call this.
-is_io_future_type :: (fn(ty : TypeValue) -> bool)({
-  if(!(is_some_type(ty)), {
-    return(false);
-  });
-  // Branch (1): resolved concrete is an extern SomeType (TS
-  // state-machine.ts:521-527, `resolvedConcreteType.isExtern`). No longer a
-  // model gap: an extern opaque type IS a SomeT whose NAME is registered in
-  // the extern-type-name set, so extern-ness is `is_extern_type_name(name)`.
-  // This branch became LOAD-BEARING once Impl's `Concrete(T)` support landed:
-  // the marker now moves into the resolved-concrete cell (as in TS) instead
-  // of sitting in required_trait_types, so branch (2) alone no longer fires
-  // for `IoFuture` — and misclassifying an io future as a lazy sync future
-  // emits a `->__yo_resume_fn` cold-start on `__yo_io_future_t`, which has no
-  // such member (the fs/gc batch C errors).
-  some_id := match(ty, .SomeT({ id }) => id, _ => String.from(""));
-  rc_cell := match(ty, .SomeT({ resolved_concrete : io_src }) => io_src.get(usize(0)), _ => Option(TypeValue).None);
-  rc_final := match(
-    rc_cell,
-    .Some(io_r) => Option(TypeValue).Some(io_r),
-    .None => lookup_some_resolved_concrete(some_id)
-  );
-  match(
-    rc_final,
-    .Some(io_rcv) => match(
-      io_rcv,
-      .SomeT({ name : io_enm }) => if(is_extern_type_name(io_enm), {
-        return(true);
-      }),
-      _ => ()
-    ),
-    .None => ()
-  );
-  // Branch (2): any required trait is a `Concrete(...)` trait.
-  rts := match(ty, .SomeT({ required_trait_types }) => required_trait_types, _ => ArrayList(TypeValue).new());
-  (i : usize) = usize(0);
-  while(i < rts.len(), {
-    rt := match(rts.get(i), .Some(t) => t, .None => TypeValue.Unit);
-    if(is_concrete_trait_type(rt), {
-      return(true);
-    });
-    i = (i + usize(1));
-  });
-  false
-});
 /// Information about a generated state machine. Mirrors `StateMachineInfo`
 /// (state-machine.ts:516).
 StateMachineInfo :: ref(
@@ -1457,21 +1400,31 @@ generate_remaining_expr_future :: (
   fn(expr : AstExpr, await_point : AwaitPoint, analysis : AwaitAnalysisResult, indent : String, context : FunctionGenerationContext) -> unit
 )({
   em := context.base.emitter;
-  future_field_name := get_future_field_name(await_point, analysis);
+  // Dispatch-mode point: the store target is the point's own erased slot
+  // (never the REPRESENTATIVE's named field), and a branch awaiting a NAMED
+  // future does not store at all — it is read through its own field.
+  dispatch_mode := cond_await_point_needs_dispatch(await_point, context);
+  future_field_name := cond(
+    dispatch_mode => `await_future_${await_point.base.index.to_string()}`,
+    true => get_future_field_name(await_point, analysis)
+  );
   // varName := await(futureExpr)
   if(ast_expr_is_fn_call(expr) && ast_expr_is_fn_call_of(expr, ":=", Option(usize).None), {
     args := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
     match(
       args.get(usize(1)),
       .Some(value_expr) => if(ast_expr_is_fn_call(value_expr) && is_io_await_call(value_expr), {
+        branch_named := (dispatch_mode && match(cond_branch_future_access(value_expr, await_point, context), .Some(a) => a.is_named, .None => false));
         v_args := match(value_expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
         match(
           v_args.get(usize(0)),
-          .Some(future_expr) => {
+          .Some(future_expr) => if(branch_named, {
+            em.emit_string_line(`${indent}// Await will use this branch's named Future (dispatch)`);
+          }, {
             fc := _call_generate_expr(future_expr, indent, context);
             em.emit_string_line(`${indent}// Store Future for additional await in cond branch`);
             em.emit_string_line(`${indent}sm->${future_field_name} = ${fc};`);
-          },
+          }),
           .None => ()
         );
       }),
@@ -1481,14 +1434,17 @@ generate_remaining_expr_future :: (
   });
   // Standalone io.await(futureExpr)
   if(ast_expr_is_fn_call(expr) && is_io_await_call(expr), {
+    branch_named2 := (dispatch_mode && match(cond_branch_future_access(expr, await_point, context), .Some(a) => a.is_named, .None => false));
     args := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
     match(
       args.get(usize(0)),
-      .Some(future_expr) => {
+      .Some(future_expr) => if(branch_named2, {
+        em.emit_string_line(`${indent}// Await will use this branch's named Future (dispatch)`);
+      }, {
         fc := _call_generate_expr(future_expr, indent, context);
         em.emit_string_line(`${indent}// Store Future for additional await in cond branch`);
         em.emit_string_line(`${indent}sm->${future_field_name} = ${fc};`);
-      },
+      }),
       .None => ()
     );
     return();
@@ -1514,6 +1470,188 @@ generate_remaining_expr_future :: (
     return();
   });
   em.emit_string_line(`${indent}// Warning: unhandled await pattern in remaining expressions`);
+});
+/// The branch-info record a dispatch-mode await point dispatches on: the entry
+/// stored at the point's own index, else at its cond-source index.
+_dispatch_cbd :: (
+  fn(ap : AwaitPoint, context : FunctionGenerationContext) -> Option(AsyncCondBranchInfo)
+)({
+  source := match(ap.base.cond_branch_source_index, .Some(s) => s, .None => ap.base.index);
+  match(
+    context.async_cond_branch_info,
+    .Some(m) => match(
+      m.get(ap.base.index),
+      .Some(e) => Option(AsyncCondBranchInfo).Some(e),
+      .None => match(m.get(source), .Some(e2) => Option(AsyncCondBranchInfo).Some(e2), .None => Option(AsyncCondBranchInfo).None)
+    ),
+    .None => Option(AsyncCondBranchInfo).None
+  )
+});
+/// The suspension core for ONE future access path: state transition, readiness
+/// fast-path, cold-start (non-io futures), continuation registration, return.
+/// `acc` is the C expression reaching the future (e.g. `sm->await_future_2` or
+/// `((T*)sm->await_future_2)` or `sm->var_9`); `effect_expr` is the await call
+/// whose effect bundle gets injected on cold start. Extracted from
+/// `_emit_await_suspension` so dispatch-mode cond points can emit it once per
+/// awaiting branch with that branch's own access/type. Indentation is
+/// parameterized so the uniform path stays byte-identical (`ind` = 6 spaces).
+_emit_await_suspension_core :: (
+  fn(
+    acc : String,
+    is_io_future : bool,
+    next_s : String,
+    resume_function_name : String,
+    effect_expr : AstExpr,
+    ind : String,
+    context : FunctionGenerationContext
+  ) -> unit
+)({
+  em := context.base.emitter;
+  em.emit_string_line(`${ind}// Transition to next state after await`);
+  em.emit_string_line(`${ind}sm->state = ${next_s};`);
+  em.emit_string_line(``);
+  em.emit_string_line(`${ind}// Check if future is ready`);
+  em.emit_string_line(`${ind}int future_state = ${acc}->state;`);
+  em.emit_string_line(`${ind}if (future_state == -1 || future_state == -2) {  // -1 = completed, -2 = aborted`);
+  em.emit_string_line(`${ind}  // Already complete — bounded inline fast-path to avoid scheduler round-trip`);
+  em.emit_string_line(`${ind}  if (__yo_inline_budget > 0) {`);
+  em.emit_string_line(`${ind}    __yo_inline_budget--;`);
+  em.emit_string_line(`${ind}    goto state_${next_s};`);
+  em.emit_string_line(`${ind}  }`);
+  em.emit_string_line(`${ind}  // Budget exhausted — yield once for fairness (microtask yield)`);
+  em.emit_string_line(`${ind}  __yo_async_spawn_task((void (*)(void*))${resume_function_name}, (void*)sm);`);
+  em.emit_string_line(`${ind}  return;`);
+  em.emit_string_line(`${ind}}`);
+  em.emit_string_line(``);
+  if(!(is_io_future), {
+    em.emit_string_line(`${ind}// Future not complete — take event loop reference and start if cold`);
+    em.emit_string_line(`${ind}__yo_incr_rc((void*)${acc});  // event loop reference`);
+  }, {
+    em.emit_string_line(`${ind}// Io future: no extra ref needed (completion handler does not decr_rc)`);
+  });
+  if(!(is_io_future), {
+    em.emit_string_line(`${ind}if (future_state == 0) {  // 0 = cold (not started)`);
+    inner := ind.clone();
+    inner.push_str("  ");
+    emit_effect_injection_for_sm(effect_expr, acc.clone(), inner, context);
+    em.emit_string_line(`${ind}  // Cold future — start it via stored resume function pointer`);
+    em.emit_string_line(`${ind}  ${acc}->__yo_resume_fn((void*)${acc});`);
+    em.emit_string_line(``);
+    em.emit_string_line(`${ind}  // Re-check: may have completed synchronously`);
+    em.emit_string_line(`${ind}  future_state = ${acc}->state;`);
+    em.emit_string_line(`${ind}  if (future_state == -1 || future_state == -2) {`);
+    em.emit_string_line(`${ind}    // Completed or aborted synchronously — yield for fairness`);
+    em.emit_string_line(`${ind}    __yo_async_spawn_task((void (*)(void*))${resume_function_name}, (void*)sm);`);
+    em.emit_string_line(`${ind}    return;`);
+    em.emit_string_line(`${ind}  }`);
+    em.emit_string_line(`${ind}}`);
+  });
+  em.emit_string_line(``);
+  em.emit_string_line(`${ind}// Still pending — register continuation and suspend`);
+  em.emit_string_line(`${ind}${acc}->continuation_fn = (void (*)(void*))${resume_function_name};`);
+  em.emit_string_line(`${ind}${acc}->continuation_sm = (void*)sm;`);
+  em.emit_string_line(`${ind}return;`);
+});
+/// Dispatch-mode suspension for a shared cond/match await point whose branches
+/// await differently-shaped futures: one `case` per awaiting branch, each
+/// running the suspension core against THAT branch's future access; `default`
+/// covers "a non-await branch ran" (including the calloc-zero never-written
+/// value) by skipping straight to the next state. Replaces the uniform path's
+/// `if (sm->await_future_N != NULL)` guard, which is meaningless for a named
+/// future (a bound variable is never NULL — shape 8's wrong cold-start). See
+/// issues/async-cond-shared-await-point-only-models-representative-branch.md.
+_emit_await_suspension_dispatch :: (
+  fn(
+    ap : AwaitPoint,
+    next_s : String,
+    resume_function_name : String,
+    while_info : Option(WhileLoopInfo),
+    context : FunctionGenerationContext
+  ) -> unit
+)({
+  em := context.base.emitter;
+  source := match(ap.base.cond_branch_source_index, .Some(s) => s, .None => ap.base.index);
+  cbd := match(
+    _dispatch_cbd(ap, context),
+    .Some(e3) => e3,
+    .None => {
+      codegen_fatal(`internal: dispatch-mode await point ${ap.base.index.to_string()} has no cond branch info`);
+      return(());
+    }
+  );
+  cond_field := match(cbd.cond_branch_field_index, .Some(x) => x, .None => source);
+  if(cond_field == usize.MAX, {
+    codegen_fatal(`internal: dispatch-mode await point ${ap.base.index.to_string()} has no dispatch field`);
+    return(());
+  });
+  depth := (ap.base.index - source);
+  cf_s := cond_field.to_string();
+  em.emit_string_line(`      // Await per branch — branches await differently-shaped futures (dispatch)`);
+  em.emit_string_line(`      switch (sm->cond_branch_${cf_s}) {`);
+  (bi : usize) = usize(0);
+  while(bi < cbd.branches.len(), {
+    match(
+      cbd.branches.get(bi),
+      .Some(branch) => if(branch.has_await, {
+        ae_opt := match(
+          branch.await_exprs,
+          .Some(aes) => aes.get(depth),
+          .None => Option(AstExpr).None
+        );
+        match(
+          ae_opt,
+          // A branch with fewer awaits than this depth never reaches this
+          // state — no case; the default skips.
+          .None => (),
+          .Some(ae) => match(
+            cond_branch_future_access(ae, ap, context),
+            .None => {
+              bt := ast_expr_token(ae);
+              codegen_fatal(`internal: dispatch-mode await point ${ap.base.index.to_string()} branch ${branch.index.to_string()} future access unresolvable (${bt.module_path}:${(bt.row + usize(1)).to_string()}:${(bt.column + usize(1)).to_string()})`);
+            },
+            .Some(acc_info) => {
+              em.emit_string_line(`        case ${branch.index.to_string()}: {`);
+              if(!(acc_info.is_named), {
+                // A live code with a NULL slot means this arm's own store
+                // never ran (e.g. a nested plain arm kept the code, or this
+                // record is a dead outer layer) — nothing to await.
+                em.emit_string_line(`          if (sm->await_future_${ap.base.index.to_string()} == NULL) {`);
+                em.emit_string_line(`            sm->state = ${next_s};`);
+                em.emit_string_line(`            goto state_${next_s};`);
+                em.emit_string_line(`          }`);
+              });
+              match(
+                while_info,
+                .Some(wi) => {
+                  wli := match(wi.while_loop_origin_index, .Some(o) => o, .None => ap.base.index);
+                  em.emit_string_line(`          // Only await if while loop is still active (not broken)`);
+                  em.emit_string_line(`          if (sm->while_loop_${wli.to_string()}_active) {`);
+                  _emit_await_suspension_core(acc_info.access.clone(), acc_info.is_io_future, next_s.clone(), resume_function_name.clone(), ae, String.from("            "), context);
+                  em.emit_string_line(`          } else {`);
+                  em.emit_string_line(`            // While loop was broken, jump to code after loop`);
+                  em.emit_string_line(`            goto after_while_loop_${wli.to_string()};`);
+                  em.emit_string_line(`          }`);
+                },
+                .None => {
+                  _emit_await_suspension_core(acc_info.access.clone(), acc_info.is_io_future, next_s.clone(), resume_function_name.clone(), ae, String.from("          "), context);
+                }
+              );
+              em.emit_string_line(`          break;`);
+              em.emit_string_line(`        }`);
+            }
+          )
+        );
+      }),
+      .None => ()
+    );
+    bi = (bi + usize(1));
+  });
+  em.emit_string_line(`        default: {`);
+  em.emit_string_line(`          // Non-await cond branch was taken, skip directly to next state`);
+  em.emit_string_line(`          sm->state = ${next_s};`);
+  em.emit_string_line(`          goto state_${next_s};`);
+  em.emit_string_line(`        }`);
+  em.emit_string_line(`      }`);
 });
 /// Emit the await suspension for a segment ending at an await: transition to the
 /// next state, the bounded inline fast-path for an already-complete future, the
@@ -1549,16 +1687,23 @@ _emit_await_suspension :: (
       );
       is_io_future := match(fut_expr_ty, .Some(t) => is_io_future_type(t), .None => false);
       in_cond := match(ap.base.is_inside_cond, .Some(b) => b, .None => false);
-      if(in_cond, {
-        em.emit_string_line(`      // Only await if the cond branch with await was taken`);
-        em.emit_string_line(`      if (sm->${ffn} != NULL) {`);
-      });
       in_while := match(ap.base.is_inside_while, .Some(b) => b, .None => false);
       while_info := if(
         in_while,
         match(context.async_while_loop_info, .Some(m) => m.get(ap.base.index), .None => Option(WhileLoopInfo).None),
         Option(WhileLoopInfo).None
       );
+      // A dispatch-mode cond point: each branch's future has its own shape, so
+      // the readiness/registration block is emitted per branch, switched on
+      // the branch actually taken.
+      if(in_cond && cond_await_point_needs_dispatch(ap, context), {
+        _emit_await_suspension_dispatch(ap, next_s, resume_function_name, while_info, context);
+        return(());
+      });
+      if(in_cond, {
+        em.emit_string_line(`      // Only await if the cond branch with await was taken`);
+        em.emit_string_line(`      if (sm->${ffn} != NULL) {`);
+      });
       match(
         while_info,
         .Some(wi) => {
@@ -1568,50 +1713,9 @@ _emit_await_suspension :: (
         },
         .None => ()
       );
-      em.emit_string_line(`      // Transition to next state after await`);
-      em.emit_string_line(`      sm->state = ${next_s};`);
-      em.emit_string_line(``);
-      em.emit_string_line(`      // Check if future is ready`);
-      em.emit_string_line(`      int future_state = sm->${ffn}->state;`);
-      em.emit_string_line(`      if (future_state == -1 || future_state == -2) {  // -1 = completed, -2 = aborted`);
-      em.emit_string_line(`        // Already complete — bounded inline fast-path to avoid scheduler round-trip`);
-      em.emit_string_line(`        if (__yo_inline_budget > 0) {`);
-      em.emit_string_line(`          __yo_inline_budget--;`);
-      em.emit_string_line(`          goto state_${next_s};`);
-      em.emit_string_line(`        }`);
-      em.emit_string_line(`        // Budget exhausted — yield once for fairness (microtask yield)`);
-      em.emit_string_line(`        __yo_async_spawn_task((void (*)(void*))${resume_function_name}, (void*)sm);`);
-      em.emit_string_line(`        return;`);
-      em.emit_string_line(`      }`);
-      em.emit_string_line(``);
-      if(!(is_io_future), {
-        em.emit_string_line(`      // Future not complete — take event loop reference and start if cold`);
-        em.emit_string_line(`      __yo_incr_rc((void*)sm->${ffn});  // event loop reference`);
-      }, {
-        em.emit_string_line(`      // Io future: no extra ref needed (completion handler does not decr_rc)`);
-      });
-      if(!(is_io_future), {
-        em.emit_string_line(`      if (future_state == 0) {  // 0 = cold (not started)`);
-        ffn_access := String.from("sm->");
-        ffn_access.push_string(ffn.clone());
-        emit_effect_injection_for_sm(ap.base.expr, ffn_access, `        `, context);
-        em.emit_string_line(`        // Cold future — start it via stored resume function pointer`);
-        em.emit_string_line(`        sm->${ffn}->__yo_resume_fn((void*)sm->${ffn});`);
-        em.emit_string_line(``);
-        em.emit_string_line(`        // Re-check: may have completed synchronously`);
-        em.emit_string_line(`        future_state = sm->${ffn}->state;`);
-        em.emit_string_line(`        if (future_state == -1 || future_state == -2) {`);
-        em.emit_string_line(`          // Completed or aborted synchronously — yield for fairness`);
-        em.emit_string_line(`          __yo_async_spawn_task((void (*)(void*))${resume_function_name}, (void*)sm);`);
-        em.emit_string_line(`          return;`);
-        em.emit_string_line(`        }`);
-        em.emit_string_line(`      }`);
-      });
-      em.emit_string_line(``);
-      em.emit_string_line(`      // Still pending — register continuation and suspend`);
-      em.emit_string_line(`      sm->${ffn}->continuation_fn = (void (*)(void*))${resume_function_name};`);
-      em.emit_string_line(`      sm->${ffn}->continuation_sm = (void*)sm;`);
-      em.emit_string_line(`      return;`);
+      ffn_access := String.from("sm->");
+      ffn_access.push_string(ffn.clone());
+      _emit_await_suspension_core(ffn_access, is_io_future, next_s.clone(), resume_function_name.clone(), ap.base.expr, String.from("      "), context);
       match(
         while_info,
         .Some(wi) => {
@@ -1741,6 +1845,141 @@ _await_target_has_struct_field :: (
   });
   match(context.state_machine_field_aliases, .Some(a) => a.contains_key(target_variable_id), .None => false)
 });
+/// Dispatch-mode result extraction for a shared cond/match await point: the
+/// abort check, result copy and slot release are emitted once per awaiting
+/// branch, each against THAT branch's future access and result type. The
+/// uniform path's single representative-typed extraction reads the wrong
+/// offsets (or is skipped outright when the representative's result is unit)
+/// for every differently-shaped branch. Destinations, per branch: its own
+/// bound variable's field; else the cond's registered target when the branch
+/// VALUE is the await itself; else nothing (a discarded await result stays
+/// owned by the future and is released with it).
+_emit_prev_await_result_extraction_dispatch :: (
+  fn(
+    async_block_id : String,
+    prev_await : AwaitPoint,
+    cbd : AsyncCondBranchInfo,
+    context : FunctionGenerationContext,
+    cross_boundary_ids : Option(HashSet(String))
+  ) -> unit
+)({
+  em := context.base.emitter;
+  source := match(prev_await.base.cond_branch_source_index, .Some(s) => s, .None => prev_await.base.index);
+  cond_field := match(cbd.cond_branch_field_index, .Some(x) => x, .None => source);
+  depth := (prev_await.base.index - source);
+  prev_idx_s := prev_await.base.index.to_string();
+  slot := `sm->await_future_${prev_idx_s}`;
+  em.emit_string_line(`      // Extract per branch — branches await differently-shaped futures (dispatch)`);
+  em.emit_string_line(`      switch (sm->cond_branch_${cond_field.to_string()}) {`);
+  (bi : usize) = usize(0);
+  while(bi < cbd.branches.len(), {
+    match(
+      cbd.branches.get(bi),
+      .Some(branch) => if(branch.has_await, {
+        ae_opt := match(
+          branch.await_exprs,
+          .Some(aes) => aes.get(depth),
+          .None => Option(AstExpr).None
+        );
+        match(
+          ae_opt,
+          .None => (),
+          .Some(ae) => match(
+            cond_branch_future_access(ae, prev_await, context),
+            .None => {
+              bt2 := ast_expr_token(ae);
+              codegen_fatal(`internal: dispatch-mode await point ${prev_idx_s} branch ${branch.index.to_string()} future access unresolvable at extraction (${bt2.module_path}:${(bt2.row + usize(1)).to_string()}:${(bt2.column + usize(1)).to_string()})`);
+            },
+            .Some(acc_info) => {
+              acc := acc_info.access;
+              em.emit_string_line(`        case ${branch.index.to_string()}: {`);
+              if(!(acc_info.is_named), {
+                // NULL slot: this arm's own store never ran (nested plain arm
+                // kept the code / dead outer layer) — nothing to extract.
+                em.emit_string_line(`          if (${slot} != NULL) {`);
+              });
+              // Abort check. A named future stays owned by its binding (the
+              // dispose drops it); the anonymous slot ref is released here.
+              em.emit_string_line(`          // Check if the awaited Future was aborted`);
+              em.emit_string_line(`          if (${acc}->state == -2) {`);
+              if(!(acc_info.is_named), {
+                em.emit_string_line(`            __yo_decr_rc((void*)${slot});`);
+                em.emit_string_line(`            ${slot} = NULL;`);
+              });
+              emit_async_future_escape(em, `            `, Option(String).None, Option(String).Some(async_block_id.clone()));
+              em.emit_string_line(`          }`);
+              // This branch's result copy.
+              rt_opt := acc_info.result_type;
+              is_unit_result := match(
+                rt_opt,
+                .Some(rt) => (
+                  is_unit_type(rt) || (
+                    is_some_type(rt) && match(rt, .SomeT({ id }) => lookup_some_resolved_concrete(id).is_none(), _ => false)
+                  )
+                ),
+                .None => true
+              );
+              (dest : Option(String)) = Option(String).None;
+              match(
+                branch.await_target_variable_id,
+                .Some(btvid) => if(_await_target_has_struct_field(btvid.clone(), cross_boundary_ids, context), {
+                  fname := get_state_machine_field_name(btvid, Option(String).Some(String.from("local")), context.state_machine_field_aliases);
+                  d := String.from("sm->");
+                  d.push_string(fname);
+                  dest = Option(String).Some(d);
+                }),
+                // The branch VALUE is the await itself (no binding, nothing
+                // after it) — its result IS the cond's value.
+                .None => if(match(branch.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true), {
+                  match(
+                    cbd.target_assignment_code,
+                    .Some(tac) => {
+                      dest = Option(String).Some(tac.clone());
+                    },
+                    .None => ()
+                  );
+                })
+              );
+              if(!(is_unit_result), {
+                match(
+                  dest,
+                  .Some(d) => {
+                    rt := match(rt_opt, .Some(t) => t, .None => TypeValue.Unit);
+                    em.emit_string_line(`          // Extract result from await ${prev_idx_s} (branch ${branch.index.to_string()})`);
+                    if(type_contains_rc_type(rt), {
+                      match(
+                        get_dup_function_for_type(rt, context),
+                        .Some(dup) => em.emit_string_line(`          ${d} = ${dup}(${acc}->result);`),
+                        .None => {
+                          dup_code := generate_dup_code_for_value(`${acc}->result`, rt, context);
+                          em.emit_string_line(`          ${d} = ${dup_code};`);
+                        }
+                      );
+                    }, {
+                      em.emit_string_line(`          ${d} = ${acc}->result;`);
+                    });
+                  },
+                  .None => ()
+                );
+              });
+              if(!(acc_info.is_named), {
+                em.emit_string_line(`          if (${slot} != NULL) { __yo_decr_rc((void*)${slot}); ${slot} = NULL; }`);
+                em.emit_string_line(`          }`);
+              });
+              em.emit_string_line(`          break;`);
+              em.emit_string_line(`        }`);
+            }
+          )
+        );
+      }),
+      .None => ()
+    );
+    bi = (bi + usize(1));
+  });
+  em.emit_string_line(`        default: break;`);
+  em.emit_string_line(`      }`);
+  em.emit_string_line(String.from(""));
+});
 /// Emit the previous-await result extraction at the top of a resume state: the
 /// abort check (Future state == -2 → escape), the result copy (into
 /// `await_result_N` for cond awaits, or directly into the target SM var for
@@ -1754,6 +1993,22 @@ _emit_prev_await_result_extraction :: (
   em := context.base.emitter;
   pffn := get_future_field_name(prev_await, analysis);
   prev_idx_s := (state_number - usize(1)).to_string();
+  // Dispatch-mode cond point: extraction is per branch (each branch's own
+  // future shape, result type and destination) — the single
+  // representative-typed extraction below would read the wrong offsets.
+  if(match(prev_await.base.is_inside_cond, .Some(b) => b, .None => false) && cond_await_point_needs_dispatch(prev_await, context), {
+    match(
+      _dispatch_cbd(prev_await, context),
+      .Some(cbd) => {
+        _emit_prev_await_result_extraction_dispatch(async_block_id.clone(), prev_await, cbd, context, cross_boundary_ids);
+        return(());
+      },
+      .None => {
+        codegen_fatal(`internal: dispatch-mode await point ${prev_await.base.index.to_string()} has no cond branch info at extraction`);
+        return(());
+      }
+    );
+  });
   // Abort check.
   em.emit_string_line(`      // Check if the awaited Future was aborted`);
   em.emit_string_line(`      if (sm->${pffn}->state == -2) {`);
@@ -1891,6 +2146,10 @@ _chain_additional_remaining :: (
   ) -> unit
 )({
   has_await := (additional_remaining.len() > usize(0));
+  chained_awaits := ArrayList(AstExpr).new();
+  if(has_await, {
+    collect_branch_await_exprs(branch_value.clone(), chained_awaits);
+  });
   cb := CondBranch(
     index : branch_index,
     value : branch_value,
@@ -1899,7 +2158,11 @@ _chain_additional_remaining :: (
     deferred_drop_expressions : deferred_drops,
     // A chained OUTER-cond continuation, not an arm with its own `x := await`
     // binding — its await result (if any) belongs to the inner cond's branch.
-    await_target_variable_id : Option(String).None
+    await_target_variable_id : Option(String).None,
+    await_exprs : cond(
+      has_await => Option(ArrayList(AstExpr)).Some(chained_awaits),
+      true => Option(ArrayList(AstExpr)).None
+    )
   );
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
@@ -2214,6 +2477,13 @@ _emit_cond_branch_continuation :: (
     .Some(cbi_map) => match(
       cbi_map.get(prev_await.base.index),
       .Some(cbd) => {
+        // Dispatch-mode point: the per-branch extraction already wrote each
+        // branch's own destination — the representative-driven copies below
+        // (bfield copy, post-switch target copy) must not run.
+        dispatch_mode := (
+          match(prev_await.base.is_inside_cond, .Some(b) => b, .None => false)
+          && cond_await_point_needs_dispatch(prev_await, context)
+        );
         (any_await : bool) = false;
         (bi : usize) = usize(0);
         while((bi < cbd.branches.len()) && !(any_await), {
@@ -2249,24 +2519,41 @@ _emit_cond_branch_continuation :: (
                 // binding — every other arm read a zero-initialised field and
                 // the program silently produced `false`/`0`. Skip the arm the
                 // pre-switch copy already covers, so it is not written twice.
-                match(
-                  branch.await_target_variable_id,
-                  // Emit only when this is NOT the arm the pre-switch copy
-                  // already covers, AND the binding really lives in the state
-                  // struct (a segment-local optimized out of it has no field to
-                  // write), AND it has THIS await point's result type — an arm
-                  // may hold a SECOND await that suspends into a later state,
-                  // and its binding is that state's business.
-                  .Some(btvid) => if((
-                    match(prev_await.base.target_variable_id, .Some(ptv) => !(ptv == btvid), .None => true)
-                    && _await_target_has_struct_field(btvid.clone(), cross_boundary_ids, context)
-                  )
-                  && _branch_target_matches_await_type(btvid.clone(), prev_await.result_type, context), {
-                    bfield := get_state_machine_field_name(btvid, Option(String).Some(String.from("local")), context.state_machine_field_aliases);
-                    em.emit_string_line(`          sm->${bfield} = sm->await_result_${prev_await.base.index.to_string()};`);
-                  }),
-                  .None => ()
-                );
+                if(!(dispatch_mode), {
+                  match(
+                    branch.await_target_variable_id,
+                    // Emit only when this is NOT the arm the pre-switch copy
+                    // already covers, AND the binding really lives in the state
+                    // struct (a segment-local optimized out of it has no field to
+                    // write), AND it has THIS await point's result type — an arm
+                    // may hold a SECOND await that suspends into a later state,
+                    // and its binding is that state's business.
+                    .Some(btvid) => if((
+                      match(prev_await.base.target_variable_id, .Some(ptv) => !(ptv == btvid), .None => true)
+                      && _await_target_has_struct_field(btvid.clone(), cross_boundary_ids, context)
+                    )
+                    && _branch_target_matches_await_type(btvid.clone(), prev_await.result_type, context), {
+                      bfield := get_state_machine_field_name(btvid, Option(String).Some(String.from("local")), context.state_machine_field_aliases);
+                      em.emit_string_line(`          sm->${bfield} = sm->await_result_${prev_await.base.index.to_string()};`);
+                    }),
+                    // The branch VALUE is the await itself (no binding, nothing
+                    // after it): nothing else ever assigns the registered
+                    // target — the extraction filled `await_result_N`, so hand
+                    // it over here (shape 4:
+                    // `r := cond(flag => io.await(f, io), true => v)` returned
+                    // a zeroed r). Ownership transfers, matching the
+                    // no-target-assignment fallback below.
+                    .None => if(match(branch.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true), {
+                      match(
+                        cbd.target_assignment_code,
+                        .Some(tac) => {
+                          em.emit_string_line(`          ${tac} = sm->await_result_${prev_await.base.index.to_string()};`);
+                        },
+                        .None => ()
+                      );
+                    })
+                  );
+                });
                 _emit_cond_branch_remaining(branch, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, cbd.target_assignment_code, `          `, context);
                 if(!(skip_switch), {
                   em.emit_string_line(`          break;`);
@@ -2318,7 +2605,7 @@ _emit_cond_branch_continuation :: (
           // is emitted AFTER the branch switch, so with target_assignment_code
           // present it would overwrite the branch value (computed after the
           // await) with the raw await result. Mirrors state-machine.ts.
-          if(cbd.target_assignment_code.is_none(), {
+          if(cbd.target_assignment_code.is_none() && !(dispatch_mode), {
             match(
               cbd.target_variable_id,
               .Some(tvid) => {
@@ -3063,12 +3350,17 @@ generate_async_block_resume_function :: (
             .Some(prev_await) => {
               pffn := get_future_field_name(prev_await, analysis);
               in_cond := match(prev_await.base.is_inside_cond, .Some(b) => b, .None => false);
-              if(in_cond, {
+              // Dispatch-mode points guard PER CASE (a named arm never stores,
+              // so this representative-keyed slot guard would skip its
+              // extraction entirely); the case switches default to no-ops when
+              // no awaiting arm ran.
+              guard_slot := (in_cond && !(cond_await_point_needs_dispatch(prev_await, context)));
+              if(guard_slot, {
                 em.emit_string_line(`      if (sm->${pffn} != NULL) {`);
               });
               _emit_prev_await_result_extraction(async_block_id, segment.state_number, prev_await, analysis, context, cross_boundary_ids);
               _emit_cond_branch_continuation(async_block_id, prev_await, segment, body_expr, future_type, capture_type, analysis, context, cross_boundary_ids);
-              if(in_cond, {
+              if(guard_slot, {
                 em.emit_string_line(`      }`);
               });
               _emit_outer_chained_branch_layers(prev_await, segment, body_expr, future_type, capture_type, analysis, context);

--- a/src/codegen/exprs/async.yo
+++ b/src/codegen/exprs/async.yo
@@ -15,7 +15,7 @@
 //! key — yo-self `Func` types carry no `.id`).
 open(import("std/string"));
 { ArrayList } :: import("std/collections/array_list");
-{ await_is_while_condition } :: import("../async/state_code_gen.yo");
+{ await_is_while_condition, cond_await_point_needs_dispatch } :: import("../async/state_code_gen.yo");
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
 {
@@ -734,7 +734,19 @@ emit_async_block_struct_definition :: (
     while(ai2 < aps.len(), {
       match(
         aps.get(ai2),
-        .Some(ap) => match(
+        // Dispatch-mode cond point: branches store differently-shaped futures
+        // into ONE slot, so it is declared type-erased and every access casts
+        // to the running branch's exact type (dispatched on cond_branch_N).
+        // Declared even when the REPRESENTATIVE awaited a named variable —
+        // other branches may be anonymous (shape 6). See
+        // issues/async-cond-shared-await-point-only-models-representative-branch.md.
+        .Some(ap) => if(cond_await_point_needs_dispatch(ap, context), {
+          if(!(emitted_header), {
+            em.emit_declaration_line("  // Future references for awaits");
+            emitted_header = true;
+          });
+          em.emit_declaration_string_line(`  void* await_future_${ap.base.index.to_string()};  // erased: cond branches await differently-shaped futures`);
+        }, match(
           ap.future_variable_id,
           .Some(_) => (),
           .None => {
@@ -761,7 +773,7 @@ emit_async_block_struct_definition :: (
               );
             });
           }
-        ),
+        )),
         .None => ()
       );
       ai2 = (ai2 + usize(1));

--- a/src/codegen/functions/context.yo
+++ b/src/codegen/functions/context.yo
@@ -223,7 +223,14 @@ CondBranch :: ref(
     /// — every other arm's binding was left unassigned and read a
     /// zero-initialised field. Recorded per branch and assigned inside that
     /// branch's `case`. See issues/fixed/async-await-in-nested-match-arms.md.
-    await_target_variable_id : Option(String)
+    await_target_variable_id : Option(String),
+    /// THIS branch's own `io.await` call exprs, in source order. A shared cond
+    /// await point stands in for one await per awaiting branch, and those can
+    /// await futures of different C types or named vs anonymous futures — the
+    /// dispatch-mode emitters access each branch's future through its own
+    /// exact shape instead of the representative's. See
+    /// issues/async-cond-shared-await-point-only-models-representative-branch.md.
+    await_exprs : Option(ArrayList(AstExpr))
   )
 );
 /// A chained cond/match continuation: an outer cond's remaining code that shares

--- a/src/evaluator/async/await_analysis.yo
+++ b/src/evaluator/async/await_analysis.yo
@@ -388,7 +388,8 @@ detect_await_expr_ :: (
         while_nesting_depth : Option(usize).None,
         cond_branch_source_index : Option(usize).None,
         needs_own_cond_branch_field : Option(bool).None,
-        enclosing_while_expr : Option(AstExpr).None
+        enclosing_while_expr : Option(AstExpr).None,
+        cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
       );
       points.push(sp);
     }
@@ -710,6 +711,9 @@ export(
   is_io_state_call,
   is_io_spawn_call,
   is_join_handle_await_call,
+  // Named-future resolution (codegen's dispatch-mode cond awaits resolve each
+  // BRANCH's future the same way the analysis resolved the representative's)
+  get_future_variable_id_,
   // Main analysis entry points
   analyze_await_points,
   get_local_variables_from_body

--- a/src/evaluator/effects/effect_analysis.yo
+++ b/src/evaluator/effects/effect_analysis.yo
@@ -649,7 +649,8 @@ detect_effect_expr_ :: (
             while_nesting_depth : Option(usize).None,
             cond_branch_source_index : Option(usize).None,
             needs_own_cond_branch_field : Option(bool).None,
-            enclosing_while_expr : Option(AstExpr).None
+            enclosing_while_expr : Option(AstExpr).None,
+            cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
           );
           key := ast_expr_token(expr.clone()).character.to_string();
           effect_extras.set(
@@ -746,7 +747,8 @@ detect_effect_expr_ :: (
                   while_nesting_depth : Option(usize).None,
                   cond_branch_source_index : Option(usize).None,
                   needs_own_cond_branch_field : Option(bool).None,
-                  enclosing_while_expr : Option(AstExpr).None
+                  enclosing_while_expr : Option(AstExpr).None,
+                  cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
                 );
                 key := ast_expr_token(expr.clone()).character.to_string();
                 effect_extras.set(

--- a/src/evaluator/shared/suspension_analysis.yo
+++ b/src/evaluator/shared/suspension_analysis.yo
@@ -583,6 +583,60 @@ walk_expr_ :: (
                   if(pos > usize(0), {
                     rep.cond_branch_source_index = Option(usize).Some(first_index_b);
                   });
+                  // Record EVERY branch's suspension expr at this position —
+                  // the representative alone cannot type the shared slot or
+                  // drive per-branch registration/extraction when branches
+                  // suspend on differently-shaped futures. See
+                  // issues/async-cond-shared-await-point-only-models-representative-branch.md.
+                  branch_exprs := ArrayList(AstExpr).new();
+                  (bpi3 : usize) = usize(0);
+                  while(bpi3 < n_branches, {
+                    branch3 := match(
+                      per_branch_points.get(bpi3),
+                      .None => {
+                        bpi3 = n_branches;
+                        return(());
+                      },
+                      .Some(b) => b
+                    );
+                    if(pos < branch3.len(), {
+                      match(
+                        branch3.get(pos),
+                        .Some(p3) => {
+                          // A branch whose point at this position is ITSELF a
+                          // merged representative (a nested cond/match with
+                          // awaiting arms) stands in for all of its arms'
+                          // suspensions — flatten its list, or a nested match
+                          // whose arms await different futures classifies as
+                          // uniform and keeps a concretely-typed shared slot.
+                          // Inner merges run before outer ones, so the nested
+                          // list is already fully flattened.
+                          match(
+                            p3.cond_branch_suspension_exprs,
+                            .Some(nested) => {
+                              (ni : usize) = usize(0);
+                              while(ni < nested.len(), {
+                                match(
+                                  nested.get(ni),
+                                  .Some(ne) => {
+                                    branch_exprs.push(ne);
+                                  },
+                                  .None => ()
+                                );
+                                ni = (ni + usize(1));
+                              });
+                            },
+                            .None => {
+                              branch_exprs.push(p3.expr);
+                            }
+                          );
+                        },
+                        .None => ()
+                      );
+                    });
+                    bpi3 = (bpi3 + usize(1));
+                  });
+                  rep.cond_branch_suspension_exprs = Option(ArrayList(AstExpr)).Some(branch_exprs);
                   points.push(rep);
                 }
               );

--- a/src/evaluator/shared/suspension_analysis_types.yo
+++ b/src/evaluator/shared/suspension_analysis_types.yo
@@ -58,7 +58,15 @@ SuspensionPoint :: ref(
     needs_own_cond_branch_field : Option(bool),
     /// The enclosing while loop expression.
     /// TypeScript uses `unknown` to avoid circular import; we use `AstExpr`.
-    enclosing_while_expr : Option(AstExpr)
+    enclosing_while_expr : Option(AstExpr),
+    /// Set on a merged cond/match representative: EVERY branch's suspension
+    /// expr at this depth position, in branch order. A shared cond await point
+    /// stands in for one suspension per awaiting branch, and those can await
+    /// futures of different C types, mix named and anonymous futures, or mix
+    /// io/state-machine future kinds — everything downstream that used to
+    /// assume the representative's shape consults this list instead. See
+    /// issues/async-cond-shared-await-point-only-models-representative-branch.md.
+    cond_branch_suspension_exprs : Option(ArrayList(AstExpr))
   )
 );
 // ---------------------------------------------------------------------------

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -4192,3 +4192,276 @@ test("nested awaiting whiles over real I/O futures drop outer arm locals once pe
   got := io.await(probe(io, exn), IoExn(io : io, exn : exn));
   assert(got == usize(6), "3 outer x 2 inner, every pair visited exactly once");
 });
+// ─── shared cond await point: branches awaiting differently-shaped futures ───
+// Regression: a cond/match whose branches await shares ONE await point, and
+// everything hung off it (slot type, registration, extraction, target copy)
+// came from the REPRESENTATIVE branch only. Eight defect shapes catalogued in
+// issues/async-cond-shared-await-point-only-models-representative-branch.md;
+// the tests below pin each one. The helper futures are top-level so each gets
+// its own C state-machine type (that heterogeneity IS the point).
+shape_ten :: (fn(io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    return(i32(10))
+  })
+);
+shape_twenty :: (fn(io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    io.await(yield(io), io);
+    return(i32(20))
+  })
+);
+shape_str :: (fn(io : Io) -> Impl(Future(String, Io)))(
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    return(`hello`)
+  })
+);
+shape_unit :: (fn(io : Io) -> Impl(Future(unit, Io)))(
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    return(())
+  })
+);
+shape_val :: (fn(v : i32, io : Io) -> Impl(Future(i32, Io)))({
+  b := Box(i32)(v);
+  io.async((io : Io) => {
+    io.await(yield(io), io);
+    return(b.*)
+  })
+});
+test("cond branches tail-await two DIFFERENT async fns (same result type)", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      r := cond(
+        flag => aio.await(shape_ten(aio), aio),
+        true => aio.await(shape_twenty(aio), aio)
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(true, io), io) == i32(10), "first-branch future value survives");
+  assert(io.await(drive(false, io), io) == i32(20), "second-branch (differently-typed) future value survives");
+});
+test("cond branches await String-result and unit-result futures", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(usize, Io)))(
+    rio.async((aio : Io) => {
+      r := cond(
+        flag => {
+          s := aio.await(shape_str(aio), aio);
+          s.len()
+        },
+        true => {
+          aio.await(shape_unit(aio), aio);
+          usize(0)
+        }
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(true, io), io) == usize(5), "String-result branch extracts through its own layout");
+  assert(io.await(drive(false, io), io) == usize(0), "unit-result branch neither corrupts nor deadlocks");
+});
+test("cond unit-result representative does not skip the other branch's binding", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      r := cond(
+        flag => {
+          aio.await(shape_unit(aio), aio);
+          i32(0)
+        },
+        true => {
+          x := aio.await(shape_ten(aio), aio);
+          x + i32(1)
+        }
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(true, io), io) == i32(0), "unit representative branch");
+  assert(io.await(drive(false, io), io) == i32(11), "bound branch's variable is written despite unit representative");
+});
+test("cond branch value IS the await (no remaining exprs)", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      r := cond(
+        flag => aio.await(shape_ten(aio), aio),
+        true => i32(7)
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(true, io), io) == i32(10), "await-as-branch-value reaches the bound target");
+  assert(io.await(drive(false, io), io) == i32(7), "plain branch unaffected");
+});
+test("cond branches await two DIFFERENT named futures", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      f1 := shape_val(i32(100), aio);
+      f2 := shape_val(i32(200), aio);
+      r := cond(
+        flag => {
+          x := aio.await(f1, aio);
+          x + i32(1)
+        },
+        true => {
+          y := aio.await(f2, aio);
+          y + i32(2)
+        }
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(true, io), io) == i32(101), "first named future awaited, not the representative's");
+  assert(io.await(drive(false, io), io) == i32(202), "second named future awaited, not the representative's");
+});
+test("cond mixes a named future branch with an anonymous one", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      f1 := shape_val(i32(100), aio);
+      r := cond(
+        flag => {
+          x := aio.await(f1, aio);
+          x + i32(1)
+        },
+        true => {
+          y := aio.await(shape_val(i32(200), aio), aio);
+          y + i32(2)
+        }
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(true, io), io) == i32(101), "named branch");
+  assert(io.await(drive(false, io), io) == i32(202), "anonymous branch");
+});
+test("cond single branch binds from a named future", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      f1 := shape_val(i32(100), aio);
+      r := cond(
+        flag => {
+          x := aio.await(f1, aio);
+          x + i32(1)
+        },
+        true => i32(7)
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(true, io), io) == i32(101), "named-future binding inside a cond branch compiles and runs");
+  assert(io.await(drive(false, io), io) == i32(7), "plain branch");
+});
+// Top-level like the other helpers: a LOCAL fn value creating the future hits
+// the separate, pre-existing capture divergence documented at the top of this
+// file (issues/await-in-branch-positions-matrix.md) — unrelated to the shared
+// await point.
+shape_started :: (fn(marker : Box(i32), io : Io) -> Impl(Future(unit, Io)))(
+  io.async((io : Io) => {
+    marker.* = (marker.* + 1);
+    io.await(yield(io), io);
+    return(())
+  })
+);
+test("not-taken branch's lazy named future is neither started nor awaited", {
+  drive := (fn(flag : bool, m : Box(i32), rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      f1 := shape_started(m, aio);
+      r := cond(
+        flag => {
+          aio.await(f1, aio);
+          i32(1)
+        },
+        true => i32(2)
+      );
+      return(r)
+    })
+  );
+  m1 := Box(i32)(0);
+  assert(io.await(drive(true, m1, io), io) == i32(1), "awaiting branch value");
+  assert(m1.* == i32(1), "future ran when its branch was taken");
+  m2 := Box(i32)(0);
+  assert(io.await(drive(false, m2, io), io) == i32(2), "plain branch value");
+  assert(m2.* == i32(0), "lazy future must NOT be started when its branch was not taken");
+});
+test("tail cond (async body result) with await-as-branch-value", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async(
+      (aio : Io) => cond(
+        flag => aio.await(shape_ten(aio), aio),
+        true => i32(7)
+      )
+    )
+  );
+  assert(io.await(drive(true, io), io) == i32(10), "await-as-value feeds sm->result");
+  assert(io.await(drive(false, io), io) == i32(7), "plain branch feeds sm->result");
+});
+test("tail cond with branches tail-awaiting two DIFFERENT async fns", {
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async(
+      (aio : Io) => cond(
+        flag => aio.await(shape_ten(aio), aio),
+        true => aio.await(shape_twenty(aio), aio)
+      )
+    )
+  );
+  assert(io.await(drive(true, io), io) == i32(10), "first branch");
+  assert(io.await(drive(false, io), io) == i32(20), "second, differently-typed branch");
+});
+test("match arms tail-await two DIFFERENT async fns", {
+  drive := (fn(o : Option(i32), rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      r := match(
+        o,
+        .Some => aio.await(shape_ten(aio), aio),
+        .None => aio.await(shape_twenty(aio), aio)
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(Option(i32).Some(i32(1)), io), io) == i32(10), "Some arm's future value survives");
+  assert(io.await(drive(Option(i32).None, io), io) == i32(20), "None arm's differently-typed future value survives");
+});
+test("nested cond arms await two DIFFERENT async fns", {
+  // The nested-branch shape that escaped the first classifier: the OUTER
+  // merge records one representative per outer branch, so the inner arms'
+  // heterogeneity is only visible via the flattened nested expr lists.
+  drive := (fn(n : usize, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      r := cond(
+        (n == usize(0)) => i32(1),
+        true => cond(
+          (n == usize(1)) => aio.await(shape_ten(aio), aio),
+          true => aio.await(shape_twenty(aio), aio)
+        )
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(usize(0), io), io) == i32(1), "plain outer branch");
+  assert(io.await(drive(usize(1), io), io) == i32(10), "nested first arm");
+  assert(io.await(drive(usize(2), io), io) == i32(20), "nested second, differently-typed arm");
+});
+test("cond mixes an anonymous branch with a named future branch (reverse order)", {
+  // The representative here is the ANONYMOUS branch, so the old
+  // representative-keyed slot guard would skip the NAMED branch's extraction.
+  drive := (fn(flag : bool, rio : Io) -> Impl(Future(i32, Io)))(
+    rio.async((aio : Io) => {
+      f2 := shape_val(i32(200), aio);
+      r := cond(
+        flag => {
+          x := aio.await(shape_val(i32(100), aio), aio);
+          x + i32(1)
+        },
+        true => {
+          y := aio.await(f2, aio);
+          y + i32(2)
+        }
+      );
+      return(r)
+    })
+  );
+  assert(io.await(drive(true, io), io) == i32(101), "anonymous branch");
+  assert(io.await(drive(false, io), io) == i32(202), "named branch extracted despite anonymous representative");
+});

--- a/tests/internal/await_analysis_types.test.yo
+++ b/tests/internal/await_analysis_types.test.yo
@@ -41,7 +41,8 @@ make_sp :: (fn(idx : usize) -> SuspensionPoint)(
     while_nesting_depth : Option(usize).None,
     cond_branch_source_index : Option(usize).None,
     needs_own_cond_branch_field : Option(bool).None,
-    enclosing_while_expr : Option(AstExpr).None
+    enclosing_while_expr : Option(AstExpr).None,
+    cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
   )
 );
 test("await_analysis_result_empty has no awaits", {
@@ -84,7 +85,8 @@ test("AwaitPoint target_variable_id from parent assign", {
     while_nesting_depth : Option(usize).None,
     cond_branch_source_index : Option(usize).None,
     needs_own_cond_branch_field : Option(bool).None,
-    enclosing_while_expr : Option(AstExpr).None
+    enclosing_while_expr : Option(AstExpr).None,
+    cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
   );
   ap := AwaitPoint(
     base : sp,

--- a/tests/internal/effect_analysis_types.test.yo
+++ b/tests/internal/effect_analysis_types.test.yo
@@ -42,7 +42,8 @@ make_sp :: (fn(idx : usize) -> SuspensionPoint)(
     while_nesting_depth : Option(usize).None,
     cond_branch_source_index : Option(usize).None,
     needs_own_cond_branch_field : Option(bool).None,
-    enclosing_while_expr : Option(AstExpr).None
+    enclosing_while_expr : Option(AstExpr).None,
+    cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
   )
 );
 test("effect_analysis_result_empty has no effects", {

--- a/tests/internal/suspension_analysis.test.yo
+++ b/tests/internal/suspension_analysis.test.yo
@@ -80,7 +80,8 @@ make_detect_all_detector :: (fn() -> SuspensionPointDetector)(
         while_nesting_depth : Option(usize).None,
         cond_branch_source_index : Option(usize).None,
         needs_own_cond_branch_field : Option(bool).None,
-        enclosing_while_expr : Option(AstExpr).None
+        enclosing_while_expr : Option(AstExpr).None,
+        cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
       );
       points.push(sp);
     }),
@@ -176,7 +177,7 @@ test("analyze_suspension_points: suspension point index is sequential", {
     result.suspension_points.get(usize(0)),
     .None => {
       assert(false, "sp0 missing");
-      SuspensionPoint(index : usize(99), expr : make_ident_expr("?"), target_variable_id : Option(String).None, is_inside_cond : Option(bool).None, is_body_result : Option(bool).None, is_inside_while : Option(bool).None, while_nesting_depth : Option(usize).None, cond_branch_source_index : Option(usize).None, needs_own_cond_branch_field : Option(bool).None, enclosing_while_expr : Option(AstExpr).None)
+      SuspensionPoint(index : usize(99), expr : make_ident_expr("?"), target_variable_id : Option(String).None, is_inside_cond : Option(bool).None, is_body_result : Option(bool).None, is_inside_while : Option(bool).None, while_nesting_depth : Option(usize).None, cond_branch_source_index : Option(usize).None, needs_own_cond_branch_field : Option(bool).None, enclosing_while_expr : Option(AstExpr).None, cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None)
     },
     .Some(p) => p
   );
@@ -184,7 +185,7 @@ test("analyze_suspension_points: suspension point index is sequential", {
     result.suspension_points.get(usize(1)),
     .None => {
       assert(false, "sp1 missing");
-      SuspensionPoint(index : usize(99), expr : make_ident_expr("?"), target_variable_id : Option(String).None, is_inside_cond : Option(bool).None, is_body_result : Option(bool).None, is_inside_while : Option(bool).None, while_nesting_depth : Option(usize).None, cond_branch_source_index : Option(usize).None, needs_own_cond_branch_field : Option(bool).None, enclosing_while_expr : Option(AstExpr).None)
+      SuspensionPoint(index : usize(99), expr : make_ident_expr("?"), target_variable_id : Option(String).None, is_inside_cond : Option(bool).None, is_body_result : Option(bool).None, is_inside_while : Option(bool).None, while_nesting_depth : Option(usize).None, cond_branch_source_index : Option(usize).None, needs_own_cond_branch_field : Option(bool).None, enclosing_while_expr : Option(AstExpr).None, cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None)
     },
     .Some(p) => p
   );

--- a/tests/internal/suspension_analysis_types.test.yo
+++ b/tests/internal/suspension_analysis_types.test.yo
@@ -45,7 +45,8 @@ test("SuspensionPoint constructor sets all fields", {
     while_nesting_depth : Option(usize).Some(usize(1)),
     cond_branch_source_index : Option(usize).None,
     needs_own_cond_branch_field : Option(bool).Some(true),
-    enclosing_while_expr : Option(AstExpr).None
+    enclosing_while_expr : Option(AstExpr).None,
+    cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
   );
   assert(sp.index == usize(0), "index");
   result := match(sp.target_variable_id, .Some(id) => id, .None => String.from(""));
@@ -68,7 +69,8 @@ test("SuspensionPoint optional fields default to None", {
     while_nesting_depth : Option(usize).None,
     cond_branch_source_index : Option(usize).None,
     needs_own_cond_branch_field : Option(bool).None,
-    enclosing_while_expr : Option(AstExpr).None
+    enclosing_while_expr : Option(AstExpr).None,
+    cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
   );
   has_target := match(sp.target_variable_id, .Some(_) => true, .None => false);
   assert(!(has_target), "target_variable_id should be None");
@@ -120,7 +122,8 @@ test("SuspensionAnalysisResult can hold suspension points", {
     while_nesting_depth : Option(usize).None,
     cond_branch_source_index : Option(usize).None,
     needs_own_cond_branch_field : Option(bool).None,
-    enclosing_while_expr : Option(AstExpr).None
+    enclosing_while_expr : Option(AstExpr).None,
+    cond_branch_suspension_exprs : Option(ArrayList(AstExpr)).None
   );
   r.suspension_points.push(sp);
   assert(r.suspension_points.len() == usize(1), "one suspension point");


### PR DESCRIPTION
## What

A `cond`/`match` whose branches await shares ONE await point, and everything hung off it — the `await_future_N` slot's C type, registration, extraction, the target copy — came from a single REPRESENTATIVE branch. Every branch shaped differently from the representative was miscompiled. Eight defect shapes catalogued in `issues/async-cond-shared-await-point-only-models-representative-branch.md`:

| shape | today |
| --- | --- |
| 1. tail-awaits of two different async fns | wrong value (0) + ill-typed C |
| 2. String-result vs unit-result branches | ill-typed C + wrong-offset registration/extraction (corruption/deadlock when the branch's future actually suspends) |
| 3. unit representative, other branch binds | extraction skipped; bound var zeroed |
| 4. branch value IS the await (`r := cond(f => io.await(x, io), true => v)`) | **silently returns 0 in the current release, all platforms, no heterogeneity needed** |
| 5. two named futures | C compile fails + registration polls the WRONG future |
| 6. named + anonymous | C compile fails |
| 7. `x := io.await(named, io)` in a branch | has never compiled |
| 8. standalone named await, other branch taken | **the not-taken branch's lazy future is cold-started and awaited anyway** (measured side effects) |

Two more members surfaced during validation (same root, fixed here too): a MATCH arm whose value IS the await recorded no branch info at all, so even uniform tail-await match arms lost their value; and NESTED cond/match arms, whose records the outer store overwrote — their (globally unique) dispatch codes were left caseless, so the switch's `default:` skipped the await entirely. Dispatch points now UNION branch records, and anonymous cases carry a NULL-slot guard so dead/outer codes and never-stored paths skip cleanly.

Inherited from the retired TS compiler (attic `state-code-gen.ts:2527`) — not a porting regression.

This is also what blocks the **windows-arm64 release leg**: the cross-emitted C carries five `-Wincompatible-pointer-types` sites, and that diagnostic is a **default error in clang 22 that `-w` does not downgrade**. arm64-vs-x64 was never an architecture difference — `windows-latest` pre-installs LLVM 20 (so `choco install llvm` no-ops) while `windows-11-arm` gets choco's 22.1.7. The moment the x64 image ships LLVM 22+, every leg fails; this PR defuses that.

## How

One predicate, consulted by every site that touches a cond point's future (`cond_await_point_needs_dispatch`, fed by per-branch suspension exprs the analysis now records on the merged representative):

- **Uniform-anonymous points** (all awaiting branches anonymous + same future C type — the overwhelming majority): emission byte-identical to before (the suspension core is the same text, parameterized).
- **Dispatch points** (any named-future branch, or any type mismatch): the slot is a type-erased `void*`; registration and extraction are emitted inside `switch (sm->cond_branch_N)`, each case accessing the future through ITS branch's exact type; results extract per the branch's own result type directly into the branch's own destination. Named branches don't store into the slot at all (fixes the over-release and wrong-future registration), and the switch's `default` replaces the NULL guard (fixes shape 8's wrong cold-start).
- Shape 4 (uniform): an awaiting branch with empty remaining exprs whose value is the await gets `<target> = sm->await_result_N;` in its dispatch case.

## Validation

- `issues/repros/async-cond-branch-await-shapes.yo`: all 12 assertions correct (were: two zeros, one corruption path, two compile failures).
- `tests/async_await.test.yo`: **181/181** (15 new regression tests: shapes 1–8, two tail-cond variants, heterogeneous MATCH arms, NESTED cond arms, reverse named/anonymous mix).
- `tests/algebraic_effects.test.yo`: 74/74 (the analysis change touches the shared suspension walker).
- windows-arm64 cross-emit of the whole compiler: completes, **0** incompatible-pointer stores (was 5), 5 erased slots + 10 dispatch blocks — exactly the five known sites.
- Native emit strict-checked with clang (no `-w`): no incompatible-pointer diagnostics.
- Full language suite (`./tests` minus internal/cli-cases): green locally.

`issues/windows-arm64-emitted-c-state-machine-pointer-mismatch.md` is retired (two of its claims were wrong: the defect was never arm64-specific, and v0.2.12's arm64 emit was NOT clean — its log just died at mimalloc first). windows-arm64 stays `experimental: true` in release.yml until a release run proves the leg end-to-end; flipping it is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
