### PR TITLE
tests: build-cache golden asserts only the cached-skip lines

### DIFF
--- a/tests/cli-cases/build-cache/expected_stdout
+++ b/tests/cli-cases/build-cache/expected_stdout
@@ -1,19 +1,2 @@
-$ yo build
-Building cachedemo → yo-out/<TARGET>/bin/cachedemo
-Using system allocator
-yo-out/<TARGET>/bin/cachedemo.c:1560:8: warning: ISO C does not allow indirection on operand of type 'void *' [-Wvoid-ptr-dereference]
- 1560 |       (*((void*)NULL));
-      |        ^~~~~~~~~~~~~~
-yo-out/<TARGET>/bin/cachedemo.c:1611:8: warning: ISO C does not allow indirection on operand of type 'void *' [-Wvoid-ptr-dereference]
- 1611 |       (*((void*)NULL));
-      |        ^~~~~~~~~~~~~~
-2 warnings generated.
-Building cachedemo → yo-out/<TARGET>/lib/libcachedemo-lib.a
-Using system allocator
-rc=0
-$ yo build
-Building cachedemo → yo-out/<TARGET>/bin/cachedemo
-  (cached: inputs unchanged, skipping compile)
-Building cachedemo → yo-out/<TARGET>/lib/libcachedemo-lib.a
-  (cached: inputs unchanged, skipping compile)
-rc=0
+(cached: inputs unchanged, skipping compile)
+(cached: inputs unchanged, skipping compile)

--- a/tests/cli-cases/build-cache/opts
+++ b/tests/cli-cases/build-cache/opts
@@ -1,5 +1,8 @@
 # Artifact input cache (plans/backlog/INCREMENTAL_COMPILATION.md Phase A):
 # the second identical `yo build` in the same sandbox must SKIP the child
-# compile and print the "(cached: inputs unchanged...)" line. Trees are
-# ignored for the .inputs-sha256 stamp via the ignore file.
+# compile. stdout is NOT strict — the first build's output embeds clang
+# diagnostics whose text and generated-C line numbers vary by platform
+# (Linux CI vs the macOS recording; caught on PR #212) — the kept substring
+# asserts THE behavior: the cached-skip line fired.
+stdout_keep_match=\(cached: inputs unchanged, skipping compile\)
 timeout=240


### PR DESCRIPTION
Platform-portability fix for #213's cli-case: strict stdout embedded clang diagnostics whose text/line numbers vary by platform (diffed on PR #212's Linux CI). `stdout_keep_match` keeps exactly the two cached-skip lines; rc and tree snapshots stay asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)