### PR TITLE
evaluator: shared Variable handles in FuncVal capture rebuilds (env-sharing campaign 2)

### DIFF
--- a/plans/FUNCVAL_ENV_SHARING.md
+++ b/plans/FUNCVAL_ENV_SHARING.md
@@ -1,6 +1,45 @@
-# FuncVal env sharing (env-sharing campaign 2) — replace the flat capture rebuild with a frozen shared Environment
+# FuncVal env sharing (env-sharing campaign 2) — shared Variable handles in the capture rebuild
 
-**Status: ACTIVE (designed 2026-08-22).** Successor to the landed §3 def-time
+**DESIGN REVISED 2026-08-23.** The original mechanism below (§3: freeze a
+multi-frame def-scope env per definition, registry-preferred at call time)
+was BUILT AND REJECTED the same day, twice over — keep this record, the
+failure modes generalize:
+
+1. **Semantics.** The call machinery's frame-level arithmetic grew up against
+   `capture_env_for`'s SINGLE-frame env shape. Multi-frame callee envs broke
+   `(!)`/Call-tuple dispatch (`_Self : (LogicalNot)` refused to bind `bool` —
+   the trial rejection surfaced as "No matching call found" at the prelude's
+   `!=` default) and derive rules ("derive rule must return comptime(Expr);
+   got Comptime"). A single-frame frozen env fixed both repros — the depth
+   was the poison, not the sharing.
+2. **Performance.** Freezing per DEFINITION (eagerly, fresh `index_key` per
+   frame) thrashed `g_frame_indexes`' 2048-entry wholesale clear:
+   `check src/env.yo` went 24.7 s → >9 min with 78% of CPU in `__yo_decr_rc`
+   + TLS reads under the two env-lookup functions. `capture_env_for` never
+   thrashed because it builds LAZILY at first call, memoised, bounding the
+   number of distinct capture frames.
+3. Also fixed en route: the frozen env carried the DEF module's
+   `module_path` where the flat env stamps the CALLER's — relative-import
+   resolution (`import("./rune.yo")`) flows through `env.module_path`, so
+   def-module stamping mis-resolved sibling imports.
+
+**The revision keeps `capture_env_for`'s laziness, per-instance memo, and env
+shape untouched and changes exactly one thing: the definition site registers
+the ORIGINAL `Variable` handles (`g_funcval_cap_vars`, keyed by a fresh
+`FuncValData.env_key`), and the rebuild pushes those handles into the capture
+frame instead of re-minting Variable + value cell + name string per binding.**
+Semantic deltas vs the flat rebuild, accepted and gate-tested: captured
+variables keep their true `is_compile_time_only` flags and live value cells
+(the flat loop marked EVERYTHING comptime and used `VarRef` sentinels for
+valueless bindings).
+
+Measured (self-emit, M4): step 2 alone (direct definition sites only)
+141.3 → 138.6 s / 17.19 → 16.53 GB footprint — the big population is DERIVED
+FuncVals (step 3): today all 17 derived construction sites leave `env_key = 0`
+and fall back to the flat rebuild, safely.
+
+**Status: step 2 (revised) implemented; original design below kept for the
+record (its §1/§2 ground-truth research and §6 risk checklist remain valid).** Successor to the landed §3 def-time
 sharing (`plans/backlog/YO_SELF_ENV_SHARING.md`, `_share_def_time_frames`).
 Target: the `capture_env_for` population — **242,154 rebuilds minting
 144.5 M `Variable`s per self-emit (~597/rebuild), 99% from DERIVED FuncVal

--- a/plans/FUNCVAL_ENV_SHARING.md
+++ b/plans/FUNCVAL_ENV_SHARING.md
@@ -1,0 +1,185 @@
+# FuncVal env sharing (env-sharing campaign 2) — replace the flat capture rebuild with a frozen shared Environment
+
+**Status: ACTIVE (designed 2026-08-22).** Successor to the landed §3 def-time
+sharing (`plans/backlog/YO_SELF_ENV_SHARING.md`, `_share_def_time_frames`).
+Target: the `capture_env_for` population — **242,154 rebuilds minting
+144.5 M `Variable`s per self-emit (~597/rebuild), 99% from DERIVED FuncVal
+creation** (specialization, impl shells, ctl-inline). Memo variants were built
+twice and REFUTED twice (37 hits / 587 hits + 2.1 GB retention) — this
+campaign is the only remaining lever for the site, and it is a SEMANTICS
+change gated accordingly.
+
+## 1. Ground truth (verified against the `src-attic-final` TS attic)
+
+- TS keeps the definition scope on the **function type**: `FunctionType.env`
+  (`src/types/definitions.ts:881-886`), set once at signature evaluation from
+  the live env minus the params frame (`evaluator/types/function.ts:2643`).
+  `FunctionValue` carries only `frameLevel`. There are ZERO flat capture
+  lists on the TS value.
+- Call time is one choke point: `calleeEnv = pushEnvFrame(functionType.env)`
+  (`evaluator/calls/helper.ts:1141-1144`); Self/foralls/params are then bound
+  into that env. Specialization/impl/ctl derivations INHERIT the env
+  (`{...functionType, env: functionType.env}`) — they never rebuild scope.
+- The env selection at definition is **three-way**: live env as-is (closures,
+  `closure-type.ts:66`), live env as-is (module-level fns,
+  `function-type.ts:298-304`), `keepTopLevelFrameAndComptimeVariablesFromEnv`
+  (nested non-closures; frame 0 whole, other frames filtered to comptime-only
+  — same Variable objects, never new ones).
+- TS gets snapshot semantics FOR FREE: its `Environment` is persistent/COW
+  (`addVariableToEnv`/`updateExistingVariable` build new frames). yo-self
+  frames append IN PLACE, so every stored env must be FROZEN explicitly —
+  the §3 rule: share `Variable` handles, rebuild every `Frame` (frame 0
+  included) with a fresh variables list and a **fresh `index_key`**
+  (`issues/env-sharing-live-frame-membership-leak.md`; the rule is stated in
+  the backlog doc as binding on this campaign).
+- Codegen does NOT read any of this: the C closure struct comes from the
+  separate captured-variables analysis
+  (`create_capture_type_and_value` → `register_closure_capture_info`),
+  already ported. This campaign is evaluator-only.
+- TS has no `__recur_fn`: `recur` resolves through the function-body
+  evaluation CONTEXT (`context.ts:9-18`, `recur.ts:124-134`), and by-name
+  recursion uses the enclosing declaration's forward-reference variable.
+  yo-self's `__recur_fn` frame stays as-is for now (it is pushed onto the
+  callee env AFTER the base env is built, so the mechanism is orthogonal);
+  its visibility must simply not change.
+
+## 2. The yo-self placement problem, and the decision
+
+`Environment` cannot live on `FuncValData` or on yo's `FunctionType`:
+env.yo imports value.yo (Variable holds EvalValue), and types/definitions.yo
+sits below both. Forward references across top-level types are rejected
+(probed 2026-08-22), so direct mutual recursion is out. Two candidates:
+
+- **(A) Genericize the env types** (`EnvG(V)` in a leaf module;
+  `EvalValue.FuncVal(..., env : EnvG(Self))` — the `ArrayList(Self)`
+  precedent suggests it types). REJECTED for this campaign: it drags every
+  definition in env.yo (and its ~50 importers' type identities) through a
+  genericization purely to move a field, multiplying the id-reseed blast
+  radius the §3 campaign already showed is the dangerous part.
+- **(B) A def-env side table in env.yo**, keyed by a fresh per-construction
+  id stored on `FuncValData`. CHOSEN. Precedent: `ExprInfo` is a side table
+  for exactly this reason, and `src/function_value.yo` already keeps
+  func-id-keyed registries (`g_closure_fid_source`,
+  closure-capture info). Divergence from TS placement (value-side key vs
+  type-side field) is recorded here deliberately: yo's call paths all have
+  the FuncVal in hand at the moment TS reads `functionType.env`, and the
+  mechanism being ported is "the frozen definition scope is reachable at
+  call time", not the field's address.
+
+Known hazards of a registry, addressed up front:
+- *Key identity*: `func_id` is NOT unique per FuncValData (impl.yo:149 and
+  :4004 reuse it with the same lists; `_inject_forall_captures` reuses it
+  with new lists) — the registry key is a FRESH `env_key : usize` minted per
+  construction that stores an env; `usize(0)` = absent.
+- *Mis-port class* ("TS reads off the value, yo-self keys a global table"):
+  during migration every registry MISS falls back to the existing
+  `capture_env_for` flat rebuild, so a lost key degrades to today's
+  behavior, never to `.None`-shaped wrongness. The fallback is removed only
+  in the endgame, when creation sites are provably total.
+- *Retention*: entries live for the process, like TS's `FunctionType.env`.
+  Under sharing, a derived FuncVal's entry is one `Environment` shell +
+  frames list (+ one pushed binding frame) — pointers, not Variables.
+  Budget check in §5 measures it. Every frozen frame's `index_key` is
+  tracked for `g_frame_indexes` eviction exactly as `capture_env_for` does
+  today (`g_capture_env_index_keys` pattern).
+
+## 3. Mechanism
+
+New, in env.yo (alongside `capture_env_for`, which stays during migration):
+
+```rust
+// Frozen def-scope registry (TS: FunctionType.env).
+(g_funcval_def_envs : HashMap(usize, Environment)) = ...;
+(g_def_env_index_keys : ArrayList(usize)) = ...;   // g_frame_indexes eviction
+
+// Freeze a LIVE env for capture: share Variable handles; rebuild every
+// Frame (frame 0 included) with a fresh variables list, same frame id,
+// shared where_clause_constraints, FRESH index_key.  (§3 pattern, hoisted
+// out of function_type.yo so both campaigns share one implementation.)
+freeze_env_for_capture :: (fn(env : Environment) -> Environment)(...);
+
+register_funcval_def_env :: (fn(env_key : usize, frozen : Environment) -> unit)(...);
+get_funcval_def_env :: (fn(env_key : usize) -> Option(Environment))(...);
+// Derived FuncVals: snapshot the parent's FROZEN env (frames already
+// immutable → sharing them outright is safe), push one binding frame.
+extend_funcval_def_env :: (fn(parent_key : usize, bindings...) -> usize)(...);
+```
+
+`FuncValData` gains `(env_key : usize)` (last field; `derive(Clone)` shares
+it — intended: TS clones share the env object).
+
+Call-path change (function.yo:5029, helper.yo:4750, and the manual rebuild
+loops at index_trait.yo:1227, ctfe_analysis.yo:160, function.yo:2927/6341,
+helper.yo:3416): `match(get_funcval_def_env(fvd.env_key))` →
+`.Some(fe) => snapshot_env(fe)` (+ push frames as today), `.None => ` the
+existing flat rebuild. The callee then proceeds identically (param frame,
+`__recur_fn` frame, foralls).
+
+What the flat lists KEEP doing (unchanged this campaign): the
+generic-binding channel — `_funcval_bind_foralls` (function.yo:1619),
+`_inject_forall_captures` (impl.yo:1321), `_impl_type_captures_sig`
+(helper.yo:1578) and the specialization-guard, the TypeVal appends at
+helper.yo:3132/4070, codegen/functions/collection.yo:928. These read only
+TypeVal/IntLit captures = "the impl/forall bindings stamped on this
+FuncVal", which a scope reference does not distinguish. Shrinking those
+lists to bindings-only is the endgame (§6), not this campaign.
+
+## 4. Step plan (each step lands only through the full gate battery)
+
+1. **Infra**: `env_key` field (default `usize(0)` at all 19 construction
+   sites), `freeze_env_for_capture` (hoist/share with
+   `_share_def_time_frames`'s core), registry + eviction accounting, the
+   call-path fallback match (no keys registered yet → behaviorally inert;
+   gates prove the plumbing is a no-op).
+2. **Real definition sites** (the two snapshot loops): 
+   `evaluate_anonymous_function` (anonymous_function.yo:942-982) and the
+   `fn(...)`-type path (function_type.yo:1019-1100) mint `env_key` +
+   register `freeze_env_for_capture(env-in-hand)` (matching TS's three-way
+   selection: the filtered variant shares frame 0 and keeps
+   comptime-only + module-level Variables elsewhere — same predicate as
+   `_share_def_time_frames(strip=true)`). Flat lists still built (consumers
+   + fallback). `has_fwd_comptime_fn_cap` stays with the loop.
+3. **Derived sites inherit**: helper.yo:3173 / 4081, impl.yo:149 / 1413 /
+   3957 / 4004, ctfe_analysis.yo:352, function.yo:4058 (partial app builds
+   its 3-entry env directly), function.yo:5040 (`fv_for_recur` shares the
+   callee's key). Each inherits the parent key or extends it with its
+   binding frame via `extend_funcval_def_env`.
+4. **Flip the call paths' preference** (they already prefer the registry
+   from step 1) and measure: wall + peak footprint on the self-emit and on
+   `check ./src`, attribution of remaining `capture_env_for` misses.
+5. **Endgame** (separate PR): delete `capture_env_for` + memo + the two
+   snapshot loops + the manual rebuild loops once misses are zero on the
+   full corpus; shrink cap lists to the generic-binding channel.
+
+## 5. Gates (every step)
+
+- `yo check ./src --std-path ./std` and the language suite subset touching
+  closures/impls/specialization; `tests/late_sibling_method_name_shadow.test.yo`
+  explicitly.
+- `S1=<bin> P=<tag> scripts/bootstrap/gates_fast.sh`;
+  `scripts/bootstrap/fixpoint_only.sh` (stage-2 ≡ stage-3).
+- **Emitted C**: steps 1-3 must be byte-identical to baseline (fallback in
+  force = no behavior change). Step 4 is where the emit may legally shift
+  (SomeT `pf_level` depth, id reseed) — gate with the corpus diff-test and
+  the per-function dup/drop-count diff (fewer dups = potential UAF —
+  memory rule), plus the hollow-sweep ratchet.
+- Peak **footprint** (never RSS) on the self-emit; registry retention
+  measured and recorded here.
+
+## 6. Risk checklist (inherited from campaign 1 — binding)
+
+1. Frozen membership: never store a live `Frame` handle; fresh `index_key`
+   per rebuilt frame; eviction path for every long-lived index entry.
+2. Never mutate a shared `Variable`; fixups = shadow bindings in a pushed
+   frame.
+3. `pf_level`/SomeT stamping deepens when the call path stops flattening
+   (step 4) — corpus diff-test is the gate; `sig_some_ts` stays until gates
+   (not reasoning) prove it redundant.
+4. Id reseed re-exposes HashMap-iteration-order first-match bugs (two prior:
+   `_find_bundle_var_field`, dup/drop) — re-audit on any new differential.
+5. `__recur_fn` must not become visible through the shared env (the frozen
+   rebuild excludes nothing, but `__recur_fn` is bound in a frame pushed
+   AFTER capture at function.yo:5036 — verify with a lookup probe test).
+6. Dup-accounting on runtime captures: the VarRef placeholders vanish from
+   the callee env in step 4; the closure-capture C pipeline is separate, but
+   the emit-diff + dup/drop gate is the proof, not this sentence.

--- a/plans/FUNCVAL_ENV_SHARING.md
+++ b/plans/FUNCVAL_ENV_SHARING.md
@@ -52,9 +52,14 @@ application and the empty-capture placeholder sites deliberately stay at
 `env_key = 0`.
 
 Measured cumulative (self-emit, M4): 141.3 → 138.3 s wall,
-17.19 → 16.08 GB footprint (−1.11 GB). Below the census ceiling — the
-remaining flat-fallback population (attribution probe) is the step-4
-follow-up, along with the endgame deletion of the flat triple lists.
+17.19 → 16.08 GB footprint (−1.11 GB). Attribution probe (2026-08-23):
+**>19,000 shared-handle builds vs <1,000 flat fallbacks per self-emit** —
+coverage is essentially total. The gap to the census ceiling is explained:
+the 144.5 M mints were TRANSIENT allocation churn (memo-evicted rebuilds),
+which the post-allocator-flip system malloc absorbs cheaply — the durable
+saving is the live share (the −1.11 GB). Remaining follow-ups: the endgame
+deletion of the flat triple lists (blocked on the generic-binding-channel
+consumers), and re-running the live census to re-rank the §4 levers.
 
 Original design below kept for the record (its §1/§2 ground-truth research
 and §6 risk checklist remain valid).** Successor to the landed §3 def-time

--- a/plans/FUNCVAL_ENV_SHARING.md
+++ b/plans/FUNCVAL_ENV_SHARING.md
@@ -38,8 +38,26 @@ Measured (self-emit, M4): step 2 alone (direct definition sites only)
 FuncVals (step 3): today all 17 derived construction sites leave `env_key = 0`
 and fall back to the flat rebuild, safely.
 
-**Status: step 2 (revised) implemented; original design below kept for the
-record (its §1/§2 ground-truth research and §6 risk checklist remain valid).** Successor to the landed §3 def-time
+**Status: steps 2+3 (revised design) implemented and gate-green
+(gates_fast failures=0, FIXPOINT_HOLDS, late_sibling 2/2, check ./src
+260/260).** Step 3 wired the derived-FuncVal sites: verbatim-reuse sites
+(_stamp_impl_forall_on_method, trait-default materialization x2,
+_build_comptime_clone, fv_for_recur) pass `env_key` through;
+binding-appending sites (create_specialized_function_inline,
+create_ctl_specialized_function, _inject_forall_captures) inherit the
+parent's handle list and append looked-up Variable handles or
+`make_capture_variable` mints, registering under a fresh key — all guarded
+to stay on the flat fallback when the parent never registered. Partial
+application and the empty-capture placeholder sites deliberately stay at
+`env_key = 0`.
+
+Measured cumulative (self-emit, M4): 141.3 → 138.3 s wall,
+17.19 → 16.08 GB footprint (−1.11 GB). Below the census ceiling — the
+remaining flat-fallback population (attribution probe) is the step-4
+follow-up, along with the endgame deletion of the flat triple lists.
+
+Original design below kept for the record (its §1/§2 ground-truth research
+and §6 risk checklist remain valid).** Successor to the landed §3 def-time
 sharing (`plans/backlog/YO_SELF_ENV_SHARING.md`, `_share_def_time_frames`).
 Target: the `capture_env_for` population — **242,154 rebuilds minting
 144.5 M `Variable`s per self-emit (~597/rebuild), 99% from DERIVED FuncVal

--- a/src/env.yo
+++ b/src/env.yo
@@ -1843,6 +1843,43 @@ mint_funcval_env_key :: (fn() -> usize)({
   g_funcval_env_key_counter = (g_funcval_env_key_counter + usize(1));
   g_funcval_env_key_counter
 });
+/// The registered handle list for a FuncValData, if any. `usize(0)` is the
+/// reserved "absent" key and always misses.
+get_funcval_cap_vars :: (fn(env_key : usize) -> Option(ArrayList(Variable)))({
+  if(env_key == usize(0), {
+    return(Option(ArrayList(Variable)).None);
+  });
+  g_funcval_cap_vars.get(env_key)
+});
+/// Mint ONE capture Variable for a binding a DERIVED FuncVal appends to its
+/// inherited handle list (impl generics, specialization bindings, ctl
+/// forall types). Field-for-field what `add_variable_to_env` constructs for
+/// a comptime capture, minus the frame push — `frame_level` 0 matches the
+/// single capture frame `capture_env_for` builds.
+make_capture_variable :: (fn(name : String, ty : TypeValue, value : Option(EvalValue), module_path : String) -> Variable)(
+  Variable(
+    id : generate_variable_id(module_path, name),
+    name : name,
+    ty : ty,
+    is_compile_time_only : true,
+    frame_level : usize(0),
+    value : value_cell_of(value),
+    is_owning_the_rc_value : false,
+    is_owning_the_same_rc_value_as : Option(Box(Variable)).None,
+    is_reassignable : false,
+    token : synthetic_token(name, module_path),
+    initialized_at_token : Option(Token).Some(synthetic_token(name, module_path)),
+    consumed_at_token : Option(Box(Token)).None,
+    is_implicit : false,
+    is_created_from_destructuring_atom_variable : false,
+    rare : Option(VariableRare).None,
+    is_from_effect_spread : false,
+    is_effect_param : false,
+    is_module_level : false,
+    is_ref : false,
+    is_parameter : false
+  )
+);
 /// Register the def-time capture snapshot as SHARED `Variable` handles.
 /// The list must be built by the same walk (same order, same `__recur_fn`
 /// skip) as the flat `cap_names`/`cap_tys`/`cap_vals` lists it parallels.
@@ -4092,6 +4129,8 @@ export(
   capture_env_for,
   mint_funcval_env_key,
   register_funcval_cap_vars,
+  get_funcval_cap_vars,
+  make_capture_variable,
   YO_SELF,
   set_env_containing_prelude,
   clear_env_containing_prelude,

--- a/src/env.yo
+++ b/src/env.yo
@@ -1915,6 +1915,103 @@ capture_env_for :: (
   );
   snapshot_env(fenv)
 });
+// ---------------------------------------------------------------------------
+// Frozen def-scope registry (env-sharing campaign 2 —
+// plans/FUNCVAL_ENV_SHARING.md). TS keeps the definition Environment on the
+// function type (`FunctionType.env`, definitions.ts:881) and a call just does
+// `pushEnvFrame(functionType.env)` (helper.ts:1141). yo-self cannot store an
+// `Environment` on `FuncValData` (env.yo imports value.yo), so the frozen env
+// lives HERE, keyed by `FuncValData.env_key` (a fresh id per construction —
+// `func_id` is NOT unique per FuncValData and cannot key this). A miss falls
+// back to the flat-capture rebuild (`capture_env_for`), so a lost key
+// degrades to the pre-campaign behavior, never to wrongness.
+//
+// Retention is process-lifetime by design, like TS's `FunctionType.env`.
+// The frozen frames' lazy name indexes accumulate in `g_frame_indexes`,
+// which is already bounded by the 2048-entry wholesale clear in
+// `_frame_positions` (sound since `invalidate_frame_index` covers the shrink
+// sites) — no separate eviction accounting is needed here.
+(g_funcval_def_envs : HashMap(usize, Environment)) = HashMap(usize, Environment).new();
+/// Mint a registry key for a FuncValData about to capture its def scope.
+mint_funcval_env_key :: (fn() -> usize)(
+  generate_variable_id(String.from(""), String.from("fvenv"))
+);
+/// Freeze a LIVE env for capture: share the `Variable` handles, rebuild every
+/// `Frame` (frame 0 included) with a fresh variables list and a FRESH
+/// `index_key`. Same frozen-membership rule as `_share_def_time_frames`
+/// (function_type.yo) — pushing live Frame handles lets bindings added AFTER
+/// the capture leak into the recorded scope
+/// (issues/env-sharing-live-frame-membership-leak.md). With `strip` true,
+/// frames 1..n keep only comptime-only or module-level bindings (TS's
+/// `keepTopLevelFrameAndComptimeVariablesFromEnv`, env.ts:2245 — the
+/// `is_module_level` keep is the same justified yo-self divergence as in
+/// `_share_def_time_frames`).
+freeze_env_for_capture :: (fn(env : Environment, strip : bool) -> Environment)({
+  new_frames := ArrayList(Frame).new();
+  n := env.frames.len();
+  (i : usize) = usize(0);
+  while(i < n, {
+    match(
+      env.frames.get(i),
+      .Some(frame) => {
+        new_vars := ArrayList(Variable).new();
+        m := frame.variables.len();
+        (j : usize) = usize(0);
+        while(j < m, {
+          match(
+            frame.variables.get(j),
+            .Some(v) => {
+              keep := cond(
+                !(strip) => true,
+                (i == usize(0)) => true,
+                v.is_compile_time_only => true,
+                v.is_module_level => true,
+                true => false
+              );
+              if(keep, {
+                new_vars.push(v);
+              });
+            },
+            .None => ()
+          );
+          j = (j + usize(1));
+        });
+        new_frames.push(
+          Frame(
+            id : frame.id,
+            variables : new_vars,
+            is_begin_block : frame.is_begin_block,
+            where_clause_constraints : frame.where_clause_constraints,
+            index_key : generate_variable_id(String.from(""), String.from("fidx"))
+          )
+        );
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  Environment(
+    frames : new_frames,
+    module_path : env.module_path,
+    function_declaration_frame_level : env.function_declaration_frame_level,
+    input_string : env.input_string
+  )
+});
+/// Register a frozen def-scope env under a key minted by
+/// `mint_funcval_env_key`. The env must already be frozen — the registry
+/// never freezes on the caller's behalf, so a live env stored here is a bug.
+register_funcval_def_env :: (fn(env_key : usize, frozen : Environment) -> unit)({
+  g_funcval_def_envs.set(env_key, frozen);
+  ()
+});
+/// The frozen def scope for a FuncValData, if its creation site registered
+/// one. `usize(0)` is the reserved "absent" key and always misses.
+get_funcval_def_env :: (fn(env_key : usize) -> Option(Environment))({
+  if(env_key == usize(0), {
+    return(Option(Environment).None);
+  });
+  g_funcval_def_envs.get(env_key)
+});
 /// Deep-clone a single `WhereClauseConstraints` entry: a fresh
 /// `some_type` reference plus fresh trait-list arrays sharing the
 /// same `TypeValue` references inside. Mirrors the inline
@@ -3980,6 +4077,10 @@ export(
   clone_env,
   snapshot_env,
   capture_env_for,
+  mint_funcval_env_key,
+  freeze_env_for_capture,
+  register_funcval_def_env,
+  get_funcval_def_env,
   YO_SELF,
   set_env_containing_prelude,
   clear_env_containing_prelude,

--- a/src/env.yo
+++ b/src/env.yo
@@ -1810,6 +1810,51 @@ CaptureEnvEntry :: ref(
 /// so an eviction can drop those frames' entries in `g_frame_indexes` (which is
 /// keyed per Frame and has no other eviction path).
 (g_capture_env_index_keys : ArrayList(usize)) = ArrayList(usize).new();
+// ---------------------------------------------------------------------------
+// Shared-handle capture registry (env-sharing campaign 2 —
+// plans/FUNCVAL_ENV_SHARING.md, REVISED design). The first design (freeze a
+// multi-frame def-scope env per definition) was built and measured 2026-08-22
+// and REJECTED twice over:
+//   (a) semantics — the call machinery's frame-level arithmetic (SomeT
+//       pf_level stamping, comptime-visibility, closure frame tests) grew up
+//       against `capture_env_for`'s SINGLE-frame shape; multi-frame callee
+//       envs broke `(!)`/Call-tuple dispatch ("_Self : (LogicalNot)" refused
+//       `bool`) and derive rules ("got Comptime").
+//   (b) performance — one frozen frame per DEFINITION (fresh `index_key`
+//       each) thrashed the 2048-entry `g_frame_indexes` wholesale clear;
+//       `check src/env.yo` went 24.7 s -> >9 min, 78% of CPU in
+//       `__yo_decr_rc` + TLS under the two env lookups.
+// The revision keeps `capture_env_for`'s laziness, per-instance memo, and
+// env SHAPE untouched, and changes exactly one thing: when the definition
+// site registered the ORIGINAL `Variable` handles, the rebuild pushes those
+// handles into the capture frame instead of re-minting a Variable + value
+// cell + name string per binding (~597 mints x 242,154 rebuilds per
+// self-emit). Registered handle lists are keyed by `FuncValData.env_key`
+// (fresh per construction; `func_id` is NOT unique per FuncValData).
+// FuncValData CLONES share the key on purpose - a derived FuncVal that
+// clones the data therefore hits the SAME memoised env, which the old
+// ptr-identity memo never could.
+(g_funcval_cap_vars : HashMap(usize, ArrayList(Variable))) = HashMap(usize, ArrayList(Variable)).new();
+/// Private counter for `mint_funcval_env_key` — deliberately NOT
+/// `generate_variable_id`, so registrations do not reseed variable/frame ids.
+(g_funcval_env_key_counter : usize) = usize(0);
+/// Mint a registry key for a FuncValData about to capture its def scope.
+mint_funcval_env_key :: (fn() -> usize)({
+  g_funcval_env_key_counter = (g_funcval_env_key_counter + usize(1));
+  g_funcval_env_key_counter
+});
+/// Register the def-time capture snapshot as SHARED `Variable` handles.
+/// The list must be built by the same walk (same order, same `__recur_fn`
+/// skip) as the flat `cap_names`/`cap_tys`/`cap_vals` lists it parallels.
+register_funcval_cap_vars :: (fn(env_key : usize, vars : ArrayList(Variable)) -> unit)({
+  g_funcval_cap_vars.set(env_key, vars);
+  ()
+});
+/// One memoised shared-handle capture env per `env_key` (the shared-path
+/// analogue of `g_capture_envs`; module_path revalidated like the flat memo).
+SharedCaptureEnvEntry :: ref(struct(module_path : String, env : Environment));
+(g_shared_capture_envs : HashMap(usize, SharedCaptureEnvEntry)) = HashMap(usize, SharedCaptureEnvEntry).new();
+(g_shared_capture_env_index_keys : ArrayList(usize)) = ArrayList(usize).new();
 /// Rebuild (or reuse) the lexical-scope `Environment` of a `FuncVal` from its
 /// flat capture snapshot (`cap_names`/`cap_tys`/`cap_vals`).
 ///
@@ -1833,12 +1878,77 @@ CaptureEnvEntry :: ref(
 capture_env_for :: (
   fn(
     func_id : String,
+    env_key : usize,
     cap_names : ArrayList(String),
     cap_tys : ArrayList(TypeValue),
     cap_vals : ArrayList(EvalValue),
     module_path : String
   ) -> Environment
 )({
+  // Shared-handle fast path (campaign 2): the definition site registered the
+  // ORIGINAL Variable handles — build (once per env_key) a capture frame of
+  // those handles instead of re-minting a Variable per name. Same env shape
+  // as the legacy loop below: ONE begin-block frame, caller module_path,
+  // handed out as a `snapshot_env` copy.
+  if(env_key != usize(0), {
+    match(
+      g_shared_capture_envs.get(env_key),
+      .Some(sh) => if(sh.module_path == module_path, {
+        return(snapshot_env(sh.env));
+      }),
+      .None => ()
+    );
+    match(
+      g_funcval_cap_vars.get(env_key),
+      .Some(shared_vars) => {
+        sfr := ArrayList(Frame).new();
+        sfr.push(
+          Frame(
+            id : generate_variable_id(String.from(""), String.from("frame")),
+            variables : shared_vars,
+            is_begin_block : true,
+            where_clause_constraints : HashMap(String, WhereClauseConstraints).new(),
+            index_key : generate_variable_id(String.from(""), String.from("fidx"))
+          )
+        );
+        senv := Environment(
+          frames : sfr,
+          module_path : module_path,
+          function_declaration_frame_level : Option(usize).None,
+          input_string : String.from("")
+        );
+        if(g_shared_capture_envs.len() > usize(512), {
+          (sek : usize) = usize(0);
+          while(sek < g_shared_capture_env_index_keys.len(), {
+            match(
+              g_shared_capture_env_index_keys.get(sek),
+              .Some(k) => {
+                g_frame_indexes.remove(k);
+                ()
+              },
+              .None => ()
+            );
+            sek = (sek + usize(1));
+          });
+          g_shared_capture_env_index_keys.clear();
+          g_shared_capture_envs.clear();
+        });
+        match(
+          senv.frames.get(usize(0)),
+          .Some(sf0) => {
+            g_shared_capture_env_index_keys.push(sf0.index_key);
+          },
+          .None => ()
+        );
+        g_shared_capture_envs.set(
+          env_key,
+          SharedCaptureEnvEntry(module_path : module_path, env : senv)
+        );
+        return(snapshot_env(senv));
+      },
+      .None => ()
+    );
+  });
   match(
     g_capture_envs.get(func_id),
     .Some(hit) => if(unsafe(__yo_ptr_eq(hit.cap_vals, cap_vals)), {
@@ -1914,103 +2024,6 @@ capture_env_for :: (
     CaptureEnvEntry(cap_vals : cap_vals, module_path : module_path, env : fenv)
   );
   snapshot_env(fenv)
-});
-// ---------------------------------------------------------------------------
-// Frozen def-scope registry (env-sharing campaign 2 —
-// plans/FUNCVAL_ENV_SHARING.md). TS keeps the definition Environment on the
-// function type (`FunctionType.env`, definitions.ts:881) and a call just does
-// `pushEnvFrame(functionType.env)` (helper.ts:1141). yo-self cannot store an
-// `Environment` on `FuncValData` (env.yo imports value.yo), so the frozen env
-// lives HERE, keyed by `FuncValData.env_key` (a fresh id per construction —
-// `func_id` is NOT unique per FuncValData and cannot key this). A miss falls
-// back to the flat-capture rebuild (`capture_env_for`), so a lost key
-// degrades to the pre-campaign behavior, never to wrongness.
-//
-// Retention is process-lifetime by design, like TS's `FunctionType.env`.
-// The frozen frames' lazy name indexes accumulate in `g_frame_indexes`,
-// which is already bounded by the 2048-entry wholesale clear in
-// `_frame_positions` (sound since `invalidate_frame_index` covers the shrink
-// sites) — no separate eviction accounting is needed here.
-(g_funcval_def_envs : HashMap(usize, Environment)) = HashMap(usize, Environment).new();
-/// Mint a registry key for a FuncValData about to capture its def scope.
-mint_funcval_env_key :: (fn() -> usize)(
-  generate_variable_id(String.from(""), String.from("fvenv"))
-);
-/// Freeze a LIVE env for capture: share the `Variable` handles, rebuild every
-/// `Frame` (frame 0 included) with a fresh variables list and a FRESH
-/// `index_key`. Same frozen-membership rule as `_share_def_time_frames`
-/// (function_type.yo) — pushing live Frame handles lets bindings added AFTER
-/// the capture leak into the recorded scope
-/// (issues/env-sharing-live-frame-membership-leak.md). With `strip` true,
-/// frames 1..n keep only comptime-only or module-level bindings (TS's
-/// `keepTopLevelFrameAndComptimeVariablesFromEnv`, env.ts:2245 — the
-/// `is_module_level` keep is the same justified yo-self divergence as in
-/// `_share_def_time_frames`).
-freeze_env_for_capture :: (fn(env : Environment, strip : bool) -> Environment)({
-  new_frames := ArrayList(Frame).new();
-  n := env.frames.len();
-  (i : usize) = usize(0);
-  while(i < n, {
-    match(
-      env.frames.get(i),
-      .Some(frame) => {
-        new_vars := ArrayList(Variable).new();
-        m := frame.variables.len();
-        (j : usize) = usize(0);
-        while(j < m, {
-          match(
-            frame.variables.get(j),
-            .Some(v) => {
-              keep := cond(
-                !(strip) => true,
-                (i == usize(0)) => true,
-                v.is_compile_time_only => true,
-                v.is_module_level => true,
-                true => false
-              );
-              if(keep, {
-                new_vars.push(v);
-              });
-            },
-            .None => ()
-          );
-          j = (j + usize(1));
-        });
-        new_frames.push(
-          Frame(
-            id : frame.id,
-            variables : new_vars,
-            is_begin_block : frame.is_begin_block,
-            where_clause_constraints : frame.where_clause_constraints,
-            index_key : generate_variable_id(String.from(""), String.from("fidx"))
-          )
-        );
-      },
-      .None => ()
-    );
-    i = (i + usize(1));
-  });
-  Environment(
-    frames : new_frames,
-    module_path : env.module_path,
-    function_declaration_frame_level : env.function_declaration_frame_level,
-    input_string : env.input_string
-  )
-});
-/// Register a frozen def-scope env under a key minted by
-/// `mint_funcval_env_key`. The env must already be frozen — the registry
-/// never freezes on the caller's behalf, so a live env stored here is a bug.
-register_funcval_def_env :: (fn(env_key : usize, frozen : Environment) -> unit)({
-  g_funcval_def_envs.set(env_key, frozen);
-  ()
-});
-/// The frozen def scope for a FuncValData, if its creation site registered
-/// one. `usize(0)` is the reserved "absent" key and always misses.
-get_funcval_def_env :: (fn(env_key : usize) -> Option(Environment))({
-  if(env_key == usize(0), {
-    return(Option(Environment).None);
-  });
-  g_funcval_def_envs.get(env_key)
 });
 /// Deep-clone a single `WhereClauseConstraints` entry: a fresh
 /// `some_type` reference plus fresh trait-list arrays sharing the
@@ -4078,9 +4091,7 @@ export(
   snapshot_env,
   capture_env_for,
   mint_funcval_env_key,
-  freeze_env_for_capture,
-  register_funcval_def_env,
-  get_funcval_def_env,
+  register_funcval_cap_vars,
   YO_SELF,
   set_env_containing_prelude,
   clear_env_containing_prelude,

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -5050,7 +5050,8 @@ Fix: wrap the call:
               body : body_box,
               cap_names : cap_names,
               cap_tys : cap_tys,
-              func_id : random_id(env.module_path)
+              func_id : random_id(env.module_path),
+              env_key : fv_env_key
             )
           ),
           cap_vals

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -64,8 +64,7 @@ _(env : fncall_dbg_env) :: import("std/env");
   get_receiver_methods_by_name_from_env,
   get_type_trait_methods_by_name_from_env,
   snapshot_env,
-  capture_env_for,
-  get_funcval_def_env
+  capture_env_for
 } :: import("../../env.yo");
 { TypeValue, FuncMeta } :: import("../../types/definitions.yo");
 { get_func_param_defaults, get_func_param_default_exprs, get_func_param_comptime, register_func_param_comptime, is_param_quoted, is_macro_fn, macro_return_is_unquote, evaluate_function_return_type_again, get_func_return_type_expr, get_func_variadic_param, get_func_param_type_exprs, evaluate_function_parameter_type_again, _collect_type_arg_somes } :: import("../types/function.yo");
@@ -5024,22 +5023,20 @@ Fix: wrap the call:
             n_supplied_reg = (n_supplied_reg + n_spliced);
           });
         });
-        // Build (or reuse) the function body's lexical environment. Preferred
-        // source: the frozen def-scope registry (plans/FUNCVAL_ENV_SHARING.md)
-        // — TS's `pushEnvFrame(functionType.env)`. Fallback: the flat capture
-        // snapshot rebuild, memoised per closure instance by `capture_env_for`
-        // (re-binding every captured name on every call was 31 M `Variable`
-        // constructions per self-emit from this site alone).
-        fresh_env := match(
-          get_funcval_def_env(fv_env_key),
-          .Some(fe) => snapshot_env(fe),
-          .None => capture_env_for(
-            func_id_fv,
-            cap_names,
-            cap_tys,
-            cap_vals,
-            env.module_path
-          )
+        // Build (or reuse) the function body's lexical environment from the
+        // FuncVal's capture snapshot, memoised per closure instance by
+        // `capture_env_for`. With a registered `env_key` the frame holds the
+        // ORIGINAL Variable handles (plans/FUNCVAL_ENV_SHARING.md); the flat
+        // triple rebuild is the fallback (re-binding every captured name on
+        // every call was 31 M `Variable` constructions per self-emit from
+        // this site alone).
+        fresh_env := capture_env_for(
+          func_id_fv,
+          fv_env_key,
+          cap_names,
+          cap_tys,
+          cap_vals,
+          env.module_path
         );
         // Push a frame and bind `__recur_fn`.
         _fr := fresh_env.push_frame(false);

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -64,7 +64,8 @@ _(env : fncall_dbg_env) :: import("std/env");
   get_receiver_methods_by_name_from_env,
   get_type_trait_methods_by_name_from_env,
   snapshot_env,
-  capture_env_for
+  capture_env_for,
+  get_funcval_def_env
 } :: import("../../env.yo");
 { TypeValue, FuncMeta } :: import("../../types/definitions.yo");
 { get_func_param_defaults, get_func_param_default_exprs, get_func_param_comptime, register_func_param_comptime, is_param_quoted, is_macro_fn, macro_return_is_unquote, evaluate_function_return_type_again, get_func_return_type_expr, get_func_variadic_param, get_func_param_type_exprs, evaluate_function_parameter_type_again, _collect_type_arg_somes } :: import("../types/function.yo");
@@ -3933,6 +3934,7 @@ Fix: wrap the call:
         cap_names := __fvm7.*.cap_names;
         cap_tys := __fvm7.*.cap_tys;
         func_id_fv := __fvm7.*.func_id;
+        fv_env_key := __fvm7.*.env_key;
         n_p := param_names.len();
         n_ev := evidence_names.len();
         (n_a : usize) = args.len();
@@ -5022,16 +5024,22 @@ Fix: wrap the call:
             n_supplied_reg = (n_supplied_reg + n_spliced);
           });
         });
-        // Build (or reuse) the function body's lexical environment from the
-        // FuncVal's flat capture snapshot. Memoised per closure instance by
-        // `capture_env_for` — re-binding every captured name on every call was
-        // 31 M `Variable` constructions per self-emit from this site alone.
-        fresh_env := capture_env_for(
-          func_id_fv,
-          cap_names,
-          cap_tys,
-          cap_vals,
-          env.module_path
+        // Build (or reuse) the function body's lexical environment. Preferred
+        // source: the frozen def-scope registry (plans/FUNCVAL_ENV_SHARING.md)
+        // — TS's `pushEnvFrame(functionType.env)`. Fallback: the flat capture
+        // snapshot rebuild, memoised per closure instance by `capture_env_for`
+        // (re-binding every captured name on every call was 31 M `Variable`
+        // constructions per self-emit from this site alone).
+        fresh_env := match(
+          get_funcval_def_env(fv_env_key),
+          .Some(fe) => snapshot_env(fe),
+          .None => capture_env_for(
+            func_id_fv,
+            cap_names,
+            cap_tys,
+            cap_vals,
+            env.module_path
+          )
         );
         // Push a frame and bind `__recur_fn`.
         _fr := fresh_env.push_frame(false);

--- a/src/evaluator/calls/function_type.yo
+++ b/src/evaluator/calls/function_type.yo
@@ -45,7 +45,9 @@ _(env : fnty_env) :: import("std/env");
   add_parameter_to_env,
   synthetic_token,
   snapshot_env,
-  generate_variable_id
+  generate_variable_id,
+  mint_funcval_env_key,
+  register_funcval_cap_vars
 } :: import("../../env.yo");
 { TypeValue } :: import("../../types/definitions.yo");
 { t_unit, t_some_t, t_ptr, resolve_some_binder_kind } :: import("../../types/creators.yo");
@@ -1027,6 +1029,9 @@ try_to_implement_function_by_function_type :: (
       cap_names := ArrayList(String).new();
       cap_tys := ArrayList(TypeValue).new();
       cap_vals := ArrayList(EvalValue).new();
+      // Campaign 2: parallel snapshot of the ORIGINAL Variable handles (see
+      // the twin comment in evaluator/values/anonymous_function.yo).
+      cap_vars := ArrayList(Variable).new();
       (has_fwd_comptime_fn_cap : bool) = false;
       n_cap_fr := caller_env.frames.len();
       (cap_fi : usize) = usize(0);
@@ -1087,6 +1092,7 @@ try_to_implement_function_by_function_type :: (
                       has_fwd_comptime_fn_cap = true;
                     });
                     cap_vals.push(cap_val);
+                    cap_vars.push(cv);
                   });
                 },
                 .None => ()
