### PR TITLE
codegen: mangle Windows-macro local names (near/far/pascal/…)

### DIFF
--- a/issues/fixed/emitted-c-locals-collide-with-windows-macros.md
+++ b/issues/fixed/emitted-c-locals-collide-with-windows-macros.md
@@ -1,5 +1,15 @@
 # Emitted C keeps user local names — a local named `near` breaks the Windows target
 
+**Status: FIXED 2026-08-22 — option 1 (mangler blocklist) implemented.**
+`_build_c_reserved_words` (src/codegen/utils/index.yo) now includes the
+legacy Windows macro set (`near far pascal cdecl IN OUT OPTIONAL interface
+small hyper`), so `sanitize_for_c_identifier` renames such locals to
+`__yo_c_reserved_<name>` — with the existing extern-C escape hatch keeping
+real C symbols untouched. Verified red-first on the emit (bare `near` ×2
+pre-fix → `__yo_c_reserved_near` ×2, zero bare, post-fix) and gated by
+tests/basic.test.yo "locals named after Windows macros survive codegen",
+which runs on every CI platform including the windows legs.
+
 **Found:** 2026-08-22 by PR #218's `test (windows-latest)` leg: the
 cross-emitted `cross/yo-windows-x64.c` failed with
 `error: expected expression` at `if (near) {`. `near` (and `far`,

--- a/src/codegen/utils/index.yo
+++ b/src/codegen/utils/index.yo
@@ -566,6 +566,22 @@ _build_c_reserved_words :: (fn() -> HashSet(String))({
   _w48 := words.add(String.from("NULL"));
   _w49 := words.add(String.from("true"));
   _w50 := words.add(String.from("false"));
+  // Legacy Windows macros: windef.h defines these to NOTHING, so a user
+  // local named `near` emitted verbatim became `if ()` in the windows
+  // cross-emit (PR #218's windows leg;
+  // issues/fixed/emitted-c-locals-collide-with-windows-macros.md). The
+  // extern-C escape hatch in sanitize_for_c_identifier still lets real C
+  // symbols keep their names.
+  _w51 := words.add(String.from("near"));
+  _w52 := words.add(String.from("far"));
+  _w53 := words.add(String.from("pascal"));
+  _w54 := words.add(String.from("cdecl"));
+  _w55 := words.add(String.from("IN"));
+  _w56 := words.add(String.from("OUT"));
+  _w57 := words.add(String.from("OPTIONAL"));
+  _w58 := words.add(String.from("interface"));
+  _w59 := words.add(String.from("small"));
+  _w60 := words.add(String.from("hyper"));
   words
 });
 _c_reserved_words := _build_c_reserved_words();

--- a/tests/basic.test.yo
+++ b/tests/basic.test.yo
@@ -2341,3 +2341,18 @@ test("cond arm struct literal with `return` in field name", {
   assert(f.return_flag, "cond arm 1 must set return_flag = true");
   assert(!(f.other_flag), "cond arm 1 must leave other_flag = false");
 });
+test("locals named after Windows macros survive codegen", {
+  // windef.h defines the legacy Win16 set (near/far/pascal/...) to NOTHING,
+  // so an unmangled local named `near` emitted `if ()` on the windows
+  // target. sanitize_for_c_identifier now renames them
+  // (issues/fixed/emitted-c-locals-collide-with-windows-macros.md); this
+  // exercises the mangling end-to-end on every CI platform.
+  near := true;
+  far := i32(2);
+  interface := i32(3);
+  (small : i32) = i32(0);
+  if(near, {
+    small = (far + interface);
+  });
+  assert(small == i32(5), "windows-macro-named locals must behave as plain locals");
+});


### PR DESCRIPTION
Stacked on #218 (whose windows leg found the instance this generalizes; the one-local hotfix rides #218).

## Why

`windef.h` defines the legacy Win16 macro set (`near`, `far`, `pascal`, …) to NOTHING, and emitted C keeps user local names — so a local named `near` compiled everywhere except the windows target, where `if (near)` became `if ()` (`cross/yo-windows-x64.c: error: expected expression`).

## Fix

`_build_c_reserved_words` gains `near far pascal cdecl IN OUT OPTIONAL interface small hyper`; `sanitize_for_c_identifier` already prefixes reserved words with `__yo_c_reserved_`, and its extern-C escape hatch keeps real C symbols untouched (same mechanism that protects `errno`/`stdout`).

## Verification

- Red-first on the emit: bare `near` ×2 with the pre-fix compiler → `__yo_c_reserved_near` ×2 / zero bare with the fixed one; probe binary runs correctly.
- New `tests/basic.test.yo` case declares `near`/`far`/`interface`/`small` locals and asserts behavior — runs on every CI platform **including the windows legs**.
- `issues/fixed/emitted-c-locals-collide-with-windows-macros.md` records the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)