### PR TITLE
codegen: chunked C emission — design + step 1 (opt-in shared header + N=1 chunk)

### DIFF
--- a/plans/CHUNKED_C_EMISSION.md
+++ b/plans/CHUNKED_C_EMISSION.md
@@ -1,0 +1,95 @@
+# Chunked C emission + parallel/cached clang
+
+**Status: ACTIVE (designed 2026-08-23; step 0 measured, step 1 in progress).**
+Goal: `yo build`'s C leg — clang -O2 on the single ~148 MB emitted `yo.c` —
+measured **74.8 s single-threaded** (step 0 baseline, M4, of a ~220 s full
+rebuild). Split the emitted program into N translation units compiled in
+parallel with a content-hashed `.o` cache, then link. Opt-in
+(`--emit-chunks N`, default 0 = today's single file, bit-for-bit): the
+single-file `yo.c` is a DISTRIBUTION REQUIREMENT
+(`plans/PORTABLE_C_DISTRIBUTION.md`), and the bootstrap fixpoint gates
+compare default emissions.
+
+## Ground truth
+
+- Emitter: three buffers — `headers`, `declarations`, `code` — concatenated
+  by `Emitter.print()` (src/emitter.yo:305). `compile_module`
+  (src/codegen/codegen_c.yo:289-410) returns the single String;
+  `run_compile` writes it and runs ONE `cc` Command (src/main.yo:1477,
+  :1733).
+- The per-function boundary is exact: `generate_all_functions`'s loop
+  (src/codegen/functions/generation.yo:691-713), one `generate_function`
+  call per function at :705, and ~95% of the emitted bytes. Do NOT rotate
+  files mid-stream: specializations are minted mid-emission (the loop
+  re-reads `function_order.len()`), and `generate_function` can truncate the
+  buffer tail (superseded-stub rewrite :629-645) — a function's extent is
+  final only when the call returns. Record `(c_name, start, end)` byte
+  ranges instead and slice post-emission; everything outside the ranges
+  (runtimes before the loop; dyn/async/main/dispatch after) is chunk-0
+  residue in original order.
+
+## Linkage split (the risk mass)
+
+| Symbol class | Chunked treatment |
+|---|---|
+| Preprocessor/`#include`s, `__yo_tN` typedefs, FSM/GC structs | shared header verbatim |
+| `yo_id_N` prototypes (declarations.yo:660) + definitions (generation.yo:435) | drop `static inline ` → external; prototypes in the header |
+| RC helpers `___dup`/`___drop`/`___dispose`, `__yo_new_*` constructors | **stay `static inline` with BODIES in the shared header** (per-TU copies). They are the RC hot path (`__yo_decr_rc` history: 54% of a self-compile); their addresses are stored (`dispose_fn`) but never compared (verified: no fn-pointer `==` in the emit), so duplication is safe. `__yo_dispose_dispatch` must be externalized (header-inlined helpers call it from every TU). |
+| Runtime functions (GC/sys/async/parallelism string literals) | definitions in **chunk 0** with `static` dequalified on the externally-referenced subset (allowlist, seeded from declarations.yo:298-309 + clang undefined-symbol errors); extern prototypes in the header |
+| Runtime-private `static _Thread_local` globals inside the runtime literals | unchanged — private to chunk 0 (the key simplification) |
+| Declarations-buffer globals: unwind buffers (gc_runtime.yo:149,154,280), argv shim (codegen_c.yo:368-375), module-level `g_*` vars (generation.yo:781) | `extern (_Thread_local)` in header + single definition in chunk 0 — read/written from every chunk; duplication would silently break unwind/args/state |
+| `__yo_typeid_X` chars + dyn vtables | `extern const` decl + chunk-0 definition — **address identity is the semantics** |
+| String literals | compound literals inside bodies — travel with their function |
+
+`-flto=thin` is the opt-in mitigation (`--chunk-lto`) for lost cross-TU
+inlining; not default (thin-link + backends re-run per rebuild, eroding the
+cache win). Perf gate: chunked binary within ~5% of baseline on self-`check`.
+
+## Determinism
+
+- Stage2/stage3: `function_order` is insertion-ordered and identical across
+  stages — any pure function of `(c_name, N)` chunks both identically. The
+  fixpoint scripts compare DEFAULT emissions anyway.
+- Edit stability: assignment = `fnv1a(c_name) mod N` (round-robin by
+  definition order shifts every later function on any insertion). N default
+  16 (≥ 2× cores; ±10-20% skew acceptable).
+- **Honest caveat**: `yo_id_N` names embed the single global expr-id counter
+  (src/expr.yo:311-323), so an edit that changes expr counts renames symbols
+  in every module parsed after it — chunk hashes then churn broadly.
+  Per-chunk caching reliably pays for flag-only changes and edits that keep
+  expr counts (many bug fixes), and late-parsed leaf modules. Content-stable
+  symbol naming is a separate future project that would unlock full
+  incrementality.
+- Cache key: `sha256(shared_header ‖ chunk_text ‖ clang argv ‖ compiler
+  version)` — a type renumbering must invalidate every chunk.
+
+## Driver
+
+Refactor `run_compile`'s flag assembly (main.yo:1492-1732) into a helper
+shared by: the unchanged single-file command (byte-identical argv), per-chunk
+`cc -c` jobs, and the link. Parallelism via `io.spawn` windows (`--jobs J`,
+default 8, `YO_JOBS` override — no CPU-count API in std yet). `.o` cache
+mirrors Phase A's sha256 stamp pattern (build_runner.yo:436-490) under
+`<c_base>.chunks/cache/`; `YO_BUILD_NO_CACHE=1` honored; mimalloc `static.c`
+becomes one more parallel job.
+
+## Steps and gates
+
+0. **Baseline (DONE 2026-08-23)**: clang -O2 -c on the emitted self-build C
+   = **74.8 s** (M4, 148 MB, 2.35 M lines).
+1. **Chunk plumbing, degenerate N=1**: byte-range recording around
+   generation.yo:705, `--emit-chunks` flag, `yo_shared.h` + one all-static
+   `.c` that `#include`s it. Gate: default emission byte-identical; N=1
+   self-build binary passes `yo check`.
+2. **Linkage split** (the hard step): the table above. Gate: N=4 self-build
+   links cleanly; full `tests/` green on the chunked binary; fn-pointer
+   equality audit on duplicated inlines.
+3. **Parallel driver + `.o` cache**. Gate: N=16 C-phase ≤ ~20 s; touch-nothing
+   rebuild = 100% cache hits; corrupt `.o` falls back.
+4. **Perf validation + LTO experiment** (3 configs). Gate: runtime within
+   ~5% of baseline.
+5. **build.yo surface + CI gate**: `Executable.emit_chunks`, a behavioral
+   fixpoint gate (chunked-built binary emits byte-identical single-file C),
+   cli-case golden. Default off everywhere including portable-C.
+
+Honest total: ~2-3 weeks; the risk is Step 2.

--- a/src/codegen/codegen_c.yo
+++ b/src/codegen/codegen_c.yo
@@ -286,7 +286,7 @@ static void __yo_dispose_dispatch(void* ptr) {
 /// preRegisterAsyncBlockTypes / preRegisterEffectfulFunctions /
 /// generateDeferredAsyncBlocks (Phase 5), generateClosureDisposeFunctions
 /// (Phase 5), generateSpecialized* (Gap 2), generateLibraryInitFunction.
-compile_module :: (fn(module_value : EvalValue, info : ExprInfoTable, target : TargetInfo, allocator : String, debug_gc : bool, debug_parallelism : bool, debug_async_await : bool, is_library : bool, eval_ctx : EvalContext, module_env : Environment, exn : Exception) -> String)({
+compile_module :: (fn(module_value : EvalValue, info : ExprInfoTable, target : TargetInfo, allocator : String, debug_gc : bool, debug_parallelism : bool, debug_async_await : bool, is_library : bool, eval_ctx : EvalContext, module_env : Environment, exn : Exception, (chunk_parts_out : ArrayList(String)) ?= ArrayList(String).new()) -> String)({
   // Route fatal emitter errors (codegen_fatal) through this compile's exn so
   // they exit rc=1 like a TS compile error instead of __yo_panic's SIGABRT.
   set_codegen_fatal_exn(exn);
@@ -406,6 +406,13 @@ static Slice_uint8_t_u42_ __yo_args;
   });
   // Type-tag dispose dispatch switch.
   emit_dispose_dispatch(base);
+  // Chunked emission (plans/CHUNKED_C_EMISSION.md step 1): hand the three
+  // emitter buffers to the caller so it can assemble a shared header +
+  // chunk file(s) instead of one concatenated unit. Pushing the String
+  // HANDLES is O(1) — the buffers are not mutated after this point.
+  chunk_parts_out.push(base.emitter.headers);
+  chunk_parts_out.push(base.emitter.declarations);
+  chunk_parts_out.push(base.emitter.code);
   base.emitter.print()
 });
 export(compute_needs_cycle_gc, emit_dispose_dispatch, compile_module);

--- a/src/main.yo
+++ b/src/main.yo
@@ -998,6 +998,7 @@ run_compile :: (
   (target_triple : String) = String.from("");
   (sysroot : String) = String.from("");
   (allocator : String) = String.from("system");
+  (emit_chunks : usize) = usize(0);
   (optimize : String) = String.from(""); // "" = unset; "0".."3"
   (sanitize : String) = String.from(""); // "" / "address" / "leak" / "thread"
   (cflags : String) = String.from("");
@@ -1190,6 +1191,11 @@ run_compile :: (
       (a == "--debug-gc") => {
         debug_gc = true;
         ai = (ai + usize(1));
+      },
+      (a == "--emit-chunks") => {
+        ecv := _arg_val_req(argv, ai, String.from("--emit-chunks"), exn);
+        emit_chunks = match(ecv.parse_u64(), .Some(n) => usize(n), .None => usize(0));
+        ai = (ai + usize(2));
       },
       (a == "--debug-parallelism") => {
         debug_parallelism = true;
@@ -1412,7 +1418,8 @@ run_compile :: (
     // Generate C11 from the evaluated module. A static library has no main()
     // wrapper (is_library = true). Allocator + debug-logging flags are threaded
     // through to the code generator (mirrors CodeGeneratorC.compileModule).
-    c_src := compile_module(module_value, ctx.expr_info_table, target, allocator.clone(), debug_gc, debug_parallelism, debug_async_await, static_library, ctx, env, exn);
+    chunk_parts := ArrayList(String).new();
+    c_src := compile_module(module_value, ctx.expr_info_table, target, allocator.clone(), debug_gc, debug_parallelism, debug_async_await, static_library, ctx, env, exn, chunk_parts);
     // --emit-c prints the generated C to stdout (module-manager.ts:473-475) —
     // and compilation continues; only --skip-c-compiler stops before the link.
     if(emit_c, {
@@ -1449,7 +1456,32 @@ run_compile :: (
         .None => ()
       );
     });
-    io.await(write_file(Path.new(c_path.clone()), c_src, io), IoExn(io : io, exn : exn));
+    cond(
+      (emit_chunks >= usize(1)) => {
+        // Chunked emission, step-1 degenerate mode (plans/CHUNKED_C_EMISSION.md):
+        // ONE all-static chunk that #includes the shared header — proves the
+        // split assembly end-to-end before the step-2 linkage work makes
+        // N > 1 linkable. The chunk file becomes the cc input (`c_path`).
+        shared_h := `${c_base}_shared.h`;
+        hdr := String.new();
+        hdr.push_string(match(chunk_parts.get(usize(0)), .Some(x) => x, .None => String.new()));
+        hdr.push_str("
+");
+        hdr.push_string(match(chunk_parts.get(usize(1)), .Some(x) => x, .None => String.new()));
+        io.await(write_file(Path.new(shared_h.clone()), hdr, io), IoExn(io : io, exn : exn));
+        chunk0 := `${c_base}_chunk000.c`;
+        cbody := String.new();
+        cbody.push_str("#include \"");
+        cbody.push_string(shared_h.clone());
+        cbody.push_str("\"\n");
+        cbody.push_string(match(chunk_parts.get(usize(2)), .Some(x) => x, .None => String.new()));
+        io.await(write_file(Path.new(chunk0.clone()), cbody, io), IoExn(io : io, exn : exn));
+        c_path = chunk0;
+      },
+      true => {
+        io.await(write_file(Path.new(c_path.clone()), c_src, io), IoExn(io : io, exn : exn));
+      }
+    );
   };
   // The scope above has dropped the AST, the evaluated module, the env, the
   // eval context and the 140 MB C string. The module-manager GLOBALS still


### PR DESCRIPTION
First slice of `plans/CHUNKED_C_EMISSION.md` (committed here): the campaign to cut the ~75s single-threaded clang -O2 leg of a rebuild via N parallel translation units with a content-hashed `.o` cache.

**Step 0 (measured):** clang -O2 alone on the emitted self-build C = 74.8s (M4, 148 MB).

**Step 1 (this PR):** `yo compile --emit-chunks N` (opt-in; default 0 = bit-for-bit today's single-file path) assembles `<base>_shared.h` (headers+declarations) + `<base>_chunk000.c` (`#include` + code buffer) and feeds the chunk to the existing cc invocation. `compile_module` exposes the three emitter buffers via an optional out-param (handle pushes, O(1)).

Gates run locally: default emission byte-identical vs a pre-change binary's emit; N=1 chunked hello runs correctly; **N=1 chunked self-build passes `check ./std` 154/154**. The single-file `yo.c` distribution path and the fixpoint comparisons are untouched by construction.

Next slices per the plan: step 2 linkage split (the risk mass — the symbol-class table is in the plan doc), step 3 parallel driver + sha256 `.o` cache, step 4 thin-LTO experiment, step 5 `Executable.emit_chunks` + CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)