### PR TITLE
release: musl-only Linux — the static musl bundles are THE Linux bundles

### DIFF
--- a/.github/actions/install-seed/action.yml
+++ b/.github/actions/install-seed/action.yml
@@ -13,8 +13,13 @@ runs:
       shell: bash
       run: |
         case "${{ runner.os }}-${{ runner.arch }}" in
-          Linux-X64) T=linux-x64 ;;
-          Linux-ARM64) T=linux-arm64 ;;
+          # Musl-only Linux (2026-08-20): the static musl bundles ARE the
+          # Linux bundles — they run on glibc hosts too, which is what these
+          # runners are. Seeds older than the musl legs (x64: v0.2.7+,
+          # arm64: v0.2.12+) would need the removed glibc names; SEED_VERSION
+          # is pinned well past both.
+          Linux-X64) T=linux-x64-musl ;;
+          Linux-ARM64) T=linux-arm64-musl ;;
           macOS-ARM64) T=macos-arm64 ;;
           macOS-X64) T=macos-x64 ;;
           Windows-X64) T=windows-x64 ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,278 +375,6 @@ jobs:
   # CI consumers extract it, put bin/ on PATH, and set YO_STD to the bundled
   # std/. The Linux bundle is glibc + liburing dynamic for now — the
   # static-musl user-facing story is Phase 3 (distribution), not the seed.
