### PR TITLE
incremental: Phase B — LSP module invalidation + registry purge

### DIFF
--- a/plans/INCREMENTAL_COMPILATION.md
+++ b/plans/INCREMENTAL_COMPILATION.md
@@ -80,12 +80,26 @@ IMPORTING document's next analysis; (b) a repeated-didChange case whose
 registry sizes are asserted stable via a debug counter (or, minimally, a
 dot-completion answer that stays correct and duplicate-free after N edits).
 
-### Measurement baseline (to collect at B kickoff)
+### Measurement baseline
 
-- `yo check ./src --std-path ./std` wall time on the dev machine
-- LSP re-analysis latency for one keystroke in a compiler-sized module
-  (didChange → publishDiagnostics, measured via the harness stdin clock)
-- Registry entry counts after 1 vs 50 re-analyses of the same document
+Measured 2026-08-22 on the Mac Mini M4 (both binaries -O2, interleaved
+A/B, 3 rounds each):
+
+- **A 12-message LSP session (initialize + didOpen + 10 didChange) on a
+  small ArrayList-importing document: ~0.34-0.35 s wall for the WHOLE
+  session** (~30 ms per analysis including the first one's prelude cost),
+  identical pre- and post-Phase-B — the invalidation + purge add no
+  measurable per-edit cost. All 11 publishDiagnostics verified present
+  (hollow-measurement check).
+- Registry growth per edit before B2 (the leak the red-first probe
+  demonstrated): each round grew both registries by the document's impl
+  surface; after B2 the counts are flat across rounds
+  (tests/internal/module_invalidation.test.yo).
+- Still to collect when it matters: `yo check ./src` wall time (whole-tree
+  check is the build-side number, not an LSP-latency one), and re-analysis
+  latency on a compiler-SIZED module (a src/ file with a deep import
+  closure) — the small-doc number above says nothing about evaluator-heavy
+  documents.
 
 ## Phase C — cross-process evaluated-export reuse (DEFERRED)
 

--- a/src/evaluator/module_loader.yo
+++ b/src/evaluator/module_loader.yo
@@ -30,6 +30,7 @@ open(import("std/string"));
 { TypeValue } :: import("../types/definitions.yo");
 { Environment } :: import("../env.yo");
 { LoadModuleResult } :: import("./context.yo");
+{ set_registration_owner } :: import("./values/type_trait_methods.yo");
 // ---------------------------------------------------------------------------
 // In-progress (currently-loading) registry — enables CIRCULAR imports under
 // demand-driven loading (main.yo `demand_load_module`). When module A is mid-
@@ -40,10 +41,22 @@ open(import("std/string"));
 // ---------------------------------------------------------------------------
 (g_loading_keys : ArrayList(String)) = ArrayList(String).new();
 (g_loading_envs : ArrayList(Environment)) = ArrayList(Environment).new();
+/// Keep the registries' owner tag in sync with the loading-stack top
+/// (Phase B2, plans/INCREMENTAL_COMPILATION.md). The tag lives in
+/// type_trait_methods.yo — see `set_registration_owner`'s doc there.
+_sync_registration_owner :: (fn() -> unit)({
+  n := g_loading_keys.len();
+  owner := cond(
+    (n > usize(0)) => match(g_loading_keys.get(n - usize(1)), .Some(k) => k.clone(), .None => String.new()),
+    true => String.new()
+  );
+  set_registration_owner(owner);
+});
 /// Register `path` as currently-loading with its live evaluation `env`.
 register_loading :: (fn(path : String, env : Environment) -> unit)({
   g_loading_keys.push(path);
   g_loading_envs.push(env);
+  _sync_registration_owner();
 });
 /// Remove the most-recent loading entry for `path` (LIFO — nested loads).
 unregister_loading :: (fn(path : String) -> unit)({
@@ -55,12 +68,22 @@ unregister_loading :: (fn(path : String) -> unit)({
       .Some(k) => if(k == path, {
         g_loading_keys.remove(i, usize(1));
         g_loading_envs.remove(i, usize(1));
+        _sync_registration_owner();
         return(());
       }),
       .None => ()
     );
   });
 });
