### PR TITLE
ci: deploy-site checkout needs submodules

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -41,6 +41,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version }}
+          # build_site.yo imports vendor/markdown_yo — without submodules the
+          # compile dies with "file or directory not found" (first dispatch,
+          # 2026-08-22). Recursive, matching release.yml's checkouts.
+          submodules: recursive
 
       # The seed is a dynamically linked Linux binary whose async runtime
       # links liburing — it cannot start without it (release.yml's site-build


### PR DESCRIPTION
One-line fix: the first `deploy-site.yml` dispatch (v0.2.15) died at `yo compile scripts/build_site.yo` with "file or directory not found" — the tag checkout had no submodules, and `build_site.yo` imports `vendor/markdown_yo`. Now `submodules: recursive`, matching release.yml's checkouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)