### PR TITLE
std json: ToJson/FromJson traits + evaluator forall-binding fix

### DIFF
--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -1056,6 +1056,26 @@ fn :: (fn() -> T)(match(x, arms))
 fn :: (fn() -> T)({ match(x, arms); })
 ```
 
+### Sibling match/cond arms must agree in type — brace statement-like arms
+
+An unbraced arm's value is the expression's value, and `list.push(x)` /
+`map.set(k, v)` return non-unit — so mixing an unbraced push arm with a
+block-shaped (unit) sibling arm is a type error ("Incompatible types" /
+"{ ... } without semicolons"). Brace-and-semicolon every arm whose result
+is not meant to be the value: `(c) => { bytes.push(b); },`.
+
+### Static (self-less) trait methods work — the FromJson pattern
+
+A trait method with no `self` (`Maker :: trait(make : (fn(x : i32) -> Self))`)
+dispatches as `Point.make(x)` on any impl'd type, and through a generic
+where-constrained fn (`(fn(comptime(T) : Type, x : i32, where(T <: Maker)) -> T)(T.make(x))`).
+Constructor-style traits (`FromJson.from_json`) are therefore expressible.
+CAVEAT: inside a GENERIC IMPL body, calling `T.method(v)` whose return
+type wraps Self in a type application (`Result(Self, E)`) can mis-resolve
+in some contexts — route the call through a module-level where-constrained
+helper fn instead, and if a container decode still fails see
+issues/generic-impl-fromjson-container-decode-failures.md.
+
 ### Template strings cannot be nested inside `${...}` interpolations
 
 A template string literal (`` ` `` ... `` ` ``) inside a `${...}` interpolation of another template string closes the outer string. The compiler gives confusing parse errors.

--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -1070,11 +1070,10 @@ A trait method with no `self` (`Maker :: trait(make : (fn(x : i32) -> Self))`)
 dispatches as `Point.make(x)` on any impl'd type, and through a generic
 where-constrained fn (`(fn(comptime(T) : Type, x : i32, where(T <: Maker)) -> T)(T.make(x))`).
 Constructor-style traits (`FromJson.from_json`) are therefore expressible.
-CAVEAT: inside a GENERIC IMPL body, calling `T.method(v)` whose return
-type wraps Self in a type application (`Result(Self, E)`) can mis-resolve
-in some contexts — route the call through a module-level where-constrained
-helper fn instead, and if a container decode still fails see
-issues/generic-impl-fromjson-container-decode-failures.md.
+(A forall-binding-order bug that broke this inside generic impls on
+multi-param receivers — `HashMap(String, V)` bound `V := String` — was
+fixed 2026-08-22:
+issues/fixed/generic-impl-fromjson-container-decode-failures.md.)
 
 ### Template strings cannot be nested inside `${...}` interpolations
 

--- a/issues/fixed/generic-impl-fromjson-container-decode-failures.md
+++ b/issues/fixed/generic-impl-fromjson-container-decode-failures.md
@@ -1,11 +1,42 @@
 # Generic FromJson impls on prelude containers: Option decode miscompiles, HashMap decode fails to unify
 
+**Status: FIXED 2026-08-22, same session — ONE evaluator root for both.**
+
+## Root cause and fix
+
+`_funcval_bind_foralls` (src/evaluator/calls/function.yo) resolves a
+static generic-impl method's un-inferable foralls through two fallbacks,
+and their ORDER was wrong: the positional receiver-type-args fallback
+(forall[i] ← receiver.type_arguments[i]) ran BEFORE the injected-capture
+fallback. Captures come from the impl resolver's PATTERN unification
+(`_inject_forall_captures`), so they are authoritative; the positional
+stand-in only holds when the impl's foralls happen to align 1:1 with the
+constructor's params. For `impl(generic(V), HashMap(String, V), …)` the
+single forall V sits at receiver position 1, so positional-first bound
+`V := String` (type_arguments[0]) — every `HashMap(String, i32).from_json`
+value decode dispatched to STRING's impl (runtime "expected a string";
+at def time the same mis-binding surfaced as the location-less
+`Cannot unify "i32" and "String"`). The Option failure — broken emitted C —
+was the same wrong binding flowing into the specialization.
+
+Fix: capture fallback FIRST, gated on the captured type being CONCRETE
+(`type_contains_some_type_deep` — an unresolved-SomeT capture falls
+through to positional; binding it unconditionally regressed
+`ArrayList(u8).with_capacity` to "member _bytes … Got: Type(1)").
+Positional stays as the last resort, preserving
+issues/fixed/self-dispatch-loses-type-args.md.
+
+Verified: both repros below pass through the fixed compiler; the full
+json suite (48/48) covers Option and HashMap ROUNDTRIPS now; std checks
+154/154 with the concreteness gate.
+
+## Original record
+
 **Found:** 2026-08-22, implementing `ToJson`/`FromJson` (std/encoding/json.yo).
 Two independent failures in the DECODE direction of generic trait impls on
 prelude type constructors; the ENCODE direction (ToJson) of the identical
 shapes works, and `ArrayList(T)`'s FromJson — the same pattern with one
-generic param — works in BOTH directions. The failing impls were removed
-from std v1 (Option/HashMap ship encode-only); restore them when fixed.
+generic param — works in BOTH directions. The impls were TEMPORARILY removed from std v1 and are now restored.
 
 ## Failure 1 — `Option(T)` FromJson: emitted C does not compile
 

--- a/issues/generic-impl-fromjson-container-decode-failures.md
+++ b/issues/generic-impl-fromjson-container-decode-failures.md
@@ -1,0 +1,77 @@
+# Generic FromJson impls on prelude containers: Option decode miscompiles, HashMap decode fails to unify
+
+**Found:** 2026-08-22, implementing `ToJson`/`FromJson` (std/encoding/json.yo).
+Two independent failures in the DECODE direction of generic trait impls on
+prelude type constructors; the ENCODE direction (ToJson) of the identical
+shapes works, and `ArrayList(T)`'s FromJson — the same pattern with one
+generic param — works in BOTH directions. The failing impls were removed
+from std v1 (Option/HashMap ship encode-only); restore them when fixed.
+
+## Failure 1 — `Option(T)` FromJson: emitted C does not compile
+
+Impl shape (see `issues/repros/json-option-fromjson-codegen.test.yo`, run
+`yo test` on it):
+
+```rust
+impl(
+  generic(T : Type),
+  where(T <: FromJson),
+  Option(T),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(
+        v,
+        .Null => .Ok(Option(T).None),
+        _ => match(_from_json_of(T, v), .Ok(x) => .Ok(Option(T).Some(x)), .Err(e) => .Err(e))
+      )
+    )
+  )
+);
+```
+
+`json_decode(Option(i32), \`null\`)` passes the evaluator but the
+specialization's emitted C fails to compile —
+`error: expected expression` at a line shaped `(*((void*)NULL))`, plus
+several `(*((__yo_tN**)NULL))` null-deref patterns nearby. Something in
+the `Option(T).None` / `Option(T).Some(x)` construction path (a comptime
+type-constructor call in runtime position, with T bound by the generic
+impl) emits a NULL placeholder instead of the value.
+
+Layered history (each shape moved the failure, none fixed it):
+- `Self.Some(x)` / `Self.None` in the impl body fail at DEF time:
+  `Type mismatch for type member "value": Expected <enum>, Got Type(1)`.
+- calling `T.from_json(v)` DIRECTLY (instead of through the
+  where-constrained helper `_from_json_of`) fails at def time the same way
+  — yet the minimal probe (trait method returning `Result(Self, String)`
+  called inside a generic impl on a two-line struct constructor) PASSES,
+  so the trigger needs more of the json context than the obvious shape.
+- `.map((x) -> …)` on the helper's `Result(T, JsonError)` fails dispatch
+  inside the generic impl body (`No matching call found`).
+
+## Failure 2 — `HashMap(String, V)` FromJson: def-time unify error
+
+Impl shape (see `issues/repros/json-hashmap-fromjson-unify.test.yo`):
+mixed concrete + generic instantiation `HashMap(String, V)`, body decodes
+each value via `_from_json_of(V, jv)` and `out.set(k, decoded_v)`.
+
+`json_decode(HashMap(String, i32), \`{"a":1,"b":2}\`)` fails during the
+batch module's def-time evaluation with
+`Cannot unify incompatible types: "i32" and "String"` and NO source
+location (anchor is `batch:1:1`). The i32-vs-String pairing smells like
+positional confusion between the pattern's concrete `String` param and
+the bound `V = i32` somewhere in the match/specialization path. Binder
+shadowing was ruled out (renamed; same error).
+
+## Notes for the fix
+
+- `ArrayList(T)` FromJson (single generic param, same helper, same
+  Result-matching body) works end to end — both bugs need either the
+  ENUM-constructor payload path (failure 1) or the mixed
+  concrete/generic two-param instantiation (failure 2).
+- The encode direction of the SAME impl heads works, so impl matching
+  itself is fine; the decode direction differs in constructing/returning
+  `Result(Self, …)`-shaped values through the specialization.
+- When fixed: restore the two impls in std/encoding/json.yo (the removed
+  code is in this issue's repro files verbatim), turn the repros into
+  `tests/encoding/json.test.yo` cases, and drop the "encode-only" caveat
+  from the ToJson/FromJson doc comments.

--- a/issues/repros/json-hashmap-fromjson-unify.test.yo
+++ b/issues/repros/json-hashmap-fromjson-unify.test.yo
@@ -1,0 +1,63 @@
+{ assert } :: import("std/assert");
+open(import("std/string"));
+{ json_parse, json_stringify, JsonValue, JsonError, ToJson, FromJson, json_encode, json_decode, json_parse_result } :: import("std/encoding/json");
+{ HashMap } :: import("std/collections/hash_map");
+{ ArrayList } :: import("std/collections/array_list");
+{ Error, AnyError, Exception } :: import("std/error");
+// ===== ToJson / FromJson =====
+_TPoint :: struct(x : i32, y : i32);
+impl(
+  _TPoint,
+  ToJson(
+    to_json : (fn(inout(self) : Self) -> JsonValue)({
+      keys := ArrayList(String).new();
+      values := ArrayList(JsonValue).new();
+      keys.push(`x`);
+      values.push(self.x.to_json());
+      keys.push(`y`);
+      values.push(self.y.to_json());
+      JsonValue.Object(keys : keys, values : values)
+    })
+  ),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))({
+      xv := match(
+        v.get(`x`),
+        .Some(j) => match(
+          i32.from_json(j),
+          .Ok(n) => n,
+          .Err(e) => {
+            return(.Err(e));
+          }
+        ),
+        .None => {
+          return(.Err(.Other(`missing field x`)));
+        }
+      );
+      yv := match(
+        v.get(`y`),
+        .Some(j2) => match(
+          i32.from_json(j2),
+          .Ok(n2) => n2,
+          .Err(e2) => {
+            return(.Err(e2));
+          }
+        ),
+        .None => {
+          return(.Err(.Other(`missing field y`)));
+        }
+      );
+      .Ok(Self(x : xv, y : yv))
+    })
+  )
+);
+test("map decode", {
+  match(
+    json_decode(HashMap(String, i32), `{"a":1,"b":2}`),
+    .Ok(back) => {
+      assert(back.get(`a`).unwrap() == i32(1), "key a");
+      assert(back.get(`b`).unwrap() == i32(2), "key b");
+    },
+    .Err(_) => assert(false, "map decode should succeed")
+  );
+});

