### PR TITLE
docs: P3 status — v0.2.14 proves the reworked release machinery

### DIFF
--- a/plans/P3_DISTRIBUTION.md
+++ b/plans/P3_DISTRIBUTION.md
@@ -5,6 +5,37 @@
 as `P1_CLI_PARITY.md`/`P2_RETIRE_SRC.md`: measured numbers, live status,
 traps recorded as found. Drafted 2026-08-11; **item 1 landed 2026-08-12**.
 
+## Status 2026-08-21 — every item PROVEN by shipped releases; only the gate run remains
+
+**v0.2.14 (2026-08-21) is the first release through the fully reworked
+machinery, and every leg was green on the first dispatch:**
+
+- **musl-only Linux** (#190): `linux-x64-musl` + `linux-arm64-musl` are the
+  ONLY Linux bundles — the glibc `seed-bundles` job is deleted. `install.sh`
+  is musl-first with a pre-musl fallback; `version_cache` retries the pre-musl
+  name on 404 (x64: v0.2.7+, arm64: v0.2.12+ have musl assets).
+- **Per-target portable `yo.c`** (#193): six `yo-v0.2.14-<target>.c.gz`
+  assets published; the merged assembly is kept as a gate but no longer
+  uploaded (download/disk win 30→6 MiB — compile time measured at 1%).
+- **windows-arm64** is a full, non-experimental leg (first bundle shipped in
+  v0.2.13; second in v0.2.14).
+
+**The language suite now runs on ALL SIX targets** — Linux both arches per-PR
+(test.yml), and macos-arm64/macos-x64/windows-x64/windows-arm64 weekly via
+`.github/workflows/suite-cross-targets.yml` (#194: candidate cross-emits
+per-target C, native runners compile and run the full corpus). Its first three
+runs surfaced and then gated two real Windows bugs:
+`issues/fixed/test-runner-windows-batch-cleanup-exe-lock.md` (#195) and
+`issues/fixed/native-windows-compile-trusts-clang-default-triple.md` (#196 —
+an x64 LLVM under Windows-on-ARM emulation defaults to x86_64, so native
+Windows compiles now pin `--target=` explicitly). Run 3 (32421399142): all
+four native legs green.
+
+Still open before this doc can close: the **Gate** below (fresh-VM
+`curl … | sh` → `yo init && yo build test` per platform, Alpine included) has
+not been executed in its literal form, and item 1's optional `--vscode` flag
+remains unbuilt.
+
 ## CRITICAL PATH 2026-08-15 — cutting a release is now the blocker
 
 Four P3 deliverables are built, committed and CI-verified, and every one of them

--- a/plans/SELF_HOSTING_COMPLETION.md
+++ b/plans/SELF_HOSTING_COMPLETION.md
@@ -362,7 +362,7 @@ from its merge.
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | P1 CLI parity    | **COMPLETE** 2026-08-10                                                                                                                               |
 | P2 retire `src/` | 2.1/2.2/2.4 **DONE**; 2.3 **in review** (needs a v0.2.4 seed); 2.5 planned, 2.6 after it                                                              |
-| P3 distribution  | five bundles **shipping**; installers **landed**; `yo version` on Releases and static-musl **open** — and musl now has a second reason (NixOS/Alpine) |
+| P3 distribution  | **PROVEN by v0.2.14 (2026-08-21)**: six bundles (musl-only Linux, windows-arm64 included) + six per-target `yo.c`; installers landed; `yo version` on Releases; suite runs on all six targets — only the fresh-VM gate run remains (`P3_DISTRIBUTION.md`) |
 | P4 LSP           | **scoped**, blocked on the def-eval swallow                                                                                                           |
 
 The strict phase order has held with one exception worth noting: P3's


### PR DESCRIPTION
Docs-only. Records in `plans/P3_DISTRIBUTION.md` and the umbrella doc that v0.2.14 (first release through the reworked machinery, green on first dispatch) proves musl-only Linux (#190), the per-target `yo.c` split (#193), and windows-arm64 as a full leg — and that the language suite now runs on all six targets (#194), with the two Windows bugs it surfaced fixed (#195, #196). Remaining before P3 can close: the literal fresh-VM gate run and item 1's optional `--vscode` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)