### PR TITLE
evaluator: reject duplicate inherent method impls (site-keyed)

### DIFF
--- a/.github/instructions/yo-design.instructions.md
+++ b/.github/instructions/yo-design.instructions.md
@@ -307,7 +307,7 @@ Yo does **not** support function overloading — same stance as Rust, and ENFORC
 
 Use separate `impl` blocks with `where(Self <: Comptime)` constraints for comptime method variants on generic types like `Option(T)` and `Result(T, E)`.
 
-**Duplicate method names across impl blocks are disallowed** — as policy; the compiler does not yet enforce it. Today a second same-name inherent impl is silently accepted (identical signature: first wins; different arity: both dispatch) — `issues/duplicate-inherent-method-impls-not-rejected.md`. Use distinct names (e.g., `comptime_unwrap`) instead. This ensures unambiguous method extraction via `Type.method_name`.
+**Duplicate method names across impl blocks are disallowed** — ENFORCED since 2026-08-21: a second same-name INHERENT impl for the same type errors with `Method "X" is already defined for this type` (gated at inherent registration in `src/evaluator/values/impl.yo`, keyed on the defining site so loader re-evaluation and per-instantiation generic re-registration stay legal — `plans/backlog/DUPLICATE_INHERENT_METHOD_REJECTION.md`). Trait-provided methods sharing a name remain legal by design. Use distinct names (e.g., `comptime_unwrap`) for variants. This ensures unambiguous method extraction via `Type.method_name`.
 
 **Enum type method extraction** works: `Option(i32).unwrap` returns the method as a callable function value, matching struct type behavior.
 

--- a/.github/skills/yo-core-patterns/core-patterns-cheatsheet.md
+++ b/.github/skills/yo-core-patterns/core-patterns-cheatsheet.md
@@ -273,10 +273,10 @@ everywhere, and an exported `Call` tuple of ≥2 candidates (an overload set)
 is rejected outside std/prelude.yo — the prelude's runtime/comptime operator
 pairs (`Call :: (neg, comptime_neg)`) are the ONLY sanctioned overload sets.
 A single-function `Call` (callable module) is fine. Duplicate same-name
-inherent methods are disallowed as POLICY but not yet enforced — today the
-compiler silently accepts them (same signature: first wins; different arity:
-both dispatch) — so never rely on it either way
-(issues/duplicate-inherent-method-impls-not-rejected.md). But
+inherent methods are REJECTED (2026-08-21): a second `impl(T, m : ...)` for
+the same (type, name) from a different source site errors with
+`Method "X" is already defined for this type`
+(plans/backlog/DUPLICATE_INHERENT_METHOD_REJECTION.md). But
 **trait-provided methods may share a name** with an inherent
 method and with same-name methods from other traits; dispatch picks by
 argument types. This is how std gives `String` both `contains(String)`

--- a/plans/FUNCTION_OVERLOADING_POLICY.md
+++ b/plans/FUNCTION_OVERLOADING_POLICY.md
@@ -76,6 +76,16 @@ three `Call` pairs, which the gate itself sanctions.
 - Prelude exception's continued function is covered by the whole suite
   (every `-x` / `!x` / `~x` fold) and `tests/operator_grouping.test.yo`.
 
+## Relation to `plans/backlog/OVERLOADING_REDESIGN.md`
+
+That earlier redesign (owner decision 2026-06-22) covers METHOD-level
+arg-type overloading: it already removed std's `StrPattern` overload
+pattern and landed inherent-first resolution (§6,
+`issues/fixed/yo-inherent-first-resolution.md`). This policy enforces the
+function-level and definition-level bans both documents assume; the
+redesign's remaining trait-bound-generics migration is orthogonal and
+stays in its own backlog.
+
 ## Rejected alternatives
 
 - **A `Pragma.AllowOverload` opt-in** (mirroring `AllowMacroDef`): rejected

--- a/plans/backlog/DUPLICATE_INHERENT_METHOD_REJECTION.md
+++ b/plans/backlog/DUPLICATE_INHERENT_METHOD_REJECTION.md
@@ -1,8 +1,8 @@
 # Reject duplicate inherent method impls (make the documented model real)
 
