### PR TITLE
ci: release-tail hardening (seed-bump own job, idempotent publish, manual site deploy); seed → v0.2.15

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,69 @@
+name: Deploy site (manual)
+
+# Manual redeploy lever for the documentation website. The site normally
+# deploys ONLY from release.yml's deploy-site job (on purpose — see the
+# invariant recorded there), which deploys the Pages artifact built inside
+# the same release run. When that job is skipped by an unrelated failure in
+# its `needs` chain — exactly what happened on the v0.2.15 release, where
+# the then-in-job seed-bump step failed AFTER the release was public and
+# took deploy-site down with it — the release run cannot be salvaged
+# (reruns execute the original workflow snapshot). This workflow rebuilds
+# the site from the release TAG with the released compiler and deploys it.
+#
+# Inputs: `version` — a PUBLISHED release tag (e.g. v0.2.15). The tree is
+# checked out at that tag and the site is built by that same release's own
+# binary, so the deployed bytes match what the release run would have
+# deployed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published release tag to build and deploy the site for (e.g. v0.2.15)"
+        required: true
+        type: string
+
+env:
+  # See test.yml's APT_OPTS comment: a bare apt-get can hang forever on the
+  # dpkg lock held by the runner's unattended-upgrades timer.
+  APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"
+
+jobs:
+  build-and-deploy:
+    name: Build the site at the tag and deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      # The seed is a dynamically linked Linux binary whose async runtime
+      # links liburing — it cannot start without it (release.yml's site-build
+      # step records the v0.2.10 failure this caused).
+      - name: Install liburing
+        run: |
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y liburing-dev
+
+      - name: Install the released compiler
+        uses: ./.github/actions/install-seed
+        with:
+          version: ${{ inputs.version }}
+
+      - name: Generate documentation website
+        run: |
+          yo compile scripts/build_site.yo --release -o /tmp/build-site
+          /tmp/build-site --output yo-out/site --version "${{ inputs.version }}" --yo yo
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: yo-out/site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/fixpoint-arm64.yml
+++ b/.github/workflows/fixpoint-arm64.yml
@@ -45,7 +45,7 @@ env:
   # then v0.2.9 — that drift is why the pins are now guarded (test.yml
   # `changes` job) and bumped automatically at release time (release.yml
   # publish-release). Full rationale: test.yml's SEED_VERSION comment.
-  SEED_VERSION: v0.2.14
+  SEED_VERSION: v0.2.15
   # See test.yml's APT_OPTS comment: a bare apt-get can hang forever on the
   # dpkg lock held by the runner's unattended-upgrades timer.
   APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
   # lockstep by the auto-bump in publish-release below and the consistency
   # guard in test.yml's `changes` job
   # (plans/backlog/SEED_VERSION_AUTOMATION.md).
-  SEED_VERSION: v0.2.14
+  SEED_VERSION: v0.2.15
 
   # apt-get waits on /var/lib/dpkg/lock-frontend FOREVER by default, and the
   # runner images run unattended-upgrades / apt-daily timers in the background.
@@ -1148,29 +1148,53 @@ jobs:
         run: |
           release_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases"             --jq '.[] | select(.tag_name == "v${{ needs.release.outputs.version }}" and .draft) | .id')
           if [ -z "$release_id" ]; then
-            echo "::error::no draft release found for v${{ needs.release.outputs.version }}"
+            # IDEMPOTENT on rerun: the v0.2.15 run failed in a LATER step of
+            # this job after the flip had already happened, and rerunning the
+            # job then died HERE ("no draft release found") because the draft
+            # no longer existed — blocking the still-skipped deploy-site
+            # forever. If the tag is already public, that is this step's goal
+            # state: continue instead of failing.
+            published_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases"             --jq '.[] | select(.tag_name == "v${{ needs.release.outputs.version }}" and (.draft | not)) | .id')
+            if [ -n "$published_id" ]; then
+              echo "Release v${{ needs.release.outputs.version }} is already published (id ${published_id}) — continuing."
+              exit 0
+            fi
+            echo "::error::no release (draft or published) found for v${{ needs.release.outputs.version }}"
             exit 1
           fi
           gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}"             -F draft=false -f make_latest=true --jq .html_url
 
