### PR TITLE
test runner: tolerate Windows exe lock in batch cleanup (retry + warn)

### DIFF
--- a/issues/fixed/test-runner-windows-batch-cleanup-exe-lock.md
+++ b/issues/fixed/test-runner-windows-batch-cleanup-exe-lock.md
@@ -1,0 +1,63 @@
+# `yo test` aborts the whole suite when Windows still holds a just-exited batch `.exe`
+
+**Status: FIXED** — tolerant removal (`_remove_batch_artifact`, retry + warn) in
+`src/main.yo`'s batch cleanup.
+
+## Symptom
+
+First `suite-cross-targets.yml` run (32402145272), **windows-arm64** native
+suite leg (job 96539243685): every test in `arc.test.yo` passed, then
+
+```
+yo: error: permission denied
+```
+
+and the entire run aborted — two files into a ~190-file corpus. Timestamps
+show the error at `18:44:28.2878`, ~40 ms after the last test child exited
+(`18:44:28.2473`). The windows-x64 leg of the same run passed the full corpus,
+so the failure is a timing race, not an arm64 semantic difference.
+
+## Root cause
+
+The test runner compiles each batch into a temp executable, runs it as a child
+process per test, then deletes the artifacts:
+
+```rust
+// src/main.yo batch cleanup (before the fix)
+io.await(remove_file(Path.new(tmp_yo.clone()), io), IoExn(io : io, exn : exn));
+io.await(remove_file(Path.new(tmp_bin.clone()), io), IoExn(io : io, exn : exn));
+io.await(remove_file(Path.new(tmp_c.clone()), io), IoExn(io : io, exn : exn));
+```
+
+On Windows, deleting an executable milliseconds after its process exits can
+transiently return `ERROR_ACCESS_DENIED`: the process object may not be fully
+reaped, and Windows Defender's real-time scan commonly opens a just-exited
+binary. The raw `remove_file` failure threw through `IoExn` into the suite's
+top-level handler, aborting the run.
+
+The retired TS runner (`src-attic-final:src/test-runner.ts:485-499`) used bare
+`fs.unlinkSync` with no Windows handling — it never ran the suite on Windows,
+so there are no reference semantics to mirror.
+
+## Fix
+
+`_remove_batch_artifact` in `src/main.yo`: up to 8 attempts, each under a
+swallowing handler (`_try_remove_once`, same fn-boundary pattern as
+`_probe_liburing`), with exponential backoff (25 ms doubling, ~3.2 s total
+budget). A final failure prints a warning naming the leaked path and
+continues — a leaked temp artifact must never abort a test run. This is
+correct semantics, not a workaround: cleanup is best-effort by nature.
+
+Applied to all four batch artifacts (`tmp_yo`, `tmp_bin`, `tmp_c`, and the
+emcc sibling `.wasm`).
+
+## Validation
+
+- Retry/warn semantics verified in isolation: a standalone program using the
+  helper against a nonexistent path retries, warns, and exits 0 (never
+  throws).
+- `yo test ./tests/arc.test.yo` with the fixed binary: 15/15 passed, no
+  leftover artifacts, no warnings (the happy path still removes on the first
+  attempt).
+- End-to-end proof: re-dispatch `suite-cross-targets.yml` after merge — the
+  windows-arm64 leg is the reproducer.

--- a/src/main.yo
+++ b/src/main.yo
@@ -31,6 +31,7 @@ _(env : proc_env) :: import("std/env");
 { read_file, write_file, exists } :: import("std/fs/file");
 { metadata } :: import("std/fs/metadata");
 { read_dir, FileType, remove_file, create_dir_all } :: import("std/fs/dir");
+{ sleep } :: import("std/time/sleep");
 { Command } :: import("std/process/command");
 { exit } :: import("std/libc/stdlib");
 { ArrayList } :: import("std/collections/array_list");
