### PR TITLE
p4: textDocument/rename + formatting (slice 5 continues)

### DIFF
--- a/src/lsp/rename.yo
+++ b/src/lsp/rename.yo
@@ -1,0 +1,106 @@
+//! lsp/rename — textDocument/rename (plans/P4_LSP.md slice 5).
+//!
+//! Port of the attic `rename.ts`: rename all same-file references by name.
+//! Produces a WorkspaceEdit whose `changes` map the document uri to one
+//! TextEdit per occurrence (deduplicated by position — the same Atom can be
+//! reachable through several AST paths).
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ HashSet } :: import("std/collections/hash_set");
+open(import("std/error"));
+{ Token, TokenKind } :: import("../token.yo");
+{ tokenize } :: import("../lexer.yo");
+{ AstExpr } :: import("../expr.yo");
+{ JsonValue } :: import("std/encoding/json");
+{ jb, jstr, j_range } :: import("./protocol.yo");
+{ _find_token_at } :: import("./hover.yo");
+
+_collect_rename_edits :: (
+  fn(
+    e : AstExpr,
+    old_name : String,
+    new_name : String,
+    seen : HashSet(String),
+    out : ArrayList(JsonValue)
+  ) -> unit
+)({
+  match(
+    e,
+    .Atom(_, tok) => {
+      if(tok.value == old_name, {
+        key := `${tok.row}:${tok.column}`;
+        if(!(seen.contains(key.clone())), {
+          _a := seen.add(key);
+          out.push(
+            jb().put("range", j_range(tok.row, tok.column, tok.row, tok.column + old_name.len())).put("newText", jstr(new_name.clone())).obj()
+          );
+        });
+      });
+    },
+    .FnCall(_, func_box, args, _, _) => {
+      recur(func_box, old_name, new_name, seen, out);
+      (i : usize) = usize(0);
+      while(i < args.len(), {
+        match(
+          args.get(i),
+          .Some(a) => recur(a, old_name, new_name, seen, out),
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+    }
+  );
+});
+
+/// Build the WorkspaceEdit for renaming the symbol at (line, character), or
+/// `.None` when there is nothing renameable under the cursor.
+handle_rename :: (
+  fn(
+    text : String,
+    doc_abs : String,
+    uri : String,
+    exprs : ArrayList(AstExpr),
+    line : usize,
+    character : usize,
+    new_name : String
+  ) -> Option(JsonValue)
+)({
+  lex_exn := Exception(
+    throw : (
+      (_err) -> unwind(Option(JsonValue).None)
+    )
+  );
+  tokens := tokenize(text.clone(), doc_abs.clone(), lex_exn);
+  target := match(
+    _find_token_at(tokens, line, character),
+    .Some(t) => t,
+    .None => {
+      return(Option(JsonValue).None);
+    }
+  );
+  if((target.kind != TokenKind.Identifier) || (new_name.len() == usize(0)), {
+    return(Option(JsonValue).None);
+  });
+  edits := ArrayList(JsonValue).new();
+  seen := HashSet(String).new();
+  (ei : usize) = usize(0);
+  while(ei < exprs.len(), {
+    match(
+      exprs.get(ei),
+      .Some(e) => _collect_rename_edits(e, target.value.clone(), new_name.clone(), seen, edits),
+      .None => ()
+    );
+    ei = (ei + usize(1));
+  });
+  if(edits.len() == usize(0), {
+    return(Option(JsonValue).None);
+  });
+  changes_keys := ArrayList(String).new();
+  changes_vals := ArrayList(JsonValue).new();
+  changes_keys.push(uri.clone());
+  changes_vals.push(JsonValue.Array(items : edits));
+  Option(JsonValue).Some(
+    jb().put("changes", JsonValue.Object(keys : changes_keys, values : changes_vals)).obj()
+  )
+});
+export(handle_rename);

--- a/src/lsp/server.yo
+++ b/src/lsp/server.yo
@@ -21,6 +21,7 @@ open(import("std/fmt"));
   jstr,
   jnum,
   j_diagnostic,
+  j_range,
   j_response,
   j_error_response,
   j_notification
@@ -31,6 +32,8 @@ open(import("std/fmt"));
 { handle_document_symbols } :: import("./symbols.yo");
 { handle_references } :: import("./references.yo");
 { handle_folding_ranges } :: import("./folding.yo");
+{ handle_rename } :: import("./rename.yo");
+{ format_yo_source } :: import("../formatter.yo");
 { resolve_std_path } :: import("../module_manager.yo");
 { BufReader } :: import("std/sys/bufio/buf_reader");
 
@@ -159,7 +162,7 @@ _publish_empty :: (fn(uri : String) -> unit)({
 /// capability flag. Feature providers (hover, completion, …) arrive with
 /// their P4 slices.
 _initialize_result :: (fn() -> JsonValue)(
-  jb().put("capabilities", jb().put("textDocumentSync", jnum(usize(1))).put("hoverProvider", JsonValue.Bool(value : true)).put("definitionProvider", JsonValue.Bool(value : true)).put("documentSymbolProvider", JsonValue.Bool(value : true)).put("referencesProvider", JsonValue.Bool(value : true)).put("foldingRangeProvider", JsonValue.Bool(value : true)).obj()).put(
+  jb().put("capabilities", jb().put("textDocumentSync", jnum(usize(1))).put("hoverProvider", JsonValue.Bool(value : true)).put("definitionProvider", JsonValue.Bool(value : true)).put("documentSymbolProvider", JsonValue.Bool(value : true)).put("referencesProvider", JsonValue.Bool(value : true)).put("foldingRangeProvider", JsonValue.Bool(value : true)).put("renameProvider", JsonValue.Bool(value : true)).put("documentFormattingProvider", JsonValue.Bool(value : true)).obj()).put(
     "serverInfo",
     // No `version` field on purpose: it is optional in the protocol, the
     // client can ask `yo --version`, and a version here would churn the
@@ -167,6 +170,28 @@ _initialize_result :: (fn() -> JsonValue)(
     jb().put("name", jstr(String.from("yo-lsp"))).obj()
   ).obj()
 );
+
+/// Whole-document formatting via `yo fmt`'s format_yo_source. Returns the
+/// LSP result: an ARRAY with one whole-document TextEdit, an EMPTY array
+/// when already canonical, or Null (own unwind frame) when the source does
+/// not parse — the client keeps the buffer untouched.
+_format_document :: (fn(text : String, doc_abs : String) -> JsonValue)({
+  fmt_exn := Exception(
+    throw : (
+      (_err) -> unwind(JsonValue.Null)
+    )
+  );
+  formatted := format_yo_source(text.clone(), doc_abs.clone(), fmt_exn);
+  if(formatted == text, {
+    return(JsonValue.Array(items : ArrayList(JsonValue).new()));
+  });
+  line_count := text.split(String.from("\n")).len();
+  edits := ArrayList(JsonValue).new();
+  edits.push(
+    jb().put("range", j_range(usize(0), usize(0), line_count, usize(0))).put("newText", jstr(formatted)).obj()
+  );
+  JsonValue.Array(items : edits)
+});
 
 /// Handle one JSON-RPC message. Returns 0 = keep serving, 10 = exit(0),
 /// 11 = exit(1) (`exit` without a preceding `shutdown`).
@@ -434,6 +459,93 @@ _handle_message :: (
       match(
         id_opt,
         .Some(id) => write_lsp_message(json_stringify(j_response(id, fold_result))),
+        .None => ()
+      );
+    },
+    (method == String.from("textDocument/rename")) => {
+      (rn_result : JsonValue) = JsonValue.Null;
+      match(
+        v.get(String.from("params")),
+        .Some(params) => {
+          uri := match(
+            params.get(String.from("textDocument")),
+            .Some(td) => _jfield_str(td, "uri"),
+            .None => String.new()
+          );
+          new_name := _jfield_str(params, "newName");
+          (line : usize) = usize(0);
+          (character : usize) = usize(0);
+          match(
+            params.get(String.from("position")),
+            .Some(pos) => {
+              match(
+                pos.get(String.from("line")),
+                .Some(lv) => match(
+                  lv,
+                  .Number(ln) => {
+                    line = usize(ln);
+                  },
+                  _ => ()
+                ),
+                .None => ()
+              );
+              match(
+                pos.get(String.from("character")),
+                .Some(cv) => match(
+                  cv,
+                  .Number(cn) => {
+                    character = usize(cn);
+                  },
+                  _ => ()
+                ),
+                .None => ()
+              );
+            },
+            .None => ()
+          );
+          match(
+            docs.get(uri.clone()),
+            .Some(st) => match(
+              handle_rename(st.text, st.entry_abs, uri.clone(), st.outcome.exprs, line, character, new_name),
+              .Some(we) => {
+                rn_result = we;
+              },
+              .None => ()
+            ),
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+      match(
+        id_opt,
+        .Some(id) => write_lsp_message(json_stringify(j_response(id, rn_result))),
+        .None => ()
+      );
+    },
+    (method == String.from("textDocument/formatting")) => {
+      (fmt_result : JsonValue) = JsonValue.Null;
+      match(
+        v.get(String.from("params")),
+        .Some(params) => {
+          uri := match(
+            params.get(String.from("textDocument")),
+            .Some(td) => _jfield_str(td, "uri"),
+            .None => String.new()
+          );
+          match(
+            docs.get(uri.clone()),
+            .Some(st) => {
+              fmt_result = _format_document(st.text, st.entry_abs);
+            },
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+      match(
+        id_opt,
+        .Some(id) => write_lsp_message(json_stringify(j_response(id, fmt_result))),
         .None => ()
       );
     },

--- a/tests/cli-cases/lsp-handshake/stdin
+++ b/tests/cli-cases/lsp-handshake/stdin
@@ -18,12 +18,18 @@ Content-Length: 107
 
 {"jsonrpc":"2.0","id":6,"method":"textDocument/references","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":3,"character":9},"context":{"includeDeclaration":true}}}Content-Length: 120
 
-{"jsonrpc":"2.0","id":7,"method":"textDocument/foldingRange","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 61
+{"jsonrpc":"2.0","id":7,"method":"textDocument/foldingRange","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 170
 
-{"jsonrpc":"2.0","id":8,"method":"unknown/probe","params":{}}Content-Length: 109
+{"jsonrpc":"2.0","id":8,"method":"textDocument/rename","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"position":{"line":3,"character":9},"newName":"add_uno"}}Content-Length: 193
 
-{"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 44
+{"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///virtual/doc.yo","version":3},"contentChanges":[{"text":"main::(fn()->unit)(());\nexport(main);\n"}]}}Content-Length: 162
 
-{"jsonrpc":"2.0","id":9,"method":"shutdown"}Content-Length: 33
+{"jsonrpc":"2.0","id":9,"method":"textDocument/formatting","params":{"textDocument":{"uri":"file:///virtual/doc.yo"},"options":{"tabSize":2,"insertSpaces":true}}}Content-Length: 62
+
+{"jsonrpc":"2.0","id":10,"method":"unknown/probe","params":{}}Content-Length: 109
+
+{"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file:///virtual/doc.yo"}}}Content-Length: 45
+
+{"jsonrpc":"2.0","id":11,"method":"shutdown"}Content-Length: 33
 
 {"jsonrpc":"2.0","method":"exit"}


### PR DESCRIPTION
**Stacked on #212.** Rename (WorkspaceEdit over same-file occurrences) and whole-document formatting through `format_yo_source` — the extension's formatOnSave default now works end-to-end. Golden-covered in the lsp-handshake case.

Validation: `check ./src` clean · 44/44 CLI goldens · gates_fast failures=0 · stage-2/3 FIXPOINT HOLDS, hollow=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)