### PR TITLE
ci: pin docs-site builder to v0.2.14 until a fixed seed exists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,10 +288,17 @@ jobs:
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev
 
-      - name: Install the seed compiler (previous release)
+      # PINNED to v0.2.14, NOT env.SEED_VERSION (revert at the next seed
+      # bump): v0.2.15's evaluator deep-clones the source into every AST
+      # node while compiling the markdown_yo closure this site build needs
+      # (issues/desugar-token-clones-evaluator-regression.md, fixed in #207
+      # but the fix only reaches a BINARY at the next release) — with the
+      # v0.2.15 seed this job sits at the 7 GB runner's OOM boundary and
+      # dies as "runner received a shutdown signal" on most runs.
+      - name: Install the seed compiler (site builder)
         uses: ./.github/actions/install-seed
         with:
-          version: ${{ env.SEED_VERSION }}
+          version: v0.2.14
 
       # The same two commands release.yml runs, with the version read from the
       # same source of truth the release computes its bump from.


### PR DESCRIPTION
v0.2.15's evaluator regression (`issues/desugar-token-clones-evaluator-regression.md`, fixed in #207 — but the fix only reaches a *binary* at the next release) puts the docs-site build at the 7 GB runner's OOM boundary: the runner agent itself dies ("runner received a shutdown signal"), seen on PR #205, three v0.2.15 deploy-site dispatches, and PR #208. Pins only this job's builder; the SEED_VERSION pins and guard are untouched. **Revert at the next seed bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)