### PR TITLE
p4: textDocument/definition + documentSymbol (slice 3 complete)

### DIFF
--- a/src/lsp/definition.yo
+++ b/src/lsp/definition.yo
@@ -1,0 +1,108 @@
+//! lsp/definition — textDocument/definition (plans/P4_LSP.md slice 3).
+//!
+//! Port of the attic `definition.ts` VARIABLE channel: token at position →
+//! best Atom candidate → its ExprInfo env → the selected variable's
+//! `initialized_at_token` → an LSP Location. The TS file's further channels
+//! (struct-field definitions, enum-variant constructors, import-path
+//! strings) are recorded follow-ups — the variable channel already covers
+//! locals, functions, types, and imported names bound with `::`.
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+open(import("std/error"));
+{ Token, TokenKind } :: import("../token.yo");
+{ tokenize } :: import("../lexer.yo");
+{ AstExpr, ast_expr_id } :: import("../expr.yo");
+{ ExprInfoTable, expr_info_table_get } :: import("../expr_info.yo");
+{ get_variables_from_env } :: import("../env.yo");
+{ JsonValue } :: import("std/encoding/json");
+{ jb, jstr, j_range } :: import("./protocol.yo");
+{
+  _find_token_at,
+  _collect_candidates,
+  _best_candidate,
+  _select_best_variable
+} :: import("./hover.yo");
+
+/// A token's module_path as an LSP file:// uri. Module paths arrive either
+/// as `file:///abs` (import-resolved) or plain `/abs`.
+_module_path_to_uri :: (fn(mp : String) -> String)(
+  cond(
+    mp.starts_with(String.from("file://")) => mp,
+    true => `file://${mp}`
+  )
+);
+
+/// Resolve the definition Location for (line, character), or `.None`.
+handle_definition :: (
+  fn(
+    text : String,
+    doc_abs : String,
+    exprs : ArrayList(AstExpr),
+    info_table : ExprInfoTable,
+    line : usize,
+    character : usize
+  ) -> Option(JsonValue)
+)({
+  lex_exn := Exception(
+    throw : (
+      (_err) -> unwind(Option(JsonValue).None)
+    )
+  );
+  tokens := tokenize(text.clone(), doc_abs.clone(), lex_exn);
+  target := match(
+    _find_token_at(tokens, line, character),
+    .Some(t) => t,
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  cands := ArrayList(AstExpr).new();
+  (ei : usize) = usize(0);
+  while(ei < exprs.len(), {
+    match(
+      exprs.get(ei),
+      .Some(e) => _collect_candidates(e, target, cands),
+      .None => ()
+    );
+    ei = (ei + usize(1));
+  });
+  expr := match(
+    _best_candidate(cands, info_table),
+    .Some(x) => x,
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  info := match(
+    expr_info_table_get(info_table, ast_expr_id(expr)),
+    .Some(i) => i,
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  vars := get_variables_from_env(info.env, target.value.clone());
+  if(vars.len() == usize(0), {
+    return(Option(JsonValue).None);
+  });
+  sv := match(
+    _select_best_variable(vars, target),
+    .Some(v) => v,
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  def_tok := match(
+    sv.initialized_at_token,
+    .Some(t2) => t2,
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  Option(JsonValue).Some(
+    jb().put("uri", jstr(_module_path_to_uri(def_tok.module_path.clone()))).put(
+      "range",
+      j_range(def_tok.row, def_tok.column, def_tok.row, def_tok.column + def_tok.value.len())
+    ).obj()
+  )
+});
+export(handle_definition);

--- a/src/lsp/hover.yo
+++ b/src/lsp/hover.yo
@@ -293,4 +293,4 @@ handle_hover :: (
     ).obj()
   )
 });
-export(handle_hover);
+export(handle_hover, _find_token_at, _collect_candidates, _best_candidate, _select_best_variable);

--- a/src/lsp/server.yo
+++ b/src/lsp/server.yo
@@ -27,6 +27,8 @@ open(import("std/fmt"));
 } :: import("./protocol.yo");
 { analyze_document, LspDiag, AnalyzeOutcome } :: import("./diagnostics.yo");
 { handle_hover } :: import("./hover.yo");
+{ handle_definition } :: import("./definition.yo");
+{ handle_document_symbols } :: import("./symbols.yo");
 { resolve_std_path } :: import("../module_manager.yo");
 { BufReader } :: import("std/sys/bufio/buf_reader");
 
@@ -155,7 +157,7 @@ _publish_empty :: (fn(uri : String) -> unit)({
 /// capability flag. Feature providers (hover, completion, …) arrive with
 /// their P4 slices.
 _initialize_result :: (fn() -> JsonValue)(
-  jb().put("capabilities", jb().put("textDocumentSync", jnum(usize(1))).put("hoverProvider", JsonValue.Bool(value : true)).obj()).put(
+  jb().put("capabilities", jb().put("textDocumentSync", jnum(usize(1))).put("hoverProvider", JsonValue.Bool(value : true)).put("definitionProvider", JsonValue.Bool(value : true)).put("documentSymbolProvider", JsonValue.Bool(value : true)).obj()).put(
     "serverInfo",
     // No `version` field on purpose: it is optional in the protocol, the
     // client can ask `yo --version`, and a version here would churn the
@@ -262,6 +264,92 @@ _handle_message :: (
       match(
         id_opt,
         .Some(id) => write_lsp_message(json_stringify(j_response(id, hover_result))),
+        .None => ()
+      );
+    },
+    (method == String.from("textDocument/definition")) => {
+      (def_result : JsonValue) = JsonValue.Null;
+      match(
+        v.get(String.from("params")),
+        .Some(params) => {
+          uri := match(
+            params.get(String.from("textDocument")),
+            .Some(td) => _jfield_str(td, "uri"),
+            .None => String.new()
+          );
+          (line : usize) = usize(0);
+          (character : usize) = usize(0);
+          match(
+            params.get(String.from("position")),
+            .Some(pos) => {
+              match(
+                pos.get(String.from("line")),
+                .Some(lv) => match(
+                  lv,
+                  .Number(ln) => {
+                    line = usize(ln);
+                  },
+                  _ => ()
+                ),
+                .None => ()
+              );
+              match(
+                pos.get(String.from("character")),
+                .Some(cv) => match(
+                  cv,
+                  .Number(cn) => {
+                    character = usize(cn);
+                  },
+                  _ => ()
+                ),
+                .None => ()
+              );
+            },
+            .None => ()
+          );
+          match(
+            docs.get(uri.clone()),
+            .Some(st) => match(
+              handle_definition(st.text, st.entry_abs, st.outcome.exprs, st.outcome.info_table, line, character),
+              .Some(loc) => {
+                def_result = loc;
+              },
+              .None => ()
+            ),
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+      match(
+        id_opt,
+        .Some(id) => write_lsp_message(json_stringify(j_response(id, def_result))),
+        .None => ()
+      );
+    },
+    (method == String.from("textDocument/documentSymbol")) => {
+      (sym_result : JsonValue) = JsonValue.Array(items : ArrayList(JsonValue).new());
+      match(
+        v.get(String.from("params")),
+        .Some(params) => {
+          uri := match(
+            params.get(String.from("textDocument")),
+            .Some(td) => _jfield_str(td, "uri"),
+            .None => String.new()
+          );
+          match(
+            docs.get(uri.clone()),
+            .Some(st) => {
+              sym_result = handle_document_symbols(st.outcome.exprs);
+            },
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+      match(
+        id_opt,
+        .Some(id) => write_lsp_message(json_stringify(j_response(id, sym_result))),
         .None => ()
       );
     },

--- a/src/lsp/symbols.yo
+++ b/src/lsp/symbols.yo
@@ -1,0 +1,112 @@
+//! lsp/symbols — textDocument/documentSymbol (plans/P4_LSP.md slice 3).
+//!
+//! Port of the attic `symbols.ts` core: walk the top-level statements for
+//! `name :: value` bindings and map each to an LSP DocumentSymbol whose
+//! kind follows the bound value's AST shape (fn → Function, struct →
+//! Struct, enum → Enum, trait → Interface, impl → Namespace, everything
+//! else → Constant). Purely syntactic — works even while the document has
+//! evaluation errors.
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ Token } :: import("../token.yo");
+{ AstExpr, ast_expr_token, ast_expr_is_fn_call_of, ast_expr_is_atom } :: import("../expr.yo");
+{ JsonValue } :: import("std/encoding/json");
+{ jb, jstr, jnum, j_range } :: import("./protocol.yo");
+
+/// Is `e` a function TYPE expression? `fn(...) -> T` parses as an `->`
+/// INFIX call whose first argument is the `fn(...)` call, so both shapes
+/// count.
+_is_fn_type_expr :: (fn(e : AstExpr) -> bool)({
+  if(ast_expr_is_fn_call_of(e, "fn", .None), {
+    return(true);
+  });
+  if(ast_expr_is_fn_call_of(e, "->", .Some(usize(2))), {
+    match(
+      e,
+      .FnCall(_, _, arrow_args, _, _) => match(
+        arrow_args.get(usize(0)),
+        .Some(lhs) => {
+          return(ast_expr_is_fn_call_of(lhs, "fn", .None));
+        },
+        .None => ()
+      ),
+      .Atom(_, _) => ()
+    );
+  });
+  false
+});
+
+/// LSP SymbolKind for the bound value's AST shape.
+_symbol_kind_of :: (fn(value_expr : AstExpr) -> usize)({
+  // Function 12, Struct 23, Enum 10, Interface 11, Namespace 3,
+  // Constant 14 (the LSP SymbolKind table).
+  if(_is_fn_type_expr(value_expr), {
+    return(usize(12));
+  });
+  if(ast_expr_is_fn_call_of(value_expr, "struct", .None) || ast_expr_is_fn_call_of(value_expr, "newtype", .None), {
+    return(usize(23));
+  });
+  if(ast_expr_is_fn_call_of(value_expr, "enum", .None) || ast_expr_is_fn_call_of(value_expr, "union", .None), {
+    return(usize(10));
+  });
+  if(ast_expr_is_fn_call_of(value_expr, "trait", .None), {
+    return(usize(11));
+  });
+  if(ast_expr_is_fn_call_of(value_expr, "impl", .None), {
+    return(usize(3));
+  });
+  // `(fn(...) -> T)(body)` — the common function-definition shape: the
+  // CALLEE is the fn type.
+  match(
+    value_expr,
+    .FnCall(_, func_box, _, _, _) => {
+      if(_is_fn_type_expr(func_box), {
+        return(usize(12));
+      });
+    },
+    .Atom(_, _) => ()
+  );
+  usize(14)
+});
+
+/// Collect DocumentSymbols from the top-level statements.
+handle_document_symbols :: (
+  fn(exprs : ArrayList(AstExpr)) -> JsonValue
+)({
+  items := ArrayList(JsonValue).new();
+  (i : usize) = usize(0);
+  while(i < exprs.len(), {
+    e := match(
+      exprs.get(i),
+      .Some(x) => x,
+      .None => {
+        return(JsonValue.Array(items : items));
+      }
+    );
+    if(ast_expr_is_fn_call_of(e, "::", .Some(usize(2))), {
+      match(
+        e,
+        .FnCall(_, _, args, _, _) => {
+          name_expr := match(args.get(usize(0)), .Some(a) => a, .None => e);
+          value_expr := match(args.get(usize(1)), .Some(a) => a, .None => e);
+          if(ast_expr_is_atom(name_expr), {
+            name_tok := ast_expr_token(name_expr);
+            rng := j_range(
+              name_tok.row,
+              name_tok.column,
+              name_tok.row,
+              name_tok.column + name_tok.value.len()
+            );
+            items.push(
+              jb().put("name", jstr(name_tok.value.clone())).put("kind", jnum(_symbol_kind_of(value_expr))).put("range", rng).put("selectionRange", rng).obj()
+            );
+          });
+        },
+        .Atom(_, _) => ()
+      );
+    });
+    i = (i + usize(1));
+  });
+  JsonValue.Array(items : items)
+});
+export(handle_document_symbols);

--- a/tests/cli-cases/lsp-handshake/stdin
+++ b/tests/cli-cases/lsp-handshake/stdin
@@ -10,12 +10,16 @@ Content-Length: 107
 
 {"jsonrpc":"2.0","id":2,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":3,"character":9}}}Content-Length: 149
 
-{"jsonrpc":"2.0","id":3,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":4,"character":0}}}Content-Length: 61
+{"jsonrpc":"2.0","id":3,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":4,"character":0}}}Content-Length: 154
 
-{"jsonrpc":"2.0","id":4,"method":"unknown/probe","params":{}}Content-Length: 109
+{"jsonrpc":"2.0","id":4,"method":"textDocument/definition","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":3,"character":9}}}Content-Length: 122
+
+{"jsonrpc":"2.0","id":5,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 61
+
+{"jsonrpc":"2.0","id":6,"method":"unknown/probe","params":{}}Content-Length: 109
 
 {"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 44
 
-{"jsonrpc":"2.0","id":5,"method":"shutdown"}Content-Length: 33
+{"jsonrpc":"2.0","id":7,"method":"shutdown"}Content-Length: 33
 
 {"jsonrpc":"2.0","method":"exit"}


### PR DESCRIPTION
**Stacked on #210** (hover), which stacks on #208 (transport) — merge in order.

- `definition.yo`: the attic `definition.ts` variable channel — resolves to the selected variable's `initialized_at_token` as an LSP Location (field/enum-variant/import channels are recorded follow-ups).
- `symbols.yo`: top-level `name :: value` bindings as DocumentSymbols, kind from AST shape (`fn(...) -> T` parses as an `->` infix call — the first draft missed that and reported Constant; caught by the live smoke).
- Server capabilities + dispatch; the `lsp-handshake` case now exercises **initialize → diagnostics (broken→fixed) → hover → definition → documentSymbol → MethodNotFound → close → shutdown** end-to-end against recorded goldens.

Validation: `check ./src` clean · 43/43 CLI goldens · gates_fast green · stage-2/3 FIXPOINT HOLDS, hollow=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)