--- a/issues/repros/json-option-fromjson-codegen.test.yo
+++ b/issues/repros/json-option-fromjson-codegen.test.yo
@@ -1,0 +1,60 @@
+{ assert } :: import("std/assert");
+open(import("std/string"));
+{ json_parse, json_stringify, JsonValue, JsonError, ToJson, FromJson, json_encode, json_decode, json_parse_result } :: import("std/encoding/json");
+{ HashMap } :: import("std/collections/hash_map");
+{ ArrayList } :: import("std/collections/array_list");
+{ Error, AnyError, Exception } :: import("std/error");
+// ===== ToJson / FromJson =====
+_TPoint :: struct(x : i32, y : i32);
+impl(
+  _TPoint,
+  ToJson(
+    to_json : (fn(inout(self) : Self) -> JsonValue)({
+      keys := ArrayList(String).new();
+      values := ArrayList(JsonValue).new();
+      keys.push(`x`);
+      values.push(self.x.to_json());
+      keys.push(`y`);
+      values.push(self.y.to_json());
+      JsonValue.Object(keys : keys, values : values)
+    })
+  ),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))({
+      xv := match(
+        v.get(`x`),
+        .Some(j) => match(
+          i32.from_json(j),
+          .Ok(n) => n,
+          .Err(e) => {
+            return(.Err(e));
+          }
+        ),
+        .None => {
+          return(.Err(.Other(`missing field x`)));
+        }
+      );
+      yv := match(
+        v.get(`y`),
+        .Some(j2) => match(
+          i32.from_json(j2),
+          .Ok(n2) => n2,
+          .Err(e2) => {
+            return(.Err(e2));
+          }
+        ),
+        .None => {
+          return(.Err(.Other(`missing field y`)));
+        }
+      );
+      .Ok(Self(x : xv, y : yv))
+    })
+  )
+);
+test("opt decode", {
+  match(
+    json_decode(Option(i32), `null`),
+    .Ok(o) => assert(o.is_none(), "null decodes to None"),
+    .Err(_) => assert(false, "null decode should succeed")
+  );
+});

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -1597,42 +1597,23 @@ _funcval_bind_foralls :: (
         );
       });
     });
