### PR TITLE
perf: desugar shares tokens instead of deep-cloning the source into every node

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,6 +22,11 @@ on:
         description: "Published release tag to build and deploy the site for (e.g. v0.2.15)"
         required: true
         type: string
+      builder:
+        description: "Release tag of the compiler that BUILDS the site (defaults to `version`). Use an older release when the target release's binary cannot fit the runner — e.g. v0.2.15's evaluator regression (issues/desugar-token-clones-evaluator-regression.md) OOMs 7 GB runners on the site build."
+        required: false
+        type: string
+        default: ""
 
 env:
   # See test.yml's APT_OPTS comment: a bare apt-get can hang forever on the
@@ -54,10 +59,10 @@ jobs:
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev
 
-      - name: Install the released compiler
+      - name: Install the site-builder compiler
         uses: ./.github/actions/install-seed
         with:
-          version: ${{ inputs.version }}
+          version: ${{ inputs.builder != '' && inputs.builder || inputs.version }}
 
       - name: Generate documentation website
         run: |

--- a/issues/desugar-token-clones-evaluator-regression.md
+++ b/issues/desugar-token-clones-evaluator-regression.md
@@ -1,0 +1,65 @@
+# v0.2.15 evaluator regression: the if→cond desugar deep-cloned the source into every AST node
+
+**Found:** 2026-08-22, when the manual v0.2.15 site deploy OOM-killed three
+GitHub runners in a row ("The runner has received a shutdown signal", ~40-70s
+into `yo compile scripts/build_site.yo` — severe memory pressure kills the
+runner agent itself on 7 GB `ubuntu-latest`).
+
+## Measurements (yo check of the vendor/markdown_yo import closure, M4 Mac)
+
+| binary | wall | peak RSS |
+| --- | --- | --- |
+| v0.2.14 | 14.6 s | 2.7 GB |
+| v0.2.15 (#199 content) | 50-60 s | 7.0-7.6 GB |
+| #199 with the desugar DISABLED | 25 s | 3.5 GB |
+| #199 with copy-on-write only | 56 s | 7.4 GB |
+
+Bisect: the regression is entirely #199's parse-time `if`→`cond` desugar
+(`desugar_program_if_calls`, plans/MACRO_POLICY.md); the operator and
+overloading merges are innocent. COW alone did NOT fix it — the dominant
+cost was not the rebuild but the clones (below).
+
+## Root cause — two compounding defects in `desugar_if_calls`
+
+1. **Token deep-clones of the whole source.** `_synth_desugar_tok` built
+   synthesized tokens with `ref_tok.input.clone()` (and
+   `module_path.clone()`), and every construction site passed
+   `tok.clone()`. `String.clone()` deep-copies its buffer, and
+   `Token.input` is the ENTIRE SOURCE FILE — so every rebuilt node's token
+   carried a private copy of the file. GB-scale memory on big modules, and
+   allocation+memcpy of file-sized buffers throughout parse.
+2. **The private copies then defeated the `__yo_ptr_eq` fast path** in
+   String's `Eq`. `begin.yo`'s `_m3_tokens_comparable` compares
+   `left.input == right.input` on the M3 early-return drop walk; with
+   shared buffers that is O(1) pointer equality, with per-node copies it
+   is a full-file `memcmp`. Profile (`sample`): 3,533 of ~8,300 samples in
+   `_platform_memcmp`, 3,512 of them through ONE chain —
+   `evaluate_begin_expression → _m3 walk → String ==` (v0.2.14 baseline:
+   143 memcmp samples on the same workload).
+3. (Minor, fixed alongside:) the desugar's fallthrough rebuilt EVERY
+   FnCall node of every module even when no `if` existed beneath it.
+
+## Fix (branch `perf/desugar-token-sharing`)
+
+- `_synth_desugar_tok` and all desugar construction sites SHARE
+  `module_path`/`input`/`tok` (plain field reads — copy semantics bump the
+  RC handle; `.clone()` is for when buffer INDEPENDENCE is required, which
+  a token never needs).
+- Copy-on-write: `_contains_if_call` pre-scan (allocation-free); an
+  if-free subtree is returned unchanged.
+
+## Knock-on: `deploy-site.yml` gets a `builder` input
+
+The v0.2.15 RELEASE binary keeps the regression forever, so the v0.2.15
+site deploy would OOM 7 GB runners until v0.2.16. `deploy-site.yml` now
+takes `builder` (default: `version`) so the site can be built by v0.2.14
+while checked out at the v0.2.15 tag.
+
+## Verification bar
+
+- The measurement above back at ~v0.2.14 numbers.
+- fmt idempotence + fixture corpus (desugar output unchanged in shape).
+- gates_fast + fixpoint (the desugar feeds everything).
+- The lesson for future AST rewrites: **never `.clone()` a Token or its
+  `input`** — share; and any parse-time rewriting pass must be
+  copy-on-write.

--- a/src/expr.yo
+++ b/src/expr.yo
@@ -886,8 +886,18 @@ _synth_desugar_tok :: (fn(kind : TokenKind, value : str, ref_tok : Token) -> Tok
     row : ref_tok.row,
     column : ref_tok.column,
     character : ref_tok.character,
-    module_path : ref_tok.module_path.clone(),
-    input : ref_tok.input.clone()
+    // SHARE module_path and input — never .clone() them. String.clone()
+    // deep-copies the buffer, and `input` is the ENTIRE SOURCE FILE: the
+    // original desugar cloned it into every synthesized (and, worse, every
+    // REBUILT) node's token, giving each AST node a private copy of the
+    // file. Measured on `yo check` of the vendor/markdown_yo closure:
+    // 16.5s/3.1GB -> 60s/7.0GB — the v0.2.15 evaluator regression. Sharing
+    // also restores the __yo_ptr_eq fast path in String's Eq, which
+    // begin.yo's _m3_tokens_comparable (`left.input == right.input`) relies
+    // on — with per-node copies every comparability check memcmp'd the
+    // whole file (issues/desugar-token-clones-evaluator-regression.md).
+    module_path : ref_tok.module_path,
+    input : ref_tok.input
   )
 );
 /// Unwrap an optional `label : value` wrapper on an `if` argument.