-**Status:** BACKLOG (agreed with maintainer 2026-08-21). Scheduled as the
-follow-up branch after the function-overloading-policy branch
-(`plans/FUNCTION_OVERLOADING_POLICY.md`) lands.
+**Status:** IMPLEMENTED 2026-08-21 (branch `reject-duplicate-inherent-methods`,
+stacked on the function-overloading-policy branch). Implementation notes below
+the original plan.
 
 ## Problem
 
@@ -67,3 +67,38 @@ false positives are the risk, not the mechanics:
 - No change to the `Call` overload-set gate (already landed).
 - No signature-based "compatible overload" carve-outs — the model is
   Rust's: one inherent name, one definition.
+
+## Implementation notes (2026-08-21)
+
+- **Single gate site — at the member-loop HEAD, not at registration.** The
+  first attempt gated the colon-pair fresh-registration branch
+  (`register_type_trait_method` with `current_trait_ty` `.None`) and was
+  refuted by its own red-first tests: registration FORKS — the pre-pass
+  creates `__forward_shell` entries that the member loop UPDATES in place,
+  so shelled methods (every ordinary `impl(T, m : fn...)`) never reach the
+  fresh branch. The gate therefore lives at the top of
+  `evaluate_module_value`'s per-member loop in
+  `src/evaluator/values/impl.yo` — right after `method_name`/`name_tok`
+  are extracted, before the body is even evaluated — where every colon-pair
+  member passes exactly once per evaluation regardless of shell state.
+  Trait-tagged registrations (deferred assoc types, `?=` defaults) and
+  codegen-time synthetic registrations (`codegen/functions/collection.yo`)
+  do not participate.
+- **Site registry, not a MethodEntry field.** `MethodEntry` has ~14
+  construction sites; instead of widening the struct, a separate
+  `_inherent_method_sites` map in `type_trait_methods.yo` keys
+  `type_id \n label` → `module_path:row:column` of the defining name token
+  (`note_inherent_method_site`, cleared with the main registry). Same site ⇒
+  idempotent replay (loader re-evaluation, per-instantiation generic
+  re-registration), allowed; different site ⇒
+  `Method "X" is already defined for this type (first definition: ...)`.
+- **Red-first verified**: the two new `comptime_expect_error` arms in
+  `tests/impl.test.yo` FAIL against the ungated compiler
+  ("Expected compile error, but the expression was evaluated successfully"),
+  plus a positive arm proving a generic impl instantiated at two types still
+  registers cleanly.
+- **Relation to `plans/backlog/OVERLOADING_REDESIGN.md`**: that redesign
+  (owner decision 2026-06-22) removed std's `StrPattern` arg-type overloading
+  and landed inherent-first resolution (§6). This gate enforces the
+  "inherent NO" half both documents assume; the redesign's remaining
+  trait-bound-generics migration is orthogonal.

--- a/src/evaluator/values/impl.yo
+++ b/src/evaluator/values/impl.yo
@@ -59,6 +59,7 @@ _(env : impl_dbg_env) :: import("std/env");
 {
   MethodEntry,
   register_type_trait_method,
+  note_inherent_method_site,
   register_shell_redirect,
   get_type_trait_methods_by_name,
   get_trait_default,
@@ -3587,6 +3588,45 @@ evaluate_module_value :: (
               name_tok := ast_expr_token(name_expr);
               method_name := name_tok.value.clone();
               qualified := `${receiver_name}.${method_name}`;
+              // Duplicate-INHERENT-method rejection
+              // (plans/FUNCTION_OVERLOADING_POLICY.md,
+              // issues/duplicate-inherent-method-impls-not-rejected.md):
+              // a second `impl(T, m : ...)` for the same (type, name) from a
+              // DIFFERENT source site is a genuine second definition — before
+              // this gate the first silently won (same signature) or both
+              // dispatched by arity. Keyed on the defining token's site so
+              // the loader's idempotent re-evaluation and a generic impl's
+              // per-instantiation re-registration (both replay the SAME
+              // site) stay legal. Trait-provided methods (current_trait_ty
+              // Some) may share names BY DESIGN and are not gated. Placed
+              // HERE — before the method body is even evaluated — because
+              // registration itself forks (a `__forward_shell` pre-pass
+              // entry is UPDATED in place; only shell-less members take the
+              // fresh-registration branch), so a registration-side gate
+              // misses every shelled method.
+              if(current_trait_ty.is_none() && (receiver_type_id != ""), {
+                __dup_site := note_inherent_method_site(
+                  receiver_type_id.clone(),
+                  method_name.clone(),
+                  `${name_tok.module_path}:${name_tok.row}:${name_tok.column}`
+                );
+                match(
+                  __dup_site,
+                  .Some(__prev_site) => {
+                    exn.throw(
+                      dyn(
+                        format_error_message(
+                          name_tok,
+                          `Method "${method_name}" is already defined for this type (first definition: ${__prev_site}). Duplicate inherent method impls are not allowed — use a distinct name (e.g. a comptime_ prefix), or provide the second signature via a trait (plans/FUNCTION_OVERLOADING_POLICY.md).`,
+                          false,
+                          .None
+                        )
+                      )
+                    );
+                  },
+                  .None => ()
+                );
+              });
               // Compute the expected type for this method from the trait's
               // field-by-label. This lets anonymous lambdas (e.g. the body
               // of an impl method) see the function type the trait expects.

--- a/src/evaluator/values/type_trait_methods.yo
+++ b/src/evaluator/values/type_trait_methods.yo
@@ -272,12 +272,45 @@ get_type_trait_methods_by_name :: (
   });
   result
 });