+/// The abs path of the module currently being evaluated (top of the
+/// loading stack), or `.None` outside any module evaluation. The demand
+/// loader uses it to attribute import-graph edges to their importer.
+current_loading_module :: (fn() -> Option(String))(
+  cond(
+    (g_loading_keys.len() > usize(0)) => g_loading_keys.get(g_loading_keys.len() - usize(1)),
+    true => Option(String).None
+  )
+);
 /// The live env of a currently-loading module, or `.None`.
 loading_env :: (fn(path : String) -> Option(Environment))({
   (i : usize) = g_loading_keys.len();
@@ -83,6 +106,44 @@ loading_env :: (fn(path : String) -> Option(Environment))({
 (g_module_cache_keys : ArrayList(String)) = ArrayList(String).new();
 (g_module_cache_vals : ArrayList(EvalValue)) = ArrayList(EvalValue).new();
 (g_module_cache_types : ArrayList(TypeValue)) = ArrayList(TypeValue).new();
+// Import graph, as parallel edge arrays: `g_import_edge_importers(i)`
+// imported `g_import_edge_imports(i)` (both `file://…` abs paths). Fed by
+// the demand loader on EVERY import request — cache hits included, since a
+// hit is still a dependency. Consumed by `invalidate_module`'s
+// reverse-closure walk (plans/INCREMENTAL_COMPILATION.md Phase B1).
+(g_import_edge_importers : ArrayList(String)) = ArrayList(String).new();
+(g_import_edge_imports : ArrayList(String)) = ArrayList(String).new();
+/// Record that `importer` imports `imported`. Exact-pair duplicates are
+/// dropped (a module importing the same dep from several sites is one edge).
+record_import_edge :: (fn(importer : String, imported : String) -> unit)({
+  (i : usize) = usize(0);
+  n := g_import_edge_importers.len();
+  while(i < n, {
+    same := (
+      match(g_import_edge_importers.get(i), .Some(a) => (a == importer), .None => false) &&
+        match(g_import_edge_imports.get(i), .Some(b) => (b == imported), .None => false)
+    );
+    if(same, {
+      return(());
+    });
+    i = (i + usize(1));
+  });
+  g_import_edge_importers.push(importer);
+  g_import_edge_imports.push(imported);
+});
+/// Drop every outgoing edge of `importer`. Called when a module is
+/// invalidated: its re-evaluation re-records its (possibly changed) edges.
+_drop_edges_from :: (fn(importer : String) -> unit)({
+  (i : usize) = g_import_edge_importers.len();
+  while(i > usize(0), {
+    i = (i - usize(1));
+    same := match(g_import_edge_importers.get(i), .Some(a) => (a == importer), .None => false);
+    if(same, {
+      g_import_edge_importers.remove(i, usize(1));
+      g_import_edge_imports.remove(i, usize(1));
+    });
+  });
+});
 /// Reset the cache. Call between independent `check` runs so module
 /// values from a previous file don't leak into the next.
 clear_module_cache :: (fn() -> unit)({
@@ -91,6 +152,9 @@ clear_module_cache :: (fn() -> unit)({
   g_module_cache_types = ArrayList(TypeValue).new();
   g_loading_keys = ArrayList(String).new();
   g_loading_envs = ArrayList(Environment).new();
+  g_import_edge_importers = ArrayList(String).new();
+  g_import_edge_imports = ArrayList(String).new();
+  set_registration_owner(String.new());
   ()
 });
 /// Find the cache index for `path`, or `.None`.
@@ -151,6 +215,74 @@ load_module_from_cache :: (fn(path : String) -> LoadModuleResult)(
     )
   )
 );
+/// Drop one module's cache entry (no-op when absent). Its dependencies
+/// stay cached; its own outgoing import edges are dropped so the
+/// re-evaluation records them fresh.
+remove_module :: (fn(path : String) -> unit)({
+  match(
+    _module_cache_index(path.clone()),
+    .Some(i) => {
+      g_module_cache_keys.remove(i, usize(1));
+      g_module_cache_vals.remove(i, usize(1));
+      g_module_cache_types.remove(i, usize(1));
+    },
+    .None => ()
+  );
+  _drop_edges_from(path);
+});
+/// Invalidate `path`: remove it AND every transitive DEPENDENT (reverse
+/// edge closure) from the cache, so no cached module keeps exports built
+/// against the old version. Dependencies of the removed set stay cached —
+/// they are unchanged. Returns the removed abs paths (the Phase B2 registry
+/// purge consumes this). plans/INCREMENTAL_COMPILATION.md Phase B1.
+invalidate_module :: (fn(path : String) -> ArrayList(String))({
+  removed := ArrayList(String).new();
+  worklist := ArrayList(String).new();
+  worklist.push(path);
+  while(worklist.len() > usize(0), {
+    p := match(
+      worklist.pop(),
+      .Some(x) => x,
+      .None => {
+        return(removed);
+      }
+    );
+    (already : bool) = false;
+    (ri : usize) = usize(0);
+    while(ri < removed.len(), {
+      match(
+        removed.get(ri),
+        .Some(r) => if(r == p, {
+          already = true;
+        }),
+        .None => ()
+      );
+      ri = (ri + usize(1));
+    });
+    if(!(already), {
+      removed.push(p.clone());
+      // Collect p's dependents BEFORE remove_module drops p's own edges
+      // (dependents are INCOMING edges — unaffected — but keep the order
+      // obvious anyway).
+      (ei : usize) = usize(0);
+      while(ei < g_import_edge_imports.len(), {
+        hits := match(g_import_edge_imports.get(ei), .Some(t) => (t == p), .None => false);
+        if(hits, {
+          match(
+            g_import_edge_importers.get(ei),
+            .Some(dep) => {
+              worklist.push(dep);
+            },
+            .None => ()
+          );
+        });
+        ei = (ei + usize(1));
+      });
+      remove_module(p);
+    });
+  });
+  removed
+});
 export(
   clear_module_cache,
   module_cache_has,
@@ -158,5 +290,9 @@ export(
   load_module_from_cache,
   register_loading,
   unregister_loading,
-  loading_env
+  loading_env,
+  current_loading_module,
+  record_import_edge,
+  remove_module,
+  invalidate_module
 );

--- a/src/evaluator/values/impl.yo
+++ b/src/evaluator/values/impl.yo
@@ -66,7 +66,8 @@ _(env : impl_dbg_env) :: import("std/env");
   register_provisional_trait_method,
   get_provisional_trait_methods_by_name,
   clear_provisional_trait_methods,
-  type_id_or_empty
+  type_id_or_empty,
+  registration_owner
 } :: import("./type_trait_methods.yo");
 { FuncMeta, TypeValue } :: import("../../types/definitions.yo");
 { type_to_string } :: import("../../types/string.yo");
@@ -207,6 +208,16 @@ GenericImplEntry :: struct(
 (g_impl_registry_keys : ArrayList(String)) = ArrayList(String).new();
 (g_impl_registry_entry_lists : ArrayList(ArrayList(GenericImplEntry))) =
   ArrayList(ArrayList(GenericImplEntry)).new();
+// Owner tags, bucket-parallel to `g_impl_registry_entry_lists` (same outer
+// AND inner index): the `file://` module path whose evaluation registered
+// each entry, from `registration_owner()` (type_trait_methods.yo). `""` =
+// registered outside any module load, never purged. Enables
+// `purge_generic_impls_owned_by` — LSP re-analysis must not leak a registry
+// generation per edit (plans/INCREMENTAL_COMPILATION.md Phase B2), and
+// stale entries here are a PER-KEYSTROKE cost: every candidate scan in
+// `find_methods_from_generic_impls` walks them.
+(g_impl_registry_entry_owners : ArrayList(ArrayList(String))) =
+  ArrayList(ArrayList(String)).new();
 /// One IN-FLIGHT Case-2 (generic) impl: enough state to lazily
 /// forward-declare a not-yet-evaluated sibling field when a def-time body
 /// trial asks for it (env.yo's provisional-lookup miss path →
@@ -357,14 +368,22 @@ register_generic_impl :: (fn(entry : GenericImplEntry) -> unit)({
     });
     ki = (ki + usize(1));
   });
+  owner := registration_owner();
   match(
     key_idx,
     .Some(idx) => {
-      // Append to existing list.
+      // Append to existing list (owner list stays index-parallel).
       match(
         g_impl_registry_entry_lists.get(idx),
         .Some(list) => {
           list.push(entry);
+        },
+        .None => ()
+      );
+      match(
+        g_impl_registry_entry_owners.get(idx),
+        .Some(olist) => {
+          olist.push(owner);
         },
         .None => ()
       );
@@ -373,10 +392,59 @@ register_generic_impl :: (fn(entry : GenericImplEntry) -> unit)({
       // New key — add parallel entries.
       new_list := ArrayList(GenericImplEntry).new();
       new_list.push(entry);
+      new_owners := ArrayList(String).new();
+      new_owners.push(owner);
       g_impl_registry_keys.push(key);
       g_impl_registry_entry_lists.push(new_list);
+      g_impl_registry_entry_owners.push(new_owners);
     }
   );
+});
+/// Drop every generic-impl entry registered by `owner` (a `file://` abs
+/// module path). Phase B2 — called for each module the LSP invalidates.
+purge_generic_impls_owned_by :: (fn(owner : String) -> unit)({
+  if(owner.len() == usize(0), {
+    return(());
+  });
+  (ki : usize) = usize(0);
+  while(ki < g_impl_registry_entry_lists.len(), {
+    match(
+      g_impl_registry_entry_lists.get(ki),
+      .Some(list) => match(
+        g_impl_registry_entry_owners.get(ki),
+        .Some(olist) => {
+          (i : usize) = olist.len();
+          while(i > usize(0), {
+            i = (i - usize(1));
+            hit := match(olist.get(i), .Some(o) => (o == owner), .None => false);
+            if(hit && (i < list.len()), {
+              list.remove(i, usize(1));
+              olist.remove(i, usize(1));
+            });
+          });
+        },
+        .None => ()
+      ),
+      .None => ()
+    );
+    ki = (ki + usize(1));
+  });
+});
+/// Total generic-impl entries across all buckets (LSP leak gate).
+generic_impl_entry_count :: (fn() -> usize)({
+  (total : usize) = usize(0);
+  (ki : usize) = usize(0);
+  while(ki < g_impl_registry_entry_lists.len(), {
+    match(
+      g_impl_registry_entry_lists.get(ki),
+      .Some(list) => {
+        total = (total + list.len());
+      },
+      .None => ()
+    );
+    ki = (ki + usize(1));
+  });
+  total
 });
 // ---------------------------------------------------------------------------
 // Negative-impl registry (Phase N THREAD_SAFETY). A negative impl
@@ -4078,3 +4146,4 @@ export(mark_concrete_impl_being_registered);
 export(unmark_concrete_impl_being_registered);
 export(has_negative_impl);
 export(GenericImplDocEntry, get_generic_impl_doc_entries);
+export(purge_generic_impls_owned_by, generic_impl_entry_count);

--- a/src/evaluator/values/type_trait_methods.yo
+++ b/src/evaluator/values/type_trait_methods.yo
@@ -156,22 +156,113 @@ MethodEntry :: ref(
 /// Module-level storage: `type id` → list of method entries.
 (_type_trait_methods : HashMap(String, ArrayList(MethodEntry))) =
   HashMap(String, ArrayList(MethodEntry)).new();
+/// Owner tags, parallel to `_type_trait_methods` (same key, same index):
+/// the `file://` abs path of the module whose evaluation registered the
+/// entry (`""` outside any module load — never purged). Enables
+/// `purge_type_trait_methods_owned_by` so LSP re-analysis stops leaking a
+/// registry generation per edit (plans/INCREMENTAL_COMPILATION.md Phase B2).
+(_type_trait_method_owners : HashMap(String, ArrayList(String))) =
+  HashMap(String, ArrayList(String)).new();
+/// The module currently being evaluated, as far as registration ownership
+/// is concerned. MAINTAINED BY module_loader's register_loading /
+/// unregister_loading (the loading-stack top) — the state lives HERE, and
+/// the loader pushes into it, because importing module_loader from this
+/// module would close the module_loader → env → type_trait_methods cycle.
+(_registration_owner : String) = String.new();
+set_registration_owner :: (fn(owner : String) -> unit)({
+  _registration_owner = owner;
+});
+/// The current owner tag ("" outside any module evaluation). Read by this
+/// module's own registration and by impl.yo's generic-impl registry.
+registration_owner :: (fn() -> String)(_registration_owner.clone());
 /// Append `entry` to the method list for `type_id`. The list is
-/// created on demand.
+/// created on demand. The owner tag is read from the module-loader's
+/// loading stack HERE so registration call sites stay unchanged.
 register_type_trait_method :: (
   fn(type_id : String, entry : MethodEntry) -> unit
 )({
+  owner := _registration_owner.clone();
   match(
-    _type_trait_methods.get(type_id),
+    _type_trait_methods.get(type_id.clone()),
     .Some(list) => {
       list.push(entry);
     },
     .None => {
       fresh := ArrayList(MethodEntry).new();
       fresh.push(entry);
-      ___set := _type_trait_methods.set(type_id, fresh);
+      ___set := _type_trait_methods.set(type_id.clone(), fresh);
     }
   );
+  match(
+    _type_trait_method_owners.get(type_id.clone()),
+    .Some(olist) => {
+      olist.push(owner);
+    },
+    .None => {
+      ofresh := ArrayList(String).new();
+      ofresh.push(owner);
+      ___oset := _type_trait_method_owners.set(type_id, ofresh);
+    }
+  );
+});
+/// Drop every method entry registered by `owner` (a `file://` abs module
+/// path). Called with each module the LSP invalidates, right before its
+/// re-evaluation re-registers the surviving impls under fresh type ids.
+purge_type_trait_methods_owned_by :: (fn(owner : String) -> unit)({
+  if(owner.len() == usize(0), {
+    return(());
+  });
+  it := _type_trait_methods.keys();
+  (go : bool) = true;
+  while(go, {
+    match(
+      it.next(),
+      .Some(key) => match(
+        _type_trait_methods.get(key.clone()),
+        .Some(list) => match(
+          _type_trait_method_owners.get(key.clone()),
+          .Some(olist) => {
+            (i : usize) = olist.len();
+            while(i > usize(0), {
+              i = (i - usize(1));
+              hit := match(olist.get(i), .Some(o) => (o == owner), .None => false);
+              if(hit && (i < list.len()), {
+                list.remove(i, usize(1));
+                olist.remove(i, usize(1));
+              });
+            });
+          },
+          .None => ()
+        ),
+        .None => ()
+      ),
+      .None => {
+        go = false;
+      }
+    );
+  });
+});
+/// Total registered method entries across all type ids (LSP leak gate).
+type_trait_methods_entry_count :: (fn() -> usize)({
+  (total : usize) = usize(0);
+  it := _type_trait_methods.keys();
+  (go : bool) = true;
+  while(go, {
+    match(
+      it.next(),
+      .Some(key) => match(
+        _type_trait_methods.get(key),
+        .Some(list) => {
+          total = (total + list.len());
+        },
+        .None => ()
+      ),
+      .None => {
+        go = false;
+      }
+    );
+  });
+  total
 });
 /// Return all method entries registered for `type_id`, or an empty
 /// list when nothing has been registered.
@@ -355,5 +446,9 @@ export(
   register_provisional_trait_method,
   get_provisional_trait_methods_by_name,
   clear_provisional_trait_methods,
-  type_id_or_empty
+  type_id_or_empty,
+  set_registration_owner,
+  registration_owner,
+  purge_type_trait_methods_owned_by,
+  type_trait_methods_entry_count
 );

--- a/src/lsp/server.yo
+++ b/src/lsp/server.yo
@@ -36,7 +36,7 @@ open(import("std/fmt"));
 { handle_signature_help } :: import("./signature_help.yo");
 { handle_completion } :: import("./completion.yo");
 { format_yo_source } :: import("../formatter.yo");
-{ resolve_std_path } :: import("../module_manager.yo");
+{ resolve_std_path, mm_invalidate_document, mm_set_open_document, mm_forget_open_document } :: import("../module_manager.yo");
 { BufReader } :: import("std/sys/bufio/buf_reader");
 
 /// Per-document retained analysis: editor text + the last evaluation's
@@ -126,6 +126,14 @@ _analyze_and_publish :: (
   fn(uri : String, text : String, std_path : String, docs : HashMap(String, DocState), io : Io) -> unit
 )({
   fs_path := uri_to_fs_path(uri.clone());
+  // Phase B1 (plans/INCREMENTAL_COMPILATION.md): the editor holds this
+  // file's newest text — record it as the loader's open-buffer overlay,
+  // then drop any cached module built from an older version PLUS every
+  // transitive dependent. Together these make an edit to an IMPORTED file
+  // visible to the next analysis of any importing document (previously:
+  // invisible until the server restarted).
+  mm_set_open_document(fs_path.clone(), text.clone());
+  _inv := mm_invalidate_document(fs_path.clone());
   out_state := ArrayList(AnalyzeOutcome).new();
   diags := analyze_document(fs_path.clone(), text.clone(), std_path, io, out_state);
   match(
@@ -748,6 +756,11 @@ _handle_message :: (
             uri := _jfield_str(td, "uri");
             if(uri.len() > usize(0), {
               _r := docs.remove(uri.clone());
+              // Phase B1: the disk becomes this file's truth again — drop
+              // the open-buffer overlay and anything cached from it.
+              closed_fs := uri_to_fs_path(uri.clone());
+              mm_forget_open_document(closed_fs.clone());
+              _inv2 := mm_invalidate_document(closed_fs);
               _publish_empty(uri);
             });
           },

--- a/src/module_manager.yo
+++ b/src/module_manager.yo
@@ -43,7 +43,9 @@ open(import("std/fmt"));
 { register_evaluate_expression } :: import("./evaluator/exprs/_expr.yo");
 { evaluate_anonymous_module_begin_exprs } :: import("./evaluator/values/anonymous_module.yo");
 { resolve_module_path, ModuleResolveResult, _build_module_val_from_env } :: import("./evaluator/exprs/import.yo");
-{ clear_module_cache, module_cache_has, register_module, load_module_from_cache, register_loading, unregister_loading, loading_env } :: import("./evaluator/module_loader.yo");
+{ clear_module_cache, module_cache_has, register_module, load_module_from_cache, register_loading, unregister_loading, loading_env, current_loading_module, record_import_edge, invalidate_module } :: import("./evaluator/module_loader.yo");
+{ purge_type_trait_methods_owned_by } :: import("./evaluator/values/type_trait_methods.yo");
+{ purge_generic_impls_owned_by } :: import("./evaluator/values/impl.yo");
 { EvalValue } :: import("./value.yo");
 { TypeValue } :: import("./types/definitions.yo");
 // ---------------------------------------------------------------------------
@@ -246,6 +248,84 @@ mm_resolve_entry_abs :: (fn(input_path : String, std_path : String) -> String)(
     .Ambiguous(_) => input_path
   )
 );
+// Open-document text overlay (Phase B1): the LSP holds newer text for open
+// buffers than the disk does. `_load_module_at_abs` consults this AFTER its
+// disk read, so an importing document's analysis sees the editor's version
+// of an imported file, saved or not. Parallel arrays, keyed by FS path.
+(g_open_doc_paths : ArrayList(String)) = ArrayList(String).new();
+(g_open_doc_texts : ArrayList(String)) = ArrayList(String).new();
+_open_doc_index :: (fn(fs_path : String) -> Option(usize))({
+  (i : usize) = usize(0);
+  n := g_open_doc_paths.len();
+  while(i < n, {
+    match(
+      g_open_doc_paths.get(i),
+      .Some(p) => if(p == fs_path, {
+        return(Option(usize).Some(i));
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  Option(usize).None
+});
+/// Record (or replace) the open-buffer text for `fs_path`.
+mm_set_open_document :: (fn(fs_path : String, text : String) -> unit)({
+  match(
+    _open_doc_index(fs_path.clone()),
+    .Some(i) => {
+      g_open_doc_texts(i) = text;
+    },
+    .None => {
+      g_open_doc_paths.push(fs_path);
+      g_open_doc_texts.push(text);
+    }
+  );
+});
+/// Drop the overlay for `fs_path` (didClose — disk becomes the truth again).
+mm_forget_open_document :: (fn(fs_path : String) -> unit)({
+  match(
+    _open_doc_index(fs_path.clone()),
+    .Some(i) => {
+      g_open_doc_paths.remove(i, usize(1));
+      g_open_doc_texts.remove(i, usize(1));
+    },
+    .None => ()
+  );
+});
+_open_doc_text :: (fn(fs_path : String) -> Option(String))(
+  match(
+    _open_doc_index(fs_path.clone()),
+    .Some(i) => g_open_doc_texts.get(i),
+    .None => Option(String).None
+  )
+);
+/// LSP invalidation entry (Phase B1, plans/INCREMENTAL_COMPILATION.md):
+/// drop the module cached for this FILESYSTEM path and every transitive
+/// dependent, so the next analysis of any document re-evaluates exactly the
+/// stale part of its import closure. Returns the removed `file://` paths
+/// (Phase B2's registry purge consumes this). The cached prelude env is NOT
+/// touched — editing std/prelude.yo still needs a server restart.
+mm_invalidate_document :: (fn(fs_path : String) -> ArrayList(String))({
+  removed := invalidate_module(`file://${fs_path}`);
+  // Phase B2: each removed module's registry entries go with it — its
+  // re-evaluation re-registers them (under fresh type ids). Without this,
+  // every LSP edit leaked a registry generation, and stale generic-impl
+  // entries lengthened every candidate scan.
+  (i : usize) = usize(0);
+  while(i < removed.len(), {
+    match(
+      removed.get(i),
+      .Some(owner) => {
+        purge_type_trait_methods_owned_by(owner.clone());
+        purge_generic_impls_owned_by(owner);
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  removed
+});
 /// TS `ModuleManager.resetAllState()`. Drops the module cache, the cached
 /// prelude env, the shared ExprInfoTable and the loader context, so the next
 /// load starts from a clean evaluator universe.
@@ -320,7 +400,18 @@ _load_module_at_abs :: (fn(abs : String) -> Option(String))({
   exn := match(g_loader_exn, .Some(e) => e, .None => return(Option(String).None));
   fs_path := abs.replace(String.from("file://"), String.from(""));
   src_bytes := io.await(read_file(Path.new(fs_path.clone()), io), IoExn(io : io, exn : exn));
-  src := String.from_bytes(src_bytes);
+  (src : String) = String.from_bytes(src_bytes);
+  // Open-buffer overlay (Phase B1): the editor's text wins over the disk
+  // read above. The read still ALWAYS runs — the await stays a top-level
+  // statement (the async-lowering rule), and import resolution requires the
+  // file to exist on disk anyway.
+  match(
+    _open_doc_text(fs_path.clone()),
+    .Some(open_text) => {
+      src = open_text.clone();
+    },
+    .None => ()
+  );
   mod_exprs := parse(src, abs.clone(), exn);
   env := mm_fresh_module_env(abs.clone());
   ctx := eval_context_new(std_path.clone(), abs.clone());
@@ -369,6 +460,15 @@ _load_module_at_abs :: (fn(abs : String) -> Option(String))({
 /// computed by `evaluate_import`. Cache hit -> cached exports; currently-loading
 /// (cycle) -> partial exports from the module's live env; else load on demand.
 demand_load_module :: (fn(path : String) -> LoadModuleResult)({
+  // Import-graph edge: whoever is mid-evaluation (loading-stack top) depends
+  // on `path`. Recorded on EVERY request — a cache hit is still a dependency
+  // — so `invalidate_module` can walk dependents. Phase B1,
+  // plans/INCREMENTAL_COMPILATION.md.
+  match(
+    current_loading_module(),
+    .Some(importer) => record_import_edge(importer, path.clone()),
+    .None => ()
+  );
   if(module_cache_has(path.clone()), {
     return(load_module_from_cache(path));
   });
@@ -666,6 +766,9 @@ export(
   mm_shared_expr_info_table,
   mm_fresh_module_env,
   mm_resolve_entry_abs,
+  mm_invalidate_document,
+  mm_set_open_document,
+  mm_forget_open_document,
   mm_reset,
   demand_load_module,
   mm_load_prelude_file,

--- a/tests/internal/module_invalidation.test.yo
+++ b/tests/internal/module_invalidation.test.yo
@@ -1,0 +1,138 @@
+//! Phase B1 gates (plans/INCREMENTAL_COMPILATION.md): an edit to an
+//! IMPORTED file must be visible to the next analysis of an importing
+//! document. Drives the real LSP analysis entry (`analyze_document`)
+//! against a temp two-file project through four states:
+//!
+//!   1. baseline — clean analysis, the import gets cached;
+//!   2. overlay set, NO invalidation — the stale cache still serves the
+//!      old module (pins the pre-B1 behavior the server now compensates
+//!      for by invalidating on every didOpen/didChange);
+//!   3. overlay + `mm_invalidate_document` — the importer's next analysis
+//!      FAILS, because the import re-evaluates from the editor's text in
+//!      which the export was renamed;
+//!   4. overlay forgotten + invalidated again — disk truth restored, the
+//!      analysis is clean again.
+open(import("std/string"));
+open(import("std/error"));
+{ ArrayList } :: import("std/collections/array_list");
+{ assert } :: import("std/assert");
+{ Path } :: import("std/path");
+{ create_dir_all } :: import("std/fs/dir");
+{ write_file } :: import("std/fs/file");
+{ analyze_document, AnalyzeOutcome } :: import("../../src/lsp/diagnostics.yo");
+{
+  mm_set_open_document,
+  mm_forget_open_document,
+  mm_invalidate_document,
+  resolve_std_path
+} :: import("../../src/module_manager.yo");
+{ type_trait_methods_entry_count } :: import("../../src/evaluator/values/type_trait_methods.yo");
+{ generic_impl_entry_count } :: import("../../src/evaluator/values/impl.yo");
+
+_IMPL_DOC :: "Point :: struct(x : i32);\nimpl(\n  Point,\n  get_x : (fn(self : Self) -> i32)(self.x)\n);\nmain :: (fn() -> unit)({\n  p := Point(x : i32(1));\n  _y := p.get_x();\n});\nexport(main);\n";
+_LIB_V1 :: "answer :: (fn() -> i32)(i32(41));\nexport(answer);\n";
+_LIB_V2 :: "answer_renamed :: (fn() -> i32)(i32(42));\nexport(answer_renamed);\n";
+_APP :: "{ answer } :: import(\"./lib.yo\");\nmain :: (fn() -> unit)({\n  _x := answer();\n});\nexport(main);\n";
+
+/// One server-shaped analysis round of the impl doc: overlay + invalidate
+/// (purges the previous generation's registry entries) + analyze. Returns
+/// the outcome's `ok`.
+_impl_doc_round :: (fn(doc_path : String, std_path : String, io : Io) -> bool)({
+  mm_set_open_document(doc_path.clone(), String.from(_IMPL_DOC));
+  _inv := mm_invalidate_document(doc_path.clone());
+  out := ArrayList(AnalyzeOutcome).new();
+  _diags := analyze_document(doc_path.clone(), String.from(_IMPL_DOC), std_path.clone(), io, out);
+  match(out.get(usize(0)), .Some(oc) => oc.ok, .None => false)
+});
+
+/// Analyze the app document; return the outcome's `ok`.
+_analyze_app_ok :: (fn(app_path : String, std_path : String, io : Io) -> bool)({
+  out := ArrayList(AnalyzeOutcome).new();
+  _diags := analyze_document(app_path.clone(), String.from(_APP), std_path.clone(), io, out);
+  match(out.get(usize(0)), .Some(oc) => oc.ok, .None => false)
+});
+
+test("B1: imported-file edit visible after overlay + invalidation", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, `test io failed: ${err}`);
+      }
+    )
+  );
+  ioexn := IoExn(io : io, exn : exn);
+  dir := `/tmp/yo_b1_invalidation_fixture`;
+  io.await(create_dir_all(Path.new(dir.clone()), io), ioexn);
+  lib_path := `${dir}/lib.yo`;
+  app_path := `${dir}/app.yo`;
+  io.await(write_file(Path.new(lib_path.clone()), String.from(_LIB_V1), io), ioexn);
+  io.await(write_file(Path.new(app_path.clone()), String.from(_APP), io), ioexn);
+  std_path := resolve_std_path();
+  // Make sure no earlier state for these paths leaks between runs.
+  mm_forget_open_document(lib_path.clone());
+  _pre := mm_invalidate_document(lib_path.clone());
+
+  // 1. Baseline: clean, and lib.yo is now cached.
+  assert(_analyze_app_ok(app_path.clone(), std_path.clone(), io), "baseline analysis should be ok");
+
+  // 2. Overlay WITHOUT invalidation: the cache still serves the old lib —
+  //    this pins why the LSP must invalidate on didChange.
+  mm_set_open_document(lib_path.clone(), String.from(_LIB_V2));
+  assert(
+    _analyze_app_ok(app_path.clone(), std_path.clone(), io),
+    "without invalidation the stale cached module is still served"
+  );
+
+  // 3. Invalidate: the import re-evaluates from the OVERLAY text, whose
+  //    export was renamed — the importer's analysis must now fail.
+  removed := mm_invalidate_document(lib_path.clone());
+  // The reverse-closure walk must have found the importing document as a
+  // dependent (the import-graph edge app → lib was recorded by the demand
+  // loader during the baseline analysis): lib itself + app ≥ 2 entries.
+  assert(removed.len() >= usize(2), "invalidation should remove the dependent importer too");
+  assert(
+    !(_analyze_app_ok(app_path.clone(), std_path.clone(), io)),
+    "after invalidation the renamed export must break the importer"
+  );
+
+  // 4. Forget the overlay + invalidate again: disk truth (v1) restored.
+  mm_forget_open_document(lib_path.clone());
+  _r2 := mm_invalidate_document(lib_path.clone());
+  assert(
+    _analyze_app_ok(app_path.clone(), std_path.clone(), io),
+    "after forgetting the overlay the disk version is clean again"
+  );
+});
+
+test("B2: repeated re-analysis keeps registry entry counts stable", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, `test io failed: ${err}`);
+      }
+    )
+  );
+  ioexn := IoExn(io : io, exn : exn);
+  dir := `/tmp/yo_b1_invalidation_fixture`;
+  io.await(create_dir_all(Path.new(dir.clone()), io), ioexn);
+  doc_path := `${dir}/impl_doc.yo`;
+  io.await(write_file(Path.new(doc_path.clone()), String.from(_IMPL_DOC), io), ioexn);
+  std_path := resolve_std_path();
+  // Round 1 establishes the doc's registry generation; every later round
+  // purges it (via the invalidation) before re-registering an identical
+  // one, so the totals must be FLAT across rounds. Before Phase B2 each
+  // round grew both registries by the doc's impl surface.
+  assert(_impl_doc_round(doc_path.clone(), std_path.clone(), io), "round 1 should analyze clean");
+  ttm1 := type_trait_methods_entry_count();
+  gi1 := generic_impl_entry_count();
+  assert(_impl_doc_round(doc_path.clone(), std_path.clone(), io), "round 2 should analyze clean");
+  ttm2 := type_trait_methods_entry_count();
+  gi2 := generic_impl_entry_count();
+  assert(_impl_doc_round(doc_path.clone(), std_path.clone(), io), "round 3 should analyze clean");
+  ttm3 := type_trait_methods_entry_count();
+  gi3 := generic_impl_entry_count();
+  assert(ttm2 == ttm1, `trait-method registry leaked: ${ttm1} -> ${ttm2}`);
+  assert(ttm3 == ttm2, `trait-method registry leaked: ${ttm2} -> ${ttm3}`);
+  assert(gi2 == gi1, `generic-impl registry leaked: ${gi1} -> ${gi2}`);
+  assert(gi3 == gi2, `generic-impl registry leaked: ${gi2} -> ${gi3}`);
+});


### PR DESCRIPTION
Stacked on #218 (← #217 ← #215). Implements plans/INCREMENTAL_COMPILATION.md Phase B — the two invalidation gaps the LSP MVP documented in `src/lsp/diagnostics.yo`.

## B1 — imported-file edits reach analysis

Previously an edit to an imported file was invisible until the server restarted. Now:
- `module_loader` records an **import graph** (the demand loader logs an edge on every request — cache hits included, since a hit is still a dependency) and gains `remove_module` + `invalidate_module` (reverse-closure walk: the module plus every transitive dependent leaves the cache; dependencies stay).
- `module_manager` gains an **open-buffer overlay**: the loader's disk read is overridden by the editor's text for open files, so even unsaved edits are seen.
- The server sets the overlay + invalidates on every didOpen/didChange, and restores disk truth on didClose.

## B2 — re-analysis stops leaking registry generations

Every edit used to re-register the document's impls under fresh type ids, leaking the old generation forever — memory growth per keystroke, and longer generic-impl candidate scans (a per-keystroke cost). Both hot registries now tag entries with the registering module (owner state maintained by the loading stack; registration call sites unchanged) and `mm_invalidate_document` purges each removed module's entries before re-evaluation. Compile/check paths never purge — zero behavior change outside the LSP.

## Gates

`tests/internal/module_invalidation.test.yo`:
- B1: baseline clean → stale cache **pinned** without invalidation → renamed export breaks the importer after invalidation (dependent-closure walk asserted) → disk truth restored.
- B2: registry entry counts flat across three server-shaped re-analysis rounds — **verified red-first**: with invalidation disabled the leak gate fails.

## Validation

- `yo check ./src --std-path ./std` — 260/260
- Internal tests 2/2; CLI goldens **45 pass / 0 diff / 1 network-skip** (no re-records needed)
- Tier-1 gates 0 failures; **FIXPOINT_HOLDS, stage2 hollow=0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)