### PR TITLE
ci: SEED_VERSION consistency guard + release-time auto-bump (seed → v0.2.14)

### DIFF
--- a/.github/workflows/fixpoint-arm64.yml
+++ b/.github/workflows/fixpoint-arm64.yml
@@ -40,10 +40,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # THE THIRD PIN. test.yml's lockstep note named only itself and release.yml,
-  # so this one sat on v0.2.4 while they moved to v0.2.7 and then v0.2.9 —
-  # the same silent drift that note was written about. Bump all THREE together.
-  SEED_VERSION: v0.2.13
+  # THE THIRD PIN. test.yml's lockstep note once named only itself and
+  # release.yml, so this one sat on v0.2.4 while they moved to v0.2.7 and
+  # then v0.2.9 — that drift is why the pins are now guarded (test.yml
+  # `changes` job) and bumped automatically at release time (release.yml
+  # publish-release). Full rationale: test.yml's SEED_VERSION comment.
+  SEED_VERSION: v0.2.14
   # See test.yml's APT_OPTS comment: a bare apt-get can hang forever on the
   # dpkg lock held by the runner's unattended-upgrades timer.
   APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,22 +14,12 @@ on:
 
 env:
   # The previous-release seed used by the seed-driven steps below (the musl
-  # bundle's Yo->C emit). Same trust-chain root as test.yml's SEED_VERSION;
-  # bump to the latest PUBLISHED release whose bundle matrix covers the
-  # needed targets.
-  #
-  # v0.2.9 -> v0.2.11 (2026-08-20). v0.2.9 was cut eight hours BEFORE #145
-  # (memoize _inject_forall_captures), so it peaks at ~28.4 GB compiling this
-  # tree against v0.2.4's 14.5 GB — measured, not inferred. On 16 GB runners
-  # that put every seed-driven job onto the swapfile and made CI wall-clock a
-  # cliff function of memory; it is what turned seed-bundles' linux-x64 leg into
-  # a 159-minute job during the v0.2.10 release. v0.2.11 carries the fix in its
-  # OWN codegen, which is the generation that matters — see
-  # issues/seed-v0.2.9-memory-growth-slows-every-self-build.md.
-  #
-  # The raised timeouts (#137, #167) stay. They now buy headroom rather than
-  # bare survival, and the cliff they guard is still there for the next seed.
-  SEED_VERSION: v0.2.13
+  # bundle's Yo->C emit). Same trust-chain root as test.yml's SEED_VERSION —
+  # the full rationale and seed history live THERE. This pin is kept in
+  # lockstep by the auto-bump in publish-release below and the consistency
+  # guard in test.yml's `changes` job
+  # (plans/backlog/SEED_VERSION_AUTOMATION.md).
+  SEED_VERSION: v0.2.14
 
   # apt-get waits on /var/lib/dpkg/lock-frontend FOREVER by default, and the
   # runner images run unattended-upgrades / apt-daily timers in the background.
@@ -1162,6 +1152,47 @@ jobs:
             exit 1
           fi
           gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}"             -F draft=false -f make_latest=true --jq .html_url
+
+      # Seed auto-bump (plans/backlog/SEED_VERSION_AUTOMATION.md): the release
+      # is public with a complete bundle matrix (every artifact job is in this
+      # job's `needs`), so the just-published version becomes the new bootstrap
+      # seed in all three workflows. Pushed DIRECTLY to develop with
+      # RELEASE_PAT — the same mechanism and trust level as the release job's
+      # version-bump push — and deliberately WITHOUT [skip ci]: the push
+      # exercises the new seed on develop immediately, so a bad seed is a
+      # visible red plus a one-line revert, not a latent trap for the next PR.
+      # Runs only on this job's success path by step order: the Publish step
+      # above has already exited non-zero on any failure.
+      - name: Checkout develop for the seed bump
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          path: seed-bump
+      - name: Bump SEED_VERSION to this release on develop
+        working-directory: seed-bump
+        run: |
+          set -euo pipefail
+          new="v${{ needs.release.outputs.version }}"
+          old=$(grep -hE '^[[:space:]]*SEED_VERSION: v' .github/workflows/test.yml | awk '{print $2}')
+          if [ "$old" = "$new" ]; then
+            echo "SEED_VERSION is already ${new} — nothing to bump."
+            exit 0
+          fi
+          for f in test.yml release.yml fixpoint-arm64.yml; do
+            sed -i "s|^\([[:space:]]*SEED_VERSION:\) ${old}\$|\1 ${new}|" ".github/workflows/$f"
+          done
+          changed=$(git diff --name-only | wc -l)
+          if [ "$changed" -ne 3 ]; then
+            echo "::error::seed bump expected to touch exactly 3 workflows, touched ${changed} — did a pin move or diverge? Bump manually (see test.yml's SEED_VERSION comment)."
+            exit 1
+          fi
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .github/workflows/test.yml .github/workflows/release.yml .github/workflows/fixpoint-arm64.yml
+          git commit -m "ci: bump SEED_VERSION to ${new} (release-pipeline auto-bump)"
+          git push || { echo "::error::Seed-bump push to develop failed — is the RELEASE_PAT secret set and unexpired (fine-grained, Contents: read/write)?"; exit 1; }
+          echo "SEED_VERSION ${old} -> ${new} pushed to develop."
 
   # The site deploy waits for publish-release ON PURPOSE.
   #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,11 +60,15 @@ env:
   # seed-driven jobs at the download, which is exactly what happened on the
   # first push of this pin.
   #