-  seed-bundles:
-    name: Seed bundle (${{ matrix.target }})
-    needs: release
-    runs-on: ${{ matrix.os }}
-    # 90 was sized for the v0.2.7 seed. With v0.2.9 a single seed-driven
-    # self-build measures ~53 min on a 16 GB runner (it no longer fits in
-    # RAM and runs on the swapfile), and this job does THREE of them —
-    # candidate build, stage-2 re-emit gate, portable-c arm. A release that
-    # times out burns a version number, so the budget is sized for the
-    # measured cost, not the old one. See
-    # issues/seed-v0.2.9-memory-growth-slows-every-self-build.md.
-    #
-    # 180 -> 360 (2026-08-19): the v0.2.10 attempt was KILLED at 180 with the
-    # candidate build alone taking 159 min, against 18 min for the same step
-    # one release earlier. Root cause was the missing memory treatment below,
-    # not the budget — but the budget is what turned a slow job into a dead
-    # release, so it gets headroom too. The arm64 leg, same steps, took 32 min.
-    timeout-minutes: 360
-    permissions:
-      contents: write
-    # Only the CI-runner platforms (linux-x64, macos-arm64, windows-x64) are
-    # required for the 2.3 seed; the rest are Phase-3 coverage. Experimental
-    # legs must not block the seed: windows-x64 is the first native-Windows
-    # build of the self-hosted compiler (the plan flags a porting-tail risk),
-    # and macos-x64/linux-arm64 have never been exercised in CI. Promote a
-    # leg to experimental: false once it has produced a green bundle.
-    # linux-arm64 is glibc like linux-x64 — the static-musl story
-    # (SELF_HOSTING_COMPLETION.md Phase 3) replaces both Linux legs later.
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # seed_built: true — P2.5 step 24: this leg's bundle is built by the
-          # PREVIOUS release's seed (trust chain: previous-release-builds-next;
-          # escape hatch: bootstrap from an older tag, or the src-attic-final
-          # tag while it exists). Linux first: the seed's self-emit peaks at
-          # ~12.2 GB after env-sharing (PR #133) — it fits the 16 GB Linux
-          # runners but NOT the 7 GB macOS runners, so the macOS legs stay
-          # TS-built until P2_5_RETIRE_EXECUTION.md's step-24 option A
-          # (cross-emit fan-out) or C (larger runners) is picked. Windows
-          # runners have 16 GB, but that leg keeps the proven TS path one
-          # release longer (the windows porting tail is the youngest).
-          - os: ubuntu-latest
-            target: linux-x64
-            experimental: false
-            seed_built: true
-          # linux-arm64 promoted: green on its first v0.2.0 run.
-          - os: ubuntu-24.04-arm
-            target: linux-arm64
-            experimental: false
-            seed_built: true
-          # The two macOS legs moved to `seed-bundles-cross` (cross-emitted —
-          # P2.5 step-24 option A): the seed's self-emit needs ~12.2 GB and
-          # the free macOS runners have 7 GB, so their C is emitted by the
-          # previous seed ON LINUX and only clang-compiled + smoke-tested
-          # natively here. See the seed-cross-emit job.
-          # windows-x64 ALSO moved to the cross-emit job, for a MEMORY reason
-          # rather than the macOS 7 GB one. A seed-built native leg runs THREE
-          # self-compile phases (candidate build, stage-2 re-emit gate,
-          # portable-c arm) at ~12.2 GB each, and the 32 GB swapfile that makes
-          # that survivable is `if: runner.os == 'Linux'` — `fallocate`/`mkswap`
-          # do not exist on a Windows runner. This file already records that a
-          # swapless 16 GB runner dies of it ("runner has received a shutdown
-          # signal"). Cross-emitting keeps the heavy phase on Linux, where the
-          # swap is, and leaves Windows only a clang compile + smoke test.
-
-    steps:
-      - name: Checkout the released commit
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release.outputs.sha }}
-          submodules: recursive
-
-      - name: Install liburing
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get $APT_OPTS update
-          sudo apt-get $APT_OPTS install -y liburing-dev
-
-      # Same provisioning as seed-cross-emit and every self-building job in
-      # test.yml: the stage-2 gate below is a full self-emit, which does not
-      # fit a swapless 16 GB runner (v0.2.8 attempt 3's linux-x64 leg took the
-      # whole VM down mid-emit — "runner received a shutdown signal").
-      - name: Add swap space
-        if: runner.os == 'Linux'
-        run: |
-          sudo fallocate -l 32G /mnt/swapfile
-          sudo chmod 600 /mnt/swapfile
-          sudo mkswap /mnt/swapfile
-          sudo swapon /mnt/swapfile
-
-      # SWAP ALONE IS NOT ENOUGH — the v0.2.10 release proved it expensively.
-      # This job's linux-x64 leg spent 159 minutes on the candidate build and
-      # was killed at the budget, taking the release with it.
-      #
-      # zswap is the knob, and the comparison is unusually well controlled:
-      # test.yml's bootstrap-fixpoint "Stage 1" runs the SAME operation — the
-      # v0.2.9 seed building the compiler — on the same commit, the same
-      # ubuntu-latest runner class, with the same 32 GB swapfile. The only
-      # difference was that it turns zswap on and this job did not.
-      #
-      #     test.yml   Stage 1     zswap ON      16 min
-      #     release.yml            zswap OFF    159 min
-      #
-      # A 10x difference from one sysctl. Once the seed no longer fits in RAM
-      # (v0.2.9 peaks ~28 GB — see the issue below), every reclaimed page goes
-      # to disk; zswap keeps a compressed copy in RAM (~3x) and turns disk
-      # thrash back into memory traffic. The arm64 leg needed only 32 min
-      # without it, which is why this first looked arch-specific rather than
-      # configuration-specific.
-      #
-      # THP off for the reason test.yml sets it on its heavier emit: huge pages
-      # must be split and compacted before they can be swapped at all.
-      #
-      # DELIBERATELY NOT copied from test.yml: its `systemd-run --scope -p
-      # MemoryHigh/MemoryMax` wrapper. It is unmeasured for these steps, it
-      # would newly OOM-kill anything that legitimately exceeds the cap, and
-      # `sudo` resets PATH to secure_path — which does not contain the seed's
-      # bin/ — so wrapping the steps that invoke a bare `yo` would break them
-      # outright. release.yml gets no PR CI, so an untested change here is only
-      # discoverable by burning a release. The measurement says zswap is what
-      # mattered; that is what this applies.
-      #
-      # See issues/seed-v0.2.9-memory-growth-slows-every-self-build.md.
-      - name: Tune the kernel for a swap-heavy self-emit
-        if: runner.os == 'Linux'
-        run: |
-          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled || true
-          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/defrag || true
-          echo Y | sudo tee /sys/module/zswap/parameters/enabled || true
-          free -h
-
-      - name: Install LLVM/Clang
-        if: runner.os == 'Windows'
-        run: |
-          choco install llvm -y
-          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install the seed compiler (previous release)
-        if: ${{ matrix.seed_built }}
-        uses: ./.github/actions/install-seed
-        with:
-          version: ${{ env.SEED_VERSION }}
-
-      # SEED-ERA FLAGS ONLY (same rule as the musl job): the previous release
-      # may predate newer options. `--std-path ./std` pins the CHECKOUT's std
-      # (the seed would otherwise compile against its own bundled std).
-      - name: Build the native yo binary (previous seed)
-        if: ${{ matrix.seed_built }}
-        shell: bash
-        env:
-          YO_MAIN_STACK_MB: "4096"
-        run: yo compile src/main.yo --release --allocator mimalloc --std-path ./std -o yo-seed
-
-      # Pre-release trust-chain gate: the candidate must be able to act as the
-      # NEXT release's seed, so prove it can evaluate + emit its own source.
-      # Emit-only (--skip-c-compiler): the expensive, correctness-bearing half
-      # is the Yo->C generation — C compilability of the same generation's
-      # emit is continuously covered by test.yml's fixpoint jobs. The FTT
-      # check guards the hollow-emit trap: an untranspilable function becomes
-      # a `// Failed to transpile` COMMENT in the C with rc=0 (string
-      # LITERALS containing the phrase live inside emitted print statements,
-      # never at line start — see the hollow-sweep methodology notes).
-      - name: "Pre-release gate: the candidate re-emits itself (stage-2)"
-        if: ${{ matrix.seed_built }}
-        shell: bash
-        env:
-          YO_MAIN_STACK_MB: "4096"
-        run: |
-          if [ -f yo-seed.exe ]; then SEED2=./yo-seed.exe; else SEED2=./yo-seed; fi
-          "$SEED2" compile src/main.yo --release --allocator mimalloc \
-            --std-path ./std --emit-c --skip-c-compiler -o gate-stage2 > /dev/null
-          test -s gate-stage2.c
-          SIZE=$(wc -c < gate-stage2.c)
-          echo "stage-2 emit: $SIZE bytes"
-          if [ "$SIZE" -lt 100000000 ]; then
-            echo "::error::stage-2 emit is implausibly small ($SIZE bytes) — refusing to ship this seed."
-            exit 1
-          fi
-          if grep -qE '^\s*// (Error: )?Failed to transpile' gate-stage2.c; then
-            echo "::error::stage-2 emit contains Failed-to-transpile comments — the candidate cannot compile itself."
-            exit 1
-          fi
-          rm -f gate-stage2.c
-
-      - name: Assemble the bundle
-        shell: bash
-        run: |
-          BUNDLE="yo-v${{ needs.release.outputs.version }}-${{ matrix.target }}"
-          mkdir -p "$BUNDLE/bin"
-          if [ -f yo-seed.exe ]; then cp yo-seed.exe "$BUNDLE/bin/yo.exe"; else cp yo-seed "$BUNDLE/bin/yo"; fi
-          cp -R std "$BUNDLE/std"
-          # vendor/mimalloc must ship as a SIBLING of std: both compilers
-          # resolve it as dirname(std)/vendor, and mimalloc is the DEFAULT
-          # allocator — the self-hosted binary passes the vendor paths to
-          # clang unconditionally, so a bundle without it cannot compile
-          # anything with the default allocator.
-          mkdir -p "$BUNDLE/vendor"
-          cp -R vendor/mimalloc "$BUNDLE/vendor/mimalloc"
-          cp LICENSE.md "$BUNDLE/"
-          tar -czf "$BUNDLE.tar.gz" "$BUNDLE"
-          echo "BUNDLE=$BUNDLE" >> $GITHUB_ENV
-
-      # Compile and run a hello program with the bundled binary + bundled std,
-      # from a directory OUTSIDE the repo checkout, so the bundle is proven
-      # self-sufficient before it is published.
-      - name: Smoke-test the bundle
-        shell: bash
-        run: |
-          BUNDLE_DIR="$PWD/$BUNDLE"
-          mkdir -p "$RUNNER_TEMP/seed-smoke" && cd "$RUNNER_TEMP/seed-smoke"
-          printf '%s\n' 'open(import("std/fmt"));' 'main :: (fn() -> unit)(println("hello from the yo seed"));' 'export(main);' > hello.yo
-          if [ -f "$BUNDLE_DIR/bin/yo.exe" ]; then YO="$BUNDLE_DIR/bin/yo.exe"; else YO="$BUNDLE_DIR/bin/yo"; fi
-          # `pwd -W` yields a Windows-style path under git-bash (the native
-          # binary cannot resolve an MSYS /c/... path); elsewhere it fails and
-          # plain pwd is used.
-          YO_STD=$(cd "$BUNDLE_DIR/std" && (pwd -W 2>/dev/null || pwd))
-          YO_STD="$YO_STD" "$YO" compile hello.yo --release -o hello 2>compile.err || { cat compile.err; exit 1; }
-          cat compile.err
-          # The bundle's binary is built with mimalloc, whose diagnostics are a
-          # correctness gate the release should not ship past: a pointer that
-          # crossed allocators inside the compiler's own std usage prints
-          # "mi_free: invalid pointer" and leaks rather than crashing, so rc=0
-          # hides it. v0.2.0 and v0.2.1 both shipped that (two per compile) —
-          # issues/fixed/current-exe-realpath-cross-allocator-free.md.
-          if grep -q "mimalloc: error" compile.err; then
-            echo "::error::The bundled compiler reported allocator errors on its own stderr — refusing to ship this bundle."
-            exit 1
-          fi
-          if [ -f hello.exe ]; then OUT=$(./hello.exe); else OUT=$(./hello); fi
-          echo "smoke output: $OUT"
-          test "$OUT" = "hello from the yo seed"
-
-      - name: Attach the bundle to the release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "v${{ needs.release.outputs.version }}" "$BUNDLE.tar.gz" --clobber
-
-      # This leg's arm of the single portable `yo.c`
-      # (plans/PORTABLE_C_DISTRIBUTION.md). A SECOND emit rather than reusing
-      # the bundle's `yo-seed.c`, because that one is mimalloc-flavored: its
-      # mimalloc use is behind `#if __has_include(<mimalloc.h>)`, so it is
-      # self-contained on a box WITHOUT mimalloc headers but MIS-LINKS on one
-      # that has the headers and no -lmimalloc. The published file must not
-      # depend on what the user happens to have installed, so it is libc.
-      - name: "Emit this platform's arm of the portable yo.c (seed)"
-        if: ${{ matrix.seed_built }}
-        shell: bash
-        env:
-          YO_MAIN_STACK_MB: "4096"
-        run: |
-          mkdir -p portable-arm
-          yo compile src/main.yo --release --allocator system \
-            --std-path ./std --emit-c --skip-c-compiler \
-            -o "portable-arm/${{ matrix.target }}" > /dev/null
-          ls -la "portable-arm/${{ matrix.target }}.c"
-
-      - name: Upload the portable-C arm
-        uses: actions/upload-artifact@v4
-        with:
-          name: portable-c-${{ matrix.target }}
-          path: portable-arm/${{ matrix.target }}.c
-          retention-days: 1
-          if-no-files-found: error
-
-  # Flip the draft release public once the seed bundles are in. Runs only
-  # when the seed-bundles job succeeded — with the experimental legs on
-  # continue-on-error, the job-level result reflects exactly the REQUIRED
-  # legs (linux-x64, macos-arm64). A red required leg leaves the release as
-  # an invisible draft instead of a published release missing its binaries.
   # ONE portable `yo.c` for every platform, assembled from the per-leg arms.
   # plans/PORTABLE_C_DISTRIBUTION.md has the rationale and the measurements;
   # the short version is that each arm is a complete translation unit under a
