### PR TITLE
std json: derive(ToJson) / derive(FromJson) for structs

### DIFF
--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -1102,6 +1102,24 @@ _push_twice :: (fn(v : i32, out : ArrayList(i32)) -> unit)({ out.push(v); out.pu
 outer :: (fn(out : ArrayList(i32)) -> unit)({ _push_twice(i32(1), out); });
 ```
 
+### Writing derive rules (outside the prelude works)
+
+`derive_rule(MyTrait, __my_rule)` works in any module with
+`pragma(Pragma.AllowMacroDef)`; the deriving module imports the trait and
+whatever names the GENERATED code references. Authoring gotchas, each of
+which otherwise surfaces as the misleading
+`derive rule must return(comptime(Expr)); got Comptime`:
+
+- Code strings passed to `.to_expr()` must parse as EXACTLY ONE
+  expression — wrap statement blocks in parens: `"({ a := 1; () })"`,
+  never a bare `"{ … }"`.
+- A raw backtick inside a `"..."` code string splits the parse — generate
+  `String.from("x")` in the code instead of a template literal.
+- Invoke derives with trait arguments: `derive(Point, Eq(Point))`. The
+  bare `derive(Point, Eq)` kills the module's evaluation with an
+  error anchored somewhere else entirely
+  (issues/bare-derive-form-kills-module-eval.md).
+
 ### Template strings cannot be nested inside `${...}` interpolations
 
 A template string literal (`` ` `` ... `` ` ``) inside a `${...}` interpolation of another template string closes the outer string. The compiler gives confusing parse errors.

--- a/issues/bare-derive-form-kills-module-eval.md
+++ b/issues/bare-derive-form-kills-module-eval.md
@@ -1,0 +1,23 @@
+# `derive(T, Eq)` (bare trait, no params) kills module evaluation with a misleading error
+
+**Found:** 2026-08-22 while probing user-defined derive rules for
+derive(ToJson). `derive(Point, Eq(Point))` works; the BARE form
+`derive(Point, Eq)` does not — and instead of an error at the derive
+site, the whole module's evaluation dies and the surfaced diagnostic is
+`Variable "Point" not found.` at Point's LATER use (under `compile`), or
+a missing-method error (under `check`). Classic error-token-location lie.
+
+Likely mechanics: the bare form hands the rule empty `trait_params`; the
+prelude rules splice `Eq(...#(trait_params))` which yields `Eq()` — an
+invalid trait application — and the failure is swallowed into the
+def-time module-eval abort instead of anchoring at the `derive(...)`
+statement.
+
+## Wanted
+
+Either make the bare form legal (default trait_params to `[T]`?) or
+reject it AT THE DERIVE SITE with a real message ("derive: trait
+arguments required — write derive(Point, Eq(Point))").
+
+Repro: two-line module — `Point :: struct(x : i32); derive(Point, Eq);`
+plus any later use of Point.

--- a/std/encoding/json.yo
+++ b/std/encoding/json.yo
@@ -13,6 +13,7 @@
 //! println(json_stringify(v));
 //! ```
 pragma(Pragma.AllowUnsafe);
+pragma(Pragma.AllowMacroDef);
 open(import("../string"));
 { ArrayList } :: import("../collections/array_list");
 { HashMap } :: import("../collections/hash_map");
@@ -1299,3 +1300,73 @@ json_decode :: (fn(comptime(T) : Type, s : String, where(T <: FromJson)) -> Resu
   match(json_parse_result(s), .Ok(v) => T.from_json(v), .Err(e) => .Err(e))
 );
 export(ToJson, FromJson, json_parse_result, json_encode, json_decode);
+// ============================================================================
+// derive(ToJson) / derive(FromJson) — struct derives
+// ============================================================================
+// v1 scope: STRUCTS. Enums need an agreed representation (externally-tagged
+// vs tag-field) before a derive can commit to one; until then deriving on an
+// enum is a comptime error. The generated impls reference `JsonValue`,
+// `JsonError`, `ToJson`/`FromJson`, `ArrayList` and `String` — the deriving
+// module must have them in scope (import this module and
+// std/collections/array_list).
+__derive_to_json :: (
+  fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comptime(trait_params) : ComptimeList(Expr)) -> comptime(Expr)
+)({
+  info :: Type.get_info(T);
+  comptime_assert(info.is_struct(), "derive(ToJson) supports structs only (enum representation is not decided yet)");
+  fields :: Type.get_struct_fields(T);
+  fc :: fields.len();
+  pushes :: __yo_comptime_fold_range(
+    fc,
+    "",
+    (fn(comptime(acc) : comptime_str, comptime(fi) : usize) -> comptime(comptime_str))({
+      fname :: fields.get(fi).name;
+      acc + (((("__djt_keys.push(String.from(\"" + fname) + "\")); __djt_values.push(self.") + fname) + ".to_json()); ")
+    })
+  );
+  body :: (("({ __djt_keys := ArrayList(String).new(); __djt_values := ArrayList(JsonValue).new(); " + pushes) + "JsonValue.Object(keys : __djt_keys, values : __djt_values) })");
+  body_expr :: __yo_comptime_string_to_expr(body);
+  ctx.make_impl(
+    quote(
+      ToJson(to_json : ((self) -> #(body_expr)))
+    )
+  )
+});
+derive_rule(ToJson, __derive_to_json);
+__derive_from_json :: (
+  fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comptime(trait_params) : ComptimeList(Expr)) -> comptime(Expr)
+)({
+  info :: Type.get_info(T);
+  comptime_assert(info.is_struct(), "derive(FromJson) supports structs only (enum representation is not decided yet)");
+  fields :: Type.get_struct_fields(T);
+  fc :: fields.len();
+  type_name :: Type.to_comptime_string(T);
+  extracts :: __yo_comptime_fold_range(
+    fc,
+    "",
+    (fn(comptime(acc) : comptime_str, comptime(fi) : usize) -> comptime(comptime_str))({
+      fname :: fields.get(fi).name;
+      ftype :: Type.to_comptime_string(fields.get(fi).field_type);
+      acc + (((((((((("__djf_" + fname) + " := match(v.get(String.from(\"") + fname) + "\")), .Some(__djf_j) => match(") + ftype) + ".from_json(__djf_j), .Ok(__djf_ok) => __djf_ok, .Err(__djf_e) => { return(.Err(__djf_e)); }), .None => { return(.Err(JsonError.Other(String.from(\"missing field ") + fname) + " in ") + type_name) + "\")))); }); ")
+    })
+  );
+  ctor_args :: __yo_comptime_fold_range(
+    fc,
+    "",
+    (fn(comptime(acc) : comptime_str, comptime(fi) : usize) -> comptime(comptime_str))({
+      fname :: fields.get(fi).name;
+      part :: ((fname + " : __djf_") + fname);
+      cond(
+        (acc == "") => part,
+        true => ((acc + ", ") + part)
+      )
+    })
+  );
+  body :: (((("({ " + extracts) + ".Ok(Self(") + ctor_args) + ")) })");
+  ctx.make_impl(
+    quote(
+      FromJson(from_json : ((v) -> #(body.to_expr())))
+    )
+  )
+});
+derive_rule(FromJson, __derive_from_json);

--- a/tests/encoding/json.test.yo
+++ b/tests/encoding/json.test.yo
@@ -625,3 +625,50 @@ test("json_decode parse error is Err", {
     .Err(_) => assert(false, "valid JSON should parse")
   );
 });
+// ===== derive(ToJson) / derive(FromJson) =====
+_DInner :: struct(a : i32, b : String);
+derive(_DInner, ToJson(_DInner));
+derive(_DInner, FromJson(_DInner));
+_DOuter :: struct(name : String, inner : _DInner, flag : bool);
+derive(_DOuter, ToJson(_DOuter));
+derive(_DOuter, FromJson(_DOuter));
+test("derived struct roundtrip", {
+  v := _DInner(a : i32(7), b : `seven`);
+  s := json_encode(v);
+  assert(s == "{\"a\":7,\"b\":\"seven\"}", "derived encode shape");
+  match(
+    json_decode(_DInner, s),
+    .Ok(back) => {
+      assert(back.a == i32(7), "a roundtrip");
+      assert(back.b == "seven", "b roundtrip");
+    },
+    .Err(_) => assert(false, "derived decode should succeed")
+  );
+});
+test("derived nested struct roundtrip", {
+  o := _DOuter(name : `outer`, inner : _DInner(a : i32(1), b : `one`), flag : true);
+  s := json_encode(o);
+  assert(s == "{\"name\":\"outer\",\"inner\":{\"a\":1,\"b\":\"one\"},\"flag\":true}", "nested encode shape");
+  match(
+    json_decode(_DOuter, s),
+    .Ok(back) => {
+      assert(back.name == "outer", "name roundtrip");
+      assert(back.inner.a == i32(1), "nested a roundtrip");
+      assert(back.inner.b == "one", "nested b roundtrip");
+      assert(back.flag, "flag roundtrip");
+    },
+    .Err(_) => assert(false, "nested decode should succeed")
+  );
+});
+test("derived decode missing field errors", {
+  assert(json_decode(_DOuter, `{"name":"x","flag":true}`).is_err(), "missing inner must Err");
+  match(
+    json_decode(_DInner, `{"a":1}`),
+    .Ok(_) => assert(false, "missing b must Err"),
+    .Err(e) => match(
+      e,
+      .Other(msg) => assert(msg.contains(String.from("missing field b")), "error names the field"),
+      _ => assert(false, "expected Other error")
+    )
+  );
+});


### PR DESCRIPTION
Phase 2 of the ToJson/FromJson plan (maintainer-approved) — struct derives via the std-side derive-rule machinery, **no evaluator changes**.

## What you write

```rust
Point :: struct(x : i32, y : i32);
derive(Point, ToJson(Point));
derive(Point, FromJson(Point));
// json_encode(p) → {"x":3,"y":-4}; json_decode(Point, s) → Result(Point, JsonError)
```

## How it works

The rules fold the struct's `FieldInfo` list into generated code — ToJson builds a `JsonValue.Object` from per-field `.to_json()` calls; FromJson extracts each field by name via `<FieldType>.from_json`, propagating the first `Err` and producing `missing field <name> in <Type>` errors — then `ctx.make_impl` a quote-spliced impl. Nested derived structs compose. Enums are a **comptime error** until a representation (externally-tagged vs tag-field) is decided.

## Surfaced along the way

- Derive-rule authoring gotchas (now in the cheatsheet): generated code strings must parse as exactly ONE expression (wrap blocks in `({ … })`), and a raw backtick inside a `"..."` code string splits the parse — generate `String.from("x")` instead.
- Bare `derive(T, Eq)` kills module evaluation with a mislocated error — filed as `issues/bare-derive-form-kills-module-eval.md` (diagnostic-quality bug; the parameterized form works).

## Validation

json suite **51/51** through the tree compiler (derived flat + nested roundtrips, missing-field errors) · check std 154/154 + src 260/260

🤖 Generated with [Claude Code](https://claude.com/claude-code)