+/// INHERENT-method definition sites, keyed by `type_id` + NUL-free
+/// separator + `label`, valued by the defining token's
+/// `module_path:row:column`. This is how the duplicate-inherent-method
+/// rejection (plans/FUNCTION_OVERLOADING_POLICY.md,
+/// issues/duplicate-inherent-method-impls-not-rejected.md) tells a GENUINE
+/// second definition (different source site) from the loader's idempotent
+/// re-evaluation and from a generic impl re-registering per instantiation
+/// (both replay the SAME site). Keyed separately from `_type_trait_methods`
+/// so codegen-time synthetic registrations (codegen/functions/collection.yo)
+/// never participate.
+(_inherent_method_sites : HashMap(String, String)) = HashMap(String, String).new();
 /// Drop all registered methods. Used by test harnesses to reset
 /// global state between runs. Mirrors the cleanup helpers in
 /// `evaluator/values/impl.yo` for the generic-impl registry.
 clear_type_trait_methods :: (fn() -> unit)({
   fresh := HashMap(String, ArrayList(MethodEntry)).new();
   _type_trait_methods = fresh;
+  fresh_sites := HashMap(String, String).new();
+  _inherent_method_sites = fresh_sites;
+});
+/// Record `site` as the defining site of inherent method `label` on
+/// `type_id`. Returns `.Some(previous_site)` when the pair was already
+/// defined at a DIFFERENT site — a genuine duplicate the caller must
+/// reject — and `.None` for a fresh definition or a same-site replay.
+note_inherent_method_site :: (
+  fn(type_id : String, label : String, site : String) -> Option(String)
+)({
+  key := `${type_id}\n${label}`;
+  match(
+    _inherent_method_sites.get(key.clone()),
+    .Some(prev) => cond(
+      (prev == site) => Option(String).None,
+      true => Option(String).Some(prev)
+    ),
+    .None => {
+      ___ins := _inherent_method_sites.set(key, site);
+      Option(String).None
+    }
+  )
 });
 /// Trait-method DEFAULT values (`?=` defaults). yo-self's `TraitT` does not store
 /// per-field default values (divergence — trait_type.yo:6-8), so the trait