@@ -767,7 +495,7 @@ jobs:
           sudo swapon /mnt/swapfile
           free -h
 
-      # See the identical step in seed-bundles for why swap alone is not
+      # See the musl-bundle steps for why swap alone is not
       # enough. This job survived the v0.2.10 attempt at 64-69 min, but it runs
       # the same seed-driven self-emit on the same runner class, so it gets the
       # same treatment rather than waiting to be the next leg that collapses.
@@ -876,7 +604,7 @@ jobs:
             target: macos-x64
             experimental: false
           # windows-x64: the C is cross-emitted on Linux (see the comment on
-          # the seed-bundles matrix); this leg only compiles and smoke-tests it
+          # the removed glibc seed-bundles matrix); this leg only compiles and smoke-tests it
           # natively. `experimental: false` because the bundle itself is not
           # new — windows-x64 has shipped since v0.2.1 — only the route the C
           # takes to get here has changed.
@@ -1060,6 +788,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "v${{ needs.release.outputs.version }}" "$BUNDLE.tar.gz" --clobber
 
+  # THE Linux release legs (musl-only, 2026-08-20). The glibc seed-bundles
+  # legs were REMOVED, not renamed: the static musl bundles run on glibc and
+  # musl systems alike (measured perf delta is inside run-to-run noise and the
+  # emit is byte-identical — plans/P3_DISTRIBUTION.md), so publishing both
+  # doubled the release cost for no coverage. What the glibc legs used to
+  # carry moved here: the stage-2 re-emit gate runs against the static
+  # candidate below, and the portable-c arms are emitted at the end of this
+  # job (system-allocator flavored, same as before — the published yo.c must
+  # not depend on mimalloc headers being installed).
   musl-bundle:
     name: Static musl Linux bundle (${{ matrix.target }})
     needs: release