@@ -838,6 +839,48 @@ _path_has_extension :: (fn(p : String) -> bool)({
   // A dot counts only after the last slash and not as the basename's first
   // character (path.extname(".bashrc") === "" in Node).
   last_dot > (last_slash + isize(1))
+});
+/// One removal attempt under a swallowing handler (the `unwind` needs its own
+/// fn boundary, same pattern as `_probe_liburing`). Success is signalled by
+/// the push; a throw of any kind leaves `ok` empty.
+_try_remove_once :: (fn(path : String, io : Io, ok : ArrayList(bool)) -> unit)({
+  try_exn := Exception(
+    throw : (
+      (_e) -> {
+        unwind(());
+      }
+    )
+  );
+  io.await(remove_file(Path.new(path.clone()), io), IoExn(io : io, exn : try_exn));
+  ok.push(true);
+});
+/// Remove a test-batch artifact, tolerating Windows's just-exited-executable
+/// lock. Deleting a batch `.exe` ~40 ms after its last test child exits can
+/// return "permission denied" while the process object (or a Defender scan)
+/// still holds the file — first hit on the windows-arm64 suite run
+/// 32402145272, where the raw `remove_file` throw aborted the whole run two
+/// files in. Retries with a growing pause (~3 s total budget); a FINAL
+/// failure downgrades to a warning, because a leaked temp artifact must
+/// never abort a test run. (The TS runner's cleanup was equally non-fatal
+/// only by never having run the suite on Windows.)
+_remove_batch_artifact :: (fn(path : String, io : Io) -> unit)({
+  (attempt : usize) = usize(0);
+  (removed : bool) = false;
+  (pause_ms : usize) = usize(25);
+  while(!(removed) && (attempt < usize(8)), {
+    ok := ArrayList(bool).new();
+    _try_remove_once(path.clone(), io, ok);
+    removed = (ok.len() > usize(0));
+    attempt = (attempt + usize(1));
+    // No pause after the FINAL failed attempt — it would only delay the warning.
+    if(!(removed) && (attempt < usize(8)), {
+      sleep(pause_ms);
+      pause_ms = (pause_ms * usize(2));
+    });
+  });
+  if(!(removed), {
+    println(`  warning: could not remove batch artifact ${path} (still locked?) — leaving it behind`);
+  });
 });
 /// Is liburing available for linking? Mirrors `isLiburingAvailable` in
 /// `src/compiler-utils.ts`: probe `pkg-config --exists liburing`.
@@ -2262,15 +2305,19 @@ run_test :: (
         // failing batch's .yo/.c can be inspected — batch-only miscompiles
         // (the collections residuals) are unreproducible otherwise.
         if(proc_env.get(`YO_KEEP_BATCH`).is_none(), {
-          io.await(remove_file(Path.new(tmp_yo.clone()), io), IoExn(io : io, exn : exn));
-          io.await(remove_file(Path.new(tmp_bin.clone()), io), IoExn(io : io, exn : exn));
-          io.await(remove_file(Path.new(tmp_c.clone()), io), IoExn(io : io, exn : exn));
+          // Tolerant removal (retry + warn), NOT a raw remove_file: Windows
+          // holds a just-exited batch .exe for a few ms (process reaping /
+          // Defender), and the raw throw aborted the whole suite — see
+          // _remove_batch_artifact.
+          _remove_batch_artifact(tmp_yo.clone(), io);
+          _remove_batch_artifact(tmp_bin.clone(), io);
+          _remove_batch_artifact(tmp_c.clone(), io);
           // Emscripten's second output: the JS glue at `tmp_bin` is paired
           // with a sibling `<base>.wasm` that no other cleanup path names, so
           // without this every emcc batch leaks one file into the test tree
           // (TS tracks it as `testWasmPath`, test-runner.ts:459).
           if(run_is_emcc, {
-            io.await(remove_file(Path.new(`${batch_base}.wasm`), io), IoExn(io : io, exn : exn));
+            _remove_batch_artifact(`${batch_base}.wasm`, io);
           });
         });
         batch_start = batch_end;


### PR DESCRIPTION
## Problem

The first `suite-cross-targets.yml` run (32402145272) proved the cross-emitted native suite works — **macos-arm64, macos-x64, and windows-x64 all ran the full corpus green** — but the **windows-arm64** leg aborted two files in with `yo: error: permission denied`.

Timing in the log: last test child of `arc.test.yo` exited at 18:44:28.2473; the error fired at 18:44:28.2878 — **~40 ms later**, in the batch cleanup. Deleting a just-exited `.exe` on Windows transiently returns `ERROR_ACCESS_DENIED` (process reaping / Defender real-time scan), and the raw `remove_file` throw propagated through `IoExn` and killed the suite.

The retired TS runner used bare `fs.unlinkSync` with no Windows handling — it never ran the suite on Windows, so there are no reference semantics to mirror.

## Fix

`_remove_batch_artifact` (src/main.yo): up to 8 attempts, each under a swallowing handler (same fn-boundary pattern as `_probe_liburing`), exponential backoff 25 ms doubling (~3.2 s budget). Final failure → warning naming the leaked path, suite continues. This is correct semantics, not a workaround: cleanup is best-effort by nature; a leaked temp file must never abort a test run.

Applied to all four batch artifacts (`tmp_yo`, `tmp_bin`, `tmp_c`, emcc sibling `.wasm`).

## Validation

- Retry/warn semantics verified in isolation: standalone program using the helper against a nonexistent path retries, warns, exits 0.
- `yo test ./tests/arc.test.yo` with the fixed binary: 15/15, no leftover artifacts, no warnings (happy path unchanged — first-attempt removal).
- `yo check ./src`: 248/248.
- End-to-end proof after merge: re-dispatch `suite-cross-targets.yml` — the windows-arm64 leg is the reproducer.

Record: `issues/fixed/test-runner-windows-batch-cleanup-exe-lock.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)