### PR TITLE
p4: textDocument/hover (slice 3, first feature) + retained analysis state

### DIFF
--- a/src/lsp/diagnostics.yo
+++ b/src/lsp/diagnostics.yo
@@ -22,6 +22,8 @@ open(import("std/string"));
 { ArrayList } :: import("std/collections/array_list");
 open(import("std/error"));
 { parse } :: import("../parser.yo");
+{ AstExpr } :: import("../expr.yo");
+{ ExprInfoTable, expr_info_table_new } :: import("../expr_info.yo");
 {
   mm_resolve_entry_abs,
   mm_eval_entry_exprs,
@@ -225,24 +227,42 @@ _ensure_prelude :: (fn(std_path : String, io : Io) -> unit)({
   mm_preload_prelude(std_path.clone(), false, io, pre_exn);
 });
 
+/// The retained result of one document analysis: the parsed program and
+/// the ExprInfo side table the evaluation filled in. Hover / definition /
+/// symbols read these between edits (plans/P4_LSP.md slice 3+).
+AnalyzeOutcome :: ref(
+  struct(
+    ok : bool,
+    exprs : ArrayList(AstExpr),
+    info_table : ExprInfoTable
+  )
+);
+export(AnalyzeOutcome);
 /// Parse + evaluate the document text under a swallowing handler. The
-/// handler's `unwind(false)` exits THIS bool-typed frame (see
-/// _ensure_prelude's note). Mirrors module_manager's
+/// handler's `unwind` exits THIS AnalyzeOutcome-typed frame (see
+/// _ensure_prelude's note — the unwind value must match the frame the
+/// Exception was bound in). Mirrors module_manager's
 /// _eval_module_exprs_capturing_error structure.
 _analyze_eval :: (
-  fn(entry_abs : String, text : String, std_path : String, io : Io) -> bool
+  fn(entry_abs : String, text : String, std_path : String, io : Io) -> AnalyzeOutcome
 )({
   local_exn := Exception(
     throw : (
       (err) -> {
         _stash_parse_error(err.to_string());
-        unwind(false)
+        unwind(
+          AnalyzeOutcome(
+            ok : false,
+            exprs : ArrayList(AstExpr).new(),
+            info_table : expr_info_table_new()
+          )
+        )
       }
     )
   );
   exprs := parse(text, entry_abs.clone(), local_exn);
-  _outcome := mm_eval_entry_exprs(entry_abs.clone(), std_path.clone(), exprs, io, local_exn);
-  true
+  outcome := mm_eval_entry_exprs(entry_abs.clone(), std_path.clone(), exprs, io, local_exn);
+  AnalyzeOutcome(ok : outcome.ok, exprs : exprs, info_table : outcome.ctx.expr_info_table)
 });
 
 /// Evaluate `text` as the module at `doc_fs_path` and return diagnostics.
@@ -252,12 +272,14 @@ analyze_document :: (
     doc_fs_path : String,
     text : String,
     std_path : String,
-    io : Io
+    io : Io,
+    out_state : ArrayList(AnalyzeOutcome)
   ) -> ArrayList(LspDiag)
 )({
   _ensure_prelude(std_path.clone(), io);
   entry_abs := mm_resolve_entry_abs(doc_fs_path.clone(), std_path.clone());
-  _ok := _analyze_eval(entry_abs.clone(), text.clone(), std_path.clone(), io);
+  outcome := _analyze_eval(entry_abs.clone(), text.clone(), std_path.clone(), io);
+  out_state.push(outcome);
   diags := ArrayList(LspDiag).new();
   match(
     _take_parse_error(),

--- a/src/lsp/hover.yo
+++ b/src/lsp/hover.yo
@@ -1,0 +1,296 @@
+//! lsp/hover — textDocument/hover (plans/P4_LSP.md slice 3).
+//!
+//! Port of the retired TypeScript `src/lsp/hover.ts` + the position/match
+//! helpers from `src/lsp/utils.ts` (src-attic-final). The algorithm:
+//! find the token under the cursor, collect the Atom expressions whose
+//! token matches it by (value, row, column), pick the best candidate,
+//! then read its `ExprInfo` (type / value / env / doc comment), refining
+//! through the env's variable list when several bindings share the name.
+//! Renders the same markdown shape TS produced:
+//!
+//!   ```
+//!   name
+//!   : type
+//!   = value            (comptime values only)
+//!   ```
+//!   ---
+//!   doc comment
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+open(import("std/error"));
+{ Token, TokenKind, is_reserved_operator_name } :: import("../token.yo");
+{ tokenize } :: import("../lexer.yo");
+{ AstExpr, ast_expr_id, ast_expr_token } :: import("../expr.yo");
+{ ExprInfo, ExprInfoTable, expr_info_table_get } :: import("../expr_info.yo");
+{ get_variables_from_env, Variable, variable_doc_comment } :: import("../env.yo");
+{ type_to_string } :: import("../types/string.yo");
+{ EvalValue, value_to_string } :: import("../value.yo");
+{ JsonValue } :: import("std/encoding/json");
+{ jb, jstr, j_range } :: import("./protocol.yo");
+
+/// Find the token at (line, character), skipping whitespace and comments.
+_find_token_at :: (
+  fn(tokens : ArrayList(Token), line : usize, character : usize) -> Option(Token)
+)({
+  (i : usize) = usize(0);
+  n := tokens.len();
+  while(i < n, {
+    t := match(
+      tokens.get(i),
+      .Some(x) => x,
+      .None => {
+        return(Option(Token).None);
+      }
+    );
+    skip := (
+      (t.kind == TokenKind.Whitespace) ||
+        ((t.kind == TokenKind.SingleLineComment) || (t.kind == TokenKind.MultiLineComment))
+    );
+    if(!(skip) && (t.row == line), {
+      if((character >= t.column) && (character < (t.column + t.value.len())), {
+        return(Option(Token).Some(t));
+      });
+    });
+    i = (i + usize(1));
+  });
+  Option(Token).None
+});
+
+/// Collect Atom exprs matching the target token by (value, row, column).
+_collect_candidates :: (
+  fn(e : AstExpr, target : Token, out : ArrayList(AstExpr)) -> unit
+)({
+  match(
+    e,
+    .Atom(_, tok) => {
+      if(((tok.value == target.value) && (tok.row == target.row)) && (tok.column == target.column), {
+        out.push(e);
+      });
+    },
+    .FnCall(_, func_box, args, _, _) => {
+      recur(func_box, target, out);
+      (i : usize) = usize(0);
+      while(i < args.len(), {
+        match(
+          args.get(i),
+          .Some(a) => recur(a, target, out),
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+    }
+  );
+});
+
+/// Best candidate: prefer one WITH ExprInfo (evaluated), then the first.
+_best_candidate :: (
+  fn(cands : ArrayList(AstExpr), info_table : ExprInfoTable) -> Option(AstExpr)
+)({
+  (i : usize) = usize(0);
+  while(i < cands.len(), {
+    match(
+      cands.get(i),
+      .Some(c) => {
+        if(expr_info_table_get(info_table, ast_expr_id(c)).is_some(), {
+          return(Option(AstExpr).Some(c));
+        });
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  cands.get(usize(0))
+});
+
+/// TS selectBestVariableAtPosition, faithfully: exact-position match first,
+/// then the LATEST declaration visible at (and same module as) the target.
+_select_best_variable :: (
+  fn(vars : ArrayList(Variable), target : Token) -> Option(Variable)
+)({
+  (best_visible : Option(Variable)) = Option(Variable).None;
+  (best_row : usize) = usize(0);
+  (best_col : usize) = usize(0);
+  (i : usize) = usize(0);
+  while(i < vars.len(), {
+    v := match(
+      vars.get(i),
+      .Some(x) => x,
+      .None => {
+        return(Option(Variable).None);
+      }
+    );
+    match(
+      v.initialized_at_token,
+      .Some(it) => {
+        if(it.module_path == target.module_path, {
+          exact := ((it.row == target.row) && (it.column == target.column));
+          if(exact, {
+            return(Option(Variable).Some(v));
+          });
+          visible := (
+            (it.row < target.row) ||
+              ((it.row == target.row) && (it.column <= target.column))
+          );
+          if(visible, {
+            later := (
+              best_visible.is_none() ||
+                ((it.row > best_row) || ((it.row == best_row) && (it.column >= best_col)))
+            );
+            if(later, {
+              best_visible = Option(Variable).Some(v);
+              best_row = it.row;
+              best_col = it.column;
+            });
+          });
+        });
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  match(
+    best_visible,
+    .Some(bv) => Option(Variable).Some(bv),
+    .None => vars.get(vars.len() - usize(1))
+  )
+});
+
+/// Build the hover response value for (line, character), or `.None` when
+/// nothing meaningful is under the cursor.
+handle_hover :: (
+  fn(
+    text : String,
+    doc_abs : String,
+    exprs : ArrayList(AstExpr),
+    info_table : ExprInfoTable,
+    line : usize,
+    character : usize
+  ) -> Option(JsonValue)
+)({
+  lex_exn := Exception(
+    throw : (
+      (_err) -> unwind(Option(JsonValue).None)
+    )
+  );
+  tokens := tokenize(text.clone(), doc_abs.clone(), lex_exn);
+  target := match(
+    _find_token_at(tokens, line, character),
+    .Some(t) => t,
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  cands := ArrayList(AstExpr).new();
+  (ei : usize) = usize(0);
+  while(ei < exprs.len(), {
+    match(
+      exprs.get(ei),
+      .Some(e) => _collect_candidates(e, target, cands),
+      .None => ()
+    );
+    ei = (ei + usize(1));
+  });
+  expr := match(
+    _best_candidate(cands, info_table),
+    .Some(x) => x,
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  info_opt := expr_info_table_get(info_table, ast_expr_id(expr));
+  (name : String) = target.value.clone();
+  if(is_reserved_operator_name(name.clone()) || (target.kind == TokenKind.Operator), {
+    name = `(${name})`;
+  });
+  (ty_opt : Option(String)) = Option(String).None;
+  (val_opt : Option(String)) = Option(String).None;
+  (doc_opt : Option(String)) = Option(String).None;
+  (is_comptime : bool) = false;
+  match(
+    info_opt,
+    .Some(info) => {
+      ty_opt = Option(String).Some(type_to_string(info.ty));
+      match(
+        info.value,
+        .Some(v) => {
+          vs := value_to_string(v);
+          if(vs != "<runtime value>", {
+            val_opt = Option(String).Some(vs);
+          });
+        },
+        .None => ()
+      );
+      doc_opt = info.doc_comment;
+      // Env refinement: several bindings can share the name; pick the one
+      // declared at/nearest the cursor (mirrors TS's env pass).
+      vars := get_variables_from_env(info.env, target.value.clone());
+      if(vars.len() > usize(0), {
+        match(
+          _select_best_variable(vars, target),
+          .Some(sv) => {
+            ty_opt = Option(String).Some(type_to_string(sv.ty));
+            is_comptime = sv.is_compile_time_only;
+            match(
+              sv.value.get(usize(0)),
+              .Some(vv) => {
+                vs2 := value_to_string(vv);
+                if(vs2 != "<runtime value>", {
+                  val_opt = Option(String).Some(vs2);
+                });
+              },
+              .None => ()
+            );
+            match(
+              variable_doc_comment(sv),
+              .Some(dc) => {
+                doc_opt = Option(String).Some(dc);
+              },
+              .None => ()
+            );
+          },
+          .None => ()
+        );
+      });
+    },
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  if(is_comptime, {
+    name = `comptime(${name})`;
+  });
+  fence := String.from("```");
+  (content : String) = `${fence}\n${name}`;
+  match(
+    ty_opt,
+    .Some(ts) => {
+      content = `${content}\n: ${ts}`;
+    },
+    .None => ()
+  );
+  match(
+    val_opt,
+    .Some(vs3) => {
+      content = `${content}\n= ${vs3}`;
+    },
+    .None => ()
+  );
+  content = `${content}\n${fence}`;
+  match(
+    doc_opt,
+    .Some(dc2) => {
+      content = `${content}\n\n---\n\n${dc2}`;
+    },
+    .None => ()
+  );
+  Option(JsonValue).Some(
+    jb().put(
+      "contents",
+      jb().put("kind", jstr(String.from("markdown"))).put("value", jstr(content)).obj()
+    ).put(
+      "range",
+      j_range(target.row, target.column, target.row, target.column + target.value.len())
+    ).obj()
+  )
+});
+export(handle_hover);

--- a/src/lsp/server.yo
+++ b/src/lsp/server.yo
@@ -25,9 +25,20 @@ open(import("std/fmt"));
   j_error_response,
   j_notification
 } :: import("./protocol.yo");
-{ analyze_document, LspDiag } :: import("./diagnostics.yo");
+{ analyze_document, LspDiag, AnalyzeOutcome } :: import("./diagnostics.yo");
+{ handle_hover } :: import("./hover.yo");
 { resolve_std_path } :: import("../module_manager.yo");
 { BufReader } :: import("std/sys/bufio/buf_reader");
+
+/// Per-document retained analysis: editor text + the last evaluation's
+/// program/ExprInfo (read by hover and the later feature slices).
+DocState :: ref(
+  struct(
+    text : String,
+    entry_abs : String,
+    outcome : AnalyzeOutcome
+  )
+);
 
 /// `shutdown` latch: the LSP spec's `exit` notification exits 0 only when a
 /// `shutdown` request preceded it. Module-level because it must survive
@@ -100,12 +111,24 @@ _jfield_str :: (fn(v : JsonValue, key : str) -> String)(
   )
 );
 
-/// Analyze `text` as the document at `uri` and push publishDiagnostics.
+/// Analyze `text` as the document at `uri`, retain the analysis state for
+/// feature requests, and push publishDiagnostics.
 _analyze_and_publish :: (
-  fn(uri : String, text : String, std_path : String, io : Io) -> unit
+  fn(uri : String, text : String, std_path : String, docs : HashMap(String, DocState), io : Io) -> unit
 )({
   fs_path := uri_to_fs_path(uri.clone());
-  diags := analyze_document(fs_path, text, std_path, io);
+  out_state := ArrayList(AnalyzeOutcome).new();
+  diags := analyze_document(fs_path.clone(), text.clone(), std_path, io, out_state);
+  match(
+    out_state.get(usize(0)),
+    .Some(oc) => {
+      _st := docs.set(
+        uri.clone(),
+        DocState(text : text.clone(), entry_abs : fs_path.clone(), outcome : oc)
+      );
+    },
+    .None => ()
+  );
   items := ArrayList(JsonValue).new();
   (i : usize) = usize(0);
   while(i < diags.len(), {
@@ -132,7 +155,7 @@ _publish_empty :: (fn(uri : String) -> unit)({
 /// capability flag. Feature providers (hover, completion, …) arrive with
 /// their P4 slices.
 _initialize_result :: (fn() -> JsonValue)(
-  jb().put("capabilities", jb().put("textDocumentSync", jnum(usize(1))).obj()).put(
+  jb().put("capabilities", jb().put("textDocumentSync", jnum(usize(1))).put("hoverProvider", JsonValue.Bool(value : true)).obj()).put(
     "serverInfo",
     // No `version` field on purpose: it is optional in the protocol, the
     // client can ask `yo --version`, and a version here would churn the
@@ -146,7 +169,7 @@ _initialize_result :: (fn() -> JsonValue)(
 _handle_message :: (
   fn(
     body : String,
-    docs : HashMap(String, String),
+    docs : HashMap(String, DocState),
     std_path : String,
     io : Io
   ) -> i32
@@ -182,6 +205,66 @@ _handle_message :: (
     (method == String.from("exit")) => {
       return(cond(g_shutdown_requested => i32(10), true => i32(11)));
     },
+    (method == String.from("textDocument/hover")) => {
+      (hover_result : JsonValue) = JsonValue.Null;
+      match(
+        v.get(String.from("params")),
+        .Some(params) => {
+          uri := match(
+            params.get(String.from("textDocument")),
+            .Some(td) => _jfield_str(td, "uri"),
+            .None => String.new()
+          );
+          (line : usize) = usize(0);
+          (character : usize) = usize(0);
+          match(
+            params.get(String.from("position")),
+            .Some(pos) => {
+              match(
+                pos.get(String.from("line")),
+                .Some(lv) => match(
+                  lv,
+                  .Number(ln) => {
+                    line = usize(ln);
+                  },
+                  _ => ()
+                ),
+                .None => ()
+              );
+              match(
+                pos.get(String.from("character")),
+                .Some(cv) => match(
+                  cv,
+                  .Number(cn) => {
+                    character = usize(cn);
+                  },
+                  _ => ()
+                ),
+                .None => ()
+              );
+            },
+            .None => ()
+          );
+          match(
+            docs.get(uri.clone()),
+            .Some(st) => match(
+              handle_hover(st.text, st.entry_abs, st.outcome.exprs, st.outcome.info_table, line, character),
+              .Some(h) => {
+                hover_result = h;
+              },
+              .None => ()
+            ),
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+      match(
+        id_opt,
+        .Some(id) => write_lsp_message(json_stringify(j_response(id, hover_result))),
+        .None => ()
+      );
+    },
     (method == String.from("textDocument/didOpen")) => {
       match(
         v.get(String.from("params")),
@@ -191,8 +274,7 @@ _handle_message :: (
             uri := _jfield_str(td, "uri");
             text := _jfield_str(td, "text");
             if(uri.len() > usize(0), {
-              _s1 := docs.set(uri.clone(), text.clone());
-              _analyze_and_publish(uri, text, std_path.clone(), io);
+              _analyze_and_publish(uri, text, std_path.clone(), docs, io);
             });
           },
           .None => ()
@@ -230,8 +312,7 @@ _handle_message :: (
           match(
             text_opt,
             .Some(text) => if(uri.len() > usize(0), {
-              _s2 := docs.set(uri.clone(), text.clone());
-              _analyze_and_publish(uri, text, std_path.clone(), io);
+              _analyze_and_publish(uri, text, std_path.clone(), docs, io);
             }),
             .None => ()
           );
@@ -277,7 +358,7 @@ _handle_message :: (
 /// `yo lsp` entry: serve LSP over stdio until `exit` or EOF.
 run_lsp_server :: (fn(io : Io, exn : Exception) -> unit)({
   reader := BufReader.new(i32(0));
-  docs := HashMap(String, String).new();
+  docs := HashMap(String, DocState).new();
   std_path := resolve_std_path();
   // No startup banner: the cli-case harness merges stderr into stdout, and
   // stderr/stdout interleaving is not deterministic. Real editors surface

--- a/tests/cli-cases/lsp-handshake/stdin
+++ b/tests/cli-cases/lsp-handshake/stdin
@@ -4,14 +4,18 @@ Content-Length: 107
 
 {"jsonrpc":"2.0","method":"initialized","params":{}}Content-Length: 217
 
-{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///virtual/doc.yo","languageId":"yo","version":1,"text":"main :: (fn() -> unit)({\n  undefined_fn_xyz();\n});\nexport(main);\n"}}}Content-Length: 197
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///virtual/doc.yo","languageId":"yo","version":1,"text":"main :: (fn() -> unit)({\n  undefined_fn_xyz();\n});\nexport(main);\n"}}}Content-Length: 292
 
-{"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///virtual/doc.yo","version":2},"contentChanges":[{"text":"main :: (fn() -> unit)(());\nexport(main);\n"}]}}Content-Length: 61
+{"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///virtual/doc.yo","version":2},"contentChanges":[{"text":"/// Adds one.\nadd_one :: (fn(x : i32) -> i32)(x + i32(1));\nmain :: (fn() -> unit)({\n  y := add_one(i32(41));\n  ()\n});\nexport(main);\n"}]}}Content-Length: 149
 
-{"jsonrpc":"2.0","id":2,"method":"unknown/probe","params":{}}Content-Length: 109
+{"jsonrpc":"2.0","id":2,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":3,"character":9}}}Content-Length: 149
+
+{"jsonrpc":"2.0","id":3,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":4,"character":0}}}Content-Length: 61
+
+{"jsonrpc":"2.0","id":4,"method":"unknown/probe","params":{}}Content-Length: 109
 
 {"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 44
 
-{"jsonrpc":"2.0","id":3,"method":"shutdown"}Content-Length: 33
+{"jsonrpc":"2.0","id":5,"method":"shutdown"}Content-Length: 33
 
 {"jsonrpc":"2.0","method":"exit"}


### PR DESCRIPTION
**Stacked on #208** — merge that first.

First feature slice on the transport: `textDocument/hover`.

- `src/lsp/hover.yo` ports the attic `hover.ts` + `utils.ts` core: token-at-position (skipping trivia), Atom-candidate collection by (value,row,col), best candidate by evaluated `ExprInfo`, env-variable refinement (exact-position → latest-visible declaration), markdown render (`name`/`: type`/`= value` + doc comment when the evaluator recorded one).
- Analysis state is now retained per URI (`AnalyzeOutcome {exprs, info_table}` → server `DocState`), which is the foundation for definition/symbols/references next.
- The `lsp-handshake` cli-case grew hover coverage: a call-site hover answers `comptime(add_one) : fn(x : i32) -> i32` at the exact range; whitespace answers null. Golden re-recorded, replays deterministically.

Validation: `check ./src` clean · 43/43 CLI goldens · gates_fast green · stage-2/3 FIXPOINT HOLDS, hollow=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)