@@ -1073,6 +810,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x64-musl
+            portable_target: linux-x64
           # arm64 added 2026-08-19. Until then this job was hardcoded to x64,
           # so `yo-v<x>-linux-arm64-musl` had never existed — and an Alpine or
           # NixOS arm64 user hit install.sh's fallback path, which correctly
@@ -1084,6 +822,7 @@ jobs:
           # the whole reason this cross-compiles nothing.
           - os: ubuntu-24.04-arm
             target: linux-arm64-musl
+            portable_target: linux-arm64
     # PROMOTED 2026-08-17 per this job's own rule ("after one green release
     # run"): v0.2.7 (run 31925643271) built, smoked and shipped the bundle.
     # The earlier failures are root-caused, not mysterious — every red run's
@@ -1097,7 +836,7 @@ jobs:
     continue-on-error: false
     steps:
       # The one seed-driven self-emit in this file that had NO swapfile, while
-      # seed-bundles, seed-cross-emit and test.yml's musl leg all provision
+      # seed-cross-emit and test.yml's musl leg all provision
       # one. That asymmetry killed the v0.2.10 release: this job ran the same
       # `yo compile src/main.yo --release --allocator mimalloc` its test.yml
       # twin runs, on a bare 16 GB runner, and the runner DIED at 50 min —
