### PR TITLE
fix: enum alignment includes the int32 tag — structs embedding low-align-payload enums regain C's tail padding

### DIFF
--- a/issues/fixed/enum-alignment-ignores-tag-heap-corruption.md
+++ b/issues/fixed/enum-alignment-ignores-tag-heap-corruption.md
@@ -1,0 +1,62 @@
+# enum alignment ignored the C tag — structs embedding low-align-payload enums lost their tail padding (heap corruption)
+
+**Status: FIXED 2026-08-22** (`src/types/utils.yo`, `get_alignment_of_type`
+EnumT arm: alignment is now `max(4, max payload alignment)`).
+
+## Symptom
+
+PR #229's Linux legs (both, deterministically) died in
+`tests/net/dns.test.yo` "resolve localhost returns socket addresses":
+
+```
+==8403==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 24
+0x5080000000f8 is located 0 bytes after 88-byte region
+```
+
+88 = 4 × 22 (the evaluator's `sizeof(SocketAddr)`), while the C `memcpy`
+width/stride is 24 (clang's padded sizeof). ASan is non-functional on the
+local macOS box (memory: asan-unusable-on-this-box), so local runs of the
+same test were silently green.
+
+## Root cause
+
+`get_alignment_of_type`'s value-semantics EnumT arm returned only the max
+alignment across variant PAYLOAD fields — but the C representation is
+
+```c
+struct __yo_tN_struct { __yo_tN_tag tag; __yo_tN_data data; };
+```
+
+with an int-typed tag (C enum: 4 bytes, 4-aligned). For
+`IpAddr :: enum(V4(4×u8), V6(Array(u16, 8)))` the payload max-align is 2,
+so the evaluator said align 2 while C says 4. The enum's own SIZE arm
+already assumed the tag (`struct_align_bits = max(32, …)` — IpAddr sized
+20 correctly), so the two functions disagreed: `SocketAddr :: struct(ip :
+IpAddr, port : u16)` computed 20 + 2 = 22 with struct align 2 (no tail
+padding), while C pads to 24. Every `sizeof`-based buffer computation over
+such a struct (ArrayList element math first among them) then mixes a
+22-byte stride with 24-byte C copies → heap overflow.
+
+**TS parity note:** the attic `getAlignmentOfType` (utils.ts:1789) has the
+IDENTICAL omission — this was a faithfully ported bug, and the fix is a
+deliberate divergence (recorded at the fix site).
+
+## Why it surfaced now
+
+Nothing before S0 C3 ever put a V6 `IpAddr` into a `SocketAddr` list on an
+ASan leg: `lookup_host` dropped all AAAA records, so `resolve(localhost)`
+produced 3 all-V4 entries (reads stayed inside the undersized buffer).
+The C3 fix made it 6 entries and the growth-copy read ran off the end.
+The layout bug itself is old and independent of C3.
+
+## Repro (minimal, no ASan needed — the sizes disagree directly)
+
+```rust
+IpA :: enum(V4(a : u8, b : u8, c : u8, d : u8), V6(segments : Array(u16, 8)));
+SockA :: struct(ip : IpA, port : u16);
+// pre-fix: sizeof(IpA) = 20 (correct), sizeof(SockA) = 22 (C: 24)
+```
+
+Gate: `tests/basic.test.yo` "enum tag participates in alignment"
+(sizeof asserts + an ArrayList roundtrip that ASan legs verify at the
+memory level). Verified red (22) before the fix, green (24) after.

--- a/issues/test-runner-std-path-shadowed-by-binary-tree-std.md
+++ b/issues/test-runner-std-path-shadowed-by-binary-tree-std.md
@@ -1,0 +1,37 @@
+# `yo test --std-path` is shadowed by the binary's own tree std in batch child compiles
+
+**Status: OPEN.** Found 2026-08-22 while validating the enum-alignment fix
+across worktrees; cost ~40 minutes of misdiagnosis as a miscompile.
+
+## Symptom
+
+Running tree A's compiler binary against tree B's tests:
+
+```
+cd /tmp/yo-s0wt   # tree B (has the dns AAAA fix in std/net/dns.yo)
+/tmp/yo-fixwt/yo-out/aarch64-macos/bin/yo test tests/net/dns.test.yo --std-path ./std
+```
+
+The batch child compile resolved std to **`/tmp/yo-fixwt/std`** (tree A —
+the binary-relative std), NOT the explicit `--std-path ./std`. Verified by
+the mangled decl paths in the batch C
+(`enum_decl_…_file____private_tmp_yo_fixwt_std_net_addr_yo`). Tree A's std
+predates the AAAA fix, so the test's V6 arm didn't exist in the compiled
+std and the test failed with `len=0` — indistinguishable at first sight
+from a codegen regression in the compiler under test.
+
+The same invocation with a binary that has NO adjacent source tree
+(`cp` the binary to `/tmp/yo-fixbin` first) honors `--std-path` and passes.
+
+## Where to look
+
+Either the test runner does not forward `--std-path` to its child batch
+compiles (`src/main.yo` around the `.yo_selftest_batch` spawn), or
+`resolve_std_path` (`src/module_manager.yo`) ranks the binary-relative
+tree std above the explicit override. Explicit `--std-path` should win
+over EVERY fallback, in child processes included.
+
+## Workaround (session knowledge, also in memory)
+
+When testing tree B with tree A's binary, copy the binary out of its tree
+first (`cp .../bin/yo /tmp/…`), or build inside tree B.

--- a/src/types/utils.yo
+++ b/src/types/utils.yo
@@ -1500,7 +1500,21 @@ get_alignment_of_type :: (fn(ty_in : TypeValue) -> Option(usize))({
           );
           vi = (vi + usize(1));
         });
-        cond(unknown => Option(usize).None, true => Option(usize).Some(acc))
+        cond(
+          unknown => Option(usize).None,
+          // The C representation carries an int-typed tag (`__yo_tN_tag tag;`
+          // — a C enum, 4 bytes / 4-aligned on every supported target), so a
+          // value-semantics enum is at least 4-aligned REGARDLESS of its
+          // payload alignments. The size arm below already assumes this
+          // (`struct_align_bits = max(32, …)`). DELIBERATE DIVERGENCE from
+          // TS: getAlignmentOfType (attic utils.ts:1789) omits the tag, so an
+          // enum whose payloads align below 4 (e.g. Array(u16, 8) → 2)
+          // reported alignment 2, a struct embedding it skipped C's tail
+          // padding (evaluator 22 B vs C 24 B), and every sizeof-based buffer
+          // walk over such structs corrupted the heap —
+          // issues/fixed/enum-alignment-ignores-tag-heap-corruption.md.
+          true => Option(usize).Some(_max_usize(acc, usize(4)))
+        )
       }
     ),
     _ => .None

