### PR TITLE
p4: textDocument/references + foldingRange (slice 5 begins)

### DIFF
--- a/src/lsp/folding.yo
+++ b/src/lsp/folding.yo
@@ -1,0 +1,73 @@
+//! lsp/folding — textDocument/foldingRange (plans/P4_LSP.md slice 5).
+//!
+//! Port of the attic `folding.ts`: region ranges from multi-line `{...}`
+//! and `(...)` pairs (a shared stack, exactly like the original — a
+//! mismatched closer pops whatever is on top, which is fine for folding),
+//! plus comment ranges for multi-line block comments.
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+open(import("std/error"));
+{ Token, TokenKind } :: import("../token.yo");
+{ tokenize } :: import("../lexer.yo");
+{ JsonValue } :: import("std/encoding/json");
+{ jb, jstr, jnum } :: import("./protocol.yo");
+
+_push_fold :: (
+  fn(out : ArrayList(JsonValue), start_line : usize, end_line : usize, kind : str) -> unit
+)({
+  out.push(
+    jb().put("startLine", jnum(start_line)).put("endLine", jnum(end_line)).put("kind", jstr(String.from(kind))).obj()
+  );
+});
+
+/// Folding ranges for the document text.
+handle_folding_ranges :: (fn(text : String, doc_abs : String) -> JsonValue)({
+  out := ArrayList(JsonValue).new();
+  lex_exn := Exception(
+    throw : (
+      (_err) -> unwind(JsonValue.Array(items : ArrayList(JsonValue).new()))
+    )
+  );
+  tokens := tokenize(text.clone(), doc_abs.clone(), lex_exn);
+  open_rows := ArrayList(usize).new();
+  (i : usize) = usize(0);
+  n := tokens.len();
+  while(i < n, {
+    t := match(
+      tokens.get(i),
+      .Some(x) => x,
+      .None => {
+        return(JsonValue.Array(items : out));
+      }
+    );
+    is_open := ((t.kind == TokenKind.LCurlyBracket) || (t.kind == TokenKind.LParen));
+    is_close := ((t.kind == TokenKind.RCurlyBracket) || (t.kind == TokenKind.RParen));
+    cond(
+      is_open => {
+        open_rows.push(t.row);
+      },
+      is_close => {
+        if(open_rows.len() > usize(0), {
+          open_row := match(open_rows.get(open_rows.len() - usize(1)), .Some(r) => r, .None => t.row);
+          _p := open_rows.pop();
+          if(open_row < t.row, {
+            _push_fold(out, open_row, t.row, "region");
+          });
+        });
+      },
+      (
+        (t.kind == TokenKind.MultiLineComment) ||
+          ((t.kind == TokenKind.DocBlockComment) || (t.kind == TokenKind.InnerDocBlockComment))
+      ) => {
+        line_count := t.value.split(String.from("\n")).len();
+        if(line_count > usize(1), {
+          _push_fold(out, t.row, (t.row + line_count) - usize(1), "comment");
+        });
+      },
+      true => ()
+    );
+    i = (i + usize(1));
+  });
+  JsonValue.Array(items : out)
+});
+export(handle_folding_ranges);

