### PR TITLE
std json: accept \uXXXX escapes (RFC 8259) with surrogate-pair handling

### DIFF
--- a/issues/fixed/json-parser-no-unicode-escapes.md
+++ b/issues/fixed/json-parser-no-unicode-escapes.md
@@ -1,0 +1,40 @@
+# std json parser rejected `\uXXXX` escapes (JSON-spec violation; broke LSP didOpen on real files)
+
+**Found:** 2026-08-22, measuring LSP re-analysis latency on a compiler-sized
+module. A scripted `didOpen` of `src/lsp/hover.yo` produced ZERO
+publishDiagnostics and `yo-lsp: skipping malformed message: invalid escape
+sequence` on stderr — the server silently dropped every message carrying
+the file's text.
+
+## Root cause
+
+`_Parser.parse_string` (std/encoding/json.yo) handled `\n \t \r \" \\ \/
+\b \f` and returned `.Err(.InvalidEscape)` for everything else — including
+`\uXXXX`, which RFC 8259 §7 REQUIRES a parser to accept. Any JSON writer
+that escapes non-ASCII (Python's `json.dumps` default, many LSP clients)
+produced payloads std json could not parse. The `JsonError.InvalidUnicode`
+variant existed but nothing ever produced it.
+
+## Fix
+
+`parse_hex4` (four hex digits → code unit) + `_push_utf8` (code point →
+UTF-8 bytes, division/modulo since the closed operator set has no shifts),
+with full surrogate handling: a high surrogate must be followed by
+`\uDC00`–`\uDFFF` (combined per UTF-16), and a lone surrogate in either
+direction is `.Err(.InvalidUnicode)`.
+
+En route, the escape `cond` arms were braced: the original unbraced arms
+returned `bytes.push(...)`'s value, so a new block-shaped arm (unit) made
+the arms' types incompatible — the same "brace arms with push" rule the
+syntax cheatsheet records for match.
+
+## Verification
+
+- 5 new tests in `tests/encoding/json.test.yo`: BMP escapes byte-for-byte
+  (`A`/`é`/`中`), the surrogate pair `😀` → 4-byte
+  UTF-8, lone high / lone low surrogate errors, non-hex `\uZZZZ` error.
+  40/40 pass. (Pre-fix red established live: the LSP probe printed
+  `invalid escape sequence` for `A`-bearing payloads.)
+- The original symptom is the regression gate: a `didOpen` of hover.yo
+  (unicode in doc comments → `\u` escapes under ensure_ascii encoding)
+  must publish diagnostics instead of dropping the message.

--- a/std/encoding/json.yo
+++ b/std/encoding/json.yo
@@ -212,6 +212,41 @@ export(JsonValue, JsonKV);
 // ============================================================================
 // Parser state
 // ============================================================================
+/// UTF-8-encode code point `cp` into `bytes`. Division/modulo instead of
+/// shifts (the closed operator set has no `<<`/`>>`).
+_push_utf8 :: (fn(bytes : ArrayList(u8), cp : u32) -> unit)({
+  cond(
+    (cp < u32(0x80)) => {
+      bytes.push(u8(cp));
+    },
+    (cp < u32(0x800)) => {
+      bytes.push(u8(u32(0xC0) + (cp / u32(64))));
+      bytes.push(u8(u32(0x80) + (cp % u32(64))));
+    },
+    (cp < u32(0x10000)) => {
+      bytes.push(u8(u32(0xE0) + (cp / u32(4096))));
+      bytes.push(u8(u32(0x80) + ((cp / u32(64)) % u32(64))));
+      bytes.push(u8(u32(0x80) + (cp % u32(64))));
+    },
+    true => {
+      bytes.push(u8(u32(0xF0) + (cp / u32(262144))));
+      bytes.push(u8(u32(0x80) + ((cp / u32(4096)) % u32(64))));
+      bytes.push(u8(u32(0x80) + ((cp / u32(64)) % u32(64))));
+      bytes.push(u8(u32(0x80) + (cp % u32(64))));
+    }
+  );
+});
+
+/// One hex digit's value, or 255 for a non-hex byte.
+_hex_digit :: (fn(b : u8) -> u8)(
+  cond(
+    ((b >= u8(48)) && (b <= u8(57))) => (b - u8(48)),
+    ((b >= u8(97)) && (b <= u8(102))) => (b - u8(87)),
+    ((b >= u8(65)) && (b <= u8(70))) => (b - u8(55)),
+    true => u8(255)
+  )
+);
+
 _Parser :: ref(
   struct(
     // BYTES, not `str`: `str` is the STATIC string view and a runtime
@@ -267,6 +302,30 @@ impl(
         )
     )
   }),