@@ -1126,7 +865,7 @@ jobs:
 
       # The swapfile above (added in #166) is what this job was missing
       # entirely; zswap is what keeps the resulting swap traffic from becoming
-      # thrash. See the identical step in seed-bundles for the measurement.
+      # thrash. See the identical step in seed-cross-emit for the measurement.
       - name: Tune the kernel for a swap-heavy self-emit
         run: |
           echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled || true
@@ -1194,6 +933,32 @@ jobs:
           grep -q "statically linked" file.txt || {
             echo "::error::musl bundle is not statically linked"; exit 1; }
 
+      # Pre-release trust-chain gate, rehomed from the removed glibc legs: the
+      # candidate (the static binary above IS the candidate — the seed emitted
+      # this tree's compiler) must be able to act as the NEXT release's seed,
+      # so prove it can evaluate + emit its own source. Static means it runs
+      # on this glibc host as-is. Emit-only; the FTT check guards the
+      # hollow-emit trap (an untranspilable function becomes a
+      # `// Failed to transpile` COMMENT with rc=0).
+      - name: "Pre-release gate: the candidate re-emits itself (stage-2)"
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: |
+          ./yo-musl compile src/main.yo --release --allocator mimalloc \
+            --std-path ./std --emit-c --skip-c-compiler -o gate-stage2 > /dev/null
+          test -s gate-stage2.c
+          SIZE=$(wc -c < gate-stage2.c)
+          echo "stage-2 emit: $SIZE bytes"
+          if [ "$SIZE" -lt 100000000 ]; then
+            echo "::error::stage-2 emit is implausibly small ($SIZE bytes) — refusing to ship this seed."
+            exit 1
+          fi
+          if grep -qE '^\s*// (Error: )?Failed to transpile' gate-stage2.c; then
+            echo "::error::stage-2 emit contains Failed-to-transpile comments — the candidate cannot compile itself."
+            exit 1
+          fi
+          rm -f gate-stage2.c
+
       - name: Assemble the bundle
         run: |
           BUNDLE="yo-v${{ needs.release.outputs.version }}-${{ matrix.target }}"
@@ -1245,14 +1010,57 @@ jobs:
               test "$OUT" = "hello from the yo seed"
             '
 
+      # With the glibc legs gone this bundle is what every Linux user
+      # installs, so prove it on a glibc host too — from a directory OUTSIDE
+      # the checkout, same self-sufficiency bar the removed legs applied.
+      - name: Smoke-test the bundle on the glibc host
+        run: |
+          BUNDLE_DIR="$PWD/$BUNDLE"
+          mkdir -p "$RUNNER_TEMP/musl-smoke" && cd "$RUNNER_TEMP/musl-smoke"
+          printf '%s\n' 'open(import("std/fmt"));' 'main :: (fn() -> unit)(println("hello from the yo seed"));' 'export(main);' > hello.yo
+          YO_STD="$BUNDLE_DIR/std" "$BUNDLE_DIR/bin/yo" compile hello.yo --release -o hello 2>compile.err || { cat compile.err; exit 1; }
+          cat compile.err
+          if grep -q "mimalloc: error" compile.err; then
+            echo "::error::the bundled compiler reported allocator errors on its own stderr — refusing to ship this bundle"
+            exit 1
+          fi
+          OUT=$(./hello)
+          echo "smoke output: $OUT"
+          test "$OUT" = "hello from the yo seed"
+
       - name: Attach the bundle to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "v${{ needs.release.outputs.version }}" "$BUNDLE.tar.gz" --clobber
 
+      # This leg's arm of the single portable `yo.c`, rehomed from the removed
+      # glibc legs (plans/PORTABLE_C_DISTRIBUTION.md). A SEPARATE emit rather
+      # than reusing yo-musl.c, because that one is mimalloc-flavored: its
+      # mimalloc use is behind `#if __has_include(<mimalloc.h>)`, so it
+      # MIS-LINKS on a box that has the headers and no -lmimalloc. The
+      # published file must not depend on what the user happens to have
+      # installed, so the arm is libc-flavored (--allocator system).
+      - name: "Emit this platform's arm of the portable yo.c (seed)"
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: |
+          mkdir -p portable-arm
+          yo compile src/main.yo --release --allocator system \
+            --std-path ./std --emit-c --skip-c-compiler \
+            -o "portable-arm/${{ matrix.portable_target }}" > /dev/null
+          ls -la "portable-arm/${{ matrix.portable_target }}.c"
+
+      - name: Upload the portable-C arm
+        uses: actions/upload-artifact@v4
+        with:
+          name: portable-c-${{ matrix.portable_target }}
+          path: portable-arm/${{ matrix.portable_target }}.c
+          retention-days: 1
+          if-no-files-found: error
+
   portable-c:
     name: Portable single-file yo.c