@@ -945,12 +955,56 @@ _unwrap_if_label :: (fn(arg : AstExpr, label : str) -> Option(AstExpr))({
 /// The rewritten node KEEPS the original call's ExprId (the rewrite runs
 /// before any ExprInfo for the node is written, and the `if` node it
 /// replaces is discarded); synthesized inner nodes mint fresh ids.
+/// Allocation-free pre-scan: does `e` contain a 2- or 3-arg `if(...)` call
+/// anywhere outside quote(...)? The desugar rebuild only pays for itself on
+/// trees that actually carry one — an if-free subtree is returned unchanged
+/// by the copy-on-write check below, so parsing a module with no `if` costs
+/// one read-only walk instead of a full AST reconstruction.
+_contains_if_call :: (fn(e : AstExpr) -> bool)(
+  match(
+    e,
+    .Atom(_, _) => false,
+    .FnCall(_, func_box, args, _, _) => {
+      if(ast_expr_is_fn_call_of(e, BK_QUOTE, .None), {
+        return(false);
+      });
+      n_args := args.len();
+      if(ast_expr_is_fn_call_of(e, "if", .None) && ((n_args == usize(2)) || (n_args == usize(3))), {
+        return(true);
+      });
+      if(recur(func_box), {
+        return(true);
+      });
+      (ci : usize) = usize(0);
+      while(ci < n_args, {
+        match(
+          args.get(ci),
+          .Some(a) => if(recur(a), {
+            return(true);
+          }),
+          .None => ()
+        );
+        ci = (ci + usize(1));
+      });
+      false
+    }
+  )
+);
 desugar_if_calls :: (fn(e : AstExpr) -> AstExpr)(
   match(
     e,
     .Atom(_, _) => e,
     .FnCall(id, func_box, args, is_infix, tok) => {
       if(ast_expr_is_fn_call_of(e, BK_QUOTE, .None), {
+        return(e);
+      });
+      // COPY-ON-WRITE: an if-free subtree is returned UNCHANGED instead of
+      // being reconstructed node by node (fresh ArrayList + FnCall + token
+      // per node, for every module ever parsed). Paired with the token-
+      // sharing fix in _synth_desugar_tok — the two together close the
+      // v0.2.15 evaluator regression
+      // (issues/desugar-token-clones-evaluator-regression.md).
+      if(!(_contains_if_call(e)), {
         return(e);
       });
       n_args := args.len();
@@ -979,7 +1033,7 @@ desugar_if_calls :: (fn(e : AstExpr) -> AstExpr)(
             AstExpr.Atom(alloc_global_expr_id(), _synth_desugar_tok(TokenKind.Operator, "=>", tok)),
             arrow1_args,
             true,
-            tok.clone()
+            tok
           );
           else_expr := match(
             else_opt,
@@ -988,7 +1042,7 @@ desugar_if_calls :: (fn(e : AstExpr) -> AstExpr)(
               unit_tok := _synth_desugar_tok(TokenKind.Identifier, BK_TUPLE, tok);
               AstExpr.FnCall(
                 alloc_global_expr_id(),
-                AstExpr.Atom(alloc_global_expr_id(), unit_tok.clone()),
+                AstExpr.Atom(alloc_global_expr_id(), unit_tok),
                 ArrayList(AstExpr).new(),
                 false,
                 unit_tok
@@ -1003,7 +1057,7 @@ desugar_if_calls :: (fn(e : AstExpr) -> AstExpr)(
             AstExpr.Atom(alloc_global_expr_id(), _synth_desugar_tok(TokenKind.Operator, "=>", tok)),
             arrow2_args,
             true,
-            tok.clone()
+            tok
           );
           cond_args := ArrayList(AstExpr).new();
           cond_args.push(arrow1);
@@ -1014,7 +1068,7 @@ desugar_if_calls :: (fn(e : AstExpr) -> AstExpr)(
               AstExpr.Atom(alloc_global_expr_id(), _synth_desugar_tok(TokenKind.Identifier, BK_COND, tok)),
               cond_args,
               false,
-              tok.clone()
+              tok
             )
           );
         });
@@ -1032,7 +1086,7 @@ desugar_if_calls :: (fn(e : AstExpr) -> AstExpr)(
         );
         di = (di + usize(1));
       });
-      AstExpr.FnCall(id, recur(func_box), new_args, is_infix, tok.clone())
+      AstExpr.FnCall(id, recur(func_box), new_args, is_infix, tok)
     }
   )
 );