-    // Fallback: bind the i-th generic param from the receiver's i-th type
-    // argument when it could not be inferred from call arguments.
-    // yo-self-only mechanism (TS resolves impl generics via specializedType,
-    // never positionally) — restrict it to Type-kinded binders: pairing a
-    // VALUE binder (`generic(N : usize)`) with a receiver TYPE argument
-    // stamps `N := TypeVal(elem)` and the body throws unify(usize, Type)
-    // (the imm_list/imm_vec hollow batch main).
-    fa_kind_is_type := match(forall_kinds.get(fa_i), .Some(k) => is_type_0(k), .None => true);
-    if((!(fa_bound) && fa_kind_is_type) && (fa_i < recv_type_args.len()), {
-      match(
-        recv_type_args.get(fa_i),
-        .Some(rta) => {
-          fa_bound_names.push(fa_name.clone());
-          fa_bound_types.push(rta.clone());
-          _add_forall_rt := add_variable_to_env(
-            fresh_env,
-            fa_name,
-            TypeValue.TypeUni(usize(0)),
-            Option(EvalValue).Some(EvalValue.TypeVal(rta)),
-            true,
-            false,
-            false,
-            false,
-            synthetic_token(fa_name, env.module_path)
-          );
-          fa_bound = true;
-        },
-        .None => ()
-      );
-    });
     // Capture fallback (STATIC generic-impl methods, e.g.
     // `ArrayList(u8).new`): no arg binds `T` and the receiver Struct may
     // not carry `type_arguments`, but the generic-impl resolver injected
     // the impl's generic binding (`T = u8`) into this FuncVal's CAPTURES
     // (`_inject_forall_captures`, appended at the tail). Bind `T` from that
     // capture so the body / specialization concretize.
