### PR TITLE
release: publish the portable yo.c per target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,7 +375,8 @@ jobs:
   # CI consumers extract it, put bin/ on PATH, and set YO_STD to the bundled
   # std/. The Linux bundle is glibc + liburing dynamic for now — the
   # static-musl user-facing story is Phase 3 (distribution), not the seed.
-  # ONE portable `yo.c` for every platform, assembled from the per-leg arms.
+  # The portable-C artifacts: ONE .c.gz per platform (per-target split), with
+  # the merged assembly kept as a publish gate only.
   # plans/PORTABLE_C_DISTRIBUTION.md has the rationale and the measurements;
   # the short version is that each arm is a complete translation unit under a
   # preprocessor conditional, so the C compiler selects one and skips the rest
@@ -1107,10 +1108,23 @@ jobs:
           gcc -std=c11 -fsyntax-only -w yo.c \
             || { echo "::error::assembled yo.c does not even parse on linux-x64"; exit 1; }
 
-          gzip -9 -c yo.c > "yo-v${{ needs.release.outputs.version }}.c.gz"
-          ls -la "yo-v${{ needs.release.outputs.version }}.c.gz"
-          gh release upload "v${{ needs.release.outputs.version }}" \
-            "yo-v${{ needs.release.outputs.version }}.c.gz" --clobber
+          # PER-TARGET SPLIT (plans/PORTABLE_C_DISTRIBUTION.md): each arm is a
+          # complete translation unit, so it ships as its own artifact — a
+          # user downloads ~6 MiB instead of the ~30 MiB merged file, for a
+          # measured ~1% compile-time difference. The merged yo.c above stays
+          # as the ASSEMBLY GATE (arm presence + parse check) but is no longer
+          # published; install.sh prefers the per-target file and falls back
+          # to the merged name on releases that predate the split.
+          for required in linux-x64 linux-arm64 macos-x64 macos-arm64 windows-x64 windows-arm64; do
+            test -s "arms/$required.c" || { echo "::error::missing portable arm $required — refusing to publish a partial set"; exit 1; }
+          done
+          VER="${{ needs.release.outputs.version }}"
+          for arm in arms/*.c; do
+            t=$(basename "$arm" .c)
+            gzip -9 -c "$arm" > "yo-v${VER}-${t}.c.gz"
+          done
+          ls -la yo-v*.c.gz
+          gh release upload "v${VER}" yo-v${VER}-*.c.gz --clobber
 
   publish-release:
     name: Publish the release

--- a/plans/PORTABLE_C_DISTRIBUTION.md
+++ b/plans/PORTABLE_C_DISTRIBUTION.md
@@ -492,3 +492,18 @@ fallback.
 4. **D** (arch-identity ratchet) any time after A.
 5. "One universal C file" — only if it is ever worth the evaluator work; the
    codegen half is well understood and cheap, the evaluator half is not.
+
+## Per-target split — EXECUTED 2026-08-21 (item C, branch `release/portable-c-per-target`)
+
+Releases now publish **one `yo-<v>-<target>.c.gz` per platform** (six of them,
+windows-arm64 included since its v0.2.13 promotion) instead of the merged
+`yo-<v>.c.gz`. The win is download/disk — ~6 MiB per user instead of ~30 —
+against a measured ~1% compile-time delta; the merged-file OBJECTION above
+(decoupled platform constants) never applied to splitting, since each arm is a
+complete translation unit from one emitter run.
+
+The merged assembly is NOT gone: `scripts/make-portable-c.sh` still runs in
+the `portable-c` job as the publish GATE (arm presence + a gcc parse of the
+merged file), it just stops being uploaded. `install.sh --from-source` prefers
+the per-target file and probes back to the merged name on releases that
+predate the split.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -692,8 +692,16 @@ pick_c_compiler() {
 }
 
 install_from_source() {
-  cfile="yo-$VERSION.c.gz"
+  # Per-target split (2026-08-21): releases publish one ~6 MiB
+  # yo-<v>-<target>.c.gz per platform instead of the ~30 MiB merged file.
+  # Older releases only have the merged yo-<v>.c.gz — probe, then fall back.
+  cfile="yo-$VERSION-$OSARCH.c.gz"
   curl_url="$YO_DIST_BASE_URL/$VERSION/$cfile"
+  if ! download_probe "$curl_url"; then
+    info "$VERSION predates the per-target yo.c split — using the merged file."
+    cfile="yo-$VERSION.c.gz"
+    curl_url="$YO_DIST_BASE_URL/$VERSION/$cfile"
+  fi
   src_url="https://github.com/$YO_REPO/archive/refs/tags/$VERSION.tar.gz"
   target="$PREFIX/lib/yo/$VERSION"
   bindir="$PREFIX/bin"


### PR DESCRIPTION
**DRAFT until #192 merges** (its windows-arm64 promotion makes the arm64 arm requirable here).

Releases publish one `yo-<v>-<target>.c.gz` per platform — six files, windows-arm64 included — instead of the merged ~30 MiB `yo-<v>.c.gz`. The user win is download/disk (~6 MiB each); the measured compile-time delta is ~1%, and the merged-file objection (decoupled platform constants) never applied to splitting since each arm is a complete translation unit from one emitter run.

- `portable-c` job: requires all six arms, gzips and uploads them individually; the merged assembly (make-portable-c.sh + gcc parse) stays as the publish gate but is no longer uploaded.
- `install.sh --from-source`: prefers the per-target file, probes back to the merged name for pre-split releases.
- plans/PORTABLE_C_DISTRIBUTION.md records the execution.

release.yml half is proven by the next release cut (v0.2.14, which also proves the musl-only machinery from #190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)