### PR TITLE
codegen: chunked C emission step 2 — linkage split, N linkable TUs (opt-in, implies ThinLTO)

### DIFF
--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -802,6 +802,34 @@ process_map(counts);
 // counts now has "key" => 42
 ```
 
+### `String` out-parameters silently discard writes
+
+`String` is a **value** type whose byte buffer is lazily allocated (`_bytes : .None` until the first push). A `String` parameter is therefore a COPY: pushing into it allocates the buffer *in the copy*, and the caller sees nothing — no error, no warning, just an empty string. This is the opposite of `ArrayList`/`HashMap`/`HashSet` (RC `ref` types), where mutations DO propagate, which makes it an easy trap when a function needs to return two strings.
+
+```rust
+// WRONG — caller's `hdr`/`body` stay EMPTY, silently:
+split :: (fn(text : String, hdr_out : String, body_out : String) -> unit)({
+  hdr_out.push_str("...");   // mutates a copy
+  body_out.push_str("...");  // mutates a copy
+});
+hdr := String.new();
+body := String.new();
+split(src, hdr, body);       // hdr and body are still empty
+
+// CORRECT — return a `ref` struct:
+Split :: ref(struct(head_part : String, body_part : String));
+split :: (fn(text : String) -> Split)({
+  Split(head_part : h, body_part : b)
+});
+
+// ALSO CORRECT — collect into an RC container (mutations propagate):
+collect :: (fn(text : String, out : ArrayList(String)) -> unit)({
+  out.push(String.from("..."));
+});
+```
+
+This cost a full debug cycle in the chunked-C-emission work: an entire emitter buffer was dropped from the output, and the only symptom was a far-downstream C error (`unknown type name`) in the generated code. If a function must fill several strings, return a `ref` struct — and remember that a `String` fetched back out of an `ArrayList(String)` is likewise a value copy, so mutating it does not update the stored element.
+
 ### Forward references are NOT allowed
 
 Top-level bindings are evaluated strictly in order. A function must be defined BEFORE it is called (even inside closures that are called later).

--- a/issues/rc-helper-always-inline-linkage-branch-never-fires.md
+++ b/issues/rc-helper-always-inline-linkage-branch-never-fires.md
@@ -1,0 +1,72 @@
+# The RC-helper `always_inline` linkage branch never fires (dead predicate)
+
+**Status: OPEN (found 2026-08-23 during the chunked-C-emission step-2 audit;
+pre-existing, impact today is nil — filed so the dead intent is either removed
+or corrected deliberately).**
+
+## What the code intends
+
+Both the function-body emitter and the prototype emitter special-case
+"reference-counting helper" functions and give them the strongest inlining
+linkage available:
+
+- `src/codegen/functions/generation.yo:434-435`
+  ```rust
+  is_rc := (!(is_exported) && ((c_function_name.contains("___drop")) || ((c_function_name.contains("___dup")) || (c_function_name.contains("___dispose")))));
+  linkage := if(is_exported, String.from(""), if(is_rc, String.from("static inline __attribute__((always_inline)) "), String.from("static inline ")));
+  ```
+- `src/codegen/functions/declarations.yo:659-660` — the same predicate, so the
+  prototype's linkage matches the definition's.
+
+## What actually happens
+
+The predicate tests for a **triple** underscore immediately before the verb
+(`___drop`), but no emitted C function name ever has that shape. Verified
+against a full self-build emission (`src/main.yo --release`, 143 MB,
+~2.35 M lines):
+
+| probe | result |
+|---|---|
+| `grep -c always_inline` | **2** — and both are the compiler's own string literals (`"static inline __attribute__((always_inline)) "`), i.e. the text this branch *would* emit. Zero emitted functions carry the attribute. |
+| `grep -cE '___drop\|___dup\|___dispose'` | 66 — all string literals in the compiler's own source (`"___dup"`, `"___dup("`), never C identifiers |
+| emitted RC-ish function names | `__yo_dispose___yo_dyn_box___yo_tN` (8 of them) — "dispose" is preceded by a SINGLE underscore (`__yo_dispose`), so `.contains("___dispose")` is false |
+
+So the `is_rc` arm is unreachable and every generated function gets the plain
+`static inline ` linkage.
+
+## Why the impact is nil today
+
+RC drops are not lowered through per-type helper functions at all — they are
+lowered as **direct calls to the universal primitive**: the same emission
+contains **336,211 `__yo_decr_rc(` call sites** and 14,756 `__yo_incr_rc(`
+sites, against only 8 per-type dyn-box dispose functions. There is
+essentially no per-type RC helper population for the branch to optimize, so
+correcting the predicate would change ~8 functions.
+
+`__yo_decr_rc` / `__yo_incr_rc` themselves get `static inline` from their
+runtime templates (`src/codegen/functions/gc_runtime.yo`), not from this
+branch, so the hot path is unaffected.
+
+## Fix directions
+
+1. **Remove the dead arm** (and the matching one in `declarations.yo`), leaving
+   one `static inline ` linkage for all non-exported functions. Smallest
+   change, removes misleading intent. The two emitters MUST stay in sync — a
+   prototype/definition linkage mismatch produces "static declaration follows
+   non-static" at call sites.
+2. **Or correct the predicate** to the real naming (`__yo_drop_`, `__yo_dup_`,
+   `__yo_dispose_`) if the `always_inline` behaviour is actually wanted for the
+   dyn-box disposes. Measure first: `always_inline` on a dispose function that
+   is only ever reached through a stored function pointer (`header->dispose_fn`)
+   cannot be inlined at the indirect call anyway, so this is likely a no-op.
+
+Recommendation: (1). Discovered while auditing which symbols must be duplicated
+into every chunked translation unit (`plans/CHUNKED_C_EMISSION.md` — the
+chunk assembler has an equivalent dead predicate, `_ca_is_rc_helper`, noted in
+that plan for the same reason).
+
+## Test to add with the fix
+
+An emission assertion in `tests/internal/` (or a cli-case golden) that pins the
+linkage of a non-exported generated function, so a future predicate change
+cannot silently flip prototype and definition out of sync.

--- a/issues/ref-struct-field-named-header-collides-with-rc-header.md
+++ b/issues/ref-struct-field-named-header-collides-with-rc-header.md
@@ -1,0 +1,65 @@
+# A ref-struct field named `header` collides with the RC header member in the emitted C
+
+**Status: OPEN (found 2026-08-23 during chunked-C-emission step 2; pre-existing —
+reproduces on the un-modified develop-HEAD binary).**
+
+## Symptom
+
+Declaring a `ref(struct(...))` with a field named `header` emits invalid C:
+the generated struct already carries the built-in RC header member
+(`__yo_ref_header_small_t header;` / `__yo_ref_header_t header;`), so the
+user field produces `error: duplicate member 'header'`, and every access of
+the user field (`p.header`) emits `self->header`, which now resolves to the
+RC header — cascading into incompatible-type errors at constructor
+(`obj->header = header;`), traversal (`obj->header.data...`), and use sites.
+
+```
+error: duplicate member 'header'
+error: assigning to '__yo_ref_header_small_t' from incompatible type '__yo_t0'
+error: no member named 'data' in 'struct __yo_ref_header_small_t'
+```
+
+## Minimal reproducer (verified failing on develop HEAD 342092b7c)
+
+```rust
+{ String } :: import("std/string");
+P :: ref(struct(header : String));
+main :: (fn() -> unit)({
+  p := P(header : String.from("x"));
+  _y := p.header.len();
+});
+export(main);
+```
+
+`yo compile repro.yo --release -o repro` → 6 C errors, all the classes above.
+`yo check` passes — the evaluator has no reserved-field notion; the collision
+is purely a codegen namespace clash.
+
+## Root cause
+
+The C layout emitter gives every reference struct a first member literally
+named `header` (the RC header), and field labels are sanitized via
+`sanitize_for_c_identifier` with no reserved-name check, so a user field
+`header` maps to the same C identifier. Field-access emission likewise
+renders `->header` with no disambiguation.
+
+## Fix directions (not yet attempted)
+
+1. **Mangle the user field**, not the runtime member: a reserved-C-member
+   check in the field-label → C-name mapping (`header` → e.g. `header_u42_`),
+   applied consistently at struct declaration, constructor parameters,
+   literal initialization, and field access — the same choke points that
+   already share `get_runtime_struct_fields`/`sanitize_for_c_identifier`.
+2. Or rename the runtime member to a reserved identifier (`__yo_hdr`) —
+   touches every runtime literal and constructor/traversal emitter, much
+   larger blast radius.
+
+Option 1 is the surgical one. Until fixed, avoid `header` as a ref-struct
+field name (the chunk assembler renamed its field to `header_text` —
+src/codegen/chunk_assembly.yo).
+
+## Test to add with the fix
+
+A `tests/` case declaring a ref struct with fields named `header` (and for
+completeness `ref_count`, which lives INSIDE the header struct and does not
+collide today) that constructs, reads, and drops the value.

--- a/plans/CHUNKED_C_EMISSION.md
+++ b/plans/CHUNKED_C_EMISSION.md
@@ -1,6 +1,7 @@
 # Chunked C emission + parallel/cached clang
 
-**Status: ACTIVE (designed 2026-08-23; step 0 measured, step 1 in progress).**
+**Status: ACTIVE (designed 2026-08-23; steps 0-1 DONE — step 1 merged #233;
+step 2 in progress).**
 Goal: `yo build`'s C leg — clang -O2 on the single ~148 MB emitted `yo.c` —
 measured **74.8 s single-threaded** (step 0 baseline, M4, of a ~220 s full
 rebuild). Split the emitted program into N translation units compiled in
@@ -30,6 +31,31 @@ compare default emissions.
 
 ## Linkage split (the risk mass)
 
+**Step-2 implementation refinements (2026-08-23, src/codegen/chunk_assembly.yo):**
+
+- **The runtime allowlist is replaced by an AUTO-DEQUALIFIER.** The assembly
+  pass computes the *defined-in-header* name set (static definitions already
+  living in the declarations buffer — atomics, dyn wrappers — plus the
+  header-routed constructor/traverse block and the RC-helper ranges), then
+  strips the `static [inline]` prefix from every column-0 static FUNCTION
+  line (prototype and definition alike) whose name is NOT in that set. One
+  rule drives both sides, so prototype and definition linkage can never
+  disagree, and there is no hand-maintained list to rot. `static` DATA lines
+  are never touched by the dequalifier — address-identity statics and
+  cross-chunk globals are split at their emission sites under
+  `CodeGenContext.chunk_mode` (typeids via `emit_typeid_static`, TLS
+  unwind/effect buffers, argv shim, module-level vars → extern in the
+  header + one definition in `chunk_globals`, prepended to chunk 0).
+- **Dyn vtables stay per-TU static in the header** (no extern split): the
+  emitted C compares only `vtable->__yo_type_id` (downcast.yo) — vtable
+  ADDRESSES are stored and dereferenced, never compared — and the wrapper
+  functions they reference are per-TU header statics anyway. Only the
+  `__yo_typeid_*` chars need the extern/chunk-0 split.
+- **Constructors + traverse functions** are routed to the header as one
+  recorded byte-range block (per-TU `static` copies; each TU's constructors
+  take the address of that TU's own traverse copy, which is only ever CALLED
+  through the stored pointer).
+
 | Symbol class | Chunked treatment |
 |---|---|
 | Preprocessor/`#include`s, `__yo_tN` typedefs, FSM/GC structs | shared header verbatim |
@@ -41,9 +67,71 @@ compare default emissions.
 | `__yo_typeid_X` chars + dyn vtables | `extern const` decl + chunk-0 definition — **address identity is the semantics** |
 | String literals | compound literals inside bodies — travel with their function |
 
-`-flto=thin` is the opt-in mitigation (`--chunk-lto`) for lost cross-TU
-inlining; not default (thin-link + backends re-run per rebuild, eroding the
-cache win). Perf gate: chunked binary within ~5% of baseline on self-`check`.
+~~`-flto=thin` is the opt-in mitigation (`--chunk-lto`) for lost cross-TU
+inlining; not default.~~ **SUPERSEDED 2026-08-23 by measurement:** ThinLTO is
+REQUIRED, and `--emit-chunks` now implies it (`--no-chunk-lto` opts out). Without
+it the chunked binary runs 14.2% slower; with it, 2.9% faster than single-file.
+See "The real cause, and why ThinLTO is REQUIRED" below. Perf gate: chunked
+binary within ~5% of baseline on self-`check` — **met, with LTO**.
+
+## Chunk count: how N is chosen, and whether chunking should be default
+
+**How functions are assigned (decided, implemented):** `fnv1a(c_name) % N`
+(`String.hash()` is FNV-1a) — NOT by `.yo` source file. Measured skew on the
+self-build at N=4: chunk bodies 30/36/30/38 MB, i.e. max/mean = 1.13. By-file
+grouping was considered and rejected for now on three grounds: (1) source
+modules differ in emitted size by orders of magnitude (a hub like `expr.yo`
+against a leaf), so the slowest job — which sets wall clock — would be far
+worse than ±13%; (2) a large share of emitted functions are specializations
+minted DURING emission, which belong to no single source module in any useful
+sense; (3) hashing the name is edit-stable (inserting a function moves nothing
+else), where round-robin by definition order shifts every later function.
+By-file grouping WOULD be better for the step-3 `.o` cache — an edit to one
+leaf module would dirty one chunk — but only once symbol naming is
+content-stable; today the global expr-id counter in `yo_id_N` renames symbols
+in every module parsed after an edit, churning all chunks regardless of
+grouping. The defining module path exists in the evaluator but is not recorded
+on `CodegenFunctionEntry`, so this is a design choice, not a limitation.
+
+**The shared-header tax (measured, changed the design's assumptions):** every
+TU `#include`s the whole shared header, so aggregate compiler input is
+`bodies + N x header`. Self-build: header 9 MB, bodies 134 MB, single-file
+143 MB. N=4 -> 170 MB aggregate (+19%); N=16 -> 278 MB (+94%). Wall clock
+still falls (each job sees ~9 MB header + ~8 MB body at N=16 instead of
+143 MB) but the FLOOR is the header's own compile time, and aggregate CPU
+grows linearly with N — which matters on machines with fewer cores than N and
+for every `.o` cache MISS. So "N = 2x cores" is an assumption to MEASURE at
+step 4 (N=4/8/16/32), not a default to hard-code. The tax is worse in
+relative terms for small programs: on a ~1700-line test program the header is
+~27% of the emission, so N=4 there is ~181% of the work for a program that
+compiles in under a second.
+
+**Default-on? Not yet — deliberately.** `--emit-chunks` stays opt-in
+(default 0 = single file, bit-for-bit) until all of the following hold:
+1. steps 3-5 land (parallel driver + `.o` cache, perf validation, CI gate);
+2. step 4's runtime gate passes — chunking loses cross-TU inlining, and this
+   compiler is RC-hot (`__yo_decr_rc` has historically been ~54% of a
+   self-compile), so a silent runtime regression is the real risk;
+3. the behavioral fixpoint gate exists (a chunked-built binary emits
+   byte-identical single-file C), so flipping the default cannot quietly
+   weaken the bootstrap fixpoint story;
+4. auto-N (below) exists, so small programs and small machines do not
+   REGRESS relative to single-file.
+Even then, these paths stay single-file permanently: portable-C distribution
+(`plans/PORTABLE_C_DISTRIBUTION.md`), `--emit-c` / `--emit-c-to` (the
+single-file artifact is what humans read and bisect — see
+`.github/instructions/debugging.instructions.md`), `--static-library` (one
+input -> one `.o`; currently rejected outright with chunks), and wasm/emcc
+targets.
+
+**Auto-N (design, for step 3/4):** `--emit-chunks auto` picks
+`N = clamp(1, jobs, emitted_bytes / MIN_CHUNK_BYTES)` where `jobs` is the
+core count and `MIN_CHUNK_BYTES` (~4-8 MB, to be measured) keeps N=1 for
+programs too small to amortize the header tax. Blocker: there is no
+CPU-count API in `std` (verified — no `available_parallelism`, no `nproc`
+probe), so this needs either a new `std/sys` call or a `YO_JOBS` /
+`--jobs` override read first. Until auto-N exists, N is whatever the user
+passes.
 
 ## Determinism
 
@@ -73,6 +161,160 @@ mirrors Phase A's sha256 stamp pattern (build_runner.yo:436-490) under
 `<c_base>.chunks/cache/`; `YO_BUILD_NO_CACHE=1` honored; mimalloc `static.c`
 becomes one more parallel job.
 
+## Step 2 bring-up record (2026-08-23)
+
+Four linkage classes were NOT in the original table and had to be discovered by
+bring-up. Each is now handled in `src/codegen/chunk_assembly.yo`; the gate that
+catches regressions in seconds is `tests/internal/chunk_assembly.test.yo`
+(synthetic-C unit test of every split rule, red-first verified — 40 s vs the
+~15 min a chunked self-build costs).
+
+1. **Borrow primitives needed header routing.** `__yo_borrow_acquire` /
+   `_release` / `_assert_unborrowed` have no prototypes anywhere and are called
+   from every chunk (they are the per-container-access hot path), so they are
+   recorded as a header range in `generate_atomic_gc_runtime_functions`.
+2. **Residue functions need auto-generated prototypes** — the sys / async /
+   parallelism / GC runtimes are emitted as big string literals carrying no
+   prototypes, yet generated bodies call them across chunks. `assemble_chunks`
+   now synthesizes a prototype for every `__yo_`-named residue definition,
+   filtered to those actually REFERENCED by non-residue text.
+3. **The reference scan must skip C string literals.** This compiler's own
+   runtime emitters embed the entire runtime C text as `__yo_str` spill data,
+   so a naive scan sees every runtime function name as "referenced" and emits
+   prototypes whose signatures name chunk-0-private typedefs
+   (`__yo_io_pending_op_t`, `__yo_fs_event_entry_t`, `__yo_yield_future_t`) —
+   16+16+4 "unknown type name" errors. The scan is now string-literal aware.
+4. **External function DEFINITIONS live in the declarations buffer.** The async
+   state-machine emitter writes `<sm>_set_effect` / `_resume` / `_dispose`
+   bodies there with EXTERNAL linkage — 80 of them in a self-build. A
+   definition in the shared header is compiled by every TU: 240 duplicate
+   symbols at link. Unlike a `static` header definition it cannot be made
+   per-TU, so `_ca_split_decl_defs` relocates each block to chunk 0 (placed
+   after the residue, so residue definitions precede their uses) and leaves
+   `<signature>;` in the header.
+
+**Two Yo-level bugs surfaced along the way:**
+
+- `issues/ref-struct-field-named-header-collides-with-rc-header.md` (OPEN,
+  PRE-EXISTING): a `ref(struct(...))` field named `header` collides with the
+  built-in RC header member and emits invalid C. `yo check` passes it.
+  Reproduced on unmodified develop HEAD. The assembler's field is
+  `header_text` because of it.
+- **`String` out-parameters silently discard writes** (a Yo semantics trap, not
+  a compiler bug): `String` is a VALUE type whose byte buffer is lazily
+  allocated (`_bytes : .None` until first push), so `fn f(out : String)` +
+  `out.push_string(...)` mutates a copy. This dropped the ENTIRE declarations
+  buffer from the emission — the header came out 11.6k lines instead of 29.4k
+  and clang reported it only as far-downstream "unknown type name". Fixed by
+  returning a `ref` struct (`DeclSplit`). Recorded in the syntax cheatsheet.
+
+### The RC de-inlining regression (found, measured, fixed)
+
+A 5-lens adversarial audit of the linkage split (34 agents; 3 findings survived
+double verification) produced one dominant result, which the measurement then
+confirmed quantitatively.
+
+**Measured, interleaved A/B, both binaries `-O2`, `check ./src` (262 files):**
+
+| binary | run 1 | run 2 | run 3 | mean | verdict |
+|---|---|---|---|---|---|
+| single-file self-build | 87.54 s | 87.59 s | 87.88 s | **87.67 s** | 262/262, 0 errors |
+| N=4 chunked self-build | 102.61 s | 102.00 s | 101.93 s | **102.18 s** | 262/262, 0 errors |
+
+Functionally equivalent, **16.5% slower** — 3x over the ~5% gate. And it is
+self-defeating: a chunked-built compiler that compiles 16.5% slower cancels the
+build-time win it was made for, so this is blocking for step 2, not a step-4
+formality.
+
+**Cause.** `__yo_decr_rc` / `__yo_incr_rc` are emitted `static inline` into the
+CODE buffer with no covering header range, so they land in the residue and the
+auto-dequalifier makes them external. RC drops are lowered as DIRECT calls to
+these two primitives — the self-build emission has **336,211 `__yo_decr_rc(`
+sites** and 14,756 `__yo_incr_rc(` sites — so with N=4 roughly 78% of them
+became cross-TU calls into `chunk000.o`, on the function profiled at 54% of a
+self-compile. (Chunk 0's own sites are fine: clang -O2 still inlines from an
+in-TU body even without the `inline` keyword.)
+
+**Fix (the audit's, better than routing the globals).** The full-GC
+`__yo_decr_rc` only touches the thread-local GC state in its TRACKED tail; the
+untracked fast path needs nothing but the object header. So the tail is split
+out as `__yo_decr_rc_tracked` (stays in the residue -> chunk 0, external,
+auto-prototyped) and the inline fast path plus `__yo_incr_rc` are bracketed
+into a `chunk_header_ranges` entry, exactly as the borrow primitives are. The
+lightweight (non-cycle-GC) RC pair is header-routable as-is. `header_defined`
+then picks up both definitions, so the `declarations.yo:298-299` prototypes
+keep `static inline` automatically and prototype/definition cannot disagree.
+In a single-file build the tail is a `static` function with one call site, so
+clang inlines it back and the split is free.
+
+**Also fixed (audit F2):** `_ca_parse_static_fn_line` had no data-vs-function
+guard, so paren-QUALIFIED file-scope data — `static __declspec(thread) T x =
+init;` (11 sites in the Windows async runtime), `static _Alignas(16) char
+buf[64];`, `static _Atomic(void*) p;` — parsed as a "prototype" named after the
+qualifier and lost its `static` to the dequalifier, silently giving file-scope
+DATA external linkage. Latent on macOS (those lines hit `=` before any paren)
+but live for Windows targets, since `--emit-chunks` is not target-gated. The
+parser now requires `)` to be followed by `;` or `{`, which makes the module's
+"`static` DATA lines are never touched" invariant actually hold for all three
+consumers of the parser.
+
+**Recorded, not fixed (audit F3):** `_ca_is_rc_helper` is DEAD — it keys on a
+triple underscore (`___drop`), while real emitted names put a single one before
+the verb (`__yo_dispose___yo_dyn_box___yo_tN`). Its three branches never
+execute. Confirmed inert AND low-value: there are only 8 per-type dyn-box
+dispose functions in a whole self-build, so correcting the predicate would
+route 8 functions. Delete it once the RC measurement settles. The same dead
+predicate exists in the COMPILER (not just the assembler) and has silently
+disabled an intended `always_inline` optimization since it was written —
+filed as `issues/rc-helper-always-inline-linkage-branch-never-fires.md`.
+
+### The real cause, and why ThinLTO is REQUIRED (not an opt-in mitigation)
+
+Routing the RC primitives into the header was necessary for design conformance
+but **recovered nothing**: 102.18 s before the fix, 102.21 s after. The
+hypothesis was refuted by measurement, and the honest cause is elsewhere.
+
+Splitting the program into N translation units externalizes ~175k generated
+functions that were `static inline`, so the C compiler can no longer
+INTERNALIZE or DEAD-STRIP them. Measured on the N=4 self-build:
+
+| build | binary | defined symbols |
+|---|---|---|
+| single-file | 9 MB | 3,493 |
+| chunked N=4 | 24 MB | 7,201 |
+
+A 2.7x code-size explosion — I-cache and branch-predictor pressure, not call
+overhead, is what costs the 14%. That also explains why the RC fix was
+irrelevant: `__yo_decr_rc` was already only one of ~175k externalized symbols.
+
+`-flto=thin` restores cross-module inlining and internalization at link time.
+Measured (interleaved, `check ./src`, 262/262 on every run):
+
+| build | mean runtime | vs single-file |
+|---|---|---|
+| single-file (`yo-step3`) | 90.02 s | — |
+| **chunked N=4 + ThinLTO** | **87.41 s** | **-2.9% (faster)** |
+| chunked N=4, no LTO | 102.81 s | +14.2% |
+
+So the design decision changes: **`--emit-chunks` now implies `-flto=thin`**
+(`--no-chunk-lto` opts out, wasm excluded). It is not a tuning knob — without
+it a chunked-built compiler runs 14% slower, which cancels the build-time win
+the campaign exists for. Interestingly the LTO binary is still 23 MB / 6,821
+symbols, i.e. ThinLTO buys the speed through inlining rather than by shrinking
+the image.
+
+Side observation on the LTO build cost: the ThinLTO C phase took 65.8 s wall /
+125.9 s CPU (the backends already parallelize ~1.9x) against the 74.8 s
+single-file baseline — so chunking is *already* marginally ahead on build time
+before step 3's parallel driver exists, and the 125.9 s of CPU is what that
+driver gets to spread across cores.
+
+**Still open for step 4:** whether `-flto=thin` erodes the `.o` cache win
+enough to want the alternatives (header-routing SMALL functions as per-TU
+`static inline` via the byte-range size already recorded per function; keeping
+`static` for functions no OTHER chunk references; call-graph-aware assignment).
+Measure the cached-rebuild path before adding any of them.
+
 ## Steps and gates
 
 0. **Baseline (DONE 2026-08-23)**: clang -O2 -c on the emitted self-build C
@@ -81,9 +323,26 @@ becomes one more parallel job.
    generation.yo:705, `--emit-chunks` flag, `yo_shared.h` + one all-static
    `.c` that `#include`s it. Gate: default emission byte-identical; N=1
    self-build binary passes `yo check`.
-2. **Linkage split** (the hard step): the table above. Gate: N=4 self-build
-   links cleanly; full `tests/` green on the chunked binary; fn-pointer
-   equality audit on duplicated inlines.
+2. **Linkage split** (the hard step): the table above.
+   Gates and their status:
+   - N=4 self-build links cleanly — **DONE 2026-08-23** (after four
+     undiscovered linkage classes; see the bring-up record above).
+   - chunked binary is functionally equivalent — **DONE**: `check ./src`
+     262/262, 0 errors, identical to the single-file build.
+   - default emission byte-identical — **DONE** (`--emit-chunks 0` unchanged;
+     re-verified after every assembler change until the RC split
+     deliberately changed the emitted C for all builds).
+   - assembler unit gate — **DONE**: `tests/internal/chunk_assembly.test.yo`
+     (every split rule on synthetic C, red-first verified, 40 s).
+   - fn-pointer equality audit on duplicated inlines — **DONE**: only
+     `vtable->__yo_type_id` is ever compared (`downcast.yo:53`); no
+     function-pointer or vtable-address comparison exists in the emit, so
+     per-TU copies of constructors/traverse/RC helpers are safe and dyn
+     vtables need no extern split.
+   - runtime within ~5% of the single-file build — **the blocking gate**; see
+     "The RC de-inlining regression" above (16.5% found, RC fix landed,
+     re-measurement in progress).
+   - full `tests/` green on the chunked binary — pending the perf gate.
 3. **Parallel driver + `.o` cache**. Gate: N=16 C-phase ≤ ~20 s; touch-nothing
    rebuild = 100% cache hits; corrupt `.o` falls back.
 4. **Perf validation + LTO experiment** (3 configs). Gate: runtime within

--- a/src/codegen/chunk_assembly.yo
+++ b/src/codegen/chunk_assembly.yo
@@ -1,0 +1,777 @@
+//! Chunked C emission assembly — plans/CHUNKED_C_EMISSION.md step 2.
+//!
+//! Turns the emitter's three buffers + the byte ranges recorded under
+//! `chunk_mode` into ONE shared header and N translation-unit bodies:
+//!
+//!   header  = headers ++ dequalified declarations ++ the header-routed code
+//!             ranges (the constructor/traverse block verbatim and the
+//!             per-type RC helpers ___dup/___drop/___dispose — per-TU
+//!             `static`/`static inline` copies, they are the RC hot path and
+//!             their addresses are stored but never compared)
+//!   chunk 0 = the split-static definitions (chunk_globals: typeid chars,
+//!             TLS unwind/effect buffers, argv shim, module-level vars) ++
+//!             dequalified residue (everything outside the recorded ranges,
+//!             original order: runtimes, dyn scaffolding, deferred async
+//!             blocks, the main wrapper, the dispose dispatch) ++ its share
+//!             of the functions
+//!   chunk i = the functions whose fnv1a(c_name) % n == i, emission order
+//!
+//! Linkage rule (the auto-dequalifier): a file-scope `static` FUNCTION whose
+//! name is NOT defined in the header text loses its `static` prefix —
+//! prototype and definition alike — becoming external, because its callers
+//! may sit in any chunk. A name DEFINED in the header (atomics, dyn
+//! wrappers, constructors, RC helpers) keeps `static` everywhere: every TU
+//! gets its own copy. Both transforms are driven by the same header-defined
+//! name set, so prototype and definition can never disagree. `static` DATA
+//! lines are never touched here — address-identity statics (typeids) and
+//! cross-chunk globals are split at their emission sites instead
+//! (CodeGenContext.chunk_globals).
+{ String } :: import("std/string");
+{ ArrayList } :: import("std/collections/array_list");
+{ HashSet } :: import("std/collections/hash_set");
+{ HashMap } :: import("std/collections/hash_map");
+{ ChunkRange } :: import("./utils/index.yo");
+/// The assembled chunked emission: the shared header text and one body text
+/// per translation unit (without the `#include` line — the driver knows the
+/// header's file name). NOTE the field is `header_text`, not `header`: a ref
+/// struct field named `header` collides with the RC header member in the
+/// emitted C (issues/ref-struct-field-named-header-collides-with-rc-header.md).
+ChunkAssembly :: ref(struct(header_text : String, chunks : ArrayList(String)));
+/// True iff `b` is a C identifier byte: [A-Za-z0-9_].
+_ca_is_ident_byte :: (fn(b : u8) -> bool)(
+  ((b >= u8(48)) && (b <= u8(57))) || (((b >= u8(65)) && (b <= u8(90))) || (((b >= u8(97)) && (b <= u8(122))) || (b == u8(95))))
+);
+/// Byte at `i`, or 0 past the end.
+_ca_bget :: (fn(bytes : ArrayList(u8), i : usize) -> u8)(
+  match(bytes.get(i), .Some(b) => b, .None => u8(0))
+);
+/// True iff `bytes[pos..]` starts with `pat`'s bytes.
+_ca_matches :: (fn(bytes : ArrayList(u8), pos : usize, pat : String) -> bool)({
+  n := pat.bytes_len();
+  (i : usize) = usize(0);
+  while(i < n, {
+    if(_ca_bget(bytes, pos + i) != pat.byte_at(i), {
+      return(false);
+    });
+    i = (i + usize(1));
+  });
+  true
+});
+/// `bytes[start, end)` as a String.
+_ca_slice :: (fn(bytes : ArrayList(u8), start : usize, end : usize) -> String)({
+  out := ArrayList(u8).new();
+  (i : usize) = start;
+  while(i < end, {
+    out.push(_ca_bget(bytes, i));
+    i = (i + usize(1));
+  });
+  String.from_bytes(out)
+});
+/// A parsed column-0 `static` FUNCTION line: the function's name, whether the
+/// signature opens a definition (`{` after the closing paren) or a prototype
+/// (`;`), and how many bytes of linkage prefix (`static [inline ]
+/// [__attribute__((...)) ]`) the line carries.
+_StaticFnLine :: struct(name : String, is_def : bool, prefix_len : usize);
+/// Parse the column-0 `static`-prefixed line starting at `ls` (the caller has
+/// already matched `"static "`). Returns `.None` when the line is not a
+/// function prototype/definition open (data declarations hit `=` or `;`
+/// before any `(`). The paren scan crosses newlines, so multi-line signatures
+/// classify correctly.
+_ca_parse_static_fn_line :: (
+  fn(bytes : ArrayList(u8), ls : usize, n : usize, inline_pat : String, attr_pat : String) -> Option(_StaticFnLine)
+)({
+  (p : usize) = (ls + usize(7));
+  if(_ca_matches(bytes, p, inline_pat), {
+    p = (p + inline_pat.bytes_len());
+  });
+  // Generic `__attribute__((...)) ` skip — paren-depth over the attribute so
+  // its inner parens are not mistaken for the parameter list. The pattern
+  // ends after the double-open, so the depth starts at 2.
+  if(_ca_matches(bytes, p, attr_pat), {
+    (ad : usize) = usize(2);
+    (a : usize) = (p + attr_pat.bytes_len());
+    (adone : bool) = false;
+    while(!(adone) && (a < n), {
+      ab := _ca_bget(bytes, a);
+      cond(
+        (ab == u8(40)) => {
+          ad = (ad + usize(1));
+        },
+        (ab == u8(41)) => {
+          ad = (ad - usize(1));
+          if(ad == usize(0), {
+            adone = true;
+          });
+        },
+        (ab == u8(10)) => {
+          adone = true;
+        },
+        true => ()
+      );
+      a = (a + usize(1));
+    });
+    p = a;
+    if(_ca_bget(bytes, p) == u8(32), {
+      p = (p + usize(1));
+    });
+  });
+  prefix_len := (p - ls);
+  // The first `(` on the line (before any `=`, `;`, or the newline) opens the
+  // parameter list; the identifier run ending there is the function name.
+  (q : usize) = p;
+  (found : bool) = false;
+  while(!(found), {
+    if(q >= n, {
+      return(Option(_StaticFnLine).None);
+    });
+    b := _ca_bget(bytes, q);
+    cond(
+      (b == u8(40)) => {
+        found = true;
+      },
+      ((b == u8(10)) || ((b == u8(61)) || (b == u8(59)))) => {
+        return(Option(_StaticFnLine).None);
+      },
+      true => {
+        q = (q + usize(1));
+      }
+    );
+  });
+  (ns : usize) = q;
+  while((ns > p) && _ca_is_ident_byte(_ca_bget(bytes, ns - usize(1))), {
+    ns = (ns - usize(1));
+  });
+  if(ns == q, {
+    return(Option(_StaticFnLine).None);
+  });
+  name := _ca_slice(bytes, ns, q);
+  (depth : usize) = usize(1);
+  (r : usize) = (q + usize(1));
+  while((depth > usize(0)) && (r < n), {
+    b2 := _ca_bget(bytes, r);
+    cond(
+      (b2 == u8(40)) => {
+        depth = (depth + usize(1));
+      },
+      (b2 == u8(41)) => {
+        depth = (depth - usize(1));
+      },
+      true => ()
+    );
+    r = (r + usize(1));
+  });
+  while((r < n) && ((_ca_bget(bytes, r) == u8(32)) || ((_ca_bget(bytes, r) == u8(10)) || (_ca_bget(bytes, r) == u8(9)))), {
+    r = (r + usize(1));
+  });
+  // DATA-vs-FUNCTION guard. A prototype or definition always has `)` followed
+  // by `;` or `{`. Without this check, paren-QUALIFIED file-scope data —
+  // `static __declspec(thread) T x = init;` (the Windows async runtime's TLS
+  // globals), `static _Alignas(16) char buf[64];`, `static _Atomic(void*) p;` —
+  // parses as a "prototype" named after the qualifier and then has its
+  // `static` stripped by the dequalifier, silently giving file-scope DATA
+  // external linkage. Keeping this check here makes the module's
+  // "`static` DATA lines are never touched" invariant actually hold, for all
+  // three consumers of this parser.
+  rb := _ca_bget(bytes, r);
+  if(!((rb == u8(123)) || (rb == u8(59))), {
+    return(Option(_StaticFnLine).None);
+  });
+  Option(_StaticFnLine).Some(
+    _StaticFnLine(name : name, is_def : (rb == u8(123)), prefix_len : prefix_len)
+  )
+});
+/// Collect the names of every column-0 `static` FUNCTION DEFINITION in `text`
+/// into `into` (the header-defined set the dequalifier keys on).
+_ca_collect_static_def_names :: (fn(text : String, into : HashSet(String)) -> unit)({
+  static_pat := String.from("static ");
+  inline_pat := String.from("inline ");
+  attr_pat := String.from("__attribute__((");
+  bytes := text.as_bytes();
+  n := bytes.len();
+  (ls : usize) = usize(0);
+  while(ls < n, {
+    if(_ca_matches(bytes, ls, static_pat), {
+      match(
+        _ca_parse_static_fn_line(bytes, ls, n, inline_pat, attr_pat),
+        .Some(info) => if(info.is_def, {
+          _a := into.add(info.name);
+          ()
+        }),
+        .None => ()
+      );
+    });
+    while((ls < n) && (_ca_bget(bytes, ls) != u8(10)), {
+      ls = (ls + usize(1));
+    });
+    ls = (ls + usize(1));
+  });
+});
+/// Strip the `static [inline ] [__attribute__((...)) ]` prefix from every
+/// column-0 static FUNCTION line (prototype or definition) whose name is NOT
+/// in `header_defined` — those functions become external so any chunk can
+/// call them. Everything else is copied byte-for-byte.
+_ca_dequalify_statics :: (fn(text : String, header_defined : HashSet(String)) -> String)({
+  static_pat := String.from("static ");
+  inline_pat := String.from("inline ");
+  attr_pat := String.from("__attribute__((");
+  bytes := text.as_bytes();
+  n := bytes.len();
+  out := ArrayList(u8).new();
+  (ls : usize) = usize(0);
+  while(ls < n, {
+    (strip : usize) = usize(0);
+    if(_ca_matches(bytes, ls, static_pat), {
+      match(
+        _ca_parse_static_fn_line(bytes, ls, n, inline_pat, attr_pat),
+        .Some(info) => if(!(header_defined.contains(info.name)), {
+          strip = info.prefix_len;
+        }),
+        .None => ()
+      );
+    });
+    (i : usize) = (ls + strip);
+    (le : usize) = ls;
+    while((le < n) && (_ca_bget(bytes, le) != u8(10)), {
+      le = (le + usize(1));
+    });
+    le = if(le < n, le + usize(1), le);
+    while(i < le, {
+      out.push(_ca_bget(bytes, i));
+      i = (i + usize(1));
+    });
+    ls = le;
+  });
+  String.from_bytes(out)
+});
+/// True iff `name` is a per-type RC helper (routed into the shared header —
+/// same predicate as generate_function's `is_rc` linkage branch).
+_ca_is_rc_helper :: (fn(name : String) -> bool)(
+  name.contains("___drop") || (name.contains("___dup") || name.contains("___dispose"))
+);
+/// True iff the column-0 line at `ls` opens a linkage-qualified or type-level
+/// construct that is NEVER a relocatable external definition.
+_ca_decl_line_is_qualified :: (fn(bytes : ArrayList(u8), ls : usize) -> bool)(
+  _ca_matches(bytes, ls, String.from("static ")) || (_ca_matches(bytes, ls, String.from("extern ")) || (_ca_matches(bytes, ls, String.from("typedef ")) || (_ca_matches(bytes, ls, String.from("inline ")) || (_ca_matches(bytes, ls, String.from("struct ")) || (_ca_matches(bytes, ls, String.from("union ")) || _ca_matches(bytes, ls, String.from("enum ")))))))
+);
+/// Result of `_ca_split_decl_defs`. A REF struct return, not two `String`
+/// out-parameters: `String` is a VALUE type whose buffer is lazily allocated
+/// (`_bytes : .None` until first push), so pushing into a `String` parameter
+/// mutates a copy and the caller sees nothing.
+DeclSplit :: ref(struct(header_part : String, moved_part : String));
+/// Split the declarations text into the part that stays in the SHARED HEADER
+/// and the EXTERNAL function DEFINITIONS that must be relocated to chunk 0.
+///
+/// The async state-machine emitter writes its `<sm>_set_effect` / `_resume` /
+/// `_dispose` BODIES into the declarations buffer with EXTERNAL linkage (80 of
+/// them in a self-build). A definition in the shared header is compiled by
+/// every TU — "duplicate symbol" at link time — and unlike a `static` header
+/// definition it cannot be made per-TU. So each such block moves to chunk 0
+/// and leaves `<signature>;` behind in the header, which is exactly what the
+/// other chunks need to reference it.
+///
+/// Block extent: emitted C closes a file-scope body with `}` at COLUMN 0 and
+/// indents everything inside it, and C string literals cannot span a raw
+/// newline — so the first column-0 `}` after the opening line ends the body.
+_ca_split_decl_defs :: (fn(text : String) -> DeclSplit)({
+  bytes := text.as_bytes();
+  n := bytes.len();
+  hdr := ArrayList(u8).new();
+  mov := ArrayList(u8).new();
+  (ls : usize) = usize(0);
+  while(ls < n, {
+    // Line extent [ls, le) including its newline.
+    (le : usize) = ls;
+    while((le < n) && (_ca_bget(bytes, le) != u8(10)), {
+      le = (le + usize(1));
+    });
+    le = if(le < n, le + usize(1), le);
+    b0 := _ca_bget(bytes, ls);
+    ident_start := (((b0 >= u8(65)) && (b0 <= u8(90))) || (((b0 >= u8(97)) && (b0 <= u8(122))) || (b0 == u8(95))));
+    (moved : bool) = false;
+    if(ident_start && !(_ca_decl_line_is_qualified(bytes, ls)), {
+      // Parse `<return type> name(<params>)` then require ` {` — the same
+      // shape check the residue-prototype scanner uses.
+      (q : usize) = ls;
+      (found : bool) = false;
+      (stop : bool) = false;
+      while(!(found) && (!(stop) && (q < n)), {
+        bq := _ca_bget(bytes, q);
+        cond(
+          (bq == u8(40)) => {
+            found = true;
+          },
+          ((bq == u8(10)) || ((bq == u8(61)) || (bq == u8(59)))) => {
+            stop = true;
+          },
+          true => {
+            q = (q + usize(1));
+          }
+        );
+      });
+      if(found, {
+        (ns : usize) = q;
+        while((ns > ls) && _ca_is_ident_byte(_ca_bget(bytes, ns - usize(1))), {
+          ns = (ns - usize(1));
+        });
+        // A definition has a return type before the name, and the paren must
+        // be preceded by an identifier at all.
+        if((ns > ls) && (ns < q), {
+          (depth : usize) = usize(1);
+          (r : usize) = (q + usize(1));
+          while((depth > usize(0)) && (r < n), {
+            b2 := _ca_bget(bytes, r);
+            cond(
+              (b2 == u8(40)) => {
+                depth = (depth + usize(1));
+              },
+              (b2 == u8(41)) => {
+                depth = (depth - usize(1));
+              },
+              true => ()
+            );
+            r = (r + usize(1));
+          });
+          close_pos := r;
+          (w : usize) = r;
+          while((w < n) && ((_ca_bget(bytes, w) == u8(32)) || (_ca_bget(bytes, w) == u8(9))), {
+            w = (w + usize(1));
+          });
+          if(_ca_bget(bytes, w) == u8(123), {
+            // Prototype into the header.
+            (pi : usize) = ls;
+            while(pi < close_pos, {
+              hdr.push(_ca_bget(bytes, pi));
+              pi = (pi + usize(1));
+            });
+            hdr.push(u8(59));
+            hdr.push(u8(10));
+            // Body (from the opening line through the column-0 `}` line) into
+            // the relocated text.
+            (be : usize) = le;
+            (done : bool) = false;
+            while(!(done) && (be < n), {
+              (ble : usize) = be;
+              while((ble < n) && (_ca_bget(bytes, ble) != u8(10)), {
+                ble = (ble + usize(1));
+              });
+              ble = if(ble < n, ble + usize(1), ble);
+              if(_ca_bget(bytes, be) == u8(125), {
+                done = true;
+              });
+              be = ble;
+            });
+            (mi : usize) = ls;
+            while(mi < be, {
+              mov.push(_ca_bget(bytes, mi));
+              mi = (mi + usize(1));
+            });
+            ls = be;
+            moved = true;
+          });
+        });
+      });
+    });
+    if(!(moved), {
+      (ci : usize) = ls;
+      while(ci < le, {
+        hdr.push(_ca_bget(bytes, ci));
+        ci = (ci + usize(1));
+      });
+      ls = le;
+    });
+  });
+  DeclSplit(header_part : String.from_bytes(hdr), moved_part : String.from_bytes(mov))
+});
+/// Collect a candidate extern prototype (`<signature>`) for every `__yo_`-
+/// named FUNCTION DEFINITION found at column 0 of the (already dequalified)
+/// chunk-0 residue: `names_out` keeps the residue definition order (the
+/// header emission must be deterministic — HashMap iteration is not),
+/// `protos_out` maps name → signature text. Only definitions REFERENCED by
+/// non-residue code get emitted (see `_ca_collect_yo_refs`) — internal
+/// runtime helpers mention residue-local typedefs that are invisible in the
+/// header, and nothing outside chunk 0 calls them. A non-empty name is
+/// required: FSM emitters write `switch (...) {` at column 0, which has no
+/// identifier before its paren.
+_ca_collect_residue_protos :: (
+  fn(text : String, names_out : ArrayList(String), protos_out : HashMap(String, String)) -> unit
+)({
+  yo_pat := String.from("__yo_");
+  bytes := text.as_bytes();
+  n := bytes.len();
+  (ls : usize) = usize(0);
+  while(ls < n, {
+    b0 := _ca_bget(bytes, ls);
+    is_start := (((b0 >= u8(65)) && (b0 <= u8(90))) || (((b0 >= u8(97)) && (b0 <= u8(122))) || (b0 == u8(95))));
+    if(is_start, {
+      (q : usize) = ls;
+      (found : bool) = false;
+      (stop : bool) = false;
+      while(!(found) && (!(stop) && (q < n)), {
+        bq := _ca_bget(bytes, q);
+        cond(
+          (bq == u8(40)) => {
+            found = true;
+          },
+          ((bq == u8(10)) || ((bq == u8(61)) || (bq == u8(59)))) => {
+            stop = true;
+          },
+          true => {
+            q = (q + usize(1));
+          }
+        );
+      });
+      if(found, {
+        (ns : usize) = q;
+        while((ns > ls) && _ca_is_ident_byte(_ca_bget(bytes, ns - usize(1))), {
+          ns = (ns - usize(1));
+        });
+        // `ns > ls`: a definition has a return type before the name;
+        // `ns < q`: the paren must be preceded by an identifier at all.
+        if((ns > ls) && ((ns < q) && _ca_matches(bytes, ns, yo_pat)), {
+          nm := _ca_slice(bytes, ns, q);
+          (depth : usize) = usize(1);
+          (r : usize) = (q + usize(1));
+          while((depth > usize(0)) && (r < n), {
+            b2 := _ca_bget(bytes, r);
+            cond(
+              (b2 == u8(40)) => {
+                depth = (depth + usize(1));
+              },
+              (b2 == u8(41)) => {
+                depth = (depth - usize(1));
+              },
+              true => ()
+            );
+            r = (r + usize(1));
+          });
+          close_pos := r;
+          (w : usize) = r;
+          while((w < n) && ((_ca_bget(bytes, w) == u8(32)) || ((_ca_bget(bytes, w) == u8(10)) || (_ca_bget(bytes, w) == u8(9)))), {
+            w = (w + usize(1));
+          });
+          if((_ca_bget(bytes, w) == u8(123)) && !(protos_out.contains_key(nm.clone())), {
+            names_out.push(nm.clone());
+            _s := protos_out.set(nm, _ca_slice(bytes, ls, close_pos));
+            ()
+          });
+        });
+      });
+    });
+    while((ls < n) && (_ca_bget(bytes, ls) != u8(10)), {
+      ls = (ls + usize(1));
+    });
+    ls = (ls + usize(1));
+  });
+});
+/// Collect every `__yo_`-prefixed identifier occurring in CODE POSITION in
+/// `text` into `into` (token starts only — a preceding identifier byte
+/// disqualifies). Content inside C string literals is SKIPPED: the
+/// compiler's own runtime-emitter literals carry the entire runtime C text
+/// as `__yo_str` spill data, and matching names inside them would mark every
+/// runtime function as referenced. Emitted C strings never span lines (their
+/// newlines are `\n` escapes), so the in-string state resets per line.
+_ca_collect_yo_refs :: (fn(text : String, into : HashSet(String)) -> unit)({
+  yo_pat := String.from("__yo_");
+  bytes := text.as_bytes();
+  n := bytes.len();
+  (i : usize) = usize(0);
+  (in_str : bool) = false;
+  while(i < n, {
+    b := _ca_bget(bytes, i);
+    cond(
+      (b == u8(10)) => {
+        in_str = false;
+        i = (i + usize(1));
+      },
+      in_str => {
+        cond(
+          (b == u8(92)) => {
+            i = (i + usize(2));
+          },
+          (b == u8(34)) => {
+            in_str = false;
+            i = (i + usize(1));
+          },
+          true => {
+            i = (i + usize(1));
+          }
+        );
+      },
+      (b == u8(34)) => {
+        in_str = true;
+        i = (i + usize(1));
+      },
+      ((b == u8(95)) && _ca_matches(bytes, i, yo_pat)) => {
+        prev_ident := if(i > usize(0), _ca_is_ident_byte(_ca_bget(bytes, i - usize(1))), false);
+        if(!(prev_ident), {
+          (e : usize) = i;
+          while((e < n) && _ca_is_ident_byte(_ca_bget(bytes, e)), {
+            e = (e + usize(1));
+          });
+          _a := into.add(_ca_slice(bytes, i, e));
+          i = e;
+        }, {
+          i = (i + usize(1));
+        });
+      },
+      true => {
+        i = (i + usize(1));
+      }
+    );
+  });
+});
+/// Merge two start-ascending range lists into one start-ascending list.
+_ca_merge_ranges :: (
+  fn(a : ArrayList(ChunkRange), b : ArrayList(ChunkRange)) -> ArrayList(ChunkRange)
+)({
+  out := ArrayList(ChunkRange).new();
+  (i : usize) = usize(0);
+  (j : usize) = usize(0);
+  while((i < a.len()) || (j < b.len()), {
+    ai := a.get(i);
+    bj := b.get(j);
+    match(
+      ai,
+      .Some(ra) => match(
+        bj,
+        .Some(rb) => if(ra.start_b <= rb.start_b, {
+          out.push(ra);
+          i = (i + usize(1));
+        }, {
+          out.push(rb);
+          j = (j + usize(1));
+        }),
+        .None => {
+          out.push(ra);
+          i = (i + usize(1));
+        }
+      ),
+      .None => match(
+        bj,
+        .Some(rb) => {
+          out.push(rb);
+          j = (j + usize(1));
+        },
+        .None => ()
+      )
+    );
+  });
+  out
+});
+/// Assemble the chunked emission. `n_chunks` >= 1; chunk 0 additionally
+/// carries the split-static definitions and the residue (see file header).
+assemble_chunks :: (
+  fn(
+    headers : String,
+    declarations : String,
+    code : String,
+    fn_ranges : ArrayList(ChunkRange),
+    header_ranges : ArrayList(ChunkRange),
+    globals : String,
+    n_chunks : usize
+  ) -> ChunkAssembly
+)({
+  n := if(n_chunks < usize(1), usize(1), n_chunks);
+  code_bytes := code.as_bytes();
+  // 1. The header-defined name set: static definitions already living in the
+  //    declarations text (atomics, dyn wrappers), the constructor/traverse
+  //    block, and the RC helper ranges (their c_name IS the defined name).
+  header_defined := HashSet(String).new();
+  _ca_collect_static_def_names(declarations.clone(), header_defined);
+  (hi : usize) = usize(0);
+  while(hi < header_ranges.len(), {
+    match(
+      header_ranges.get(hi),
+      .Some(hr) => _ca_collect_static_def_names(_ca_slice(code_bytes, hr.start_b, hr.end_b), header_defined),
+      .None => ()
+    );
+    hi = (hi + usize(1));
+  });
+  (ri : usize) = usize(0);
+  while(ri < fn_ranges.len(), {
+    match(
+      fn_ranges.get(ri),
+      .Some(fr) => if(_ca_is_rc_helper(fr.c_name.clone()), {
+        _a := header_defined.add(fr.c_name.clone());
+        ()
+      }),
+      .None => ()
+    );
+    ri = (ri + usize(1));
+  });
+  // 2. Residue: everything in `code` outside the recorded ranges, original
+  //    order, dequalified — into chunk 0 after the split-static definitions.
+  //    Built BEFORE the header so its auto-generated prototypes can be
+  //    inserted right after the declarations.
+  all_ranges := _ca_merge_ranges(header_ranges, fn_ranges);
+  residue := ArrayList(u8).new();
+  (prev_end : usize) = usize(0);
+  (ai : usize) = usize(0);
+  while(ai < all_ranges.len(), {
+    match(
+      all_ranges.get(ai),
+      .Some(rr) => {
+        (ci : usize) = prev_end;
+        while(ci < rr.start_b, {
+          residue.push(_ca_bget(code_bytes, ci));
+          ci = (ci + usize(1));
+        });
+        prev_end = rr.end_b;
+      },
+      .None => ()
+    );
+    ai = (ai + usize(1));
+  });
+  (ti : usize) = prev_end;
+  cb_len := code_bytes.len();
+  while(ti < cb_len, {
+    residue.push(_ca_bget(code_bytes, ti));
+    ti = (ti + usize(1));
+  });
+  residue_deq := _ca_dequalify_statics(String.from_bytes(residue), header_defined);
+  // 3. Per-chunk function texts: fnv1a(c_name) % n picks the chunk (stable
+  //    under unrelated edits — round-robin by position would shift every
+  //    later function on any insertion). RC helpers (assignment n) are
+  //    header-routed. Each text is built in a LOCAL String — a String
+  //    fetched back out of a list is a value copy whose first lazy
+  //    allocation would not propagate to the stored element.
+  assigned := ArrayList(usize).new();
+  (fi : usize) = usize(0);
+  while(fi < fn_ranges.len(), {
+    match(
+      fn_ranges.get(fi),
+      .Some(fr) => if(_ca_is_rc_helper(fr.c_name.clone()), {
+        assigned.push(n);
+      }, {
+        nm := fr.c_name.clone();
+        assigned.push(usize(nm.hash() % u64(n)));
+      }),
+      .None => {
+        assigned.push(n);
+      }
+    );
+    fi = (fi + usize(1));
+  });
+  fns_texts := ArrayList(String).new();
+  (mi : usize) = usize(0);
+  while(mi < n, {
+    body := String.new();
+    body.push_str("\n");
+    (gi : usize) = usize(0);
+    while(gi < fn_ranges.len(), {
+      if(match(assigned.get(gi), .Some(x) => (x == mi), .None => false), {
+        match(
+          fn_ranges.get(gi),
+          .Some(fr) => body.push_string(_ca_dequalify_statics(_ca_slice(code_bytes, fr.start_b, fr.end_b), header_defined)),
+          .None => ()
+        );
+      });
+      gi = (gi + usize(1));
+    });
+    fns_texts.push(body);
+    mi = (mi + usize(1));
+  });
+  // 4. Auto-generated prototypes: collect candidates from the residue, then
+  //    emit ONLY those referenced by non-residue code (the chunk function
+  //    texts and the header-routed bodies) — internal runtime helpers whose
+  //    signatures mention residue-local typedefs stay chunk-0-private.
+  proto_names := ArrayList(String).new();
+  proto_map := HashMap(String, String).new();
+  _ca_collect_residue_protos(residue_deq.clone(), proto_names, proto_map);
+  referenced := HashSet(String).new();
+  (sx : usize) = usize(0);
+  while(sx < fns_texts.len(), {
+    match(
+      fns_texts.get(sx),
+      .Some(ft) => _ca_collect_yo_refs(ft, referenced),
+      .None => ()
+    );
+    sx = (sx + usize(1));
+  });
+  (sh : usize) = usize(0);
+  while(sh < header_ranges.len(), {
+    match(
+      header_ranges.get(sh),
+      .Some(hr) => _ca_collect_yo_refs(_ca_slice(code_bytes, hr.start_b, hr.end_b), referenced),
+      .None => ()
+    );
+    sh = (sh + usize(1));
+  });
+  protos := String.from("// Prototypes for referenced chunk-0 runtime definitions (auto-generated)\n");
+  (pn : usize) = usize(0);
+  while(pn < proto_names.len(), {
+    match(
+      proto_names.get(pn),
+      .Some(pname) => if(referenced.contains(pname.clone()), {
+        match(
+          proto_map.get(pname),
+          .Some(sig) => {
+            protos.push_string(sig);
+            protos.push_str(";\n");
+          },
+          .None => ()
+        );
+      }),
+      .None => ()
+    );
+    pn = (pn + usize(1));
+  });
+  // 5. Shared header: headers ++ dequalified declarations (with their
+  //    EXTERNAL function definitions relocated to chunk 0, prototypes left
+  //    behind) ++ the referenced prototypes ++ header-routed code ranges
+  //    verbatim (borrow primitives, constructor block, RC helpers).
+  decl_split := _ca_split_decl_defs(_ca_dequalify_statics(declarations.clone(), header_defined));
+  header_text := String.new();
+  header_text.push_string(headers.clone());
+  header_text.push_str("\n");
+  header_text.push_string(decl_split.header_part.clone());
+  header_text.push_str("\n");
+  header_text.push_string(protos);
+  header_text.push_str("\n");
+  (h2 : usize) = usize(0);
+  while(h2 < header_ranges.len(), {
+    match(
+      header_ranges.get(h2),
+      .Some(hr) => header_text.push_string(_ca_slice(code_bytes, hr.start_b, hr.end_b)),
+      .None => ()
+    );
+    h2 = (h2 + usize(1));
+  });
+  (r2 : usize) = usize(0);
+  while(r2 < fn_ranges.len(), {
+    match(
+      fn_ranges.get(r2),
+      .Some(fr) => if(_ca_is_rc_helper(fr.c_name.clone()), {
+        header_text.push_string(_ca_slice(code_bytes, fr.start_b, fr.end_b));
+      }),
+      .None => ()
+    );
+    r2 = (r2 + usize(1));
+  });
+  // 6. Final chunk bodies: chunk 0 = split globals + residue + its share.
+  chunks := ArrayList(String).new();
+  (ci2 : usize) = usize(0);
+  while(ci2 < n, {
+    body := String.new();
+    if(ci2 == usize(0), {
+      body.push_string(globals.clone());
+      body.push_str("\n");
+      body.push_string(residue_deq.clone());
+      // The relocated declarations-buffer definitions go LAST in chunk 0:
+      // they call residue runtime functions, and following the residue means
+      // every such definition precedes its use in this TU regardless of
+      // whether a prototype was generated for it.
+      body.push_str("\n");
+      body.push_string(decl_split.moved_part.clone());
+    });
+    match(
+      fns_texts.get(ci2),
+      .Some(ft) => body.push_string(ft),
+      .None => ()
+    );
+    chunks.push(body);
+    ci2 = (ci2 + usize(1));
+  });
+  ChunkAssembly(header_text : header_text, chunks : chunks)
+});
+export(ChunkAssembly, assemble_chunks);

--- a/src/codegen/codegen_c.yo
+++ b/src/codegen/codegen_c.yo
@@ -44,6 +44,7 @@ open(import("std/string"));
 { _generate_sm_atom } :: import("./exprs/atom.yo");
 { preregister_async_block_types, generate_deferred_async_blocks } :: import("./exprs/async.yo");
 { register_fsm_emitters_impl } :: import("./async/state_code_gen.yo");
+{ assemble_chunks } :: import("./chunk_assembly.yo");
 /// True if any field of the struct contains a SomeType (generic). Mirrors the
 /// `!type.fields.some(field => typeContainsSomeType(field.type))` guard.
 /// On-demand recovery for a type first seen DURING emission (a lazily-minted
@@ -286,7 +287,7 @@ static void __yo_dispose_dispatch(void* ptr) {
 /// preRegisterAsyncBlockTypes / preRegisterEffectfulFunctions /
 /// generateDeferredAsyncBlocks (Phase 5), generateClosureDisposeFunctions
 /// (Phase 5), generateSpecialized* (Gap 2), generateLibraryInitFunction.
-compile_module :: (fn(module_value : EvalValue, info : ExprInfoTable, target : TargetInfo, allocator : String, debug_gc : bool, debug_parallelism : bool, debug_async_await : bool, is_library : bool, eval_ctx : EvalContext, module_env : Environment, exn : Exception, (chunk_parts_out : ArrayList(String)) ?= ArrayList(String).new()) -> String)({
+compile_module :: (fn(module_value : EvalValue, info : ExprInfoTable, target : TargetInfo, allocator : String, debug_gc : bool, debug_parallelism : bool, debug_async_await : bool, is_library : bool, eval_ctx : EvalContext, module_env : Environment, exn : Exception, (chunk_parts_out : ArrayList(String)) ?= ArrayList(String).new(), (emit_chunks : usize) ?= usize(0)) -> String)({
   // Route fatal emitter errors (codegen_fatal) through this compile's exn so
   // they exit rc=1 like a TS compile error instead of __yo_panic's SIGABRT.
   set_codegen_fatal_exn(exn);
@@ -306,6 +307,10 @@ compile_module :: (fn(module_value : EvalValue, info : ExprInfoTable, target : T
   set_lookup_some_resolved_concrete(lookup_some_resolved_concrete);
   emitter := Emitter.new();
   base := CodeGenContext.new(emitter, info, target, allocator, debug_gc, debug_parallelism, debug_async_await, is_library);
+  // Chunked emission (plans/CHUNKED_C_EMISSION.md): record function byte
+  // ranges and split cross-chunk statics. MUST stay false by default — the
+  // single-file emission is gated byte-identical.
+  base.chunk_mode = (emit_chunks >= usize(1));
   // Seed the always-needed standard C headers (mirrors the cIncludes set the TS
   // CodeGeneratorC.compileModule constructs). <unistd.h>/<sys/stat.h> are
   // platform-specific and added by emit_c_includes.
@@ -364,16 +369,32 @@ typedef enum {
   // Mirrors codegen-c.ts: fixupDynImplKeys → generateDynBoxTypes.
   fixup_dyn_impl_keys(base);
   generate_dyn_box_types(base);
-  // Command-line arguments runtime shim.
-  base.emitter.emit_declaration_string_line(
-    `
+  // Command-line arguments runtime shim. Chunked emission: written by main
+  // (chunk 0), read from any chunk — one definition, extern in the header.
+  if(base.chunk_mode, {
+    base.emitter.emit_declaration_string_line(
+      `
+// Command-line arguments (initialized in main)
+typedef struct { uint8_t** data; size_t length; } Slice_uint8_t_u42_;
+extern int32_t __yo_argc;
+extern uint8_t** __yo_argv;
+extern Slice_uint8_t_u42_ __yo_args;
+`
+    );
+    base.chunk_globals.push_string(
+      String.from("int32_t __yo_argc;\nuint8_t** __yo_argv;\nSlice_uint8_t_u42_ __yo_args;\n")
+    );
+  }, {
+    base.emitter.emit_declaration_string_line(
+      `
 // Command-line arguments (initialized in main)
 typedef struct { uint8_t** data; size_t length; } Slice_uint8_t_u42_;
 static int32_t __yo_argc;
 static uint8_t** __yo_argv;
 static Slice_uint8_t_u42_ __yo_args;
 `
-  );
+    );
+  });
   // Pre-register async-block state-machine types (forward-declared struct
   // typedefs + uses_async flag) before function declarations, so prototypes use
   // the right SM struct names. Mirrors codegen-c.ts:205.
@@ -406,13 +427,33 @@ static Slice_uint8_t_u42_ __yo_args;
   });
   // Type-tag dispose dispatch switch.
   emit_dispose_dispatch(base);
-  // Chunked emission (plans/CHUNKED_C_EMISSION.md step 1): hand the three
-  // emitter buffers to the caller so it can assemble a shared header +
-  // chunk file(s) instead of one concatenated unit. Pushing the String
-  // HANDLES is O(1) — the buffers are not mutated after this point.
-  chunk_parts_out.push(base.emitter.headers);
-  chunk_parts_out.push(base.emitter.declarations);
-  chunk_parts_out.push(base.emitter.code);
+  // Chunked emission (plans/CHUNKED_C_EMISSION.md step 2): assemble the
+  // shared header + N linkable translation units from the recorded ranges;
+  // hand them to the driver as parts[0] = header, parts[1..] = chunk bodies
+  // (without the #include line — the driver knows the header's file name).
+  if(base.chunk_mode, {
+    asm2 := assemble_chunks(
+      base.emitter.headers,
+      base.emitter.declarations,
+      base.emitter.code,
+      base.chunk_fn_ranges,
+      base.chunk_header_ranges,
+      base.chunk_globals,
+      emit_chunks
+    );
+    chunk_parts_out.push(asm2.header_text);
+    (ci2 : usize) = usize(0);
+    while(ci2 < asm2.chunks.len(), {
+      match(
+        asm2.chunks.get(ci2),
+        .Some(cb) => {
+          chunk_parts_out.push(cb);
+        },
+        .None => ()
+      );
+      ci2 = (ci2 + usize(1));
+    });
+  });
   base.emitter.print()
 });
 export(compute_needs_cycle_gc, emit_dispose_dispatch, compile_module);

--- a/src/codegen/exprs/downcast.yo
+++ b/src/codegen/exprs/downcast.yo
@@ -45,11 +45,7 @@ generate_downcast :: (fn(expr : AstExpr, indent : String, context : FunctionGene
   if(!(context.base.type_id_static_names.contains(static_var_name.clone())), {
     _n := context.base.type_id_static_names.add(static_var_name.clone());
     _r := context.base.type_id_statics.set(type_id.clone(), static_var_name.clone());
-    decl := String.from("static const char ");
-    decl.push_string(static_var_name.clone());
-    decl.push_str(" = 0;");
-    em := context.base.emitter;
-    em.emit_declaration_string_line(decl);
+    context.base.emit_typeid_static(static_var_name.clone(), String.new());
   });
   context.base.add_c_include(String.from("<stdint.h>"));
   // is-check: the Dyn's vtable type-id equals this target's static address.

--- a/src/codegen/exprs/typeid.yo
+++ b/src/codegen/exprs/typeid.yo
@@ -23,11 +23,7 @@ generate_typeid :: (fn(expr : AstExpr, indent : String, context : FunctionGenera
   if(!(context.base.type_id_static_names.contains(static_var_name.clone())), {
     _n := context.base.type_id_static_names.add(static_var_name.clone());
     _r := context.base.type_id_statics.set(type_id.clone(), static_var_name.clone());
-    decl := String.from("static const char ");
-    decl.push_string(static_var_name.clone());
-    decl.push_str(" = 0;");
-    em := context.base.emitter;
-    em.emit_declaration_string_line(decl);
+    context.base.emit_typeid_static(static_var_name.clone(), String.new());
   });
   context.base.add_c_include(String.from("<stdint.h>"));
   out := String.from("(uintptr_t)&");

--- a/src/codegen/functions/dyn.yo
+++ b/src/codegen/functions/dyn.yo
@@ -542,7 +542,7 @@ generate_dyn_vtables :: (fn(context : FunctionGenerationContext) -> unit)({
           _g := generated.add(typeid_name.clone());
           _n := context.base.type_id_static_names.add(typeid_name.clone());
           _s := context.base.type_id_statics.set(type_key(impl_entry.concrete_type.clone()), typeid_name.clone());
-          em.emit_declaration_string_line(`static const char ${typeid_name} = 0; // TypeId for ${concrete_cname}`);
+          context.base.emit_typeid_static(typeid_name.clone(), ` // TypeId for ${concrete_cname}`);
         }, {
           // Name already emitted by the typeid/downcast expression emitters —
           // still record the key mapping so vtables reference the shared static.

--- a/src/codegen/functions/gc_runtime.yo
+++ b/src/codegen/functions/gc_runtime.yo
@@ -20,7 +20,7 @@ open(import("std/string"));
 { AstExpr, ast_expr_is_fn_call, ast_expr_is_fn_call_of, BF_UNWIND } :: import("../../expr.yo");
 { EvalValue } :: import("../../value.yo");
 { is_unit_type } :: import("../../types/guards.yo");
-{ get_type_string } :: import("../utils/index.yo");
+{ get_type_string, ChunkRange } :: import("../utils/index.yo");
 { FunctionGenerationContext } :: import("./context.yo");
 { TargetInfo, is_target_windows } :: import("../../target.yo");
 // ---------------------------------------------------------------------------
@@ -146,12 +146,23 @@ emit_unwind_value_buffer :: (fn(context : FunctionGenerationContext) -> unit)({
     .None => true
   );
   if(empty, {
-    em.emit_declaration_line("static _Thread_local _Alignas(16) char __yo_unwind_value[64];  // Thread-local buffer for unwind value storage");
+    // Chunked emission: one TLS definition (chunk 0), extern in the header —
+    // the buffer is written/read from every chunk's unwind paths.
+    if(context.base.chunk_mode, {
+      em.emit_declaration_line("extern _Thread_local _Alignas(16) char __yo_unwind_value[64];  // Thread-local buffer for unwind value storage");
+      cgb := context.base;
+      cgb.chunk_globals.push_string(String.from("_Thread_local _Alignas(16) char __yo_unwind_value[64];\n"));
+    }, {
+      em.emit_declaration_line("static _Thread_local _Alignas(16) char __yo_unwind_value[64];  // Thread-local buffer for unwind value storage");
+    });
     return();
   });
   decl := String.from("// Thread-local buffer for unwind value storage, sized (via a union) to the\n");
   decl.push_str("// largest unwound value in the program so 'unwind(v)' never overflows it.\n");
-  decl.push_str("static _Thread_local _Alignas(16) union {\n");
+  // Chunked emission: the union type must be NAMED (a typedef) so the header's
+  // extern declaration and chunk 0's definition agree on one type — two
+  // anonymous unions are incompatible redeclarations in the including TU.
+  decl.push_str(if(context.base.chunk_mode, "typedef union {\n", "static _Thread_local _Alignas(16) union {\n"));
   decl.push_str("    char __pad[64];\n");
   match(
     context.unwind_value_c_types,
@@ -178,8 +189,16 @@ emit_unwind_value_buffer :: (fn(context : FunctionGenerationContext) -> unit)({
     },
     .None => ()
   );
-  decl.push_str("} __yo_unwind_value_storage;\n");
-  decl.push_str("#define __yo_unwind_value ((char*)&__yo_unwind_value_storage)");
+  if(context.base.chunk_mode, {
+    decl.push_str("} __yo_unwind_value_storage_t;\n");
+    decl.push_str("extern _Thread_local _Alignas(16) __yo_unwind_value_storage_t __yo_unwind_value_storage;\n");
+    decl.push_str("#define __yo_unwind_value ((char*)&__yo_unwind_value_storage)");
+    cgb2 := context.base;
+    cgb2.chunk_globals.push_string(String.from("_Thread_local _Alignas(16) __yo_unwind_value_storage_t __yo_unwind_value_storage;\n"));
+  }, {
+    decl.push_str("} __yo_unwind_value_storage;\n");
+    decl.push_str("#define __yo_unwind_value ((char*)&__yo_unwind_value_storage)");
+  });
   em.emit_declaration_string_line(decl);
 });
 // ---------------------------------------------------------------------------
@@ -226,6 +245,12 @@ generate_lightweight_rc_functions :: (fn(context : FunctionGenerationContext) ->
   em := context.base.emitter;
   // Forward-declare the dispose dispatch function (defined after all dispose functions).
   em.emit_declaration_line("static void __yo_dispose_dispatch(void* ptr); // Type-tag based dispose dispatch");
+  // Chunked emission: the RC primitives are the hot path and must be per-TU
+  // `static inline` copies, not one external definition in chunk 0 (measured
+  // 16.5% slower). This whole block is header-routable as-is: it touches only
+  // the object header, `__yo_free` and the externally-declared
+  // `__yo_dispose_dispatch`.
+  rc_lw_start := if(context.base.chunk_mode, em.code.as_bytes().len(), usize(0));
   em.emit_string_line(
     `// Lightweight reference counting — no cycle detection needed
 // Uses type_id dispatch instead of function pointer for dispose
@@ -250,6 +275,12 @@ static inline void* __yo_incr_rc(void* ptr) {
   return ptr;
 }`
   );
+  if(context.base.chunk_mode, {
+    cgb6 := context.base;
+    cgb6.chunk_header_ranges.push(
+      ChunkRange(c_name : String.from("__rc_primitives_lightweight"), start_b : rc_lw_start, end_b : em.code.as_bytes().len())
+    );
+  });
   em.emit_string_line(
     `
 // Atomic reference counting functions for Iso types (thread-safe)
@@ -277,7 +308,13 @@ static void __yo_decr_rc_atomic(void* ptr) {
 }`
   );
   // Effect unwind flag and value buffer (always needed).
-  em.emit_declaration_line("static _Thread_local int __yo_effect_escaped = 0;  // Thread-local flag for effect record unwind detection");
+  if(context.base.chunk_mode, {
+    em.emit_declaration_line("extern _Thread_local int __yo_effect_escaped;  // Thread-local flag for effect record unwind detection");
+    cgb3 := context.base;
+    cgb3.chunk_globals.push_string(String.from("_Thread_local int __yo_effect_escaped = 0;\n"));
+  }, {
+    em.emit_declaration_line("static _Thread_local int __yo_effect_escaped = 0;  // Thread-local flag for effect record unwind detection");
+  });
   emit_unwind_value_buffer(context);
   // No-op GC functions so references elsewhere compile.
   em.emit_string_line(
@@ -305,6 +342,10 @@ static void __yo_init_process_cleanup(void) {}`
 generate_full_gc_runtime_functions :: (fn(context : FunctionGenerationContext) -> unit)({
   em := context.base.emitter;
   ti := context.base.target_info;
+  // `__yo_decr_rc`'s tracked tail is emitted AFTER it (and, under
+  // --emit-chunks, in a different translation unit), so it needs a forward
+  // declaration.
+  em.emit_declaration_line("static void __yo_decr_rc_tracked(void* ptr); // Tracked-object RC decrement (out-of-line)");
   // Non-atomic (GC-aware) + atomic reference counting.
   em.emit_string_line(
     `// Non-atomic reference counting functions (thread-local)
@@ -320,8 +361,18 @@ static size_t __yo_gc_min_threshold = 256;       // Minimum / configured collect
 static size_t __yo_gc_collect_threshold = 256;   // Incremental: collect when possible_roots reaches this
 static size_t __yo_gc_full_threshold = 256;      // Full: allocation-driven full-heap scan when tracked_count reaches this (adaptive Nx-live)
 static size_t __yo_gc_full_pct = 200;            // Full-scan growth factor as a percent of post-collection live (default 200 = 2x-live). Lower to cap peak memory on constrained boxes; raise for fewer (but larger) scans. Env: YO_GC_FULL_PCT.
-
-static inline void __yo_decr_rc(void* ptr) {
+`
+  );
+  // Chunked emission: the RC primitives are THE hot path (__yo_decr_rc has
+  // profiled at 54% of a self-compile), so under --emit-chunks they must be
+  // duplicated into every translation unit as `static inline` rather than left
+  // external in chunk 0 — MEASURED: an N=4 chunked self-build with them
+  // external ran 16.5% slower (102.2s vs 87.7s on check ./src). Only the
+  // untracked FAST PATH is inlined; the tracked tail below reads the
+  // thread-local GC state above, so it stays out-of-line in chunk 0.
+  rc_prims_start := if(context.base.chunk_mode, em.code.as_bytes().len(), usize(0));
+  em.emit_string_line(
+    `static inline void __yo_decr_rc(void* ptr) {
   if (ptr == NULL) return;
   __yo_ref_header_t* header = (__yo_ref_header_t*)ptr;
 
@@ -346,7 +397,32 @@ static inline void __yo_decr_rc(void* ptr) {
     }
     return;
   }
+  // Tracked object: the cycle-collector bookkeeping — and the thread-local
+  // GC state it reads — lives out-of-line, so THIS function needs nothing
+  // but the object header. That is what lets it be duplicated as a per-TU
+  // static inline under --emit-chunks (plans/CHUNKED_C_EMISSION.md); a
+  // single-file build inlines the tail back into its only call site.
+  __yo_decr_rc_tracked(ptr);
+}
 
+static inline void* __yo_incr_rc(void* ptr) {
+  if (ptr == NULL) return NULL;
+  __yo_ref_header_t* header = (__yo_ref_header_t*)ptr;
+  header->ref_count++;
+  GC_DEBUG("Incr: ptr=%p RC=%zu\\n", ptr, (size_t)header->ref_count);
+  return ptr;
+}`
+  );
+  if(context.base.chunk_mode, {
+    cgb5 := context.base;
+    cgb5.chunk_header_ranges.push(
+      ChunkRange(c_name : String.from("__rc_primitives"), start_b : rc_prims_start, end_b : em.code.as_bytes().len())
+    );
+  });
+  em.emit_string_line(
+    `
+static void __yo_decr_rc_tracked(void* ptr) {
+  __yo_ref_header_t* header = (__yo_ref_header_t*)ptr;
   // Tracked object. During GC collection, skip it: the GC handles tracked
   // objects' lifecycle via trial deletion — decrementing here would
   // double-count the reference removal.
@@ -386,14 +462,6 @@ static inline void __yo_decr_rc(void* ptr) {
   }
 }
 
-static inline void* __yo_incr_rc(void* ptr) {
-  if (ptr == NULL) return NULL;
-  __yo_ref_header_t* header = (__yo_ref_header_t*)ptr;
-  header->ref_count++;
-  GC_DEBUG("Incr: ptr=%p RC=%zu\\n", ptr, (size_t)header->ref_count);
-  return ptr;
-}
-
 // Atomic reference counting functions for Iso types (thread-safe)
 // Memory ordering follows the standard Arc pattern (Rust, Swift, C++ shared_ptr):
 //   - Increment: relaxed (no ordering needed for new reference creation)
@@ -422,7 +490,13 @@ static void __yo_decr_rc_atomic(void* ptr) {
 }`
   );
   // Effect-unwind flag + value buffer (declaration section).
-  em.emit_declaration_line("static _Thread_local int __yo_effect_escaped = 0;  // Thread-local flag for effect record unwind detection");
+  if(context.base.chunk_mode, {
+    em.emit_declaration_line("extern _Thread_local int __yo_effect_escaped;  // Thread-local flag for effect record unwind detection");
+    cgb3 := context.base;
+    cgb3.chunk_globals.push_string(String.from("_Thread_local int __yo_effect_escaped = 0;\n"));
+  }, {
+    em.emit_declaration_line("static _Thread_local int __yo_effect_escaped = 0;  // Thread-local flag for effect record unwind detection");
+  });
   emit_unwind_value_buffer(context);
   // Per-thread GC tracking state + adaptive thresholds.
   em.emit_string_line(
@@ -972,7 +1046,17 @@ static void __yo_init_process_cleanup(void) {
 /// runtime when needs_cycle_gc, else the lightweight (type-tag) path. Mirrors
 /// `generateAtomicGCRuntimeFunctions`.
 generate_atomic_gc_runtime_functions :: (fn(context : FunctionGenerationContext) -> unit)({
+  // Chunked emission: the borrow primitives are the per-container-access hot
+  // path, have no prototypes anywhere, and are called from every chunk —
+  // route them into the shared header (per-TU `static inline` copies).
+  bp_start := if(context.base.chunk_mode, context.base.emitter.code.as_bytes().len(), usize(0));
   generate_borrow_runtime_primitives(context);
+  if(context.base.chunk_mode, {
+    cgb4 := context.base;
+    cgb4.chunk_header_ranges.push(
+      ChunkRange(c_name : String.from("__borrow_primitives"), start_b : bp_start, end_b : context.base.emitter.code.as_bytes().len())
+    );
+  });
   if(context.base.needs_cycle_gc, {
     generate_full_gc_runtime_functions(context);
   }, {

--- a/src/codegen/functions/generation.yo
+++ b/src/codegen/functions/generation.yo
@@ -30,7 +30,7 @@ open(import("std/string"));
 { is_temp_variable_name } :: import("../../utils.yo");
 { is_target_posix, is_target_linux, is_target_windows } :: import("../../target.yo");
 { get_func_type, is_closure_fn, get_closure_capture_info, is_effect_record_member } :: import("../../function_value.yo");
-{ get_type_string, get_variable_type_string, sanitize_for_c_identifier, get_variable_name_for_codegen } :: import("../utils/index.yo");
+{ get_type_string, get_variable_type_string, sanitize_for_c_identifier, get_variable_name_for_codegen, ChunkRange } :: import("../utils/index.yo");
 { get_shell_redirect } :: import("../../evaluator/values/type_trait_methods.yo");
 { FunctionGenerationContext } :: import("./context.yo");
 { generate_function_prototype, should_skip_function_codegen, _async_override_return_type } :: import("./declarations.yo");
@@ -679,9 +679,19 @@ generate_all_functions :: (fn(context : FunctionGenerationContext) -> unit)({
   });
   collect_unwind_value_ctypes(context);
   generate_atomic_gc_runtime_functions(context);
+  // Chunked emission: the constructor/traverse block is routed VERBATIM into
+  // the shared header (per-TU `static` copies — constructors are called from
+  // every chunk, and each TU's constructors take the address of that TU's own
+  // traverse copy, which is only ever CALLED through the stored pointer).
+  ctor_block_start := if(context.base.chunk_mode, em.code.as_bytes().len(), usize(0));
   generate_ref_struct_constructor_functions(context);
   generate_ref_enum_constructor_functions(context);
   generate_closure_constructor_functions(context);
+  if(context.base.chunk_mode, {
+    context.base.chunk_header_ranges.push(
+      ChunkRange(c_name : String.from("__ctor_block"), start_b : ctor_block_start, end_b : em.code.as_bytes().len())
+    );
+  });
   // Iterate in INSERTION order (function_order), NOT HashMap bucket order, so
   // body emission — and the specializations created during it — are ordered
   // deterministically across the TS-compiled s1 and self-compiled s2. Index by
@@ -702,7 +712,17 @@ generate_all_functions :: (fn(context : FunctionGenerationContext) -> unit)({
           // preceding the definition. Mirrors TS generateAllFunctions
           // (generation.ts:583-661), which applies the full skip set here too.
           if(!(should_skip_function_codegen(fid, entry.c_name.clone(), entry.value, context.base)), {
+            // Chunked emission: record this function's `code`-buffer byte
+            // range AFTER the call returns — generate_function may truncate
+            // the buffer tail (superseded-stub rewrite), so the extent is
+            // final only then. Ranges are non-overlapping and ascending.
+            fn_start := if(context.base.chunk_mode, em.code.as_bytes().len(), usize(0));
             generate_function(entry.value, entry.c_name, context);
+            if(context.base.chunk_mode, {
+              context.base.chunk_fn_ranges.push(
+                ChunkRange(c_name : entry.c_name.clone(), start_b : fn_start, end_b : em.code.as_bytes().len())
+              );
+            });
           });
         },
         .None => ()
@@ -827,9 +847,22 @@ emit_module_level_variable_declarations :: (
               if(!(seen.contains(c_var_name.clone())), {
                 _s2 := seen.add(c_var_name.clone());
                 c_type_str := get_type_string(vi.ty, context.base);
-                em.emit_declaration_string_line(
-                  `static ${c_type_str} ${c_var_name}; // module-level mutable variable`
-                );
+                // Chunked emission: module-level vars are read/written from
+                // every chunk — one definition (chunk 0), extern in the header.
+                if(context.base.chunk_mode, {
+                  em.emit_declaration_string_line(
+                    `extern ${c_type_str} ${c_var_name}; // module-level mutable variable`
+                  );
+                  cgb := context.base;
+                  cgb.chunk_globals.push_string(
+                    `${c_type_str} ${c_var_name};
+`
+                  );
+                }, {
+                  em.emit_declaration_string_line(
+                    `static ${c_type_str} ${c_var_name}; // module-level mutable variable`
+                  );
+                });
               });
               rhs := match(_args(init_expr).get(usize(1)), .Some(e) => e, .None => make_err_expr());
               _p := result.push(ModuleLevelVarEntry(c_var_name : c_var_name, rhs : rhs));

--- a/src/codegen/utils/index.yo
+++ b/src/codegen/utils/index.yo
@@ -144,6 +144,11 @@ DynImplEntry :: ref(
     trait_values : ArrayList(EvalValue)
   )
 );
+/// A byte range of the emitter's `code` buffer holding one complete emitted
+/// function (recorded AFTER its generate_function call returns — extents are
+/// final only then; see plans/CHUNKED_C_EMISSION.md "Ground truth"). Sliced
+/// post-emission by `assemble_chunks` into per-chunk translation units.
+ChunkRange :: ref(struct(c_name : String, start_b : usize, end_b : usize));
 /// The base C code generation context. See header above.
 CodeGenContext :: ref(
   struct(
@@ -253,7 +258,24 @@ CodeGenContext :: ref(
     // type maps to the FIRST registration's key (collect_type's stable-identity
     // dedup). Consulted by get_type_entry/get_type_c_name on a primary miss so
     // value sites keyed under either render resolve to ONE C type.
-    type_key_aliases : HashMap(String, String)
+    type_key_aliases : HashMap(String, String),
+    /// Chunked C emission (plans/CHUNKED_C_EMISSION.md, `--emit-chunks N`).
+    /// When true, emission records byte ranges + splits file-scope statics so
+    /// `assemble_chunks` can produce N linkable translation units. MUST stay
+    /// false by default: the single-file emission is gated byte-identical.
+    chunk_mode : bool,
+    /// Per-function `code`-buffer byte ranges (chunk_mode only), recorded
+    /// around each generate_function call in emission order.
+    chunk_fn_ranges : ArrayList(ChunkRange),
+    /// `code`-buffer byte ranges routed VERBATIM into the shared header
+    /// (chunk_mode only): the constructor/traverse block — per-TU `static`
+    /// copies, called from every chunk.
+    chunk_header_ranges : ArrayList(ChunkRange),
+    /// File-scope definitions for chunk 0 (chunk_mode only): the single-
+    /// definition side of split statics — typeid chars, dyn vtables, TLS
+    /// unwind/effect buffers, the argv shim, module-level vars. Their extern
+    /// declarations go to the declarations section (the shared header).
+    chunk_globals : String
   )
 );
 impl(
@@ -304,9 +326,37 @@ impl(
       declared_c_var_names : HashSet(String).new(),
       declared_scopes : ArrayList(String).new(),
       impl_closure_call_map : HashMap(String, ImplClosureCallInfo).new(),
-      type_key_aliases : HashMap(String, String).new()
+      type_key_aliases : HashMap(String, String).new(),
+      chunk_mode : false,
+      chunk_fn_ranges : ArrayList(ChunkRange).new(),
+      chunk_header_ranges : ArrayList(ChunkRange).new(),
+      chunk_globals : String.new()
     )
   ),
+  /// Emit a `__yo_typeid_*` static char whose ADDRESS is the runtime TypeId.
+  /// Chunked emission splits it — extern in the header, one definition in
+  /// chunk 0 — because per-TU copies would give the same type a different
+  /// address in every chunk (address identity IS the semantics). `comment` is
+  /// appended verbatim when non-empty (the dyn vtable pass labels its ids).
+  emit_typeid_static : (fn(self : Self, static_var_name : String, comment : String) -> unit)({
+    if(self.chunk_mode, {
+      decl := String.from("extern const char ");
+      decl.push_string(static_var_name.clone());
+      decl.push_str(";");
+      decl.push_string(comment.clone());
+      self.emitter.emit_declaration_string_line(decl);
+      def := String.from("const char ");
+      def.push_string(static_var_name);
+      def.push_str(" = 0;\n");
+      self.chunk_globals.push_string(def);
+    }, {
+      decl := String.from("static const char ");
+      decl.push_string(static_var_name);
+      decl.push_str(" = 0;");
+      decl.push_string(comment);
+      self.emitter.emit_declaration_string_line(decl);
+    });
+  }),
   /// Allocate (or reuse) the type-tag id for a dispose function's C name.
   /// Mirrors the disposeTypeIds get-or-assign in generateRefStructConstructorFunctions.
   dispose_type_id_for : (fn(self : Self, dispose_c_name : String) -> usize)(
@@ -1478,6 +1528,7 @@ find_returned_async_block :: (fn(expr : Option(AstExpr)) -> Option(AstExpr))(
 );
 export(
   CodeGenContext,
+  ChunkRange,
   CodegenTypeEntry,
   CodegenFunctionEntry,
   ImplClosureCallInfo,

--- a/src/main.yo
+++ b/src/main.yo
@@ -1001,6 +1001,16 @@ _asan_runtime_is_usable :: (fn(base : String, io : Io) -> bool)({
   g_asan_usable = Option(bool).Some(usable);
   usable
 });
+/// Zero-pad a chunk index to 3 digits (`7` → `"007"`) for the
+/// `<base>_chunkNNN.c` file names of `--emit-chunks`.
+_pad3 :: (fn(i : usize) -> String)({
+  s := i.to_string();
+  cond(
+    (s.len() >= usize(3)) => s,
+    (s.len() == usize(2)) => `0${s}`,
+    true => `00${s}`
+  )
+});
 /// Run the `compile` subcommand.
 run_compile :: (
   fn(
@@ -1024,6 +1034,7 @@ run_compile :: (
   (sysroot : String) = String.from("");
   (allocator : String) = String.from("system");
   (emit_chunks : usize) = usize(0);
+  (chunk_no_lto : bool) = false;
   (optimize : String) = String.from(""); // "" = unset; "0".."3"
   (sanitize : String) = String.from(""); // "" / "address" / "leak" / "thread"
   (cflags : String) = String.from("");
@@ -1217,6 +1228,10 @@ run_compile :: (
         debug_gc = true;
         ai = (ai + usize(1));
       },
+      (a == "--no-chunk-lto") => {
+        chunk_no_lto = true;
+        ai = (ai + usize(1));
+      },
       (a == "--emit-chunks") => {
         ecv := _arg_val_req(argv, ai, String.from("--emit-chunks"), exn);
         emit_chunks = match(ecv.parse_u64(), .Some(n) => usize(n), .None => usize(0));
@@ -1279,6 +1294,18 @@ run_compile :: (
   });
   if((emcc_environment != "") && ((emcc_environment != "web") && (emcc_environment != "node")), {
     exn.throw(dyn(`compile: invalid --emcc-environment "${emcc_environment}". Choices: web, node`));
+  });
+  // Chunked emission drives multiple TU inputs through the executable link
+  // line; the static-library path compiles ONE input to ONE `.o`.
+  if((emit_chunks >= usize(1)) && static_library, {
+    exn.throw(dyn(String.from("compile: --emit-chunks is not supported with --static-library")));
+  });
+  // Both flags decide what C files get WRITTEN, so the combination is
+  // ambiguous rather than merely redundant: `--emit-c-to` names ONE file, and
+  // the chunked path writes a header plus N chunks. (`--emit-c`, which only
+  // PRINTS the single-file equivalent, stays allowed.)
+  if((emit_chunks >= usize(1)) && (emit_c_to.len() > usize(0)), {
+    exn.throw(dyn(String.from("compile: --emit-c-to writes one C file and --emit-chunks writes a header plus N chunks — pass only one")));
   });
   // ----- C compiler resolution (src/yo-cli.ts:468-486) ---------------------
   // Auto-select emcc for wasm targets when --cc was not given; otherwise probe
@@ -1410,6 +1437,8 @@ run_compile :: (
   // it survives) and `target` are the only values the link line needs.
   // ---------------------------------------------------------------------
   (c_path : String) = String.new();
+  // Chunked emission: every written chunk `.c` (all become cc inputs).
+  chunk_c_files := ArrayList(String).new();
   {
     clear_module_cache();
     mm_clear_prelude_env();
@@ -1444,7 +1473,7 @@ run_compile :: (
     // wrapper (is_library = true). Allocator + debug-logging flags are threaded
     // through to the code generator (mirrors CodeGeneratorC.compileModule).
     chunk_parts := ArrayList(String).new();
-    c_src := compile_module(module_value, ctx.expr_info_table, target, allocator.clone(), debug_gc, debug_parallelism, debug_async_await, static_library, ctx, env, exn, chunk_parts);
+    c_src := compile_module(module_value, ctx.expr_info_table, target, allocator.clone(), debug_gc, debug_parallelism, debug_async_await, static_library, ctx, env, exn, chunk_parts, emit_chunks);
     // --emit-c prints the generated C to stdout (module-manager.ts:473-475) —
     // and compilation continues; only --skip-c-compiler stops before the link.
     if(emit_c, {
@@ -1483,25 +1512,31 @@ run_compile :: (
     });
     cond(
       (emit_chunks >= usize(1)) => {
-        // Chunked emission, step-1 degenerate mode (plans/CHUNKED_C_EMISSION.md):
-        // ONE all-static chunk that #includes the shared header — proves the
-        // split assembly end-to-end before the step-2 linkage work makes
-        // N > 1 linkable. The chunk file becomes the cc input (`c_path`).
+        // Chunked emission (plans/CHUNKED_C_EMISSION.md step 2): parts[0] is
+        // the shared header, parts[1..] the linkage-split translation-unit
+        // bodies. Each chunk #includes the header BY BASENAME (quoted
+        // includes resolve relative to the including file, and the files are
+        // siblings by construction — a full relative path would double the
+        // directory prefix). Every chunk file becomes a cc input.
         shared_h := `${c_base}_shared.h`;
-        hdr := String.new();
-        hdr.push_string(match(chunk_parts.get(usize(0)), .Some(x) => x, .None => String.new()));
-        hdr.push_str("
-");
-        hdr.push_string(match(chunk_parts.get(usize(1)), .Some(x) => x, .None => String.new()));
-        io.await(write_file(Path.new(shared_h.clone()), hdr, io), IoExn(io : io, exn : exn));
-        chunk0 := `${c_base}_chunk000.c`;
-        cbody := String.new();
-        cbody.push_str("#include \"");
-        cbody.push_string(shared_h.clone());
-        cbody.push_str("\"\n");
-        cbody.push_string(match(chunk_parts.get(usize(2)), .Some(x) => x, .None => String.new()));
-        io.await(write_file(Path.new(chunk0.clone()), cbody, io), IoExn(io : io, exn : exn));
-        c_path = chunk0;
+        shared_h_base := match(Path.new(shared_h.clone()).file_name(), .Some(bn) => bn, .None => shared_h.clone());
+        io.await(
+          write_file(Path.new(shared_h.clone()), match(chunk_parts.get(usize(0)), .Some(x) => x, .None => String.new()), io),
+          IoExn(io : io, exn : exn)
+        );
+        (pi2 : usize) = usize(1);
+        while(pi2 < chunk_parts.len(), {
+          cf := `${c_base}_chunk${_pad3(pi2 - usize(1))}.c`;
+          cbody := String.new();
+          cbody.push_str("#include \"");
+          cbody.push_string(shared_h_base.clone());
+          cbody.push_str("\"\n");
+          cbody.push_string(match(chunk_parts.get(pi2), .Some(x) => x, .None => String.new()));
+          io.await(write_file(Path.new(cf.clone()), cbody, io), IoExn(io : io, exn : exn));
+          chunk_c_files.push(cf);
+          pi2 = (pi2 + usize(1));
+        });
+        c_path = match(chunk_c_files.get(usize(0)), .Some(x) => x.clone(), .None => c_path.clone());
       },
       true => {
         io.await(write_file(Path.new(c_path.clone()), c_src, io), IoExn(io : io, exn : exn));
@@ -1563,6 +1598,20 @@ run_compile :: (
       cmd.arg(String.from("-O0"));
     }
   );
+  // Chunked emission implies ThinLTO, and this is NOT an optional tuning knob
+  // (plans/CHUNKED_C_EMISSION.md). Splitting the program into N translation
+  // units externalizes every generated function, so the C compiler can no
+  // longer internalize or dead-strip them: MEASURED on an N=4 self-build, the
+  // binary went 9 MB / 3.5k symbols -> 24 MB / 7.2k symbols and ran 14.2%
+  // SLOWER on `check ./src` (102.8s vs 90.0s). With `-flto=thin` the linker
+  // recovers the cross-module inlining and the same build runs 87.4s —
+  // slightly FASTER than single-file. A chunked compiler that runs 14% slower
+  // would cancel the build-time win it exists for, so the flag rides along
+  // with `--emit-chunks` unless explicitly disabled. Not for wasm: emcc's LTO
+  // story is separate and chunked wasm builds are out of scope.
+  if((emit_chunks >= usize(1)) && (!(chunk_no_lto) && !(is_target_wasm(target))), {
+    cmd.arg(String.from("-flto=thin"));
+  });
   if(debug_symbols, {
     cmd.arg(String.from("-g"));
   });
@@ -1717,8 +1766,19 @@ run_compile :: (
     });
     return(())
   });
-  // Executable: source + externs, output, then link libraries.
-  cmd.arg(c_path.clone());
+  // Executable: source + externs, output, then link libraries. Chunked
+  // emission passes every chunk `.c` — cc compiles each TU and links them in
+  // the one invocation (parallel per-chunk `cc -c` + a `.o` cache is step 3).
+  cond(
+    (chunk_c_files.len() > usize(0)) => {
+      (cci : usize) = usize(0);
+      while(cci < chunk_c_files.len(), {
+        match(chunk_c_files.get(cci), .Some(f) => cmd.arg(f.clone()), .None => ());
+        cci = (cci + usize(1));
+      });
+    },
+    true => cmd.arg(c_path.clone())
+  );
   (ei : usize) = usize(0);
   while(ei < externs.len(), {
     match(externs.get(ei), .Some(f) => cmd.arg(f.clone()), .None => ());
@@ -3182,6 +3242,9 @@ Examples:
   $ yo compile main.yo --release -D NDEBUG -o app
   $ yo compile main.yo -g -o app_debug
   $ yo compile main.yo --release -s --cflags='-march=native' -o app
+  $ yo compile main.yo --release --emit-chunks 16 -o app
+                                 Split the emitted C into 16 translation units
+                                 (opt-in; implies -flto=thin, --no-chunk-lto opts out)
 
 yo build [steps] [options]       Build project using build.yo
 Examples:

--- a/tests/internal/chunk_assembly.test.yo
+++ b/tests/internal/chunk_assembly.test.yo
@@ -1,0 +1,181 @@
+//! Chunked C emission assembly gates (plans/CHUNKED_C_EMISSION.md step 2;
+//! src/codegen/chunk_assembly.yo).
+//!
+//! `assemble_chunks` takes the emitter's three buffers plus the recorded byte
+//! ranges and produces one shared header + N linkable translation units. Every
+//! rule of the linkage split is checked here on SYNTHETIC C text, so a
+//! regression is caught in seconds instead of via a 15-minute chunked
+//! self-build:
+//!
+//!   - declarations content must SURVIVE into the header (a `String`
+//!     out-parameter silently dropped the whole buffer once — `String` is a
+//!     value type with a lazily allocated buffer);
+//!   - a `static` function DEFINED in the declarations buffer keeps `static`
+//!     (per-TU copy) — it is in `header_defined`;
+//!   - an EXTERNAL function definition in the declarations buffer is
+//!     relocated to chunk 0 with a prototype left in the header (this is the
+//!     async state-machine `_set_effect`/`_resume`/`_dispose` class: a
+//!     definition in the header means "duplicate symbol" in every TU);
+//!   - a `static` function defined in the CODE buffer is dequalified to
+//!     external in BOTH its prototype and its definition, so any chunk can
+//!     call it;
+//!   - header-routed ranges (borrow primitives, the RC primitives, the
+//!     constructor/traverse block) travel verbatim into the header;
+//!   - a per-type RC helper name (`___dup`/`___drop`/`___dispose`) is
+//!     header-routed. NOTE this rule is currently INERT for real emissions:
+//!     emitted C names put a single underscore before the verb
+//!     (`__yo_dispose___yo_dyn_box___yo_tN`), and a whole self-build contains
+//!     only 8 such functions because RC drops lower to direct
+//!     `__yo_decr_rc(...)` calls (336k of them). Kept as a unit test of the
+//!     mechanism; see plans/CHUNKED_C_EMISSION.md audit finding F3.
+//!   - `chunk_globals` land in chunk 0 only;
+//!   - per-function ranges are distributed by name hash, each appearing in
+//!     EXACTLY ONE chunk;
+//!   - type-level constructs (`typedef ... { ... };`) are never mistaken for
+//!     relocatable definitions.
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ assert } :: import("std/assert");
+{ ChunkRange } :: import("../../src/codegen/utils/index.yo");
+{ assemble_chunks } :: import("../../src/codegen/chunk_assembly.yo");
+_HEADERS :: "#include <stdio.h>\n";
+_DECLS :: "// decls-marker\ntypedef struct { int x; } T1;\nstatic inline int hdr_static_fn(int a) {\n  return a + 1;\n}\nvoid ext_def_fn(void* p) {\n  ext_marker();\n}\nstatic void proto_only_fn(int a);\n";
+_RUNTIME :: "static void proto_only_fn(int a) {\n  runtime_marker(a);\n}\n";
+_BORROW :: "static inline void borrow_x(void* p) {\n  borrow_marker(p);\n}\n";
+_FN_ALPHA :: "static inline int fn_alpha(void) {\n  return 1;\n}\n";
+_FN_BETA :: "static inline int fn_beta(void) {\n  return 2;\n}\n";
+_RC_DROP :: "static inline void T1___drop(void* p) {\n  rc_marker(p);\n}\n";
+_TAIL :: "int main(void) {\n  return 0;\n}\n";
+_GLOBALS :: "int g_shared;\n";
+/// True iff exactly `want` of `chunks` contain `needle`.
+_count_chunks_with :: (fn(chunks : ArrayList(String), needle : String) -> usize)({
+  (hits : usize) = usize(0);
+  (i : usize) = usize(0);
+  while(i < chunks.len(), {
+    match(
+      chunks.get(i),
+      .Some(c) => if(c.contains(needle.clone()), {
+        hits = (hits + usize(1));
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  hits
+});
+test("chunked emission: the linkage split assembles a header + N linkable units", {
+  // Code buffer = runtime ++ borrow ++ fn_alpha ++ fn_beta ++ rc_drop ++ tail.
+  // The ranges are byte offsets into exactly that concatenation.
+  code := String.new();
+  code.push_str(_RUNTIME);
+  borrow_start := code.bytes_len();
+  code.push_str(_BORROW);
+  borrow_end := code.bytes_len();
+  alpha_start := code.bytes_len();
+  code.push_str(_FN_ALPHA);
+  alpha_end := code.bytes_len();
+  beta_start := code.bytes_len();
+  code.push_str(_FN_BETA);
+  beta_end := code.bytes_len();
+  rc_start := code.bytes_len();
+  code.push_str(_RC_DROP);
+  rc_end := code.bytes_len();
+  code.push_str(_TAIL);
+  header_ranges := ArrayList(ChunkRange).new();
+  header_ranges.push(ChunkRange(c_name : String.from("__borrow_primitives"), start_b : borrow_start, end_b : borrow_end));
+  fn_ranges := ArrayList(ChunkRange).new();
+  fn_ranges.push(ChunkRange(c_name : String.from("fn_alpha"), start_b : alpha_start, end_b : alpha_end));
+  fn_ranges.push(ChunkRange(c_name : String.from("fn_beta"), start_b : beta_start, end_b : beta_end));
+  fn_ranges.push(ChunkRange(c_name : String.from("T1___drop"), start_b : rc_start, end_b : rc_end));
+  asm4 := assemble_chunks(
+    String.from(_HEADERS),
+    String.from(_DECLS),
+    code,
+    fn_ranges,
+    header_ranges,
+    String.from(_GLOBALS),
+    usize(4)
+  );
+  hdr := asm4.header_text.clone();
+  chunks := asm4.chunks;
+  assert(chunks.len() == usize(4), `expected 4 chunks, got ${chunks.len().to_string()}`);
+  chunk0 := match(chunks.get(usize(0)), .Some(c) => c, .None => String.new());
+  // 1. The declarations buffer must not be LOST (the value-type out-param bug).
+  assert(hdr.contains(String.from("// decls-marker")), "header lost the declarations buffer");
+  assert(hdr.contains(String.from("typedef struct { int x; } T1;")), "header lost a typedef");
+  // 2. A static definition IN the declarations stays static (per-TU copy).
+  assert(hdr.contains(String.from("static inline int hdr_static_fn")), "declarations-buffer static definition should stay static in the header");
+  assert(hdr.contains(String.from("return a + 1;")), "declarations-buffer static definition should keep its body in the header");
+  // 3. An EXTERNAL definition in the declarations is relocated to chunk 0,
+  //    prototype left behind. A body in the header = duplicate symbol per TU.
+  assert(hdr.contains(String.from("void ext_def_fn(void* p);")), "external declarations-buffer definition should leave a prototype in the header");
+  assert(!(hdr.contains(String.from("ext_marker()"))), "external declarations-buffer definition BODY must not stay in the header");
+  assert(chunk0.contains(String.from("void ext_def_fn(void* p) {")), "relocated external definition should land in chunk 0");
+  assert(chunk0.contains(String.from("ext_marker()")), "relocated external definition should carry its body");
+  // 4. A static function defined in the CODE buffer is dequalified on BOTH
+  //    sides so any chunk can call it.
+  assert(hdr.contains(String.from("void proto_only_fn(int a);")), "residue-defined function should get an external prototype");
+  assert(!(hdr.contains(String.from("static void proto_only_fn(int a);"))), "residue-defined function prototype should lose `static`");
+  assert(chunk0.contains(String.from("void proto_only_fn(int a) {")), "residue definition belongs to chunk 0");
+  assert(!(chunk0.contains(String.from("static void proto_only_fn"))), "residue definition should lose `static`");
+  // 5. Header-routed ranges travel verbatim (still static: per-TU copies).
+  assert(hdr.contains(String.from("static inline void borrow_x")), "borrow-primitive range should be header-routed and stay static");
+  assert(_count_chunks_with(chunks, String.from("borrow_marker")) == usize(0), "header-routed range must not also appear in a chunk");
+  // 6. RC helpers are header-routed (the RC hot path, per-TU copies).
+  assert(hdr.contains(String.from("T1___drop")), "RC helper should be header-routed");
+  assert(_count_chunks_with(chunks, String.from("rc_marker")) == usize(0), "RC helper must not also appear in a chunk");
+  // 7. chunk_globals (split cross-chunk statics) land in chunk 0 ONLY.
+  assert(chunk0.contains(String.from("int g_shared;")), "chunk_globals should be defined in chunk 0");
+  assert(_count_chunks_with(chunks, String.from("int g_shared;")) == usize(1), "chunk_globals must be defined exactly once");
+  // 8. Each per-function range lands in EXACTLY ONE chunk, dequalified.
+  assert(_count_chunks_with(chunks, String.from("fn_alpha(void)")) == usize(1), "fn_alpha must appear in exactly one chunk");
+  assert(_count_chunks_with(chunks, String.from("fn_beta(void)")) == usize(1), "fn_beta must appear in exactly one chunk");
+  assert(_count_chunks_with(chunks, String.from("static inline int fn_alpha")) == usize(0), "fn_alpha body should lose `static inline`");
+  assert(!(hdr.contains(String.from("fn_alpha(void) {"))), "a plain function body must not be header-routed");
+  // 9. The residue tail (main wrapper) stays in chunk 0, exactly once.
+  assert(_count_chunks_with(chunks, String.from("int main(void) {")) == usize(1), "the main wrapper must appear exactly once");
+  assert(chunk0.contains(String.from("int main(void) {")), "the main wrapper belongs to chunk 0 (residue)");
+});
+test("chunked emission: N=1 is degenerate — one unit holding everything", {
+  code := String.new();
+  code.push_str(_RUNTIME);
+  alpha_start := code.bytes_len();
+  code.push_str(_FN_ALPHA);
+  alpha_end := code.bytes_len();
+  fn_ranges := ArrayList(ChunkRange).new();
+  fn_ranges.push(ChunkRange(c_name : String.from("fn_alpha"), start_b : alpha_start, end_b : alpha_end));
+  asm1 := assemble_chunks(
+    String.from(_HEADERS),
+    String.from(_DECLS),
+    code,
+    fn_ranges,
+    ArrayList(ChunkRange).new(),
+    String.from(_GLOBALS),
+    usize(1)
+  );
+  assert(asm1.chunks.len() == usize(1), "N=1 must produce exactly one chunk");
+  only := match(asm1.chunks.get(usize(0)), .Some(c) => c, .None => String.new());
+  assert(only.contains(String.from("runtime_marker")), "N=1 chunk should hold the residue");
+  assert(only.contains(String.from("fn_alpha(void)")), "N=1 chunk should hold the function bodies");
+  assert(only.contains(String.from("int g_shared;")), "N=1 chunk should hold the split globals");
+  assert(asm1.header_text.contains(String.from("// decls-marker")), "N=1 header should still carry the declarations");
+});
+test("chunked emission: more chunks than functions leaves the extra units empty but valid", {
+  code := String.new();
+  alpha_start := code.bytes_len();
+  code.push_str(_FN_ALPHA);
+  alpha_end := code.bytes_len();
+  fn_ranges := ArrayList(ChunkRange).new();
+  fn_ranges.push(ChunkRange(c_name : String.from("fn_alpha"), start_b : alpha_start, end_b : alpha_end));
+  asm8 := assemble_chunks(
+    String.from(_HEADERS),
+    String.from(_DECLS),
+    code,
+    fn_ranges,
+    ArrayList(ChunkRange).new(),
+    String.new(),
+    usize(8)
+  );
+  assert(asm8.chunks.len() == usize(8), "N=8 must produce 8 chunks even with one function");
+  assert(_count_chunks_with(asm8.chunks, String.from("fn_alpha(void)")) == usize(1), "the single function lands in exactly one chunk");
+});


### PR DESCRIPTION
Step 2 of `plans/CHUNKED_C_EMISSION.md`: the linkage split that makes
`--emit-chunks N` produce N *linkable* translation units instead of step 1's
single degenerate chunk. Still opt-in — `--emit-chunks 0` (the default) emits
the same single C file, byte-for-byte.

## What lands

`src/codegen/chunk_assembly.yo` (new) turns the emitter's three buffers plus
per-function byte ranges into one shared header and N translation units. The
core rule replaces the hand-maintained allowlist the plan originally called
for: an **auto-dequalifier** computes the set of names *defined in the header*,
then strips `static [inline]` from every column-0 static function line —
prototype and definition alike — whose name is not in that set. One rule drives
both sides, so prototype and definition linkage can never disagree, and there
is no list to rot.

Cross-chunk mutable state is split at its *emission sites* instead (typeid
chars via a new `emit_typeid_static`, the TLS unwind/effect buffers, the argv
shim, module-level vars): `extern` in the header, one definition prepended to
chunk 0.

## Four linkage classes the plan's table missed

Each was found by bring-up, and each is now handled:

1. **Borrow primitives** have no prototypes anywhere and every chunk calls them
   (per-container-access hot path) → header-routed as a recorded byte range.
2. **Residue runtime functions** (sys/async/parallelism/GC, emitted as big
   string literals) carry no prototypes yet are called across chunks → the
   assembler synthesizes one per `__yo_`-named residue definition, emitting only
   those actually referenced.
3. **The reference scan must skip C string literals.** This compiler embeds the
   entire runtime C text as `__yo_str` spill data, so a naive scan marks every
   runtime function "referenced" and emits prototypes naming chunk-0-private
   typedefs — 36 "unknown type name" errors.
4. **External function definitions live in the declarations buffer.** The async
   state-machine emitter writes `_set_effect`/`_resume`/`_dispose` bodies there
   with external linkage — 80 in a self-build → 240 duplicate symbols at link.
   `_ca_split_decl_defs` relocates each to chunk 0, leaving a prototype.

## ThinLTO turned out to be required, not optional

A 5-lens adversarial audit flagged de-inlining; the measurement then refuted
the specific hypothesis and found the real cause. Splitting into N TUs
externalizes ~175k generated functions, so the C compiler can no longer
internalize or dead-strip them: the binary went **9 MB / 3.5k symbols → 24 MB /
7.2k symbols** and ran **14.2% slower**. `-flto=thin` recovers it completely.

Interleaved A/B, `check ./src`, 262/262 on every run:

| build | mean | vs single-file |
|---|---|---|
| single-file | 90.02 s | — |
| **chunked N=4 + ThinLTO** | **87.41 s** | **−2.9% (faster)** |
| chunked N=4, no LTO | 102.81 s | +14.2% |

So `--emit-chunks` now implies `-flto=thin` (`--no-chunk-lto` opts out, wasm
excluded). The plan's "opt-in mitigation" line is marked superseded with the
data.

Routing the RC primitives into the header (`__yo_decr_rc`'s untracked fast path
inline, tracked tail split out as `__yo_decr_rc_tracked`) is kept for design
conformance — it measured *free* in single-file mode (89.72 s vs 90.93 s) — but
the plan records honestly that it recovered nothing for chunked builds.

## Gates

- N=4 chunked self-build links, runs, and is functionally identical
  (`check ./src` 262/262, 0 errors).
- Default emission byte-identical (verified after every assembler change).
- Perf gate met, with LTO (table above).
- Full language suite green on the new compiler — the RC split touches the RC
  hot path, so this was mandatory.
- Bootstrap fixpoint holds (stage2 ≡ stage3) with the changed emitter.
- New: `tests/internal/chunk_assembly.test.yo` — every split rule on synthetic
  C, red-first verified, **40 s** instead of the ~15 min a chunked self-build
  costs.
- Function-pointer equality audit: only `vtable->__yo_type_id` is ever
  compared, so per-TU copies of constructors/traverse/RC helpers are safe and
  dyn vtables need no extern split.

## Two bugs found along the way

- `issues/ref-struct-field-named-header-collides-with-rc-header.md` — a
  `ref(struct(...))` field named `header` collides with the built-in RC header
  member and emits invalid C. Pre-existing, reproduced on unmodified develop;
  `yo check` passes it.
- `issues/rc-helper-always-inline-linkage-branch-never-fires.md` — the RC-helper
  `always_inline` linkage branch has never fired: it tests for `___drop`
  (triple underscore) while emitted names use `__yo_drop_`. Only 2
  `always_inline` occurrences exist in a 143 MB emission, both string literals.

Also documented a Yo semantics trap in the syntax cheatsheet: **`String`
out-parameters silently discard writes** (value type, lazily allocated buffer),
which dropped an entire emitter buffer and surfaced only as a far-downstream
`unknown type name`.

## Not in scope

Steps 3–5 (parallel per-chunk driver + sha256 `.o` cache, the LTO/cache
interaction, `build.yo` surface + CI gate). The plan also now records the
chunk-count policy — hash-of-name assignment rather than by-`.yo`-file, why
default-on is gated on four conditions, and the measured shared-header tax that
makes "N = 2× cores" something to measure rather than assume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