+    //
+    // ORDER MATTERS: captures come from the impl resolver's PATTERN
+    // unification, so they are authoritative; the positional
+    // receiver-type-args fallback below is a stand-in that only holds when
+    // the impl's foralls happen to align 1:1 with the constructor's params.
+    // For `impl(generic(V), HashMap(String, V), FromJson(...))` the single
+    // forall V sits at receiver position 1, and positional-first bound
+    // `V := String` (type_arguments[0]) — dispatching every
+    // `HashMap(String, i32).from_json` value decode to String's impl
+    // ("expected a string"). See
+    // issues/generic-impl-fromjson-container-decode-failures.md.
     if(!(fa_bound), {
       (fcap_i : usize) = usize(0);
       while((fcap_i < cap_names.len()) && !(fa_bound), {
@@ -1662,20 +1643,29 @@ _funcval_bind_foralls :: (
               },
               .TypeVal(ctb) => {
                 cap_ty := ctb;
-                fa_bound_names.push(fa_name.clone());
-                fa_bound_types.push(cap_ty.clone());
-                _add_forall_cap := add_variable_to_env(
-                  fresh_env,
-                  fa_name,
-                  TypeValue.TypeUni(usize(0)),
-                  Option(EvalValue).Some(EvalValue.TypeVal(cap_ty)),
-                  true,
-                  false,
-                  false,
-                  false,
-                  synthetic_token(fa_name, env.module_path)
-                );
-                fa_bound = true;
+                // Bind from the capture only when it is CONCRETE. A capture
+                // can hold a still-unresolved SomeT (a def-time trial's own
+                // binder echoed back) — binding that here poisons the body
+                // (`ArrayList(u8).with_capacity` regressed to "member
+                // _bytes ... Got: Type(1)" when captures ran first
+                // unconditionally); an unresolved capture falls through to
+                // the positional receiver-type-args fallback below.
+                if(!(type_contains_some_type_deep(cap_ty.clone())), {
+                  fa_bound_names.push(fa_name.clone());
+                  fa_bound_types.push(cap_ty.clone());
+                  _add_forall_cap := add_variable_to_env(
+                    fresh_env,
+                    fa_name,
+                    TypeValue.TypeUni(usize(0)),
+                    Option(EvalValue).Some(EvalValue.TypeVal(cap_ty)),
+                    true,
+                    false,
+                    false,
+                    false,
+                    synthetic_token(fa_name, env.module_path)
+                  );
+                  fa_bound = true;
+                });
               },
               _ => ()
             ),
@@ -1684,6 +1674,37 @@ _funcval_bind_foralls :: (
         });
         fcap_i = (fcap_i + usize(1));
       });
+    });
+    // Fallback: bind the i-th generic param from the receiver's i-th type
+    // argument when it could not be inferred from call arguments OR from an
+    // injected capture (see ORDER MATTERS above).
+    // yo-self-only mechanism (TS resolves impl generics via specializedType,
+    // never positionally) — restrict it to Type-kinded binders: pairing a
+    // VALUE binder (`generic(N : usize)`) with a receiver TYPE argument
+    // stamps `N := TypeVal(elem)` and the body throws unify(usize, Type)
+    // (the imm_list/imm_vec hollow batch main).
+    fa_kind_is_type := match(forall_kinds.get(fa_i), .Some(k) => is_type_0(k), .None => true);
+    if((!(fa_bound) && fa_kind_is_type) && (fa_i < recv_type_args.len()), {
+      match(
+        recv_type_args.get(fa_i),
+        .Some(rta) => {
+          fa_bound_names.push(fa_name.clone());
+          fa_bound_types.push(rta.clone());
+          _add_forall_rt := add_variable_to_env(
+            fresh_env,
+            fa_name,
+            TypeValue.TypeUni(usize(0)),
+            Option(EvalValue).Some(EvalValue.TypeVal(rta)),
+            true,
+            false,
+            false,
+            false,
+            synthetic_token(fa_name, env.module_path)
+          );
+          fa_bound = true;
+        },
+        .None => ()
+      );
     });
     fa_i = (fa_i + usize(1));
   });

--- a/std/encoding/json.yo
+++ b/std/encoding/json.yo
@@ -975,13 +975,11 @@ ToJson :: trait(
 FromJson :: trait(
   from_json : (fn(v : JsonValue) -> Result(Self, JsonError))
 );
-/// Call `T.from_json(v)` through a where-constrained helper. The container
-/// impls below route through this rather than calling `T.from_json`
-/// DIRECTLY inside their generic bodies: the direct call's
-/// `Result(Self, JsonError)` return mis-resolves during the generic-impl
-/// trial ("Type mismatch for type member \"value\"... Got: Type(1)"),
-/// while the same call through a generic function is fine — see
-/// issues/generic-impl-static-trait-method-result-misresolve.md.
+/// Call `T.from_json(v)` through a where-constrained helper — the shape
+/// the container impls below use for their element/value decodes. (During
+/// development this also worked around a forall-binding-order evaluator
+/// bug, fixed alongside this module — see
+/// issues/fixed/generic-impl-fromjson-container-decode-failures.md.)
 _from_json_of :: (fn(comptime(T) : Type, v : JsonValue, where(T <: FromJson)) -> Result(T, JsonError))(
   T.from_json(v)
 );
@@ -1148,11 +1146,20 @@ impl(
     )
   )
 );
-// NOTE: Option(T) is ENCODE-ONLY for now. Its FromJson impl (null -> None,
-// payload -> Some) is written and preserved verbatim in
-// issues/repros/json-option-fromjson-codegen.test.yo — the specialization
-// currently miscompiles (emitted C has NULL-placeholder expressions). See
-// issues/generic-impl-fromjson-container-decode-failures.md.
+impl(
+  generic(T : Type),
+  where(T <: FromJson),
+  Option(T),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(
+        v,
+        .Null => .Ok(Option(T).None),
+        _ => match(_from_json_of(T, v), .Ok(x) => .Ok(Option(T).Some(x)), .Err(e) => .Err(e))
+      )
+    )
+  )
+);
 impl(
   generic(T : Type),
   where(T <: ToJson),
@@ -1241,11 +1248,41 @@ impl(
     })
   )
 );