@@ -315,6 +348,7 @@ export(
   register_shell_redirect,
   get_shell_redirect,
   register_type_trait_method,
+  note_inherent_method_site,
   get_type_trait_methods_for_type,
   get_type_trait_methods_by_name,
   clear_type_trait_methods,

--- a/tests/impl.test.yo
+++ b/tests/impl.test.yo
@@ -272,3 +272,39 @@ test("Test inherent method shadows a same-name trait method (inherent-first)", {
   // not match it, and resolution must NOT fall through to `DelegatePickStr.pick(str)`.
   comptime_expect_error(v.pick("s"));
 });
+// Duplicate INHERENT method impls are rejected (plans/FUNCTION_OVERLOADING_POLICY.md,
+// issues/duplicate-inherent-method-impls-not-rejected.md): a second
+// `impl(T, m : ...)` for the same (type, name) from a different source site is
+// an error — before the gate the first silently won (identical signature) or
+// both dispatched by arity. Trait-provided names (arm above) stay legal.
+test("Test duplicate inherent method impl is rejected (same signature)", {
+  comptime_expect_error({
+    DupSameSig :: struct(x : i32);
+    impl(DupSameSig, get : (fn(self : Self) -> i32)(self.x));
+    impl(DupSameSig, get : (fn(self : Self) -> i32)(self.x + i32(1)));
+    ()
+  });
+});
+test("Test duplicate inherent method impl is rejected (different arity)", {
+  comptime_expect_error({
+    DupArity :: struct(x : i32);
+    impl(DupArity, get : (fn(self : Self) -> i32)(self.x));
+    impl(DupArity, get : (fn(self : Self, y : i32) -> i32)(self.x + y));
+    ()
+  });
+});
+// A generic impl registering the same method PER INSTANTIATION replays the
+// same defining site — that must stay legal (the loader's idempotent
+// re-registration works the same way).
+GenBox :: (fn(comptime(T) : Type) -> comptime(Type))(struct(v : T));
+impl(
+  generic(T : Type),
+  GenBox(T),
+  first : (fn(self : Self) -> T)(self.v)
+);
+test("Test generic impl instantiated twice registers cleanly", {
+  a := GenBox(i32)(v : i32(7));
+  b := GenBox(bool)(v : true);
+  assert(a.first() == i32(7), "GenBox(i32) instantiation");
+  assert(b.first() == true, "GenBox(bool) instantiation");
+});


### PR DESCRIPTION
**Stacked on the function-overloading-policy PR** — merge that first; this diff is the top commit until then.

Closes the last open overloading channel found by the policy audit: **duplicate INHERENT method impls are now rejected** (`plans/backlog/DUPLICATE_INHERENT_METHOD_REJECTION.md`, `issues/duplicate-inherent-method-impls-not-rejected.md`). Before this gate, a second `impl(T, m : ...)` for the same (type, name) was silently accepted — identical signature: the FIRST definition won; different arity: both dispatched — contradicting yo-design.instructions.md and the core-patterns cheatsheet, whose quoted "Method already defined" error never existed in the evaluator.

## Design

- **Gate at the member-loop head, not at registration.** The first attempt gated the fresh-registration branch and was refuted by its own red-first tests: registration FORKS — the pre-pass creates `__forward_shell` entries that the member loop UPDATES in place, so every ordinary shelled method bypasses the fresh branch. The landed gate sits at the top of `evaluate_module_value`'s per-member loop (`src/evaluator/values/impl.yo`), right after `method_name`/`name_tok` are extracted and before the body is evaluated — every colon-pair member passes it exactly once per evaluation regardless of shell state. Trait-tagged registrations and codegen-time synthetic registrations (`codegen/functions/collection.yo`) do not participate.
- **Site-keyed idempotency.** A new `_inherent_method_sites` registry (`type_trait_methods.yo`, `note_inherent_method_site`, cleared with the main registry) maps `(type_id, label)` → the defining name token's `module_path:row:column`. Same site ⇒ idempotent replay (the module loader's re-evaluation, a generic impl re-registering per instantiation) — allowed. Different site ⇒ `Method "X" is already defined for this type (first definition: ...)`.
- **Trait-provided names stay legal by design** (inherent-first resolution per `plans/backlog/OVERLOADING_REDESIGN.md` §6 is untouched).

## Tests (red-first verified)

`tests/impl.test.yo`:
- Two `comptime_expect_error` arms (same-signature and different-arity duplicates) — **fail against the ungated compiler** ("Expected compile error, but the expression was evaluated successfully") and pass with the gate.
- A positive arm: a generic impl instantiated at two types (`GenBox(i32)`, `GenBox(bool)`) still registers cleanly.

## Docs

yo-design.instructions.md and the core-patterns cheatsheet flipped from "policy, not yet enforced" to the enforced error; backlog plan doc updated to IMPLEMENTED with the registration-audit notes.

## Validation

- `yo check ./src --std-path ./std` and `yo check ./std` green with the GATED compiler — the tree itself contains no duplicate inherent impls, so no false positives on 248 compiler files + 154 std files.
- Targeted suites green with the gated binary: `impl`, `fn`, `basic`, `prefix_operators`.
- gates_fast + fixpoint_only green on this stack top (see PR thread for the run summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