-    needs: [release, seed-bundles, seed-cross-emit]
+    needs: [release, musl-bundle, seed-cross-emit]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -1313,7 +1121,7 @@ jobs:
     # its continue-on-error off (the pairing rule its comment recorded): a
     # promoted leg's failure must hold publication, or a red musl run ships a
     # release whose install.sh advertises a bundle that never arrives.
-    needs: [release, seed-bundles, seed-bundles-cross, portable-c, musl-bundle]
+    needs: [release, seed-bundles-cross, portable-c, musl-bundle]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1133,6 +1133,24 @@ jobs:
           '
           echo "static + io_uring confirmed."
 
+      # The one gate the musl-only migration waited on, now wired in per PR.
+      # scripts/bootstrap/probe-stack-sizing.sh proves BOTH directions (a 1 MB
+      # stack must overflow, 64 MB must pass), so a binary that silently
+      # ignores YO_MAIN_STACK_MB cannot pass — and it encodes the LLVM
+      # accumulator-tail-call trap that defeats naive recursion probes. It
+      # must run INSIDE Alpine: the property under test belongs to the musl
+      # build (musl threads default to ~128 KB stacks against glibc's 8 MB),
+      # and a host-side run would compile the probe against glibc and pass
+      # vacuously (plans/P3_DISTRIBUTION.md item 3's method note).
+      - name: Assert YO_MAIN_STACK_MB is honored by the static binary
+        run: |
+          docker run --rm --security-opt seccomp=unconfined \
+            -v "$PWD:/w" -w /w alpine:3.20 sh -euc '
+              apk add --no-cache build-base liburing-dev bash
+              export YO_STD=/w/std
+              bash scripts/bootstrap/probe-stack-sizing.sh /w/yo-musl
+            '
+
   test-tsan:
     name: ThreadSanitizer (sync primitives — Linux/Clang)
     runs-on: ubuntu-latest

--- a/plans/P3_DISTRIBUTION.md
+++ b/plans/P3_DISTRIBUTION.md
@@ -332,6 +332,31 @@ A/B runs disagree on sign), the emitted C is byte-identical, and static-linking
 caveats do not apply because the compiler shells out to `curl` rather than
 linking a resolver. Nothing remains to measure.
 
