### PR TITLE
ci: promote windows-arm64; seed v0.2.13; windows-11-arm test leg

### DIFF
--- a/.github/workflows/fixpoint-arm64.yml
+++ b/.github/workflows/fixpoint-arm64.yml
@@ -43,7 +43,7 @@ env:
   # THE THIRD PIN. test.yml's lockstep note named only itself and release.yml,
   # so this one sat on v0.2.4 while they moved to v0.2.7 and then v0.2.9 —
   # the same silent drift that note was written about. Bump all THREE together.
-  SEED_VERSION: v0.2.12
+  SEED_VERSION: v0.2.13
   # See test.yml's APT_OPTS comment: a bare apt-get can hang forever on the
   # dpkg lock held by the runner's unattended-upgrades timer.
   APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ env:
   #
   # The raised timeouts (#137, #167) stay. They now buy headroom rather than
   # bare survival, and the cliff they guard is still there for the next seed.
-  SEED_VERSION: v0.2.12
+  SEED_VERSION: v0.2.13
 
   # apt-get waits on /var/lib/dpkg/lock-frontend FOREVER by default, and the
   # runner images run unattended-upgrades / apt-daily timers in the background.
@@ -398,7 +398,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     # Mirrors seed-bundles / seed-bundles-cross. Every leg here is REQUIRED
-    # (experimental: false) except windows-arm64 — see its entry for why this
+    # (experimental: false), windows-arm64 included since v0.2.13 — the
     # job needing the flag at all was a latent release-killer.
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -476,10 +476,12 @@ jobs:
             # portable-c, which feeds publish-release, so a failure here leaves
             # the release an unpublished draft. v0.2.12 survived only because
             # the failure landed in the protected native-compile leg instead.
-            # Safe to skip: scripts/make-portable-c.sh requires only
-            # linux-x64, linux-arm64, macos-x64, macos-arm64 and windows-x64 —
-            # windows-arm64 is not one of its arms.
-            experimental: true
+            # PROMOTED 2026-08-21: v0.2.13 (run 32389196493) was the first
+            # release where this leg went green end-to-end and shipped
+            # yo-v0.2.13-windows-arm64.tar.gz — the emitted-C blocker was the
+            # async shared-await-point family (#187,
+            # issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md).
+            experimental: false
     steps:
       - name: Checkout the released commit
         uses: actions/checkout@v4
@@ -613,14 +615,18 @@ jobs:
             clang_target: x86_64-pc-windows-msvc
             pe_machine: "8664"
             experimental: false
-          # experimental: this leg has never produced an artifact, so it must
-          # not be able to block a release. Promote after one green bundle, the
-          # way windows-x64 was promoted at v0.2.1.
+          # PROMOTED 2026-08-21 per this entry's own rule ("after one green
+          # bundle, the way windows-x64 was promoted at v0.2.1"): v0.2.13
+          # shipped yo-v0.2.13-windows-arm64.tar.gz from this leg's first
+          # green run. Its runner installs clang 22 (no pre-installed LLVM,
+          # unlike windows-latest's 20), where -Wincompatible-pointer-types is
+          # a default ERROR — making this leg the strictest C-conformance
+          # check in the release; that is a feature.
           - os: windows-11-arm
             target: windows-arm64
             clang_target: aarch64-pc-windows-msvc
             pe_machine: "AA64"
-            experimental: true
+            experimental: false
     steps:
       # The checkout provides std + vendor/mimalloc for the bundle contents;
       # the compiler C itself arrives as an artifact from seed-cross-emit.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ env:
   #
   # The raised timeouts (#137, #167) stay. They now buy headroom rather than
   # bare survival, and the cliff they guard is still there for the next seed.
-  SEED_VERSION: v0.2.12
+  SEED_VERSION: v0.2.13
 
   # apt-get waits on /var/lib/dpkg/lock-frontend FOREVER by default, and the
   # runner images run unattended-upgrades / apt-daily timers in the background.
@@ -299,13 +299,13 @@ jobs:
     strategy:
       fail-fast: false
       # One leg per release-bundle target (see release.yml's seed matrix):
-      # linux-x64, linux-arm64, macos-arm64, macos-x64 (macos-26-intel is
-      # the last Intel label GitHub offers), windows-x64. NOT yet covered
-      # here: windows-arm64 (no published seed bundle exists — v0.2.12's
-      # release leg died before uploading one; add a windows-11-arm leg the
-      # release after a windows-arm64 bundle first ships) and
-      # linux-arm64-musl (exercised by the static-musl job and the
-      # musl-only migration, plans/backlog — not a separate leg here).
+      # linux-x64/linux-arm64 (musl bundles — Linux is musl-only), macos-arm64,
+      # macos-x64 (macos-26-intel is the last Intel label GitHub offers),
+      # windows-x64, and windows-arm64 (added once v0.2.13 shipped the first
+      # windows-arm64 seed bundle). windows-11-arm doubles as the strictest
+      # C-conformance runner: it installs clang 22 (no pre-installed LLVM,
+      # unlike windows-latest's 20), where -Wincompatible-pointer-types is a
+      # default ERROR.
       matrix:
         os:
           - ubuntu-latest
@@ -313,6 +313,7 @@ jobs:
           - macos-latest
           - macos-26-intel
           - windows-latest
+          - windows-11-arm
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
v0.2.13 (run 32389196493) was the first release where the windows-arm64 leg went green end-to-end and shipped `yo-v0.2.13-windows-arm64.tar.gz` — the blocker was the async shared-await-point emitted-C family, fixed in #187, plus the system-allocator decision (#185/#186).

- **release.yml**: `experimental: false` for windows-arm64 in both matrices, per their own promote-after-one-green-bundle rule.
- **SEED_VERSION → v0.2.13** everywhere (first release whose bundle matrix covers windows-arm64; also the first musl-only-adjacent seed — its Linux musl bundles are what install-seed now fetches).
- **test.yml**: `windows-11-arm` joins the test matrix, closing the last per-PR coverage gap in the bundle targets. Bonus: that runner installs clang 22 (windows-latest pre-installs 20), where `-Wincompatible-pointer-types` is a default error — the strictest C-conformance leg we have, and exactly the class that bit us.

This PR's own CI runs the new leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)