### PR TITLE
ci: weekly cross-emitted language suite on macOS/Windows targets

### DIFF
--- a/.github/workflows/suite-cross-targets.yml
+++ b/.github/workflows/suite-cross-targets.yml
@@ -1,0 +1,187 @@
+name: Language suite on cross-emitted targets
+
+# The remaining half of "run ./tests on ALL targets". The per-PR test matrix
+# runs the language suite only under the stage-1 binary on Linux: the suite
+# contains regression tests coupled to THIS tree's compiler, so the seed
+# cannot run it (it fails by construction on every test newer than the seed),
+# and the macOS runners (~7 GB) cannot host the ~15 GB self-build that would
+# produce a tree-built compiler natively. Cross-emit resolves both constraints
+# the same way the release does: Linux (with the swapfile) builds the
+# CANDIDATE from this tree, the candidate cross-emits per-target C, and each
+# target runner compiles that C natively and runs the FULL language suite with
+# the resulting binary against this checkout's std. This is what exercises the
+# per-platform async runtimes (the ~5,900 lines of macOS/Windows io backends)
+# at suite depth rather than hello-world depth.
+#
+# SCHEDULED + dispatchable, not per-PR: four self-emits plus four native suite
+# runs per PR is not a sane budget, and the code this covers changes rarely.
+# Same shape and reasoning as fixpoint-arm64.yml. Deliberately NOT a required
+# status check, and deliberately NO `paths:` filter (a filtered workflow later
+# promoted to required leaves unrelated PRs pending forever).
+
+on:
+  schedule:
+    # Weekly, Sundays 06:17 UTC — after fixpoint-arm64's 04:17, off-peak, odd
+    # minute to dodge the top-of-hour scheduler stampede.
+    - cron: "17 6 * * 0"
+  workflow_dispatch:
+
+concurrency:
+  group: suite-cross-targets
+  cancel-in-progress: true
+
+env:
+  # LOCKSTEP PIN with test.yml / release.yml / fixpoint-arm64.yml — bump all
+  # FOUR together (fixpoint-arm64 documents the drift this note prevents).
+  SEED_VERSION: v0.2.13
+  APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"
+
+jobs:
+  cross-emit:
+    name: Cross-emit suite compiler (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: macos-arm64
+            yo_target: aarch64-macos
+          - target: macos-x64
+            yo_target: x86_64-macos
+          - target: windows-x64
+            yo_target: x86_64-windows-msvc
+          - target: windows-arm64
+            yo_target: aarch64-windows-msvc
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # Same memory treatment as every self-emitting job (see release.yml's
+      # seed-cross-emit for the 16 min vs 159 min zswap measurement).
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 32G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+
+      - name: Tune the kernel for a swap-heavy self-emit
+        run: |
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled || true
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/defrag || true
+          echo Y | sudo tee /sys/module/zswap/parameters/enabled || true
+
+      - name: Install liburing (needed to run the seed's compiled children)
+        run: |
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y liburing-dev
+
+      - name: Install the seed compiler (previous release)
+        uses: ./.github/actions/install-seed
+        with:
+          version: ${{ env.SEED_VERSION }}
+
+      # The CANDIDATE does the cross-emit, not the seed — same rule and reason
+      # as release.yml's seed-cross-emit (a pre-f7b5cc460 seed would bake the
+      # HOST's platform constants into the target's C).
+      - name: Build the candidate compiler (previous seed, native)
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: yo compile src/main.yo --release --allocator mimalloc --std-path ./std -o yo-candidate
+
+      # --allocator system so the native leg needs no vendored-mimalloc link
+      # line: this binary exists to RUN the suite, not to be measured.
+      - name: "Cross-emit the suite compiler C (${{ matrix.yo_target }})"
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: |
+          mkdir -p cross
+          ./yo-candidate compile src/main.yo --release --allocator system \
+            --std-path ./std --target ${{ matrix.yo_target }} \
+            --emit-c --skip-c-compiler -o "cross/yo-${{ matrix.target }}" > /dev/null
+          ls -la "cross/yo-${{ matrix.target }}.c"
+
+      - name: Upload the emitted C
+        uses: actions/upload-artifact@v4
+        with:
+          name: suite-c-${{ matrix.target }}
+          path: cross/yo-${{ matrix.target }}.c
+          retention-days: 1
+          if-no-files-found: error
+
+  native-suite:
+    name: Native language suite (${{ matrix.target }})
+    needs: cross-emit
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 240
+    env:
+      YO_MAIN_STACK_MB: "4096"
+      # Same staging ratchet as test.yml's legs: leak verdicts stay off, ASan
+      # crash detection stays armed.
+      YO_TEST_LEAK_VERDICT: "0"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: macos-arm64
+          - os: macos-26-intel
+            target: macos-x64
+          - os: windows-latest
+            target: windows-x64
+          - os: windows-11-arm
+            target: windows-arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download the cross-emitted C
+        uses: actions/download-artifact@v4
+        with:
+          name: suite-c-${{ matrix.target }}
+          path: cross
+
+      - name: Install LLVM/Clang
+        if: runner.os == 'Windows'
+        run: |
+          choco install llvm -y
+          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      # Same flag set as release.yml's native legs. `--target=` is explicit on
+      # Windows for the same reason it is there: chocolatey's clang default
+      # target is not guaranteed to be this runner's.
+      - name: Compile the suite compiler natively
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            case "${{ matrix.target }}" in
+              windows-x64)   CT=x86_64-pc-windows-msvc ;;
+              windows-arm64) CT=aarch64-pc-windows-msvc ;;
+            esac
+            clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
+              --target=$CT \
+              "cross/yo-${{ matrix.target }}.c" \
+              -lws2_32 -lbcrypt -ladvapi32 \
+              -o yo-suite.exe
+            ./yo-suite.exe --version
+          else
+            clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 \
+              "cross/yo-${{ matrix.target }}.c" \
+              -o yo-suite
+            ./yo-suite --version
+          fi
+
+      # The full language corpus, natively, under the TREE-BUILT compiler —
+      # the same invocation as test.yml's Linux "Run tests" step. YO_STD pins
+      # this checkout's std (the binary sits in the repo root, so its walk-up
+      # would find ./std anyway; the pin makes it explicit).
+      - name: Run the language suite
+        shell: bash
+        run: |
+          if [ -f yo-suite.exe ]; then YO=./yo-suite.exe; else YO=./yo-suite; fi
+          YO_STD="$PWD/std" "$YO" test ./tests --exclude tests/internal --exclude tests/cli-cases --bail --verbose --c-compiler clang


### PR DESCRIPTION
Closes the last "run `./tests` on all targets" gap. The per-PR matrix runs the language suite only on Linux — the suite is regression-coupled to THIS tree's compiler (the seed fails it by construction), and macOS runners can't host the ~15 GB self-build. Cross-emit resolves both, the way the release already does:

1. **cross-emit** (ubuntu, swap+zswap): seed → candidate → per-target C (`--allocator system`) for macos-arm64/x64 and windows-x64/arm64.
2. **native-suite**: each target runner clang-compiles its C and runs the **full corpus** (`yo test ./tests --exclude tests/internal --exclude tests/cli-cases`) with this checkout's std.

Weekly (Sun 06:17 UTC) + `workflow_dispatch`, mirroring `fixpoint-arm64.yml`; deliberately not a required check and no `paths:` filter. First real suite-depth exercise of the macOS/Windows async io backends (~5,900 lines) that were previously only hello-world-smoked at release time.

After merge I'll dispatch it once to validate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)