### PR TITLE
docs(issues): async cond shared-await-point fix verified — move to fixed/

### DIFF
--- a/.github/instructions/c-codegen.instructions.md
+++ b/.github/instructions/c-codegen.instructions.md
@@ -44,7 +44,7 @@ through `cond_await_point_needs_dispatch` (`src/codegen/async/state_code_gen.yo`
 
 Mixing the two modes at different sites emits ill-typed C. Full defect history
 (eight shapes, two silently wrong at runtime in released compilers):
-`issues/async-cond-shared-await-point-only-models-representative-branch.md`.
+`issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md`.
 
 Related CI trap: `-Wincompatible-pointer-types` is a **default error in clang
 22+ that `-w` does not downgrade**, and the two Windows runners carry different

--- a/issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md
+++ b/issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md
@@ -1,12 +1,12 @@
 # async cond/match shared await point only models its REPRESENTATIVE branch
 
-**Status:** FIX IMPLEMENTED 2026-08-20 (branch
-`fix/async-cond-heterogeneous-await-slots`, commit 41592a403) — all shapes
-verified fixed at runtime, 181/181 `tests/async_await.test.yo` green (15 new
+**Status:** FIXED — merged to develop 2026-08-20 as #187 (8b7914c1d). All
+shapes verified at runtime; 181/181 `tests/async_await.test.yo` (15 new
 regression tests incl. heterogeneous MATCH arms, NESTED cond arms, and the
-reverse named/anonymous mix), 74/74 effects, emitted C clean of the
-incompatible-pointer class (native strict-clang: 0). Awaiting full-suite +
-fixpoint validation before moving to `issues/fixed/`.
+reverse named/anonymous mix), 74/74 effects, full language suite 2762/2762,
+bootstrap fixpoint + stage-3 byte-identity, all four internal-test shards,
+emitted C clean of the incompatible-pointer class on native and windows-arm64
+cross-emits.
 
 Two more members surfaced while validating (same root, now also fixed):
 - a MATCH arm whose value IS the await recorded no branch info at all

--- a/issues/repros/async-cond-branch-await-shapes.yo
+++ b/issues/repros/async-cond-branch-await-shapes.yo
@@ -1,4 +1,4 @@
-// Reproducers for issues/async-cond-shared-await-point-only-models-representative-branch.md
+// Reproducers for issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md
 // Six shapes of "a cond whose branches await differently", all sharing one
 // await point. Expected output (post-fix): every line prints its wanted value.
 // Pre-fix (2026-08-20): shape1/shape4 print 0, shape2 corrupts or deadlocks,

--- a/issues/retired/windows-arm64-emitted-c-state-machine-pointer-mismatch.md
+++ b/issues/retired/windows-arm64-emitted-c-state-machine-pointer-mismatch.md
@@ -1,5 +1,5 @@
 > **RETIRED 2026-08-20.** Root-caused and superseded by
-> `issues/async-cond-shared-await-point-only-models-representative-branch.md`.
+> `issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md`.
 > Two claims below did not survive: the defect is NOT arm64-specific (the x64
 > emit carries the byte-identical class — arm64 merely compiles with clang 22,
 > where the diagnostic is a default error), and v0.2.12's arm64 emit was NOT

--- a/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
+++ b/issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md
@@ -231,6 +231,6 @@ RSS ~72%, which is a measured, platform-specific reason that does not transfer.
 
 ### Still open, and NOT fixed by this
 
-`issues/async-cond-shared-await-point-only-models-representative-branch.md`. The arm64
+`issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md`. The arm64
 leg has a second, unrelated defect in Yo's OWN emitted C. Switching allocator
 does not touch it, so windows-arm64 stays `experimental: true`.

--- a/plans/WINDOWS_ALLOCATOR_DECISION.md
+++ b/plans/WINDOWS_ALLOCATOR_DECISION.md
@@ -125,7 +125,7 @@ Reopen this if any of the following changes:
 ## Related
 
 - `issues/windows-arm64-mimalloc-msvc-arm-intrinsics.md` — the original arm64 break
-- `issues/async-cond-shared-await-point-only-models-representative-branch.md` — a SEPARATE
+- `issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md` — a SEPARATE
   defect in Yo's own emitted C. windows-arm64 stays `experimental: true` because
   of it; the allocator change does not touch it.
 - `issues/fixed/mimalloc-performance-regression.md` — the macOS measurements

--- a/src/codegen/async/state_code_gen.yo
+++ b/src/codegen/async/state_code_gen.yo
@@ -150,7 +150,7 @@ await_call_future_arg :: (fn(await_expr : AstExpr) -> Option(AstExpr))(
 /// registration and extraction historically came from the point's
 /// REPRESENTATIVE branch only, which miscompiles every branch shaped
 /// differently from it (eight shapes catalogued in
-/// issues/async-cond-shared-await-point-only-models-representative-branch.md).
+/// issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md).
 ///
 /// Returns true when the branches do NOT all await a same-typed ANONYMOUS
 /// future — any named-future branch (shapes 5-8: the "was the await branch
@@ -1736,7 +1736,7 @@ generate_cond_branch_with_await :: (
               s_args := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
               // In dispatch mode the named/anonymous decision is PER BRANCH —
               // the representative's future_variable_id says nothing about
-              // this branch (issues/async-cond-shared-await-point-only-models-representative-branch.md).
+              // this branch (issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md).
               branch_named := (dispatch_mode && _branch_future_is_named(expr, await_point, context));
               match(
                 s_args.get(usize(0)),

--- a/src/codegen/async/state_machine.yo
+++ b/src/codegen/async/state_machine.yo
@@ -1559,7 +1559,7 @@ _emit_await_suspension_core :: (
 /// value) by skipping straight to the next state. Replaces the uniform path's
 /// `if (sm->await_future_N != NULL)` guard, which is meaningless for a named
 /// future (a bound variable is never NULL — shape 8's wrong cold-start). See
-/// issues/async-cond-shared-await-point-only-models-representative-branch.md.
+/// issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md.
 _emit_await_suspension_dispatch :: (
   fn(
     ap : AwaitPoint,

--- a/src/codegen/exprs/async.yo
+++ b/src/codegen/exprs/async.yo
@@ -739,7 +739,7 @@ emit_async_block_struct_definition :: (
         // to the running branch's exact type (dispatched on cond_branch_N).
         // Declared even when the REPRESENTATIVE awaited a named variable —
         // other branches may be anonymous (shape 6). See
-        // issues/async-cond-shared-await-point-only-models-representative-branch.md.
+        // issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md.
         .Some(ap) => if(cond_await_point_needs_dispatch(ap, context), {
           if(!(emitted_header), {
             em.emit_declaration_line("  // Future references for awaits");

--- a/src/codegen/functions/context.yo
+++ b/src/codegen/functions/context.yo
@@ -229,7 +229,7 @@ CondBranch :: ref(
     /// await futures of different C types or named vs anonymous futures — the
     /// dispatch-mode emitters access each branch's future through its own
     /// exact shape instead of the representative's. See
-    /// issues/async-cond-shared-await-point-only-models-representative-branch.md.
+    /// issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md.
     await_exprs : Option(ArrayList(AstExpr))
   )
 );

--- a/src/evaluator/shared/suspension_analysis.yo
+++ b/src/evaluator/shared/suspension_analysis.yo
@@ -587,7 +587,7 @@ walk_expr_ :: (
                   // the representative alone cannot type the shared slot or
                   // drive per-branch registration/extraction when branches
                   // suspend on differently-shaped futures. See
-                  // issues/async-cond-shared-await-point-only-models-representative-branch.md.
+                  // issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md.
                   branch_exprs := ArrayList(AstExpr).new();
                   (bpi3 : usize) = usize(0);
                   while(bpi3 < n_branches, {

--- a/src/evaluator/shared/suspension_analysis_types.yo
+++ b/src/evaluator/shared/suspension_analysis_types.yo
@@ -65,7 +65,7 @@ SuspensionPoint :: ref(
     /// futures of different C types, mix named and anonymous futures, or mix
     /// io/state-machine future kinds — everything downstream that used to
     /// assume the representative's shape consults this list instead. See
-    /// issues/async-cond-shared-await-point-only-models-representative-branch.md.
+    /// issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md.
     cond_branch_suspension_exprs : Option(ArrayList(AstExpr))
   )
 );

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -4196,7 +4196,7 @@ test("nested awaiting whiles over real I/O futures drop outer arm locals once pe
 // Regression: a cond/match whose branches await shares ONE await point, and
 // everything hung off it (slot type, registration, extraction, target copy)
 // came from the REPRESENTATIVE branch only. Eight defect shapes catalogued in
-// issues/async-cond-shared-await-point-only-models-representative-branch.md;
+// issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md;
 // the tests below pin each one. The helper futures are top-level so each gets
 // its own C state-machine type (that heterogeneity IS the point).
 shape_ten :: (fn(io : Io) -> Impl(Future(i32, Io)))(


### PR DESCRIPTION
Moves the issue record to `issues/fixed/` now that #187 merged with every gate green, and updates all path references (comment-only changes in src/tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)