### PR TITLE
compile: pin --target on native Windows compiles (x64 clang under WoA emulation)

### DIFF
--- a/issues/fixed/native-windows-compile-trusts-clang-default-triple.md
+++ b/issues/fixed/native-windows-compile-trusts-clang-default-triple.md
@@ -1,0 +1,76 @@
+# Native compile on Windows trusts clang's default triple — x64 LLVM under Windows-on-ARM silently produces x64 binaries
+
+**Status: FIXED** — native Windows compiles pin `--target=<host clang triple>`
+explicitly (`run_compile`, `src/main.yo`).
+
+## Symptom
+
+Second `suite-cross-targets.yml` run (32413596987), windows-arm64 native suite
+leg: `tests/asm.test.yo`'s batch failed C compilation with
+
+```
+tests/.yo_selftest_batch_4_0.bin.c:2752:19: error: unknown token in expression
+ 2752 |                   "add %0, %1, #5"
+<inline asm>:1:18: note: instantiated into assembly here
+    1 |         add %eax, %eax, #5
+```
+
+The asm **templates** are the aarch64 branches (`mov {0}, #42`,
+`add {0}, {1}, #5` — `#` immediates), but the **register substitution** is x86
+(`%eax`, `%ecx`): clang compiled the batch for x86_64.
+
+## Root cause
+
+Two facts combine:
+
+1. `run_compile` resolves the compilation target as "`--target` if given, else
+   `host_target()`", folds every comptime `platform`/`arch` constant for it —
+   but only puts `--target=` on the C compiler command line when the user
+   passed one. A **native** compile trusts the C compiler's *default* triple
+   to equal the host.
+2. On windows-11-arm runners, `choco install llvm` installs an **x86_64 LLVM
+   build** that runs transparently under Windows-on-ARM emulation. Its default
+   triple is `x86_64-pc-windows-msvc`.
+
+So the (genuinely arm64) suite compiler folded `arch == Aarch64` — selecting
+the aarch64 inline-asm branches — then handed the C to a clang that compiled
+for x64. Every *other* batch also silently compiled as x64 and passed by
+running under emulation; only inline asm makes the skew visible. The same
+skew affects any windows-arm64 user with an x64 LLVM installed: `yo compile`
+would produce x64 binaries with arm64-folded comptime constants.
+
+This is the same environment fact every CI workflow already compensates for by
+hand (release.yml / test.yml / suite-cross-targets.yml all pass an explicit
+`--target=` when invoking clang on Windows: "chocolatey's clang default target
+is not guaranteed to be this runner's") — but the compiler's own child
+invocations had no such pin.
+
+## Fix
+
+In `run_compile`'s C-compiler command construction: when no `--target` was
+given and the resolved (host) target is Windows and the compiler is
+clang-flavored, pass `--target=${clang_triple(target)}` explicitly. `yo build`
+shells out to `self compile --target ...` per artifact, so this one site
+covers build, compile, and the test runner's per-batch compiles.
+
+Scoped to Windows deliberately:
+
+- gcc has no `--target` flag, hence the clang guard.
+- Blanket always-passing on every OS would break native Alpine builds:
+  `detect_linux_abi` is currently a stub returning `Gnu`, so a pinned
+  `--target=x86_64-linux-gnu` on a musl host would fight clang's correct
+  `-alpine-linux-musl` default. Windows has no such ambiguity (msvc).
+
+## Validation
+
+- macOS: full local `yo test ./tests/asm.test.yo` passes (13/13); the new
+  branch is dormant off-Windows.
+- End-to-end reproducer: the `suite-cross-targets.yml` windows-arm64 leg —
+  re-dispatched after merge.
+
+## History
+
+Surfaced by the same suite run family as
+`issues/fixed/test-runner-windows-batch-cleanup-exe-lock.md` (run 1's failure);
+run 2 got past that fix and far enough to hit this. windows-x64 passes either
+way because the x64 clang default happens to match that host.

--- a/src/main.yo
+++ b/src/main.yo
@@ -72,7 +72,7 @@ _(env : proc_env) :: import("std/env");
 { evaluate_anonymous_module_begin_exprs } :: import("./evaluator/values/anonymous_module.yo");
 { clear_module_cache } :: import("./evaluator/module_loader.yo");
 { format_yo_source, format_yo_files, FormatYoFilesOptions } :: import("./formatter.yo");
-{ host_target, set_current_target, parse_target, TargetInfo, is_target_linux, is_target_windows, is_target_macos, is_target_wasm, is_target_standalone_wasi } :: import("./target.yo");
+{ host_target, set_current_target, parse_target, TargetInfo, clang_triple, is_target_linux, is_target_windows, is_target_macos, is_target_wasm, is_target_standalone_wasi } :: import("./target.yo");
 { set_target_pointer_size } :: import("./types/utils.yo");
 { compile_module } :: import("./codegen/codegen_c.yo");
 { get_needs_intel_asm_syntax, get_uses_parallelism } :: import("./codegen/utils/index.yo");
@@ -1585,6 +1585,19 @@ run_compile :: (
   if(cc != "emcc", {
     if(target_triple != "", {
       cmd.arg(`--target=${target_triple}`);
+    }, {
+      // Native compiles trust the C compiler's DEFAULT triple to equal the
+      // host. On Windows that trust is misplaced: an x86_64 LLVM build runs
+      // transparently under Windows-on-ARM emulation and defaults to
+      // x86_64-pc-windows-msvc, so a native compile on an arm64 host would
+      // silently produce an x64 binary while every comptime platform/arch
+      // constant had already folded for arm64 (first hit: suite run
+      // 32413596987, where tests/asm.test.yo's aarch64 inline-asm templates
+      // reached an x64-targeting clang). Pin the resolved host triple
+      // explicitly — clang only; gcc has no --target flag.
+      if(is_target_windows(target) && cc.contains("clang"), {
+        cmd.arg(`--target=${clang_triple(target)}`);
+      });
     });
     if(sysroot != "", {
       cmd.arg(`--sysroot=${sysroot}`);


### PR DESCRIPTION
## Problem

Second `suite-cross-targets.yml` run (32413596987): the windows-arm64 leg got past #195's cleanup fix and failed deeper, in `tests/asm.test.yo` — aarch64 inline-asm templates (`mov {0}, #42`) instantiated with **x86 registers** (`%eax`):

```
tests/.yo_selftest_batch_4_0.bin.c:2752:19: error: unknown token in expression
 "add %0, %1, #5"   →   add %eax, %eax, #5
```

Root cause: `run_compile` folds every comptime `platform`/`arch` constant for the resolved target (host when no `--target`), but only puts `--target=` on the clang line for explicit cross builds. Native compiles trust clang's **default** triple to equal the host — false on windows-11-arm, where `choco install llvm` installs an x86_64 LLVM running under Windows-on-ARM emulation, defaulting to `x86_64-pc-windows-msvc`. Every batch silently compiled as x64 and passed under emulation; only inline asm exposes the skew. Real-world impact: any windows-arm64 user with an x64 LLVM gets x64 binaries with arm64-folded comptime constants.

## Fix

When no `--target` was given, the resolved (host) target is Windows, and the compiler is clang-flavored, pass `--target=${clang_triple(target)}` explicitly. `yo build` shells to `self compile` per artifact, so this single site in `run_compile` covers build, compile, and the test runner's per-batch compiles.

Deliberately scoped to Windows: gcc has no `--target` flag, and blanket pinning would break native Alpine builds while `detect_linux_abi` is still a Gnu stub (a pinned `x86_64-linux-gnu` would fight clang's correct `-alpine-linux-musl` default). This is the same pin every CI workflow already applies by hand to its own clang invocations ("chocolatey's clang default target is not guaranteed to be this runner's") — now the compiler's own child invocations carry it too.

## Validation

- `yo check ./src`: green; full local `yo test ./tests/asm.test.yo`: 13/13 (branch dormant off-Windows).
- End-to-end reproducer: re-dispatch `suite-cross-targets.yml` after merge — its windows-arm64 leg is the regression test (run 1 → exe-lock bug #195, run 2 → this, runs 3+ gate both).

Record: `issues/fixed/native-windows-compile-trusts-clang-default-triple.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)