### PR DESCRIPTION
Fixes the v0.2.15 evaluator regression (`issues/desugar-token-clones-evaluator-regression.md`), found when the manual site deploy OOM-killed three 7 GB runners in a row.

## Root cause

#199's if→cond desugar built synthesized tokens with `ref_tok.input.clone()` — `String.clone()` deep-copies, and `Token.input` is the **entire source file** — and passed `tok.clone()` at every construction site, while its fallthrough rebuilt every FnCall of every module. Every node's token carried a private copy of the file (GB-scale memory), and the private copies defeated `__yo_ptr_eq` in String's `Eq`, so `begin.yo`'s `_m3_tokens_comparable` memcmp'd the whole file per comparison on the M3 drop-walk (3,512 of 3,533 memcmp profile samples through that one chain).

## Measurements (`yo check` of the vendor/markdown_yo closure, M4)

| binary | wall | peak RSS |
| --- | --- | --- |
| v0.2.14 | 14.6 s | 2.7 GB |
| v0.2.15 | 50–60 s | 7.0–7.6 GB |
| **this fix** | **21.7 s** | **2.3 GB** |

(Same-generation no-desugar control: 25 s — the desugar is now net-positive; the residual vs the release v0.2.14 binary is build-generation, not the desugar.)

## Changes

- `_synth_desugar_tok` + all desugar construction sites **share** `module_path`/`input`/`tok` (copy semantics bump the RC handle; `.clone()` is for buffer independence, which a token never needs).
- **Copy-on-write**: allocation-free `_contains_if_call` pre-scan; if-free subtrees return unchanged.
- `deploy-site.yml` gains a `builder` input (default `version`) so the v0.2.15 site can be built by v0.2.14 until a fixed release exists.

## Validation

gates_fast all green (incl. 42 CLI goldens), **stage-2/3 FIXPOINT HOLDS**, `check ./src` clean, basic/fn/macro-gate/for-macro-borrow suites green with the fixed binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)