+### Musl-only migration — EXECUTED 2026-08-20 (branch `release/musl-only-linux`)
+
+The migration is a REMOVAL, not a rename — the musl bundles keep their `-musl`
+suffix and the glibc bundles stop being published:
+
+- `release.yml`: the glibc `seed-bundles` job (its only two legs were
+  linux-x64/linux-arm64) is DELETED. What it carried moved into `musl-bundle`,
+  which is now THE Linux release leg pair: the stage-2 re-emit gate runs
+  against the static candidate, and the portable-c arms (`linux-x64`,
+  `linux-arm64`, system-allocator flavored as before) are emitted at the end
+  of that job. `portable-c` and `publish-release` needs rewired.
+- `install.sh`: musl-first on EVERY Linux (the static bundle runs on glibc
+  hosts too), with the glibc name as a fallback for releases that predate the
+  musl legs (x64: v0.2.7+, arm64: v0.2.12+).
+- `src/version_cache.yo`: `host_bundle_name` appends `-musl` on Linux;
+  `download_version` falls back to the pre-musl name on 404 so old versions
+  stay installable.
+- `install-seed` action: Linux seeds are the musl bundles (static — no
+  liburing.so needed to run them).
+- `test.yml` musl job: the stack-sizing probe
+  (`scripts/bootstrap/probe-stack-sizing.sh`) now runs per PR inside Alpine —
+  the gate this section answered, kept honest continuously.
+
+First release with no glibc Linux bundles: the one cut after this lands.
+
 ### The question, and the two attempts that failed to answer it (historical)
 
 Codegen requests a 1 GiB worker stack and **falls back silently** to

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -589,22 +589,24 @@ is_musl() {
 }
 
 install_dist() {
-  # On musl, prefer the static musl bundle and fall back to the glibc one.
-  # The fallback still matters even though the musl leg is no longer
-  # experimental (promoted 2026-08-17; it gates publication) and now covers
-  # arm64 as well as x64 (2026-08-19): a release older than either change
-  # legitimately lacks the bundle for this arch, and a hard failure would be
-  # worse than the loader warning the glibc path already prints.
+  # Linux is musl-only (2026-08-20): the static musl bundle is THE Linux
+  # bundle — it runs on glibc and musl systems alike, so it is preferred on
+  # EVERY Linux, not just detected-musl ones. The probe + glibc fallback
+  # stays for releases that predate the musl legs (x64: v0.2.7+,
+  # arm64: v0.2.12+); on a glibc host that fallback is fully functional,
+  # on a musl host it will not run — hence the differentiated warning.
   bundle="yo-$VERSION-$OSARCH"
-  if [ "$OSNAME" = "linux" ] && is_musl; then
+  if [ "$OSNAME" = "linux" ]; then
     musl_bundle="yo-$VERSION-$OSARCH-musl"
     if download_probe "$YO_DIST_BASE_URL/$VERSION/$musl_bundle.tar.gz"; then
-      info "musl libc detected — using the static musl bundle."
+      info "Using the static musl Linux bundle (runs on glibc and musl alike)."
       bundle="$musl_bundle"
-    else
+    elif is_musl; then
       warn "musl libc detected, but $VERSION publishes no $musl_bundle bundle."
       warn "Falling back to the glibc bundle, which will NOT run here."
       warn "Prefer:  --from-source   (compiles yo.c with your own toolchain)"
+    else
+      info "$VERSION predates the static musl bundles — using its glibc bundle."
     fi
   fi
   url="$YO_DIST_BASE_URL/$VERSION/$bundle.tar.gz"
@@ -629,7 +631,7 @@ install_dist() {
     if ! download_file "$url" "$YO_TEMP_DIR/$bundle.tar.gz"; then
       stop "Unable to download: $url
   There may be no bundle for this platform ($OSARCH) at $VERSION.
-  Available targets: linux-x64, linux-arm64, macos-arm64, macos-x64.
+  Available targets: linux-x64-musl, linux-arm64-musl, macos-arm64, macos-x64, windows-x64.
   Pick another release with --version=<tag>, or build from source."
     fi
 

--- a/src/version_cache.yo
+++ b/src/version_cache.yo
@@ -9,7 +9,8 @@
 //! mechanisms share one shape and the bundle self-locates its std.
 //!
 //! Download flow:
-//!   1. Resolve the host platform's bundle name (yo-v<v>-<os>-<arch>).
+//!   1. Resolve the host platform's bundle name (yo-v<v>-<os>-<arch>,
+//!      with a `-musl` suffix on Linux — musl-only since 2026-08-20).
 //!   2. Download `https://github.com/<repo>/releases/download/v<v>/<bundle>.tar.gz`.
 //!   3. Extract; the tarball root is a `<bundle>/` directory — move it to the
 //!      version cache directory.
@@ -207,9 +208,10 @@ cached_binary_path :: (fn(version_dir : String) -> String)({
   );
   `${version_dir}/bin/${bin_name}`
 });
-/// The release-bundle basename for a version on the HOST platform,
-/// e.g. `yo-v0.2.4-macos-arm64`. Mirrors scripts/install.sh's detect_osarch.
-host_bundle_name :: (fn(version : String, exn : Exception) -> String)({
+/// The PRE-MUSL release-bundle basename (`yo-v<v>-<os>-<arch>`, no suffix).
+/// Only the Linux glibc-era fallback in `download_version` should use this
+/// directly — everything else goes through `host_bundle_name`.
+_host_bundle_name_base :: (fn(version : String, exn : Exception) -> String)({
   target := host_target();
   os_name := cond(
     is_target_macos(target) => `macos`,
@@ -219,7 +221,7 @@ host_bundle_name :: (fn(version : String, exn : Exception) -> String)({
       platform_str := String.from(os_to_str(target.os));
       exn.throw(
         dyn(
-          `Unsupported platform for Yo release bundles: ${platform_str}. Available targets: linux-x64, linux-arm64, macos-arm64, macos-x64, windows-x64.`
+          `Unsupported platform for Yo release bundles: ${platform_str}. Available targets: linux-x64-musl, linux-arm64-musl, macos-arm64, macos-x64, windows-x64.`
         )
       );
       String.new()
@@ -238,6 +240,19 @@ host_bundle_name :: (fn(version : String, exn : Exception) -> String)({
     }
   );
   `yo-v${version}-${os_name}-${arch_name}`
+});
+/// The release-bundle basename for a version on the HOST platform,
+/// e.g. `yo-v0.2.13-linux-x64-musl` / `yo-v0.2.13-macos-arm64`. Mirrors
+/// scripts/install.sh. Linux is musl-only (2026-08-20): the static musl
+/// bundle is THE Linux bundle and runs on glibc and musl systems alike; the
+/// glibc names exist only on releases that predate the musl legs (x64:
+/// v0.2.7+, arm64: v0.2.12+), which `download_version` falls back to.
+host_bundle_name :: (fn(version : String, exn : Exception) -> String)({
+  base := _host_bundle_name_base(version, exn);
+  cond(
+    is_target_linux(host_target()) => `${base}-musl`,
+    true => base
+  )
 });
 /// Check if a specific Yo version is already cached locally.
 /// A cached version is a bundle extraction whose `bin/yo` exists.
@@ -629,16 +644,29 @@ download_version :: (
         )
       );
     });
-    bundle_name := host_bundle_name(version, e.exn);
-    url := `${_releases_download_url()}/v${version}/${bundle_name}.tar.gz`;
+    (bundle_name : String) = host_bundle_name(version, e.exn);
     version_dir := get_version_cache_dir(version);
     // 1. Download the tarball to a temp directory.
     tmp_dir := e.io.await(TempDir.new(e.io), e);
     tmp_path_str := tmp_dir.path().to_string();
-    tarball_path := `${tmp_path_str}/${bundle_name}.tar.gz`;
+    (url : String) = `${_releases_download_url()}/v${version}/${bundle_name}.tar.gz`;
+    (tarball_path : String) = `${tmp_path_str}/${bundle_name}.tar.gz`;
     println(`Downloading Yo v${version} (${bundle_name}) from GitHub Releases...`);
     code_str := e.io.await(_download_file(url, tarball_path, e.io, e.exn), e);
-    code := match(code_str.parse_i64(), .None => i64(0), .Some(c) => c);
+    (code : i64) = match(code_str.parse_i64(), .None => i64(0), .Some(c) => c);
+    // Linux glibc-era fallback: releases that predate the musl legs only
+    // published `yo-v<v>-linux-<arch>` bundles. On a glibc host that bundle
+    // is fully functional; on a musl host it will not run, but a download
+    // that exists beats a hard 404 (install.sh makes the same call).
+    if((code == i64(404)) && is_target_linux(host_target()), {
+      legacy := _host_bundle_name_base(version, e.exn);
+      println(`No ${bundle_name}.tar.gz on v${version} — retrying the pre-musl bundle name (${legacy})...`);
+      bundle_name = legacy;
+      url = `${_releases_download_url()}/v${version}/${bundle_name}.tar.gz`;
+      tarball_path = `${tmp_path_str}/${bundle_name}.tar.gz`;
+      legacy_code_str := e.io.await(_download_file(url, tarball_path, e.io, e.exn), e);
+      code = match(legacy_code_str.parse_i64(), .None => i64(0), .Some(c2) => c2);
+    });
     if(code == i64(404), {
       e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
       msg := `Yo v${version} has no ${bundle_name}.tar.gz release asset.`;
@@ -648,7 +676,7 @@ download_version :: (
     });
     if(code >= i64(400), {
       e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
-      e.exn.throw(dyn(`HTTP ${code_str} downloading ${url}`));
+      e.exn.throw(dyn(`HTTP ${code.to_string()} downloading ${url}`));
     });
     // 2. Extract; the tarball root is a `<bundleName>/` directory holding
     // bin/, std/ and vendor/ as SIBLINGS (the compiler resolves its std by


### PR DESCRIPTION
**DRAFT until v0.2.13 publishes** — this PR removes the glibc release legs, and the in-flight release should ship on unchanged machinery first.

The migration is a **removal, not a rename**: the musl bundles keep their `-musl` suffix; the glibc bundles stop being published. All gates were answered before this PR (plans/P3_DISTRIBUTION.md item 3): perf delta inside run-to-run noise, byte-identical emit, and `YO_MAIN_STACK_MB` HONOURED by the static builds on both arches (probed against the shipped v0.2.12 bundles, inside Alpine).

- **release.yml**: the glibc `seed-bundles` job is deleted (its only legs were linux-x64/linux-arm64). What it carried moves into `musl-bundle`, now THE Linux leg pair: the stage-2 re-emit gate runs against the static candidate, the portable-c arms (system-allocator flavored, same rationale as before) are emitted there, and the bundle gains a glibc-host smoke since every Linux user now installs it. `portable-c`/`publish-release` needs rewired.
- **install.sh**: musl-first on every Linux (the static bundle runs on glibc hosts too); glibc-name fallback for releases predating the musl legs.
- **src/version_cache.yo**: `host_bundle_name` appends `-musl` on Linux; `download_version` retries the pre-musl name on 404 so old versions stay installable.
- **install-seed**: Linux seeds are the static musl bundles (no liburing.so needed to run them).
- **test.yml musl job**: `scripts/bootstrap/probe-stack-sizing.sh` now runs per PR inside Alpine — the answered gate, kept honest continuously.

Note: release.yml gets no PR CI; its changes are proven by the first release cut after this lands (expected v0.2.14). The test.yml/install-seed changes ARE validated by this PR's own run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)