-  # Keep this pin in lockstep with release.yml AND fixpoint-arm64.yml: bump ALL THREE as
-  # part of each release's follow-up (the deliberate-pin rationale — chain
-  # auditability, bad-release containment, reproducible re-runs — is recorded
-  # in plans/P2_5_RETIRE_EXECUTION.md step 24). This one had silently drifted
-  # to v0.2.4 while release.yml advanced to v0.2.7.
+  # Keep this pin in lockstep with release.yml AND fixpoint-arm64.yml (the
+  # deliberate-pin rationale — chain auditability, bad-release containment,
+  # reproducible re-runs — is recorded in plans/P2_5_RETIRE_EXECUTION.md
+  # step 24). This one had silently drifted to v0.2.4 while release.yml
+  # advanced to v0.2.7. Since 2026-08-21 the lockstep is AUTOMATED: the
+  # `changes` job above guards the three pins against divergence, and
+  # release.yml's publish-release pushes the bump for every published
+  # release (plans/backlog/SEED_VERSION_AUTOMATION.md). Manual edits remain
+  # for ROLLING BACK a bad seed.
   #
   # v0.2.9 -> v0.2.11 (2026-08-20). v0.2.9 was cut eight hours BEFORE #145
   # (memoize _inject_forall_captures), so it peaks at ~28.4 GB compiling this
@@ -77,7 +81,10 @@ env:
   #
   # The raised timeouts (#137, #167) stay. They now buy headroom rather than
   # bare survival, and the cliff they guard is still there for the next seed.
-  SEED_VERSION: v0.2.13
+  #
+  # v0.2.13 -> v0.2.14 (2026-08-21): first payload of the release-time
+  # auto-bump; v0.2.14's bundle matrix is complete on all six targets.
+  SEED_VERSION: v0.2.14
 
   # apt-get waits on /var/lib/dpkg/lock-frontend FOREVER by default, and the
   # runner images run unattended-upgrades / apt-daily timers in the background.
@@ -123,6 +130,33 @@ jobs:
     outputs:
       code: ${{ steps.classify.outputs.code }}
     steps:
+      # SEED_VERSION consistency guard (plans/backlog/SEED_VERSION_AUTOMATION.md):
+      # the pin is hand-duplicated in THREE workflows, and divergence silently
+      # splits the trust chain (PRs validated against one seed, release
+      # artifacts built from another — it HAS happened: fixpoint-arm64 sat on
+      # v0.2.4 while the others moved to v0.2.9). This job is the earliest
+      # always-running gate, so the guard lives here as a STEP — deliberately
+      # not a new job, because the branch-protection required-checks list is
+      # maintained by hand and a new job would need a manual edit there.
+      - name: Checkout workflows (SEED_VERSION guard)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/workflows
+          sparse-checkout-cone-mode: false
+      - name: SEED_VERSION consistency guard
+        run: |
+          set -euo pipefail
+          pins=$(grep -hE '^[[:space:]]*SEED_VERSION: v' \
+            .github/workflows/test.yml \
+            .github/workflows/release.yml \
+            .github/workflows/fixpoint-arm64.yml | awk '{print $2}')
+          count=$(printf '%s\n' "$pins" | wc -l)
+          uniq_count=$(printf '%s\n' "$pins" | sort -u | wc -l)
+          if [ "$count" -ne 3 ] || [ "$uniq_count" -ne 1 ]; then
+            echo "::error::SEED_VERSION pins diverge or are missing (found: $(printf '%s ' $pins)) — the three workflows must carry the SAME pin. See test.yml's SEED_VERSION comment and plans/backlog/SEED_VERSION_AUTOMATION.md."
+            exit 1
+          fi
+          echo "SEED_VERSION consistent across the three workflows: $(printf '%s' "$pins" | head -1)"
       - id: classify
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Implements `plans/backlog/SEED_VERSION_AUTOMATION.md` (the design doc rides the operator-set PR; agreed 2026-08-21).

## What

1. **Consistency guard** — a STEP in `test.yml`'s always-running `changes` job (deliberately **not** a new job: the branch-protection required-checks list is maintained by hand, and a new job would silently not gate anything until hand-added). Sparse-checkouts `.github/workflows` and fails on any divergence among the three `SEED_VERSION` pins — the drift class that once left `fixpoint-arm64.yml` on v0.2.4 while the others advanced.
2. **Release-time auto-bump** — `publish-release` now ends by pushing the just-published version into all three pins on develop via `RELEASE_PAT` (same mechanism and trust level as the existing version-bump push), **deliberately without `[skip ci]`**: the push exercises the new seed on develop immediately, so a bad seed is a visible red plus a one-line revert instead of a latent trap for the next PR. Success-path only by step order; loud failure if the substitution touches anything but exactly 3 files or the PAT is missing/expired.
3. **Comment consolidation** — the full seed rationale + history stays in `test.yml`; the other two workflows now point there instead of duplicating it.
4. **First payload** — `v0.2.13 → v0.2.14` in all three pins (v0.2.14's bundle matrix is complete on all six targets), so **this PR's own CI validates the new seed before merge**.

## Rejected alternatives (recorded in the design doc)

- Bot PR for the bump: friction without much added safety — the bump only fires after the entire release pipeline (every artifact job) is green.
- Actions repo variable: seed changes would bypass review entirely.

## Validation

- All three workflows parse as YAML.
- Guard logic dry-run locally: 3 pins found, 1 unique value; the anchored grep is not confused by the scripts' own text.
- Bump `sed` dry-run: matches exactly once per file.
- This PR's CI is itself the end-to-end test of the v0.2.14 seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)