-// NOTE: HashMap(String, V) is ENCODE-ONLY for now. Its FromJson impl is
-// preserved verbatim in issues/repros/json-hashmap-fromjson-unify.test.yo —
-// the mixed concrete/generic instantiation currently fails def-time
-// unification ("Cannot unify i32 and String"). See
-// issues/generic-impl-fromjson-container-decode-failures.md.
+impl(
+  generic(V : Type),
+  where(V <: FromJson),
+  HashMap(String, V),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(
+        v,
+        .Object(keys, values) => {
+          out := Self.new();
+          (i : usize) = usize(0);
+          while(i < keys.len(), {
+            k := match(keys.get(i), .Some(key_s) => key_s, .None => String.new());
+            match(
+              values.get(i),
+              .Some(jv) => match(
+                _from_json_of(V, jv),
+                .Ok(decoded_v) => {
+                  _s := out.set(k, decoded_v);
+                },
+                .Err(e) => {
+                  return(.Err(e));
+                }
+              ),
+              .None => ()
+            );
+            i = (i + usize(1));
+          });
+          .Ok(out)
+        },
+        _ => .Err(.Other(`expected an object`))
+      )
+    )
+  )
+);
 /// Parse a JSON `String` into a `JsonValue`, as a `Result` (no Exception
 /// plumbing — the decode-side counterpart of `json_stringify`).
 json_parse_result :: (fn(s : String) -> Result(JsonValue, JsonError))({

--- a/std/encoding/json.yo
+++ b/std/encoding/json.yo
@@ -15,6 +15,7 @@
 pragma(Pragma.AllowUnsafe);
 open(import("../string"));
 { ArrayList } :: import("../collections/array_list");
+{ HashMap } :: import("../collections/hash_map");
 { assert } :: import("../assert");
 { snprintf } :: import("../libc/stdio");
 { Error, AnyError, Exception } :: import("../error");
@@ -958,3 +959,306 @@ json_stringify_pretty :: (fn(value : JsonValue, indent : usize) -> String)(
   )
 );
 export(json_stringify, json_stringify_pretty);
+// ============================================================================
+// ToJson / FromJson — typed (de)serialisation through JsonValue
+// ============================================================================
+/// Serialise a value to a `JsonValue` tree. Implement (or later, derive)
+/// this to make a type encodable; the text form always goes through
+/// `json_stringify`, so formatting stays centralized.
+ToJson :: trait(
+  to_json : (fn(inout(self) : Self) -> JsonValue)
+);
+/// Deserialise a value from a `JsonValue` tree. Returns `Result` rather
+/// than throwing: decode failures are ordinary values a caller matches
+/// on, and `JsonError` can grow structured variants without breaking
+/// this signature. Call as `T.from_json(v)` or through `json_decode`.
+FromJson :: trait(
+  from_json : (fn(v : JsonValue) -> Result(Self, JsonError))
+);
+/// Call `T.from_json(v)` through a where-constrained helper. The container
+/// impls below route through this rather than calling `T.from_json`
+/// DIRECTLY inside their generic bodies: the direct call's
+/// `Result(Self, JsonError)` return mis-resolves during the generic-impl
+/// trial ("Type mismatch for type member \"value\"... Got: Type(1)"),
+/// while the same call through a generic function is fine — see
+/// issues/generic-impl-static-trait-method-result-misresolve.md.
+_from_json_of :: (fn(comptime(T) : Type, v : JsonValue, where(T <: FromJson)) -> Result(T, JsonError))(
+  T.from_json(v)
+);
+/// Shared integer decode: `.Number` whose value is integral and within
+/// [lo, hi], as an i64. (JSON numbers are IEEE 754 doubles — integers
+/// beyond 2^53 cannot round-trip through JSON text at all.)
+_decode_int :: (fn(v : JsonValue, lo : f64, hi : f64) -> Result(i64, JsonError))(
+  match(
+    v,
+    .Number(n) => cond(
+      (f64(i64(n)) != n) => .Err(.Other(`expected an integer, got a non-integral number`)),
+      ((n < lo) || (n > hi)) => .Err(.Other(`integer out of range`)),
+      true => .Ok(i64(n))
+    ),
+    _ => .Err(.Other(`expected a number`))
+  )
+);
+impl(
+  bool,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Bool(value : self))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(v, .Bool(b) => .Ok(b), _ => .Err(.Other(`expected a bool`)))
+    )
+  )
+);
+impl(
+  i8,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(i8.MIN), f64(i8.MAX)), .Ok(n) => .Ok(i8(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  i16,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(i16.MIN), f64(i16.MAX)), .Ok(n) => .Ok(i16(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  i32,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(i32.MIN), f64(i32.MAX)), .Ok(n) => .Ok(i32(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  i64,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(i64.MIN), f64(i64.MAX)), .Ok(n) => .Ok(n), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  u8,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(0), f64(u8.MAX)), .Ok(n) => .Ok(u8(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  u16,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(0), f64(u16.MAX)), .Ok(n) => .Ok(u16(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  u32,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(0), f64(u32.MAX)), .Ok(n) => .Ok(u32(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  u64,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      // 2^53 is the last contiguous integer a double holds; larger u64s
+      // cannot survive JSON's number representation anyway.
+      match(_decode_int(v, f64(0), f64(9007199254740992)), .Ok(n) => .Ok(u64(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  usize,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(0), f64(9007199254740992)), .Ok(n) => .Ok(usize(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  isize,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(_decode_int(v, f64(i64.MIN), f64(i64.MAX)), .Ok(n) => .Ok(isize(n)), .Err(e) => .Err(e))
+    )
+  )
+);
+impl(
+  f32,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : f64(self)))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(v, .Number(n) => .Ok(f32(n)), _ => .Err(.Other(`expected a number`)))
+    )
+  )
+);
+impl(
+  f64,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Number(value : self))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(v, .Number(n) => .Ok(n), _ => .Err(.Other(`expected a number`)))
+    )
+  )
+);
+impl(
+  String,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Str(value : self.clone()))),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(v, .Str(s) => .Ok(s.clone()), _ => .Err(.Other(`expected a string`)))
+    )
+  )
+);
+// `str` is encode-only: a runtime String cannot become the static view.
+impl(
+  str,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(JsonValue.Str(value : String.from(self))))
+);
+// JsonValue round-trips through itself, so generic code can hold raw JSON.
+impl(
+  JsonValue,
+  ToJson(to_json : (fn(inout(self) : Self) -> JsonValue)(self)),
+  FromJson(from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(.Ok(v)))
+);
+impl(
+  generic(T : Type),
+  where(T <: ToJson),
+  Option(T),
+  ToJson(
+    to_json : (fn(inout(self) : Self) -> JsonValue)(
+      match(self, .Some(x) => x.to_json(), .None => JsonValue.Null)
+    )
+  )
+);
+// NOTE: Option(T) is ENCODE-ONLY for now. Its FromJson impl (null -> None,
+// payload -> Some) is written and preserved verbatim in
+// issues/repros/json-option-fromjson-codegen.test.yo — the specialization
+// currently miscompiles (emitted C has NULL-placeholder expressions). See
+// issues/generic-impl-fromjson-container-decode-failures.md.
+impl(
+  generic(T : Type),
+  where(T <: ToJson),
+  ArrayList(T),
+  ToJson(
+    to_json : (fn(inout(self) : Self) -> JsonValue)({
+      items := ArrayList(JsonValue).new();
+      (i : usize) = usize(0);
+      while(i < self.len(), {
+        match(
+          self.get(i),
+          .Some(x) => {
+            items.push(x.to_json());
+          },
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+      JsonValue.Array(items : items)
+    })
+  )
+);
+impl(
+  generic(T : Type),
+  where(T <: FromJson),
+  ArrayList(T),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))(
+      match(
+        v,
+        .Array(items) => {
+          out := Self.new();
+          (i : usize) = usize(0);
+          while(i < items.len(), {
+            match(
+              items.get(i),
+              .Some(jv) => match(
+                _from_json_of(T, jv),
+                .Ok(x) => {
+                  out.push(x);
+                },
+                .Err(e) => {
+                  return(.Err(e));
+                }
+              ),
+              .None => ()
+            );
+            i = (i + usize(1));
+          });
+          .Ok(out)
+        },
+        _ => .Err(.Other(`expected an array`))
+      )
+    )
+  )
+);
+impl(
+  generic(V : Type),
+  where(V <: ToJson),
+  HashMap(String, V),
+  ToJson(
+    to_json : (fn(inout(self) : Self) -> JsonValue)({
+      keys := ArrayList(String).new();
+      values := ArrayList(JsonValue).new();
+      it := self.keys();
+      (go : bool) = true;
+      while(go, {
+        match(
+          it.next(),
+          .Some(k) => {
+            match(
+              self.get(k.clone()),
+              .Some(x) => {
+                keys.push(k.clone());
+                values.push(x.to_json());
+              },
+              .None => ()
+            );
+          },
+          .None => {
+            go = false;
+          }
+        );
+      });
+      JsonValue.Object(keys : keys, values : values)
+    })
+  )
+);
+// NOTE: HashMap(String, V) is ENCODE-ONLY for now. Its FromJson impl is
+// preserved verbatim in issues/repros/json-hashmap-fromjson-unify.test.yo —
+// the mixed concrete/generic instantiation currently fails def-time
+// unification ("Cannot unify i32 and String"). See
+// issues/generic-impl-fromjson-container-decode-failures.md.
+/// Parse a JSON `String` into a `JsonValue`, as a `Result` (no Exception
+/// plumbing — the decode-side counterpart of `json_stringify`).
+json_parse_result :: (fn(s : String) -> Result(JsonValue, JsonError))({
+  p := _Parser.new(s.as_bytes());
+  _parse_value(p)
+});
+/// Serialise any `ToJson` value to JSON text.
+json_encode :: (fn(generic(T : Type), v : T, where(T <: ToJson)) -> String)(
+  json_stringify(v.to_json())
+);
+/// Parse JSON text and decode it into `T`:
+/// `json_decode(Point, s)` → `Result(Point, JsonError)`.
+json_decode :: (fn(comptime(T) : Type, s : String, where(T <: FromJson)) -> Result(T, JsonError))(
+  match(json_parse_result(s), .Ok(v) => T.from_json(v), .Err(e) => .Err(e))
+);
+export(ToJson, FromJson, json_parse_result, json_encode, json_decode);