@@ -1098,6 +1104,8 @@ try_to_implement_function_by_function_type :: (
         );
         cap_fi = (cap_fi + usize(1));
       });
+      ft_env_key := mint_funcval_env_key();
+      register_funcval_cap_vars(ft_env_key, cap_vars);
       fn_val_id := random_id(caller_env.module_path);
       // Faithful port of `shouldDeferBodyEvaluation` (function-type.ts:445-451):
       // defer body evaluation ONLY for functions that depend on generic type
@@ -1191,7 +1199,8 @@ try_to_implement_function_by_function_type :: (
             body : body_expr,
             cap_names : cap_names,
             cap_tys : cap_tys,
-            func_id : fn_val_id.clone()
+            func_id : fn_val_id.clone(),
+            env_key : ft_env_key
           )
         ),
         cap_vals

--- a/src/evaluator/calls/helper.yo
+++ b/src/evaluator/calls/helper.yo
@@ -47,7 +47,6 @@ open(import("std/fmt"));
   synthetic_token,
   snapshot_env,
   capture_env_for,
-  get_funcval_def_env,
   make_err_variable
 } :: import("../../env.yo");
 // dup-on-store / move for owned fn-call args (TS helper.ts:411-451). utils.yo
@@ -4744,23 +4743,19 @@ try_to_call_function_with_arguments :: (
         func_val,
         .Some(fv) => match(
           fv,
-          // Preferred source: the frozen def-scope registry
-          // (plans/FUNCVAL_ENV_SHARING.md) — TS's
-          // `pushEnvFrame(functionType.env)`. Fallback: `capture_env_for`,
-          // which memoises the rebuilt capture env per closure instance —
-          // that rebuild used to re-bind every captured name on EVERY call
-          // (~660 `add_variable_to_env` calls per call in a self-compile, the
+          // `capture_env_for` memoises the capture env per closure
+          // instance; with a registered `env_key` the frame holds the
+          // ORIGINAL Variable handles (plans/FUNCVAL_ENV_SHARING.md), else
+          // the flat rebuild re-binds every captured name (~660
+          // `add_variable_to_env` calls per call in a self-compile, the
           // top allocation site of the bootstrap). See env.yo.
-          .FuncVal(__fvm3, cv) => match(
-            get_funcval_def_env(__fvm3.*.env_key),
-            .Some(fe) => snapshot_env(fe),
-            .None => capture_env_for(
-              __fvm3.*.func_id,
-              __fvm3.*.cap_names,
-              __fvm3.*.cap_tys,
-              cv,
-              caller_env.module_path
-            )
+          .FuncVal(__fvm3, cv) => capture_env_for(
+            __fvm3.*.func_id,
+            __fvm3.*.env_key,
+            __fvm3.*.cap_names,
+            __fvm3.*.cap_tys,
+            cv,
+            caller_env.module_path
           ),
           _ => Environment.new(caller_env.module_path)
         ),

--- a/src/evaluator/calls/helper.yo
+++ b/src/evaluator/calls/helper.yo
@@ -47,6 +47,7 @@ open(import("std/fmt"));
   synthetic_token,
   snapshot_env,
   capture_env_for,
+  get_funcval_def_env,
   make_err_variable
 } :: import("../../env.yo");
 // dup-on-store / move for owned fn-call args (TS helper.ts:411-451). utils.yo
@@ -4743,16 +4744,23 @@ try_to_call_function_with_arguments :: (
         func_val,
         .Some(fv) => match(
           fv,
-          // `capture_env_for` memoises the rebuilt capture env per closure
-          // instance — this used to re-bind every captured name on EVERY call
+          // Preferred source: the frozen def-scope registry
+          // (plans/FUNCVAL_ENV_SHARING.md) — TS's
+          // `pushEnvFrame(functionType.env)`. Fallback: `capture_env_for`,
+          // which memoises the rebuilt capture env per closure instance —
+          // that rebuild used to re-bind every captured name on EVERY call
           // (~660 `add_variable_to_env` calls per call in a self-compile, the
           // top allocation site of the bootstrap). See env.yo.
-          .FuncVal(__fvm3, cv) => capture_env_for(
-            __fvm3.*.func_id,
-            __fvm3.*.cap_names,
-            __fvm3.*.cap_tys,
-            cv,
-            caller_env.module_path
+          .FuncVal(__fvm3, cv) => match(
+            get_funcval_def_env(__fvm3.*.env_key),
+            .Some(fe) => snapshot_env(fe),
+            .None => capture_env_for(
+              __fvm3.*.func_id,
+              __fvm3.*.cap_names,
+              __fvm3.*.cap_tys,
+              cv,
+              caller_env.module_path
+            )
           ),
           _ => Environment.new(caller_env.module_path)
         ),

--- a/src/evaluator/calls/helper.yo
+++ b/src/evaluator/calls/helper.yo
@@ -47,6 +47,10 @@ open(import("std/fmt"));
   synthetic_token,
   snapshot_env,
   capture_env_for,
+  get_funcval_cap_vars,
+  make_capture_variable,
+  mint_funcval_env_key,
+  register_funcval_cap_vars,
   make_err_variable
 } :: import("../../env.yo");
 // dup-on-store / move for owned fn-call args (TS helper.ts:411-451). utils.yo
@@ -3117,6 +3121,32 @@ create_specialized_function_inline :: (
           new_cap_names := ArrayList(String).new();
           new_cap_tys := ArrayList(TypeValue).new();
           new_cap_vals := ArrayList(EvalValue).new();
+          // Campaign 2 (plans/FUNCVAL_ENV_SHARING.md step 3): the derived
+          // FuncVal inherits the original's SHARED handle list and appends
+          // the generic-binding Variables looked up below — so its calls
+          // build the capture env from handles too. If the original never
+          // registered (env_key 0), stay on the flat fallback.
+          new_cap_vars := ArrayList(Variable).new();
+          (new_env_key : usize) = usize(0);
+          (have_cap_vars : bool) = false;
+          match(
+            get_funcval_cap_vars(__fvm2.*.env_key),
+            .Some(pv) => {
+              have_cap_vars = true;
+              (pvi : usize) = usize(0);
+              while(pvi < pv.len(), {
+                match(
+                  pv.get(pvi),
+                  .Some(ph) => {
+                    new_cap_vars.push(ph);
+                  },
+                  .None => ()
+                );
+                pvi = (pvi + usize(1));
+              });
+            },
+            .None => ()
+          );
           // Re-use existing captures from original function
           (oci : usize) = usize(0);
           n_oc := cap_names.len();
@@ -3154,6 +3184,9 @@ create_specialized_function_inline :: (
                       new_cap_names.push(label);
                       new_cap_tys.push(ev.ty);
                       new_cap_vals.push(v);
+                      if(have_cap_vars, {
+                        new_cap_vars.push(ev);
+                      });
                     },
                     .None => ()
                   );
@@ -3168,6 +3201,10 @@ create_specialized_function_inline :: (
           // Create the specialized function value — carries the fresh-id CLONE
           // (not the shared original body) so codegen walks this specialization's
           // own nodes and reads its own per-node ExprInfo / method-callee entries.
+          if(have_cap_vars, {
+            new_env_key = mint_funcval_env_key();
+            register_funcval_cap_vars(new_env_key, new_cap_vars);
+          });
           specialized_func_val := EvalValue.FuncVal(
             box(
               FuncValData(
@@ -3178,7 +3215,8 @@ create_specialized_function_inline :: (
                 body : cloned_body,
                 cap_names : new_cap_names,
                 cap_tys : new_cap_tys,
-                func_id : specialized_func_id
+                func_id : specialized_func_id,
+                env_key : new_env_key
               )
             ),
             new_cap_vals
@@ -3841,6 +3879,7 @@ evaluate_ctl_function_body_inline :: (
   orig_cap_tys := match(original_func_val, .FuncVal(__fvd9, _) => __fvd9.*.cap_tys, _ => ArrayList(TypeValue).new());
   orig_cap_vals := match(original_func_val, .FuncVal(_, cv) => cv, _ => ArrayList(EvalValue).new());
   orig_func_id := match(original_func_val, .FuncVal(__fvd10, _) => __fvd10.*.func_id, _ => String.from("__err_ctl"));
+  orig_env_key := match(original_func_val, .FuncVal(__fvd11, _) => __fvd11.*.env_key, _ => usize(0));
   // -------------------------------------------------------------------------
   // Determine concreteTypeForForall from context.
   // For function-body contexts, it's the enclosing function's return type.
@@ -4058,6 +4097,29 @@ evaluate_ctl_function_body_inline :: (
   ctl_cap_names := ArrayList(String).new();
   ctl_cap_tys := ArrayList(TypeValue).new();
   ctl_cap_vals := ArrayList(EvalValue).new();
+  // Campaign 2 step 3: inherit the shared handle list + mint one capture
+  // Variable per generic binding (see plans/FUNCVAL_ENV_SHARING.md).
+  ctl_cap_vars := ArrayList(Variable).new();
+  (ctl_env_key : usize) = usize(0);
+  (ctl_have_vars : bool) = false;
+  match(
+    get_funcval_cap_vars(orig_env_key),
+    .Some(pv) => {
+      ctl_have_vars = true;
+      (pvi : usize) = usize(0);
+      while(pvi < pv.len(), {
+        match(
+          pv.get(pvi),
+          .Some(ph) => {
+            ctl_cap_vars.push(ph);
+          },
+          .None => ()
+        );
+        pvi = (pvi + usize(1));
+      });
+    },
+    .None => ()
+  );
   (oci : usize) = usize(0);
   n_oc := orig_cap_names.len();
   while(oci < n_oc, {
@@ -4074,7 +4136,21 @@ evaluate_ctl_function_body_inline :: (
     ctl_cap_names.push(fl3.clone());
     ctl_cap_tys.push(ft3);
     ctl_cap_vals.push(create_type_value(concrete_type_for_forall));
+    if(ctl_have_vars, {
+      ctl_cap_vars.push(
+        make_capture_variable(
+          fl3.clone(),
+          ft3,
+          Option(EvalValue).Some(create_type_value(concrete_type_for_forall)),
+          specialized_env.module_path
+        )
+      );
+    });
     fi3 = (fi3 + usize(1));
+  });
+  if(ctl_have_vars, {
+    ctl_env_key = mint_funcval_env_key();
+    register_funcval_cap_vars(ctl_env_key, ctl_cap_vars);
   });
   ctl_func_val := EvalValue.FuncVal(
     box(
@@ -4086,7 +4162,8 @@ evaluate_ctl_function_body_inline :: (
         body : orig_body,
         cap_names : ctl_cap_names,
         cap_tys : ctl_cap_tys,
-        func_id : ctl_func_id.clone()
+        func_id : ctl_func_id.clone(),
+        env_key : ctl_env_key
       )
     ),
     ctl_cap_vals

--- a/src/evaluator/ctfe/ctfe_analysis.yo
+++ b/src/evaluator/ctfe/ctfe_analysis.yo
@@ -357,7 +357,8 @@ _build_comptime_clone :: (
       body : body_box,
       cap_names : cap_names,
       cap_tys : cap_tys,
-      func_id : ct_new_id.clone()
+      func_id : ct_new_id.clone(),
+      env_key : match(func_value, .FuncVal(__fvde, _) => __fvde.*.env_key, _ => usize(0))
     );
     register_func_type(ct_new_id.clone(), comptime_func_type.clone());
     mark_fn_unemittable(ct_new_id.clone());

--- a/src/evaluator/values/anonymous_function.yo
+++ b/src/evaluator/values/anonymous_function.yo
@@ -64,10 +64,13 @@ open(import("std/fmt"));
 { AwaitAnalysisResult } :: import("../async/await_analysis_types.yo");
 {
   Environment,
+  Variable,
   add_variable_to_env,
   synthetic_token,
   snapshot_env,
-  get_variables_from_env
+  get_variables_from_env,
+  mint_funcval_env_key,
+  register_funcval_cap_vars
 } :: import("../../env.yo");
 { Token } :: import("../../token.yo");
 { TypeValue, FuncMeta } :: import("../../types/definitions.yo");
@@ -947,6 +950,10 @@ evaluate_anonymous_function_implementation :: (
   cap_names := ArrayList(String).new();
   cap_tys := ArrayList(TypeValue).new();
   cap_vals := ArrayList(EvalValue).new();
+  // Campaign 2 (plans/FUNCVAL_ENV_SHARING.md): the same walk also snapshots
+  // the ORIGINAL Variable handles, so `capture_env_for` can build the call
+  // env by sharing them instead of re-minting one Variable per binding.
+  cap_vars := ArrayList(Variable).new();
   n_cap_fr := env.frames.len();
   (cap_fi : usize) = usize(0);
   while(cap_fi < n_cap_fr, {
@@ -969,6 +976,7 @@ evaluate_anonymous_function_implementation :: (
                     .None => EvalValue.VarRef(cv.name)
                   );
                   cap_vals.push(cap_val);
+                  cap_vars.push(cv);
                 },
                 true => ()
               );
@@ -982,6 +990,8 @@ evaluate_anonymous_function_implementation :: (
     );
     cap_fi = (cap_fi + usize(1));
   });
+  fv_env_key := mint_funcval_env_key();
+  register_funcval_cap_vars(fv_env_key, cap_vars);
   // -------------------------------------------------------------------------
   // Push a new environment frame for the function parameters.
   // -------------------------------------------------------------------------
@@ -1206,7 +1216,8 @@ evaluate_anonymous_function_implementation :: (
         body : body_expr,
         cap_names : cap_names,
         cap_tys : cap_tys,
-        func_id : func_id.clone()
+        func_id : func_id.clone(),
+        env_key : fv_env_key
       )
     ),
     cap_vals

--- a/src/evaluator/values/impl.yo
+++ b/src/evaluator/values/impl.yo
@@ -53,6 +53,10 @@ _(env : impl_dbg_env) :: import("std/env");
   get_variables_from_env,
   snapshot_env,
   synthetic_token,
+  get_funcval_cap_vars,
+  make_capture_variable,
+  mint_funcval_env_key,
+  register_funcval_cap_vars,
   set_find_methods_from_generic_impls_fn,
   set_materialize_in_flight_method_fn
 } :: import("../../env.yo");
@@ -146,7 +150,7 @@ _stamp_impl_forall_on_method :: (fn(v : EvalValue, names : ArrayList(String)) ->
       .FuncVal(__fvm8, cv) => if(
         __fvm8.*.forall_names.len() > usize(0),
         v,
-        EvalValue.FuncVal(box(FuncValData(forall_names : names.clone(), params : __fvm8.*.params, param_type_names : __fvm8.*.param_type_names, evidence_params : __fvm8.*.evidence_params, body : __fvm8.*.body, cap_names : __fvm8.*.cap_names, cap_tys : __fvm8.*.cap_tys, func_id : __fvm8.*.func_id)), cv)
+        EvalValue.FuncVal(box(FuncValData(forall_names : names.clone(), params : __fvm8.*.params, param_type_names : __fvm8.*.param_type_names, evidence_params : __fvm8.*.evidence_params, body : __fvm8.*.body, cap_names : __fvm8.*.cap_names, cap_tys : __fvm8.*.cap_tys, func_id : __fvm8.*.func_id, env_key : __fvm8.*.env_key)), cv)
       ),
       _ => v
     )
@@ -1340,6 +1344,7 @@ _inject_forall_captures :: (
         cns := __fvm9.*.cap_names;
         cts := __fvm9.*.cap_tys;
         fid := __fvm9.*.func_id;
+        ifc_orig_env_key := __fvm9.*.env_key;
         memo_key := fid.clone();
         {
           (mk_i : usize) = usize(0);
@@ -1372,6 +1377,30 @@ _inject_forall_captures :: (
             new_cns := ArrayList(String).new();
             new_cts := ArrayList(TypeValue).new();
             new_cvs := ArrayList(EvalValue).new();
+            // Campaign 2 step 3: inherit the shared handle list; the
+            // per-generic bindings appended below get minted capture
+            // Variables (plans/FUNCVAL_ENV_SHARING.md).
+            new_cvars := ArrayList(Variable).new();
+            (ifc_env_key : usize) = usize(0);
+            (ifc_have_vars : bool) = false;
+            match(
+              get_funcval_cap_vars(ifc_orig_env_key),
+              .Some(pv) => {
+                ifc_have_vars = true;
+                (pvj : usize) = usize(0);
+                while(pvj < pv.len(), {
+                  match(
+                    pv.get(pvj),
+                    .Some(ph) => {
+                      new_cvars.push(ph);
+                    },
+                    .None => ()
+                  );
+                  pvj = (pvj + usize(1));
+                });
+              },
+              .None => ()
+            );
             // Copy existing captures (do not mutate the registry's arrays).
             (ci : usize) = usize(0);
             while(ci < cns.len(), {
@@ -1399,6 +1428,9 @@ _inject_forall_captures :: (
                     fa_is_val = true;
                     _b2v := new_cts.push(t_usize());
                     _c2v := new_cvs.push(EvalValue.IntLit(bv_raw.clone()));
+                    if(ifc_have_vars, {
+                      new_cvars.push(make_capture_variable(fa_n.clone(), t_usize(), Option(EvalValue).Some(EvalValue.IntLit(bv_raw.clone())), String.from("")));
+                    });
                   },
                   _ => ()
                 ),
@@ -1407,10 +1439,17 @@ _inject_forall_captures :: (
               if(!(fa_is_val), {
                 _b2 := new_cts.push(t_type());
                 _c2 := new_cvs.push(EvalValue.TypeVal(fa_t));
+                if(ifc_have_vars, {
+                  new_cvars.push(make_capture_variable(fa_n.clone(), t_type(), Option(EvalValue).Some(EvalValue.TypeVal(fa_t)), String.from("")));
+                });
               });
               fi2 = (fi2 + usize(1));
             });
-            injected := EvalValue.FuncVal(box(FuncValData(forall_names : fns, params : ps, param_type_names : ptns, evidence_params : evs, body : body, cap_names : new_cns, cap_tys : new_cts, func_id : fid)), new_cvs);
+            if(ifc_have_vars, {
+              ifc_env_key = mint_funcval_env_key();
+              register_funcval_cap_vars(ifc_env_key, new_cvars);
+            });
+            injected := EvalValue.FuncVal(box(FuncValData(forall_names : fns, params : ps, param_type_names : ptns, evidence_params : evs, body : body, cap_names : new_cns, cap_tys : new_cts, func_id : fid, env_key : ifc_env_key)), new_cvs);
             _memo := g_ifc_memo.set(memo_key, injected);
             Option(EvalValue).Some(injected)
           }
@@ -3962,7 +4001,8 @@ evaluate_module_value :: (
                                 body : d_body_clone.clone(),
                                 cap_names : d_fvd.*.cap_names,
                                 cap_tys : d_fvd.*.cap_tys,
-                                func_id : d_fresh_id.clone()
+                                func_id : d_fresh_id.clone(),
+                                env_key : d_fvd.*.env_key
                               )
                             ),
                             d_cvs
@@ -4009,7 +4049,8 @@ evaluate_module_value :: (
                                   body : d_fvd.*.body,
                                   cap_names : d_fvd.*.cap_names,
                                   cap_tys : d_fvd.*.cap_tys,
-                                  func_id : d_fvd.*.func_id
+                                  func_id : d_fvd.*.func_id,
+                                  env_key : d_fvd.*.env_key
                                 )
                               ),
                               d_cvs

--- a/src/value.yo
+++ b/src/value.yo
@@ -24,7 +24,15 @@ FuncValData :: struct(
   body : AstExpr,
   cap_names : ArrayList(String),
   cap_tys : ArrayList(TypeValue),
-  func_id : String
+  func_id : String,
+  // Frozen def-scope registry key (plans/FUNCVAL_ENV_SHARING.md): key into
+  // env.yo's `g_funcval_def_envs` side table — the TS shape stores the
+  // definition Environment on the function type (`FunctionType.env`), but an
+  // `Environment` field cannot live here (env.yo imports value.yo). `usize(0)`
+  // = absent: call paths fall back to the flat-capture rebuild
+  // (`capture_env_for`). Clones share the key on purpose — TS derivations
+  // share the env object (`{...functionType, env: functionType.env}`).
+  (env_key : usize) ?= usize(0)
 );
 derive(FuncValData, Clone);
 /// The compile-time representation of an evaluated expression.


### PR DESCRIPTION
Campaign 2 of the env-sharing work (`plans/FUNCVAL_ENV_SHARING.md`): `capture_env_for` — laziness, per-instance memo, and single-frame env shape untouched — now builds the capture frame from the ORIGINAL `Variable` handles registered at the definition site (`g_funcval_cap_vars`, keyed by a fresh `FuncValData.env_key`), instead of re-minting a Variable + value cell + name string per binding (~597 per rebuild × 242k rebuilds per self-emit). Derived FuncVals (specialization, ctl, impl-generic injection, trait defaults, comptime clones) inherit the parent's handle list and append their bindings; every path falls back to the flat rebuild when no list was registered.

Two prior designs (multi-frame frozen def-scope envs) were built and rejected the same day — the failure record (SomeT frame-level arithmetic breakage, `g_frame_indexes` thrash: `check src/env.yo` 24.7s → >9min) is in the plan doc.

Measured (self-emit, M4): 141.3 → 138.3 s wall, 17.19 → 16.08 GB footprint (−1.11 GB). Local gates: gates_fast failures=0, FIXPOINT_HOLDS (stage2 hollow=0), `late_sibling_method_name_shadow` 2/2, `check ./src` 260/260 @ 95s.

Step 4 follow-ups tracked in the plan: attribution probe for the remaining flat-fallback population; endgame deletion of the flat triple lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)