--- a/tests/basic.test.yo
+++ b/tests/basic.test.yo
@@ -2356,3 +2356,44 @@ test("locals named after Windows macros survive codegen", {
   });
   assert(small == i32(5), "windows-macro-named locals must behave as plain locals");
 });
+LowAlignPayload :: enum(
+  Small(a : u8, b : u8, c : u8, d : u8),
+  Wide(segments : Array(u16, 8))
+);
+TagPadded :: struct(inner : LowAlignPayload, tail : u16);
+test("enum tag participates in alignment and struct tail padding", {
+  // issues/fixed/enum-alignment-ignores-tag-heap-corruption.md: the C tag is
+  // int-typed (4-aligned), so the enum aligns to 4 even though its payloads
+  // align to 2 — and the embedding struct gains C's tail padding (24, not
+  // 22). Pre-fix the evaluator said 22 and every ArrayList of TagPadded
+  // mixed a 22-byte stride with 24-byte C copies (heap overflow on the
+  // ASan CI legs).
+  assert(sizeof(LowAlignPayload) == usize(20), "enum: 4-byte tag + 16-byte payload");
+  assert(sizeof(TagPadded) == usize(24), "struct: 20 + 2 rounded up to align 4");
+  // Functional roundtrip across a growth boundary — the ASan legs check the
+  // memory behavior, every leg checks the values.
+  { ArrayList } :: import("std/collections/array_list");
+  l := ArrayList(TagPadded).new();
+  k := u16(0);
+  while(k < u16(6), {
+    segs := Array(u16, usize(8)).fill(u16(0));
+    segs(usize(0)) = (k + u16(100));
+    segs(usize(7)) = k;
+    l.push(TagPadded(inner : LowAlignPayload.Wide(segments : segs), tail : k));
+    k = (k + u16(1));
+  });
+  j := usize(0);
+  while(j < usize(6), {
+    e := l(j);
+    assert(e.tail == u16(j), "tail survives the growth copy");
+    match(
+      e.inner,
+      .Wide(segments) => {
+        assert(segments(usize(0)) == (u16(j) + u16(100)), "payload head survives");
+        assert(segments(usize(7)) == u16(j), "payload tail survives");
+      },
+      _ => assert(false, "variant survived")
+    );
+    j = (j + usize(1));
+  });
+});


### PR DESCRIPTION
`get_alignment_of_type`'s value-semantics EnumT arm returned only the max PAYLOAD alignment, ignoring the int-typed C tag (`__yo_tN_tag tag;` — 4 bytes, 4-aligned). An enum whose payloads align below 4 (e.g. `Array(u16, 8)` → 2) reported alignment 2, so a struct embedding it lost C's tail padding: evaluator `sizeof(SocketAddr)` = 22 vs C 24. Every sizeof-based buffer walk over such structs (ArrayList stride math first) then mixed a 22-byte stride with 24-byte C copies — **heap corruption**, caught by ASan on PR #229's Linux legs (88-byte region = 4×22, reads of 24). The enum's own SIZE arm already assumed the tag (`max(32, …)`), so the two functions disagreed internally.

**Deliberate divergence from TS**: the attic `getAlignmentOfType` (utils.ts:1789) has the identical omission — a faithfully ported bug.

- Fix: alignment = `max(4, payload max)` for value-semantics enums (recorded at the fix site + `issues/fixed/enum-alignment-ignores-tag-heap-corruption.md`).
- Red-first gate in `tests/basic.test.yo`: sizeof asserts (22→24) + an ArrayList growth-boundary roundtrip the ASan legs verify at the memory level.
- Validated: basic 35/35, `check ./src` 260/260, and PR #229's previously-failing dns/tcp suites 4/4 + 13/13 under the fixed compiler.
- Rides along: `issues/test-runner-std-path-shadowed-by-binary-tree-std.md` (a validation trap found on the way).

Commit `3530ed4ac` is a cherry-pick of `cfa14cf86` (coordinated with the parallel env-sharing session, which carries the same change at its branch base and will rebase-dedup after this merges). Unblocks #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)