--- a/tests/encoding/json.test.yo
+++ b/tests/encoding/json.test.yo
@@ -551,14 +551,25 @@ test("json_decode integer errors", {
   assert(json_decode(u8, `-1`).is_err(), "negative into u8 must Err");
   assert(json_decode(i32, `"nope"`).is_err(), "string into i32 must Err");
 });
-test("json Option encode", {
-  // Decode side is BLOCKED on
-  // issues/generic-impl-fromjson-container-decode-failures.md — the
-  // FromJson impl and its cases live in issues/repros/ until then.
+test("json Option roundtrip", {
   (some_v : Option(i32)) = Option(i32).Some(i32(7));
   (none_v : Option(i32)) = Option(i32).None;
   assert(json_encode(some_v) == "7", "Some encodes as payload");
   assert(json_encode(none_v) == "null", "None encodes as null");
+  match(
+    json_decode(Option(i32), `null`),
+    .Ok(o) => assert(o.is_none(), "null decodes to None"),
+    .Err(_) => assert(false, "null decode should succeed")
+  );
+  match(
+    json_decode(Option(i32), `7`),
+    .Ok(o2) => match(
+      o2,
+      .Some(n) => assert(n == i32(7), "Some payload value"),
+      .None => assert(false, "expected Some")
+    ),
+    .Err(_) => assert(false, "Some decode should succeed")
+  );
 });
 test("json ArrayList roundtrip", {
   list := ArrayList(i32).new();
@@ -577,12 +588,19 @@ test("json ArrayList roundtrip", {
   );
   assert(json_decode(ArrayList(i32), `[1,"x"]`).is_err(), "bad element must Err");
 });
-test("json HashMap encode", {
-  // Decode side is BLOCKED on
-  // issues/generic-impl-fromjson-container-decode-failures.md.
+test("json HashMap roundtrip", {
   m := HashMap(String, i32).new();
   _s := m.set(`a`, i32(1));
   assert(json_encode(m) == "{\"a\":1}", "single-key map encode");
+  match(
+    json_decode(HashMap(String, i32), `{"a":1,"b":2}`),
+    .Ok(back) => {
+      assert(back.get(`a`).unwrap() == i32(1), "key a");
+      assert(back.get(`b`).unwrap() == i32(2), "key b");
+    },
+    .Err(_) => assert(false, "map decode should succeed")
+  );
+  assert(json_decode(HashMap(String, i32), `{"a":"x"}`).is_err(), "bad value must Err");
 });
 test("json custom struct roundtrip", {
   p := _TPoint(x : i32(3), y : i32(-(4)));

--- a/tests/encoding/json.test.yo
+++ b/tests/encoding/json.test.yo
@@ -1,6 +1,7 @@
 { assert } :: import("std/assert");
 open(import("std/string"));
-{ json_parse, json_stringify, JsonValue, JsonError } :: import("std/encoding/json");
+{ json_parse, json_stringify, JsonValue, JsonError, ToJson, FromJson, json_encode, json_decode, json_parse_result } :: import("std/encoding/json");
+{ HashMap } :: import("std/collections/hash_map");
 { ArrayList } :: import("std/collections/array_list");
 { Error, AnyError, Exception } :: import("std/error");
 // ===== Parse Primitives =====
@@ -473,4 +474,136 @@ test("JsonValue.at on non-array", {
   );
   result := json_parse("42", exn);
   assert(result.at(usize(0)).is_none(), "at on number should return None");
+});
+// ===== ToJson / FromJson =====
+_TPoint :: struct(x : i32, y : i32);
+impl(
+  _TPoint,
+  ToJson(
+    to_json : (fn(inout(self) : Self) -> JsonValue)({
+      keys := ArrayList(String).new();
+      values := ArrayList(JsonValue).new();
+      keys.push(`x`);
+      values.push(self.x.to_json());
+      keys.push(`y`);
+      values.push(self.y.to_json());
+      JsonValue.Object(keys : keys, values : values)
+    })
+  ),
+  FromJson(
+    from_json : (fn(v : JsonValue) -> Result(Self, JsonError))({
+      xv := match(
+        v.get(`x`),
+        .Some(j) => match(
+          i32.from_json(j),
+          .Ok(n) => n,
+          .Err(e) => {
+            return(.Err(e));
+          }
+        ),
+        .None => {
+          return(.Err(.Other(`missing field x`)));
+        }
+      );
+      yv := match(
+        v.get(`y`),
+        .Some(j2) => match(
+          i32.from_json(j2),
+          .Ok(n2) => n2,
+          .Err(e2) => {
+            return(.Err(e2));
+          }
+        ),
+        .None => {
+          return(.Err(.Other(`missing field y`)));
+        }
+      );
+      .Ok(Self(x : xv, y : yv))
+    })
+  )
+);
+test("json_encode primitives", {
+  assert(json_encode(i32(42)) == "42", "i32 encode");
+  assert(json_encode(true) == "true", "bool encode");
+  assert(json_encode(`hi`) == "\"hi\"", "String encode");
+  assert(json_encode(f64(1.5)) == "1.5", "f64 encode");
+});
+test("json_decode primitives", {
+  match(
+    json_decode(i32, `42`),
+    .Ok(n) => assert(n == i32(42), "i32 decode value"),
+    .Err(_) => assert(false, "i32 decode should succeed")
+  );
+  match(
+    json_decode(bool, `true`),
+    .Ok(b) => assert(b, "bool decode value"),
+    .Err(_) => assert(false, "bool decode should succeed")
+  );
+  match(
+    json_decode(String, `"hello"`),
+    .Ok(s) => assert(s == "hello", "String decode value"),
+    .Err(_) => assert(false, "String decode should succeed")
+  );
+});
+test("json_decode integer errors", {
+  assert(json_decode(i8, `300`).is_err(), "i8 out of range must Err");
+  assert(json_decode(i32, `1.5`).is_err(), "non-integral must Err");
+  assert(json_decode(u8, `-1`).is_err(), "negative into u8 must Err");
+  assert(json_decode(i32, `"nope"`).is_err(), "string into i32 must Err");
+});
+test("json Option encode", {
+  // Decode side is BLOCKED on
+  // issues/generic-impl-fromjson-container-decode-failures.md — the
+  // FromJson impl and its cases live in issues/repros/ until then.
+  (some_v : Option(i32)) = Option(i32).Some(i32(7));
+  (none_v : Option(i32)) = Option(i32).None;
+  assert(json_encode(some_v) == "7", "Some encodes as payload");
+  assert(json_encode(none_v) == "null", "None encodes as null");
+});
+test("json ArrayList roundtrip", {
+  list := ArrayList(i32).new();
+  list.push(i32(1));
+  list.push(i32(2));
+  list.push(i32(3));
+  assert(json_encode(list) == "[1,2,3]", "list encode");
+  match(
+    json_decode(ArrayList(i32), `[1,2,3]`),
+    .Ok(back) => {
+      assert(back.len() == usize(3), "decoded length");
+      assert(back(usize(0)) == i32(1), "elem 0");
+      assert(back(usize(2)) == i32(3), "elem 2");
+    },
+    .Err(_) => assert(false, "list decode should succeed")
+  );
+  assert(json_decode(ArrayList(i32), `[1,"x"]`).is_err(), "bad element must Err");
+});
+test("json HashMap encode", {
+  // Decode side is BLOCKED on
+  // issues/generic-impl-fromjson-container-decode-failures.md.
+  m := HashMap(String, i32).new();
+  _s := m.set(`a`, i32(1));
+  assert(json_encode(m) == "{\"a\":1}", "single-key map encode");
+});
+test("json custom struct roundtrip", {
+  p := _TPoint(x : i32(3), y : i32(-(4)));
+  encoded := json_encode(p);
+  assert(encoded == "{\"x\":3,\"y\":-4}", "struct encode shape");
+  match(
+    json_decode(_TPoint, encoded),
+    .Ok(back) => {
+      assert(back.x == i32(3), "x roundtrip");
+      assert(back.y == i32(-(4)), "y roundtrip");
+    },
+    .Err(_) => assert(false, "struct decode should succeed")
+  );
+  assert(json_decode(_TPoint, `{"x":1}`).is_err(), "missing field must Err");
+});
+test("json_decode parse error is Err", {
+  assert(json_decode(i32, `{oops`).is_err(), "invalid JSON must Err not throw");
+  assert(json_parse_result(`[1,2`).is_err(), "json_parse_result surfaces Err");
+  match(
+    json_parse_result(`[1,2]`),
+    .Ok(v) => assert(v.at(usize(1)).is_some(), "json_parse_result Ok tree"),
+    .Err(_) => assert(false, "valid JSON should parse")
+  );
 });


### PR DESCRIPTION
Now based on develop (#220 merged). Adds typed (de)serialisation to `std/encoding/json` — and fixes the evaluator bug that initially blocked the container decodes.

## API

- `ToJson :: trait(to_json : fn(inout(self)) -> JsonValue)` and `FromJson :: trait(from_json : fn(JsonValue) -> Result(Self, JsonError))` — both route through `JsonValue`; `FromJson` is a constructor-style **static trait method** (`Point.from_json(v)`), Result-returning so decode failures are values and `JsonError` can grow without breaking the signature.
- Impls: `bool`, all integer widths (decode validates **integrality and range** — `i8` from `300`, `i32` from `1.5`, `u8` from `-1` all `Err`; `u64`/`usize` capped at 2^53), `f32`/`f64`, `String`, `str` (encode-only by nature), `JsonValue` identity, and **full roundtrips** for `Option(T)`, `ArrayList(T)`, `HashMap(String, V)`.
- `json_encode(v)`, `json_decode(T, s)` (comptime `Type` first arg — `json_decode(Point, s)`), `json_parse_result` (Result-returning parse).

## Evaluator fix: capture-first forall binding for static generic-impl methods

`_funcval_bind_foralls` resolved un-inferable foralls **positionally from the receiver's `type_arguments` before consulting the impl resolver's injected captures**. For `impl(generic(V), HashMap(String, V), FromJson(…))` that bound `V := String` (`type_arguments[0]`) — every `HashMap(String, i32).from_json` value decode dispatched to **String's** impl; `Option(T)` decode's broken emitted C was the same mis-binding downstream. Fix: injected-capture fallback first, **gated on the captured type being concrete** (`type_contains_some_type_deep` — an unconditional capture-first regressed `ArrayList(u8).with_capacity`), positional as last resort (preserving `issues/fixed/self-dispatch-loses-type-args.md`). Full record + repros: `issues/fixed/generic-impl-fromjson-container-decode-failures.md`, `issues/repros/json-{option,hashmap}-fromjson-*.test.yo`.

Phase 2 (separate PR later): `derive(ToJson)`/`derive(FromJson)`.

## Validation

48/48 json tests (full container roundtrips, integer error cases, custom-struct roundtrip) · check std 154/154 + src 259/259 · CLI goldens 44/0/1 · tier-1 gates 0 failures · **FIXPOINT_HOLDS, stage2 hollow=0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)