--- a/src/lsp/references.yo
+++ b/src/lsp/references.yo
@@ -1,0 +1,108 @@
+//! lsp/references — textDocument/references (plans/P4_LSP.md slice 5).
+//!
+//! Port of the attic `references.ts`: same-file references by NAME — walk
+//! the program for Atom expressions matching the symbol under the cursor,
+//! falling back to a raw token scan when the AST walk finds nothing (the
+//! attic's own fallback for references the walk can miss, e.g. inside
+//! quote bodies).
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+open(import("std/error"));
+{ Token, TokenKind } :: import("../token.yo");
+{ tokenize } :: import("../lexer.yo");
+{ AstExpr } :: import("../expr.yo");
+{ JsonValue } :: import("std/encoding/json");
+{ jb, jstr, j_range } :: import("./protocol.yo");
+{ _find_token_at } :: import("./hover.yo");
+
+_push_location :: (
+  fn(out : ArrayList(JsonValue), uri : String, row : usize, col : usize, len : usize) -> unit
+)({
+  out.push(
+    jb().put("uri", jstr(uri)).put("range", j_range(row, col, row, col + len)).obj()
+  );
+});
+
+/// Walk `e` collecting Atom expressions whose token value matches `name`.
+_collect_refs :: (
+  fn(e : AstExpr, name : String, uri : String, out : ArrayList(JsonValue)) -> unit
+)({
+  match(
+    e,
+    .Atom(_, tok) => {
+      if(tok.value == name, {
+        _push_location(out, uri.clone(), tok.row, tok.column, tok.value.len());
+      });
+    },
+    .FnCall(_, func_box, args, _, _) => {
+      recur(func_box, name, uri, out);
+      (i : usize) = usize(0);
+      while(i < args.len(), {
+        match(
+          args.get(i),
+          .Some(a) => recur(a, name, uri, out),
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+    }
+  );
+});
+
+/// All same-file references to the symbol at (line, character).
+handle_references :: (
+  fn(
+    text : String,
+    doc_abs : String,
+    uri : String,
+    exprs : ArrayList(AstExpr),
+    line : usize,
+    character : usize
+  ) -> JsonValue
+)({
+  empty := ArrayList(JsonValue).new();
+  lex_exn := Exception(
+    throw : (
+      (_err) -> unwind(JsonValue.Array(items : ArrayList(JsonValue).new()))
+    )
+  );
+  tokens := tokenize(text.clone(), doc_abs.clone(), lex_exn);
+  target := match(
+    _find_token_at(tokens, line, character),
+    .Some(t) => t,
+    .None => {
+      return(JsonValue.Array(items : empty));
+    }
+  );
+  if(target.kind != TokenKind.Identifier, {
+    return(JsonValue.Array(items : empty));
+  });
+  out := ArrayList(JsonValue).new();
+  (ei : usize) = usize(0);
+  while(ei < exprs.len(), {
+    match(
+      exprs.get(ei),
+      .Some(e) => _collect_refs(e, target.value.clone(), uri.clone(), out),
+      .None => ()
+    );
+    ei = (ei + usize(1));
+  });
+  // Fallback: raw token scan (references inside quote bodies etc.).
+  if(out.len() == usize(0), {
+    (ti : usize) = usize(0);
+    while(ti < tokens.len(), {
+      match(
+        tokens.get(ti),
+        .Some(tk) => {
+          if((tk.value == target.value) && (tk.kind == TokenKind.Identifier), {
+            _push_location(out, uri.clone(), tk.row, tk.column, tk.value.len());
+          });
+        },
+        .None => ()
+      );
+      ti = (ti + usize(1));
+    });
+  });
+  JsonValue.Array(items : out)
+});
+export(handle_references);

--- a/src/lsp/server.yo
+++ b/src/lsp/server.yo
@@ -29,6 +29,8 @@ open(import("std/fmt"));
 { handle_hover } :: import("./hover.yo");
 { handle_definition } :: import("./definition.yo");
 { handle_document_symbols } :: import("./symbols.yo");
+{ handle_references } :: import("./references.yo");
+{ handle_folding_ranges } :: import("./folding.yo");
 { resolve_std_path } :: import("../module_manager.yo");
 { BufReader } :: import("std/sys/bufio/buf_reader");
 
@@ -157,7 +159,7 @@ _publish_empty :: (fn(uri : String) -> unit)({
 /// capability flag. Feature providers (hover, completion, …) arrive with
 /// their P4 slices.
 _initialize_result :: (fn() -> JsonValue)(
-  jb().put("capabilities", jb().put("textDocumentSync", jnum(usize(1))).put("hoverProvider", JsonValue.Bool(value : true)).put("definitionProvider", JsonValue.Bool(value : true)).put("documentSymbolProvider", JsonValue.Bool(value : true)).obj()).put(
+  jb().put("capabilities", jb().put("textDocumentSync", jnum(usize(1))).put("hoverProvider", JsonValue.Bool(value : true)).put("definitionProvider", JsonValue.Bool(value : true)).put("documentSymbolProvider", JsonValue.Bool(value : true)).put("referencesProvider", JsonValue.Bool(value : true)).put("foldingRangeProvider", JsonValue.Bool(value : true)).obj()).put(
     "serverInfo",
     // No `version` field on purpose: it is optional in the protocol, the
     // client can ask `yo --version`, and a version here would churn the
@@ -350,6 +352,88 @@ _handle_message :: (
       match(
         id_opt,
         .Some(id) => write_lsp_message(json_stringify(j_response(id, sym_result))),
+        .None => ()
+      );
+    },
+    (method == String.from("textDocument/references")) => {
+      (refs_result : JsonValue) = JsonValue.Array(items : ArrayList(JsonValue).new());
+      match(
+        v.get(String.from("params")),
+        .Some(params) => {
+          uri := match(
+            params.get(String.from("textDocument")),
+            .Some(td) => _jfield_str(td, "uri"),
+            .None => String.new()
+          );
+          (line : usize) = usize(0);
+          (character : usize) = usize(0);
+          match(
+            params.get(String.from("position")),
+            .Some(pos) => {
+              match(
+                pos.get(String.from("line")),
+                .Some(lv) => match(
+                  lv,
+                  .Number(ln) => {
+                    line = usize(ln);
+                  },
+                  _ => ()
+                ),
+                .None => ()
+              );
+              match(
+                pos.get(String.from("character")),
+                .Some(cv) => match(
+                  cv,
+                  .Number(cn) => {
+                    character = usize(cn);
+                  },
+                  _ => ()
+                ),
+                .None => ()
+              );
+            },
+            .None => ()
+          );
+          match(
+            docs.get(uri.clone()),
+            .Some(st) => {
+              refs_result = handle_references(st.text, st.entry_abs, uri.clone(), st.outcome.exprs, line, character);
+            },
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+      match(
+        id_opt,
+        .Some(id) => write_lsp_message(json_stringify(j_response(id, refs_result))),
+        .None => ()
+      );
+    },
+    (method == String.from("textDocument/foldingRange")) => {
+      (fold_result : JsonValue) = JsonValue.Array(items : ArrayList(JsonValue).new());
+      match(
+        v.get(String.from("params")),
+        .Some(params) => {
+          uri := match(
+            params.get(String.from("textDocument")),
+            .Some(td) => _jfield_str(td, "uri"),
+            .None => String.new()
+          );
+          match(
+            docs.get(uri.clone()),
+            .Some(st) => {
+              fold_result = handle_folding_ranges(st.text, st.entry_abs);
+            },
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+      match(
+        id_opt,
+        .Some(id) => write_lsp_message(json_stringify(j_response(id, fold_result))),
         .None => ()
       );
     },

--- a/tests/cli-cases/lsp-handshake/stdin
+++ b/tests/cli-cases/lsp-handshake/stdin
@@ -14,12 +14,16 @@ Content-Length: 107
 
 {"jsonrpc":"2.0","id":4,"method":"textDocument/definition","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":3,"character":9}}}Content-Length: 122
 
-{"jsonrpc":"2.0","id":5,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 61
+{"jsonrpc":"2.0","id":5,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 192
 
-{"jsonrpc":"2.0","id":6,"method":"unknown/probe","params":{}}Content-Length: 109
+{"jsonrpc":"2.0","id":6,"method":"textDocument/references","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":3,"character":9},"context":{"includeDeclaration":true}}}Content-Length: 120
+
+{"jsonrpc":"2.0","id":7,"method":"textDocument/foldingRange","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 61
+
+{"jsonrpc":"2.0","id":8,"method":"unknown/probe","params":{}}Content-Length: 109
 
 {"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 44
 
-{"jsonrpc":"2.0","id":7,"method":"shutdown"}Content-Length: 33
+{"jsonrpc":"2.0","id":9,"method":"shutdown"}Content-Length: 33
 
 {"jsonrpc":"2.0","method":"exit"}


### PR DESCRIPTION
**Stacked on #211** — merge the chain in order (#208 merged, #210 → #211 → this).

Same-file references (AST walk + the attic's raw-token fallback) and folding ranges (brace/paren pairs + multi-line comments), wired with capabilities and covered by the extended `lsp-handshake` golden.

Validation: `check ./src` clean · 43/43 CLI goldens · gates_fast green · stage-2/3 FIXPOINT HOLDS, hollow=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)