### PR TITLE
ci: seed v0.2.12, install-seed windows-arm64 case, Windows curl shell-out assertion

### DIFF
--- a/.github/actions/install-seed/action.yml
+++ b/.github/actions/install-seed/action.yml
@@ -18,6 +18,7 @@ runs:
           macOS-ARM64) T=macos-arm64 ;;
           macOS-X64) T=macos-x64 ;;
           Windows-X64) T=windows-x64 ;;
+          Windows-ARM64) T=windows-arm64 ;;
           *) echo "::error::unsupported runner ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
         esac
         URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/yo-${{ inputs.version }}-${T}.tar.gz"

--- a/.github/workflows/fixpoint-arm64.yml
+++ b/.github/workflows/fixpoint-arm64.yml
@@ -43,7 +43,7 @@ env:
   # THE THIRD PIN. test.yml's lockstep note named only itself and release.yml,
   # so this one sat on v0.2.4 while they moved to v0.2.7 and then v0.2.9 —
   # the same silent drift that note was written about. Bump all THREE together.
-  SEED_VERSION: v0.2.11
+  SEED_VERSION: v0.2.12
   # See test.yml's APT_OPTS comment: a bare apt-get can hang forever on the
   # dpkg lock held by the runner's unattended-upgrades timer.
   APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ env:
   #
   # The raised timeouts (#137, #167) stay. They now buy headroom rather than
   # bare survival, and the cliff they guard is still there for the next seed.
-  SEED_VERSION: v0.2.11
+  SEED_VERSION: v0.2.12
 
   # apt-get waits on /var/lib/dpkg/lock-frontend FOREVER by default, and the
   # runner images run unattended-upgrades / apt-daily timers in the background.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -517,19 +517,6 @@ jobs:
           cd tmp/hello-world
           "$S1" build run
 
-      # `yo version list --remote` reaches the GitHub Releases API by shelling
-      # out to `curl`. Windows is the platform where that shell-out was in
-      # question — settle it by RUNNING it (curl.exe ships in Windows 10+ and
-      # on the runner images), and assert the listing has substance so an
-      # empty-but-zero-exit degradation cannot pass silently.
-      - name: "Version listing via the curl shell-out (Windows)"
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          OUT="$("$S1" version list --remote)"
-          echo "$OUT"
-          echo "$OUT" | grep -q "v0\." || { echo "::error::'yo version list --remote' printed no releases — the curl shell-out is broken on this platform"; exit 1; }
-
       # `tests/internal` (the compiler's own tests — they import src/ evaluator
       # and codegen internals) is excluded here and runs as its own job below.
       # Without the exclude this step would pull in files that each cost minutes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ env:
   #
   # The raised timeouts (#137, #167) stay. They now buy headroom rather than
   # bare survival, and the cliff they guard is still there for the next seed.
-  SEED_VERSION: v0.2.11
+  SEED_VERSION: v0.2.12
 
   # apt-get waits on /var/lib/dpkg/lock-frontend FOREVER by default, and the
   # runner images run unattended-upgrades / apt-daily timers in the background.
@@ -229,7 +229,12 @@ jobs:
       fail-fast: false
       # One leg per release-bundle target (see release.yml's seed matrix):
       # linux-x64, linux-arm64, macos-arm64, macos-x64 (macos-26-intel is
-      # the last Intel label GitHub offers), windows-x64.
+      # the last Intel label GitHub offers), windows-x64. NOT yet covered
+      # here: windows-arm64 (no published seed bundle exists — v0.2.12's
+      # release leg died before uploading one; add a windows-11-arm leg the
+      # release after a windows-arm64 bundle first ships) and
+      # linux-arm64-musl (exercised by the static-musl job and the
+      # musl-only migration, plans/backlog — not a separate leg here).
       matrix:
         os:
           - ubuntu-latest
@@ -511,6 +516,19 @@ jobs:
           "$S1" init ./tmp/hello-world --name hello-world
           cd tmp/hello-world
           "$S1" build run
+
+      # `yo version list --remote` reaches the GitHub Releases API by shelling
+      # out to `curl`. Windows is the platform where that shell-out was in
+      # question — settle it by RUNNING it (curl.exe ships in Windows 10+ and
+      # on the runner images), and assert the listing has substance so an
+      # empty-but-zero-exit degradation cannot pass silently.
+      - name: "Version listing via the curl shell-out (Windows)"
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          OUT="$("$S1" version list --remote)"
+          echo "$OUT"
+          echo "$OUT" | grep -q "v0\." || { echo "::error::'yo version list --remote' printed no releases — the curl shell-out is broken on this platform"; exit 1; }
 
       # `tests/internal` (the compiler's own tests — they import src/ evaluator
       # and codegen internals) is excluded here and runs as its own job below.


### PR DESCRIPTION
Splits the prepared test.yml work into what can land now (the windows-arm64 TEST leg itself must wait for a release that ships a windows-arm64 seed bundle — v0.2.12's release leg died before uploading one):

- **SEED_VERSION v0.2.11 → v0.2.12** in test.yml, release.yml, fixpoint-arm64.yml. v0.2.12 is published with every bundle leg the seed matrix needs (windows-arm64 legs are cross-emitted and never install a seed).
- **install-seed learns `Windows-ARM64) T=windows-arm64`** — inert until a leg uses it.
- **The matrix comment stops claiming one-leg-per-bundle parity** and states the actual gaps (windows-arm64, linux-arm64-musl) and when each closes.

**Settled along the way, no code kept:** whether `yo version list --remote`'s `curl` shell-out works on Windows. A temporary assertion step ran once and printed the full release listing ('0.2.12 (current)') on windows-latest — it works (curl.exe ships in Windows 10+). The step was then dropped rather than fixed: it would put an unauthenticated GitHub API call (rate-limit flake) into every PR run for a now-settled fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)