+  /// Four hex digits after `\u`, as a code unit. `.Err(.InvalidUnicode)`
+  /// on a short read or a non-hex byte.
+  parse_hex4 : (fn(self : Self) -> Result(u32, JsonError))({
+    (cp : u32) = u32(0);
+    (i : usize) = usize(0);
+    while(i < usize(4), {
+      match(
+        self.peek(),
+        .None => {
+          return(.Err(.UnexpectedEnd));
+        },
+        .Some(h) => {
+          d := _hex_digit(h);
+          if(d == u8(255), {
+            return(.Err(.InvalidUnicode));
+          });
+          self.advance();
+          cp = ((cp * u32(16)) + u32(d));
+        }
+      );
+      i = (i + usize(1));
+    });
+    .Ok(cp)
+  }),
   parse_string : (fn(self : Self) -> Result(String, JsonError))({
     self.advance(); // skip opening '"'
     bytes := ArrayList(u8).new();
@@ -294,22 +353,82 @@ impl(
                 .Some(e) => {
                   self.advance();
                   cond(
-                    (e == u8(110)) => bytes.push(u8(10)),
-                    // \n
-                    (e == u8(116)) => bytes.push(u8(9)),
-                    // \t
-                    (e == u8(114)) => bytes.push(u8(13)),
-                    // \r
-                    (e == u8(34)) => bytes.push(u8(34)),
-                    // \"
-                    (e == u8(92)) => bytes.push(u8(92)),
-                    // \\
-                    (e == u8(47)) => bytes.push(u8(47)),
-                    // \/
-                    (e == u8(98)) => bytes.push(u8(8)),
-                    // \b
-                    (e == u8(102)) => bytes.push(u8(12)),
-                    // \f
+                    (e == u8(110)) => {
+                      bytes.push(u8(10)); // \n
+                    },
+                    (e == u8(116)) => {
+                      bytes.push(u8(9)); // \t
+                    },
+                    (e == u8(114)) => {
+                      bytes.push(u8(13)); // \r
+                    },
+                    (e == u8(34)) => {
+                      bytes.push(u8(34)); // \"
+                    },
+                    (e == u8(92)) => {
+                      bytes.push(u8(92)); // \\
+                    },
+                    (e == u8(47)) => {
+                      bytes.push(u8(47)); // \/
+                    },
+                    (e == u8(98)) => {
+                      bytes.push(u8(8)); // \b
+                    },
+                    (e == u8(102)) => {
+                      bytes.push(u8(12)); // \f
+                    },
+                    (e == u8(117)) => {
+                      // \uXXXX — with surrogate-pair handling: a high
+                      // surrogate must be followed by `\uDC00`-`\uDFFF`,
+                      // and a lone low surrogate is invalid (JSON spec /
+                      // RFC 8259 §7).
+                      (cp : u32) = match(
+                        self.parse_hex4(),
+                        .Ok(v) => v,
+                        .Err(err) => {
+                          return(.Err(err));
+                        }
+                      );
+                      if((cp >= u32(0xD800)) && (cp <= u32(0xDBFF)), {
+                        bs := match(
+                          self.peek(),
+                          .Some(x) => x,
+                          .None => {
+                            return(.Err(.UnexpectedEnd));
+                          }
+                        );
+                        if(bs != u8(92), {
+                          return(.Err(.InvalidUnicode));
+                        });
+                        self.advance();
+                        bu := match(
+                          self.peek(),
+                          .Some(x2) => x2,
+                          .None => {
+                            return(.Err(.UnexpectedEnd));
+                          }
+                        );
+                        if(bu != u8(117), {
+                          return(.Err(.InvalidUnicode));
+                        });
+                        self.advance();
+                        lo := match(
+                          self.parse_hex4(),
+                          .Ok(v2) => v2,
+                          .Err(err2) => {
+                            return(.Err(err2));
+                          }
+                        );
+                        if((lo < u32(0xDC00)) || (lo > u32(0xDFFF)), {
+                          return(.Err(.InvalidUnicode));
+                        });
+                        cp = ((u32(0x10000) + ((cp - u32(0xD800)) * u32(1024))) + (lo - u32(0xDC00)));
+                      });
+                      if((cp >= u32(0xDC00)) && (cp <= u32(0xDFFF)), {
+                        return(.Err(.InvalidUnicode));
+                      });
+                      _push_utf8(bytes, cp);
+                    },
                     true => {
                       return(.Err(.InvalidEscape));
                     }

--- a/tests/encoding/json.test.yo
+++ b/tests/encoding/json.test.yo
@@ -105,6 +105,78 @@ test("json_parse string with escapes", {
   assert(bytes.len() == usize(11), "escaped string should have 11 bytes");
   assert(bytes(usize(5)) == u8(10), "byte 5 should be newline");
 });
+test("json_parse unicode escape BMP", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  // \u0041 = 'A' (1-byte UTF-8), \u00e9 = 'é' (2-byte), \u4e2d = '中' (3-byte).
+  v := json_parse("\"\\u0041 \\u00e9 \\u4e2d\"", exn);
+  s := v.as_string().unwrap();
+  bytes := s.as_bytes();
+  assert(bytes.len() == usize(8), "A + sp + 2-byte + sp + 3-byte = 8 bytes");
+  assert(bytes(usize(0)) == u8(65), "first byte should be 'A'");
+  assert(bytes(usize(2)) == u8(0xC3), "é lead byte");
+  assert(bytes(usize(3)) == u8(0xA9), "é continuation byte");
+  assert(bytes(usize(5)) == u8(0xE4), "中 lead byte");
+  assert(bytes(usize(6)) == u8(0xB8), "中 continuation byte 1");
+  assert(bytes(usize(7)) == u8(0xAD), "中 continuation byte 2");
+});
+test("json_parse unicode escape surrogate pair", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  // \ud83d\ude00 = U+1F600 (😀), 4-byte UTF-8 F0 9F 98 80.
+  v := json_parse("\"\\ud83d\\ude00\"", exn);
+  bytes := v.as_string().unwrap().as_bytes();
+  assert(bytes.len() == usize(4), "one astral code point = 4 bytes");
+  assert(bytes(usize(0)) == u8(0xF0), "byte 0");
+  assert(bytes(usize(1)) == u8(0x9F), "byte 1");
+  assert(bytes(usize(2)) == u8(0x98), "byte 2");
+  assert(bytes(usize(3)) == u8(0x80), "byte 3");
+});
+test("json_parse lone high surrogate error", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        unwind(());
+      }
+    )
+  );
+  json_parse("\"\\ud83d\"", exn);
+  assert(false, "lone high surrogate should throw");
+});
+test("json_parse lone low surrogate error", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        unwind(());
+      }
+    )
+  );
+  json_parse("\"\\udc00 tail\"", exn);
+  assert(false, "lone low surrogate should throw");
+});
+test("json_parse invalid unicode escape hex error", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        unwind(());
+      }
+    )
+  );
+  json_parse("\"\\uZZZZ\"", exn);
+  assert(false, "non-hex \\u escape should throw");
+});
 test("json_parse empty string", {
   exn := Exception(
     throw : (


### PR DESCRIPTION
Independent of the LSP stack (branched off develop).

## Bug

`_Parser.parse_string` rejected `\uXXXX` entirely — an RFC 8259 §7 violation. Practical impact: the LSP silently dropped any `didOpen`/`didChange` whose text JSON-encodes with unicode escapes (Python `json.dumps` default, various LSP clients) — opening `src/lsp/hover.yo` published **zero** diagnostics with `invalid escape sequence` on stderr. The `JsonError.InvalidUnicode` variant existed but nothing produced it.

## Fix

`parse_hex4` + `_push_utf8` (UTF-8 encode via division/modulo — the closed operator set has no shifts), full surrogate handling: high surrogate must be followed by `\uDC00`–`\uDFFF` (combined per UTF-16); lone surrogates in either direction are `InvalidUnicode`. The escape `cond` arms are now braced blocks (the unbraced arms returned `bytes.push()`'s value — any block-shaped sibling arm was a type error).

## Tests

5 new byte-exact cases in `tests/encoding/json.test.yo` (40/40): `\u0041`/`\u00e9`/`\u4e2d` byte-for-byte, `\ud83d\ude00` → 4-byte UTF-8, lone-high error, lone-low error, non-hex error. Regression gate for the original symptom: didOpen of hover.yo now publishes 3/3 diagnostics with clean stderr.

## Validation

check std 154/154 + src 258/258 · CLI goldens 44 pass / 0 diff / 1 skip · tier-1 gates 0 failures · **FIXPOINT_HOLDS, stage2 hollow=0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)