-      # Seed auto-bump (plans/backlog/SEED_VERSION_AUTOMATION.md): the release
-      # is public with a complete bundle matrix (every artifact job is in this
-      # job's `needs`), so the just-published version becomes the new bootstrap
-      # seed in all three workflows. Pushed DIRECTLY to develop with
-      # RELEASE_PAT — the same mechanism and trust level as the release job's
-      # version-bump push — and deliberately WITHOUT [skip ci]: the push
-      # exercises the new seed on develop immediately, so a bad seed is a
-      # visible red plus a one-line revert, not a latent trap for the next PR.
-      # Runs only on this job's success path by step order: the Publish step
-      # above has already exited non-zero on any failure.
-      - name: Checkout develop for the seed bump
+  # Seed auto-bump (plans/backlog/SEED_VERSION_AUTOMATION.md): once the
+  # release is public with a complete bundle matrix, the just-published
+  # version becomes the new bootstrap seed in all three workflows, pushed
+  # DIRECTLY to develop with RELEASE_PAT and deliberately WITHOUT
+  # [skip ci] — the push exercises the new seed on develop immediately, so
+  # a bad seed is a visible red plus a one-line revert.
+  #
+  # A SEPARATE JOB (2026-08-22), not a tail step of publish-release: its
+  # first live firing failed and, because it shared a job with the publish
+  # flip, took deploy-site down with it (needs: publish-release saw
+  # `failure`). A bump failure must never block the site deploy.
+  #
+  # REQUIREMENT the first firing discovered (GH013): RELEASE_PAT must be a
+  # fine-grained PAT with BOTH "Contents: read and write" AND "Workflows:
+  # read and write" — this push modifies .github/workflows/*, which GitHub
+  # refuses for any token without the workflow permission
+  # (issues/release-seed-bump-needs-workflow-scope-pat.md).
+  seed-bump:
+    name: Bump SEED_VERSION on develop
+    # `release` is in needs only for its `version` output; publish-release is
+    # the actual gate.
+    needs: [release, publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
         uses: actions/checkout@v4
         with:
           ref: develop
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
-          path: seed-bump
+
       - name: Bump SEED_VERSION to this release on develop
-        working-directory: seed-bump
         run: |
           set -euo pipefail
           new="v${{ needs.release.outputs.version }}"
@@ -1191,7 +1215,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add .github/workflows/test.yml .github/workflows/release.yml .github/workflows/fixpoint-arm64.yml
           git commit -m "ci: bump SEED_VERSION to ${new} (release-pipeline auto-bump)"
-          git push || { echo "::error::Seed-bump push to develop failed — is the RELEASE_PAT secret set and unexpired (fine-grained, Contents: read/write)?"; exit 1; }
+          git push || { echo "::error::Seed-bump push to develop failed — RELEASE_PAT must be fine-grained with Contents AND Workflows read/write (this push modifies .github/workflows/*, refused as GH013 without the workflow permission), and unexpired."; exit 1; }
           echo "SEED_VERSION ${old} -> ${new} pushed to develop."
 
   # The site deploy waits for publish-release ON PURPOSE.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,12 @@ env:
   #
   # v0.2.13 -> v0.2.14 (2026-08-21): first payload of the release-time
   # auto-bump; v0.2.14's bundle matrix is complete on all six targets.
-  SEED_VERSION: v0.2.14
+  #
+  # v0.2.14 -> v0.2.15 (2026-08-22, MANUAL): the auto-bump's first live
+  # firing was rejected by GH013 — RELEASE_PAT lacked the fine-grained
+  # "Workflows: read and write" permission, which any push touching
+  # .github/workflows/ requires (issues/release-seed-bump-needs-workflow-scope-pat.md).
+  SEED_VERSION: v0.2.15
 
   # apt-get waits on /var/lib/dpkg/lock-frontend FOREVER by default, and the
   # runner images run unattended-upgrades / apt-daily timers in the background.

--- a/issues/release-seed-bump-needs-workflow-scope-pat.md
+++ b/issues/release-seed-bump-needs-workflow-scope-pat.md
@@ -1,0 +1,58 @@
+# Seed auto-bump push rejected: RELEASE_PAT lacks the Workflows permission (GH013)
+
+**Found:** 2026-08-21/22, on the v0.2.15 release — the FIRST live firing of
+the release-time SEED_VERSION auto-bump (#200,
+`plans/backlog/SEED_VERSION_AUTOMATION.md`).
+
+## Symptom
+
+`publish-release` flipped v0.2.15 public (all 13 assets), then its final
+step — pushing the `ci: bump SEED_VERSION to v0.2.15` commit to develop —
+was rejected:
+
+```
+remote: error: GH013: Repository rule violations found for refs/heads/develop.
+remote: - refusing to allow a Personal Access Token to create or update
+         workflow `.github/workflows/fixpoint-arm64.yml` without `workflow` scope
+```
+
+Two knock-on effects:
+
+1. The seed bump never landed (pins stayed at v0.2.14).
+2. Because the bump ran as a TAIL STEP of `publish-release`, its failure
+   marked the whole job `failure`, and `deploy-site` (`needs:
+   publish-release`) was **skipped** — the docs site kept advertising
+   v0.2.14. The run is unsalvageable: reruns execute the original workflow
+   snapshot, and the rerun path died at the Publish step ("no draft release
+   found" — the draft was already public).
+
+## Root cause
+
+The seed-bump commit modifies `.github/workflows/*` — GitHub refuses such a
+push from ANY token that does not carry the workflow permission. RELEASE_PAT
+was created fine-grained with **Contents: read/write only** (sufficient for
+the version-bump push, which touches no workflow files). The dry-runs
+validated the sed and the guard, but nothing could exercise the PAT's scope
+before the real push.
+
+## Fixes
+
+- **Workflow side (branch `ci/release-tail-hardening`):**
+  - The seed bump moved to its OWN `seed-bump` job (`needs: [release,
+    publish-release]`) so a bump failure can never take `deploy-site` down
+    again.
+  - The Publish step is idempotent on rerun (already-published tag ⇒
+    continue, not error).
+  - New `deploy-site.yml` manual workflow (`workflow_dispatch`, input:
+    release tag) — rebuilds the site from the tag with that release's own
+    compiler and deploys it; used to publish v0.2.15's site.
+  - The v0.2.14→v0.2.15 pin bump rides the same PR (manual completion of
+    what the auto-bump could not push; the PR's CI validates the v0.2.15
+    seed pre-merge, same as #200 did for v0.2.14).
+- **PAT side (USER ACTION, still open):** regenerate/edit `RELEASE_PAT`
+  (fine-grained) to carry **both** "Contents: read and write" **and**
+  "Workflows: read and write". Until then the `seed-bump` job will keep
+  failing (now harmlessly) on every release.
+
+Move this to `issues/fixed/` once a release's `seed-bump` job has pushed
+successfully with the updated PAT.

--- a/plans/backlog/SEED_VERSION_AUTOMATION.md
+++ b/plans/backlog/SEED_VERSION_AUTOMATION.md
@@ -53,3 +53,16 @@ paren-less prefix calls inside `src/`/`std/`
 (`plans/PREFIX_OPERATOR_OPERAND_RULE.md`) — each unlocks only once a
 release CONTAINING those features becomes the seed, i.e. typically the
 bump after next.
+
+## Status addendum (2026-08-22)
+
+Landed in #200; guard live in test.yml's `changes` job. The auto-bump's
+FIRST live firing (v0.2.15 release) was rejected — GH013: `RELEASE_PAT`
+lacked the fine-grained "Workflows: read and write" permission, which any
+push touching `.github/workflows/` requires — and, because the bump ran as
+a tail step of `publish-release`, the failure also skipped `deploy-site`.
+Full record: `issues/release-seed-bump-needs-workflow-scope-pat.md`.
+Hardening (branch `ci/release-tail-hardening`): bump moved to its own
+`seed-bump` job, Publish made rerun-idempotent, manual `deploy-site.yml`
+lever added, v0.2.14→v0.2.15 pins bumped manually via PR. Remaining USER
+ACTION: add the Workflows permission to `RELEASE_PAT`.


### PR DESCRIPTION
The v0.2.15 release **published fully** (13 assets, flipped public 2026-08-21T16:44Z), but its last step — the first live firing of #200's seed auto-bump — was rejected with **GH013: `RELEASE_PAT` lacks the fine-grained "Workflows: read and write" permission**, which any push touching `.github/workflows/` requires. Because the bump ran as a tail step of `publish-release`, the failure also **skipped `deploy-site`**, and the run is unsalvageable (reruns execute the original workflow snapshot and die at the Publish step, whose draft no longer exists). Full record: `issues/release-seed-bump-needs-workflow-scope-pat.md`.

## Changes

1. **`seed-bump` becomes its own job** (`needs: [release, publish-release]`) — a bump failure can never take the site deploy down again; its failure message now names the real requirement (Contents **and** Workflows read/write).
2. **Publish step is rerun-idempotent** — an already-published tag is the goal state: continue instead of `no draft release found`.
3. **New `deploy-site.yml`** (`workflow_dispatch`, input: release tag) — manual site-redeploy lever that rebuilds from the tag with that release's own compiler. Will be dispatched for v0.2.15 once this merges (a dispatch workflow must be on the default branch).
4. **Seed pins v0.2.14 → v0.2.15** in all three workflows — manual completion of the failed auto-bump. **This PR's CI validates the v0.2.15 seed pre-merge**, exactly as #200's did for v0.2.14.

## Remaining user action (documented in the issue)

Edit `RELEASE_PAT` to carry both "Contents: read and write" and "Workflows: read and write" — until then the (now-isolated) `seed-bump` job will keep failing harmlessly on each release.

Validation: YAML parses, actionlint clean, guard/sed logic unchanged from #200 (dry-run verified there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)