### PR TITLE
driver: tie chunked-build ThinLTO to the optimization level (-O0 chunking is 3.3x faster and free)

### DIFF
--- a/issues/binding-a-unit-returning-call-emits-invalid-c.md
+++ b/issues/binding-a-unit-returning-call-emits-invalid-c.md
@@ -1,0 +1,74 @@
+# Binding a `unit`-returning call emits invalid C (`void x = ;`)
+
+**Status: OPEN (found 2026-08-23 while writing async-spawn probes; pre-existing).**
+
+## Symptom
+
+`name := <call returning unit>` type-checks (`yo check` passes) but emits C that
+does not compile:
+
+```
+error: variable has incomplete type 'void'
+ 1466 |   void _file____priv_temp_5685 = ;
+      |        ^
+error: expected expression
+ 1466 |   void _file____priv_temp_5685 = ;
+      |                                  ^
+```
+
+Two problems in one line: the declared C type is `void`, and the initializer is
+empty (the unit value emits nothing).
+
+## Minimal reproducer (verified failing on develop + PR #234)
+
+```rust
+{ println } :: import("std/fmt");
+{ String } :: import("std/string");
+_noop :: (fn(x : i32) -> unit)(
+  ()
+);
+main :: (fn() -> unit)({
+  _r := _noop(i32(1));
+  println(String.from("ok"));
+});
+export(main);
+```
+
+`yo check repro.yo` → OK. `yo compile repro.yo --release -o repro` → the two C
+errors above.
+
+Note the discard name (`_r`, or `_` / `___`) makes no difference — the binding
+is still emitted. Calling the function as a statement (`_noop(i32(1));`) is
+correct and compiles.
+
+## Why it is worth fixing
+
+The evaluator accepts a program the backend cannot emit, so the diagnostic
+surfaces as a raw C compiler error with a generated temp name and no source
+location. It is easy to hit by habit: `_x := f(...)` is the idiomatic way to
+discard a result in this codebase (it appears hundreds of times in `src/`), and
+it silently only works when `f` returns a non-unit value. Whether a call
+returns `unit` is not visible at the call site.
+
+## Fix directions
+
+1. **Codegen (smallest):** when the bound value's resolved type is `unit`, emit
+   the initializer expression as a STATEMENT and skip the declaration entirely
+   — the same treatment the unit-statement path already applies. The binding has
+   no readable value by definition, so nothing downstream can reference it.
+   (Guard on the resolved type, not the syntactic one: a `SomeT` that resolves
+   to unit must take the same path — compare the `result_is_unit` /
+   `resolve_some_type_to_concrete` handling in
+   `src/codegen/functions/generation.yo`.)
+2. **Evaluator (stricter):** reject `x := <unit>` with a real diagnostic
+   ("a unit-valued call has no value to bind; call it as a statement"). This is
+   a breaking change for any existing `_x := unit_call()` in the wild — grep
+   `src/` and `std/` before choosing it.
+
+(1) is the surgical fix and keeps existing code working.
+
+## Test to add with the fix
+
+A `tests/` case that binds a unit-returning call (plain fn, a method, and one
+whose `unit` comes from a resolved `SomeT`) and then runs — currently it fails
+to compile, so it is a valid red-first gate.

--- a/issues/io-spawn-in-loop-or-recursion-hangs.md
+++ b/issues/io-spawn-in-loop-or-recursion-hangs.md
@@ -1,0 +1,191 @@
+# `io.spawn` inside a loop or a recursive call hangs (spins at 100% CPU)
+
+**Status: OPEN (found 2026-08-23 while designing the parallel per-chunk C
+driver, `plans/CHUNKED_C_EMISSION.md` step 3 — this is the blocker for it).**
+
+## Symptom
+
+`io.spawn(task, io)` gives real concurrency when the spawn calls are UNROLLED
+in a function body, but the program **hangs forever, spinning at 100% CPU**,
+when the `io.async` + `io.spawn` pair is executed from inside a `while` loop
+body or from a recursive (`recur`) call. No output, no progress, no children
+started; `timeout` has to kill it (rc=124).
+
+`yo check` passes all of these, and so does codegen — the C compiles and links
+cleanly. The failure is purely at runtime.
+
+## Bisected: six variants, same task shape
+
+All variants spawn tasks that `io.await(sleep(500ms))` and then join them.
+`clang -O2`, macOS arm64, compiler at develop + PR #234.
+
+| # | shape | result |
+|---|---|---|
+| A | 2 tasks + 2 `io.spawn`, unrolled, directly in `main` | **works — 504 ms** (concurrent) |
+| C | as A, but the `JoinHandle.await` calls are in a `while` loop over `ArrayList(JoinHandle(u64))` | **works — 509 ms** |
+| E | as A, but moved into a helper `fn(io : Io) -> usize` (io as a plain parameter) | **works — 501 ms** |
+| F | a `while` loop in `main` that CALLS the variant-E helper twice | **works — 1013 ms** (2 waves) |
+| B | `io.async` + `io.spawn` INSIDE a `while` loop, handles pushed to an `ArrayList` | **HANGS** (killed at 30 s) |
+| D | `io.async` + `io.spawn` in a helper that ends with `recur(n - 1, …)` | **HANGS** (killed at 30 s) |
+
+So: awaiting handles in a loop is fine, collecting handles in an `ArrayList` is
+fine, and spawning from a plain-`io`-parameter helper is fine. The trigger is
+specifically **creating/spawning a task from a loop body or a recursive call**.
+
+## Minimal reproducer (variant B — hangs)
+
+```rust
+{ String } :: import("std/string");
+{ println } :: import("std/fmt");
+{ ArrayList } :: import("std/collections/array_list");
+sleep_mod :: import("std/sys/timer");
+
+main :: (fn(io : Io) -> unit)({
+  handles := ArrayList(JoinHandle(u64)).new();
+  (i : usize) = usize(0);
+  while(i < usize(4), {
+    task := io.async((io : Io) => {
+      _a := io.await(sleep_mod.sleep(u64(500)), io);
+      u64(1)
+    });
+    handles.push(io.spawn(task, io));
+    i = (i + usize(1));
+  });
+  (done : usize) = usize(0);
+  (j : usize) = usize(0);
+  while(j < handles.len(), {
+    match(handles.get(j), .Some(h) => match(h.await(io), .Some(_v) => { done = (done + usize(1)); }, .None => ()), .None => ());
+    j = (j + usize(1));
+  });
+  println(`done=${done.to_string()}/4`);
+});
+export(main);
+```
+
+Control (variant A, same file structure without the loop) completes in ~504 ms.
+
+## Why it matters
+
+Any "fan out N concurrent tasks" loop — the natural way to write a worker pool,
+a parallel download, or a parallel compile driver — deadlocks. The pattern is
+idiomatic and the failure mode is the worst kind: silent, total, and invisible
+to `yo check` and to codegen.
+
+It currently blocks `plans/CHUNKED_C_EMISSION.md` step 3 (spawn one `cc -c` per
+chunk), where N is dynamic by construction.
+
+## Workaround (verified, variant F)
+
+Put the unrolled spawns in a helper function and loop over WAVES of that
+helper — the loop then contains only a plain call, no `io.async`/`io.spawn`:
+
+```rust
+_wave :: (fn(a : String, b : String, io : Io, exn : Exception) -> usize)({
+  t1 := io.async((io : Io) => { /* … a … */ u64(1) });
+  t2 := io.async((io : Io) => { /* … b … */ u64(1) });
+  h1 := io.spawn(t1, io);
+  h2 := io.spawn(t2, io);
+  /* await both */
+});
+// caller: while(more_waves, { total = (total + _wave(x, y, io, exn)); … });
+```
+
+This bounds the concurrency window to the unrolled arity, which for a job
+scheduler is acceptable (it is the `--jobs` cap anyway) but it is not a fix.
+
+## ROOT CAUSE (confirmed at the C level, not a guess)
+
+**A `JoinHandle` stores a BORROWED raw pointer to the task future and takes no
+reference, so the handle dangles as soon as the future's owning local goes out
+of scope. A loop body is a scope; a function body is not.**
+
+The spawn lowering (`src/codegen/exprs/generation.yo:324-363`,
+`_generate_io_spawn`) ends with
+
+```rust
+.Some(jh) => `(${jh}){ .__future = (void*)${spawn_var.clone()} }`,
+```
+
+— its own comment calls the handle a "non-owning view". The only `__yo_incr_rc`
+it emits (`:354`) is inside the cold-start branch and represents the
+RUNNING/scheduled task, not the handle. `JoinHandle.await`
+(`src/codegen/exprs/await.yo:715-753`) then reads `handle.__future`, polls
+`header->state` in a `while (__jh_state != -1 && __jh_state != -2)` loop
+calling `__yo_async_poll_step()`, and never touches the refcount either.
+
+So the refcount history of a spawned future is:
+
+| step | RC |
+|---|---|
+| `io.async(...)` creates it, bound to a local | 1 |
+| `io.spawn` cold-starts it (`:354` incr) | 2 |
+| enclosing SCOPE ends -> local's drop | 1 |
+| task completes -> runtime releases the running ref | **0 -> freed** |
+| `JoinHandle.await` dereferences `handle.__future` | use-after-free |
+
+In the UNROLLED variants the local's drop is at FUNCTION end, i.e. after the
+awaits, so RC never reaches 0 while a handle is live. In the loop variant the
+drop is emitted at the end of each ITERATION — the emitted C is literally
+
+```c
+while (true) {
+  ...
+  { // begin block (loop body)
+  _file____priv_temp_6446_state_t* task = __yo_new__file____priv_temp_6446(...);
+  // io.spawn — start cold Future, return JoinHandle
+  ...
+  push(handles, (__yo_t3){ .__future = (void*)__spawn_future_... });
+  if (task != NULL) { __yo_decr_rc((void*)task); };   // <-- kills the handle
+  } // end begin block (loop body)
+}
+```
+
+so every handle in `handles` points at a future that will be freed on
+completion. The await then polls freed memory forever — which is exactly the
+observed 100% CPU spin. Recursion (variant D) hangs for the same reason: each
+frame's local is dropped when that frame returns, before the caller awaits.
+
+**Proof:** deleting that single `__yo_decr_rc((void*)task)` line from the
+emitted C of the hanging variant B and recompiling makes it pass —
+`done=4/4 in 507ms`, fully concurrent. Nothing else changed.
+
+This also means the current design carries an undocumented aliasing invariant:
+*the future's owning binding must outlive every `JoinHandle.await` on it.*
+Nothing checks it.
+
+## Fix directions
+
+The complete fix is to make `JoinHandle(T)` an OWNING handle: `__yo_incr_rc` the
+future when constructing the handle, and release it when the handle dies. That
+needs the handle's RC treatment wired up (its `__future` field is a bare
+`void*`, so dup/drop/dispose do not know it owns anything) — the same
+dup/drop/dispose plumbing every other RC-carrying type gets.
+
+Two smaller changes are each a strict safety improvement but LEAK one reference
+per spawned task (a future SM struct), so neither is a complete answer:
+
+1. incr at handle construction with no matching release — turns the UAF into a
+   leak. Careful: adding a release inside `JoinHandle.await` instead would
+   reintroduce a UAF for a handle awaited twice.
+2. mark `io.spawn`'s argument as CONSUMED in the evaluator so the local's
+   scope-end drop is never emitted (ownership moves into the runtime) — same
+   leak, but it removes the drop rather than adding an incr.
+
+Note this is NOT a port error: the lowering is a faithful port of the TS
+`generateFuncCall` io.spawn block (generation.ts:702), so the TS compiler has
+the same gap.
+
+## Where to look
+
+`src/codegen/exprs/generation.yo:324-363` (`_generate_io_spawn`),
+`src/codegen/exprs/await.yo:665-755` (`generate_join_handle_await`), and the
+scope-end drop emission in `src/codegen/exprs/drop_dup.yo` /
+`_optimize_dup_drop_pairs` in `src/evaluator/exprs/begin.yo` for the consumed
+route.
+
+## Test to add with the fix
+
+`tests/async_await.test.yo`: a spawn-in-loop test (4 tasks, assert all four
+complete and the elapsed time is closer to one task's duration than to four).
+**Do not add it before the fix** — a hanging test would hang the whole suite
+and CI, since the runner has no per-test timeout.

--- a/plans/CHUNKED_C_EMISSION.md
+++ b/plans/CHUNKED_C_EMISSION.md
@@ -296,10 +296,11 @@ Measured (interleaved, `check ./src`, 262/262 on every run):
 | **chunked N=4 + ThinLTO** | **87.41 s** | **-2.9% (faster)** |
 | chunked N=4, no LTO | 102.81 s | +14.2% |
 
-So the design decision changes: **`--emit-chunks` now implies `-flto=thin`**
-(`--no-chunk-lto` opts out, wasm excluded). It is not a tuning knob — without
-it a chunked-built compiler runs 14% slower, which cancels the build-time win
-the campaign exists for. Interestingly the LTO binary is still 23 MB / 6,821
+So the design decision changes: **a chunked build at `-O1`+ gets `-flto=thin`
+automatically** (`--no-chunk-lto` opts out, wasm excluded; at `-O0` it is
+skipped — see the `-O0` measurement under step 3). It is not a tuning knob at
+`-O2` — without it a chunked-built compiler runs 14% slower, which cancels the
+build-time win the campaign exists for. Interestingly the LTO binary is still 23 MB / 6,821
 symbols, i.e. ThinLTO buys the speed through inlining rather than by shrinking
 the image.
 
@@ -366,11 +367,26 @@ Measure the cached-rebuild path before adding any of them.
    - **Without LTO the picture inverts**: a cached no-change rebuild is a
      0.1 s link. That is only usable if the 14.2% runtime penalty does not
      matter — which is exactly the case at `-O0`, where there is no
-     cross-module inlining to lose in the first place. HYPOTHESIS TO MEASURE at
-     step 4: chunking at `-O0` (the default, non-`--release` build) is pure win
-     — full parallelism, near-free cached rebuilds, no runtime cost — and LTO
-     should be tied to `-O2`+ rather than to `--emit-chunks`. If that holds,
-     the default-on decision gets much easier for dev builds.
+     cross-module inlining to lose in the first place.
+
+   **`-O0` measured, hypothesis CONFIRMED (2026-08-23):** at `-O0` clang
+   neither inlines nor dead-strips, so externalizing every function costs
+   almost nothing there:
+
+   | `-O0` build | C phase | runtime (`check ./std`, 154/154) | defined symbols |
+   |---|---|---|---|
+   | single-file | 18.25 s | 40.73 s | 6,848 |
+   | chunked, 4 parallel | **5.49 s (3.3x)** | **40.23 s (identical)** | 7,693 (+12%) |
+
+   Contrast the `-O2` symbol blow-up (3,493 -> 7,201, i.e. 2.1x): at `-O0` the
+   single-file build cannot dead-strip either, so the gap is only 12%. So
+   **LTO tracks the OPTIMIZATION LEVEL, not the chunk flag** — implemented as
+   `chunk_lto_wanted` in `run_compile`, mirroring the `-O` selection exactly.
+   At `-O0` a chunked build now skips the thin-link entirely and is 3.3x
+   faster with no runtime cost; at `-O1`+ it gets `-flto=thin` and is
+   perf-neutral. This also materially changes the default-on calculus for dev
+   builds: `-O0` chunking is a pure win, and with a `.o` cache the no-change
+   rebuild is a 0.13 s link.
 
    **BLOCKER, found while prototyping the fan-out:** `io.spawn` inside a
    `while` loop or a recursive call hangs (spins at 100% CPU) — the JoinHandle

--- a/plans/CHUNKED_C_EMISSION.md
+++ b/plans/CHUNKED_C_EMISSION.md
@@ -345,6 +345,42 @@ Measure the cached-rebuild path before adding any of them.
    - full `tests/` green on the chunked binary — pending the perf gate.
 3. **Parallel driver + `.o` cache**. Gate: N=16 C-phase ≤ ~20 s; touch-nothing
    rebuild = 100% cache hits; corrupt `.o` falls back.
+
+   **Measured up front (2026-08-23, N=4, 10-core M4), so the driver is built
+   against numbers rather than hopes:**
+
+   | configuration | compile | link | total | binary runtime |
+   |---|---|---|---|---|
+   | single-file (today's default) | — | — | 72.3 s | baseline |
+   | chunked, ONE clang call + LTO (what the driver does after step 2) | — | — | 65.8 s | −2.9% |
+   | chunked, 4 parallel `cc -c` + LTO link | 11.5 s | 24.8 s | **36.2 s** | −2.9% |
+   | chunked, 4 parallel `cc -c`, no LTO | 26.3 s | 0.1 s | **26.4 s** | +14.2% |
+
+   Two consequences for the design:
+   - **The link becomes the bottleneck under LTO** (24.8 s of 36.2 s), and it
+     is not cacheable — it re-runs on every build. So a `.o` cache saves at
+     most the 11.5 s compile, putting the cached-rebuild floor at ~25 s. Raising
+     N past ~4 mostly does not help either; the thin-link/backend phase already
+     parallelizes internally (~1.9x). The cache is still worth having, but
+     "N=16 C-phase ≤ 20 s" is unreachable WITH LTO and should be restated.
+   - **Without LTO the picture inverts**: a cached no-change rebuild is a
+     0.1 s link. That is only usable if the 14.2% runtime penalty does not
+     matter — which is exactly the case at `-O0`, where there is no
+     cross-module inlining to lose in the first place. HYPOTHESIS TO MEASURE at
+     step 4: chunking at `-O0` (the default, non-`--release` build) is pure win
+     — full parallelism, near-free cached rebuilds, no runtime cost — and LTO
+     should be tied to `-O2`+ rather than to `--emit-chunks`. If that holds,
+     the default-on decision gets much easier for dev builds.
+
+   **BLOCKER, found while prototyping the fan-out:** `io.spawn` inside a
+   `while` loop or a recursive call hangs (spins at 100% CPU) — the JoinHandle
+   holds a borrowed pointer and the loop body's scope-end drop frees the future
+   under it. Root-caused at the C level and filed as
+   `issues/io-spawn-in-loop-or-recursion-hangs.md`. A verified workaround
+   exists (unrolled spawns inside a helper fn, and loop over WAVES of that
+   helper — measured 2 waves x 500 ms concurrent = 1013 ms), which also bounds
+   the job window the way `--jobs` would anyway. Either fix the bug first or
+   build the driver on the wave pattern.
 4. **Perf validation + LTO experiment** (3 configs). Gate: runtime within
    ~5% of baseline.
 5. **build.yo surface + CI gate**: `Executable.emit_chunks`, a behavioral

--- a/src/main.yo
+++ b/src/main.yo
@@ -1598,18 +1598,24 @@ run_compile :: (
       cmd.arg(String.from("-O0"));
     }
   );
-  // Chunked emission implies ThinLTO, and this is NOT an optional tuning knob
-  // (plans/CHUNKED_C_EMISSION.md). Splitting the program into N translation
-  // units externalizes every generated function, so the C compiler can no
-  // longer internalize or dead-strip them: MEASURED on an N=4 self-build, the
-  // binary went 9 MB / 3.5k symbols -> 24 MB / 7.2k symbols and ran 14.2%
-  // SLOWER on `check ./src` (102.8s vs 90.0s). With `-flto=thin` the linker
-  // recovers the cross-module inlining and the same build runs 87.4s —
-  // slightly FASTER than single-file. A chunked compiler that runs 14% slower
-  // would cancel the build-time win it exists for, so the flag rides along
-  // with `--emit-chunks` unless explicitly disabled. Not for wasm: emcc's LTO
-  // story is separate and chunked wasm builds are out of scope.
-  if((emit_chunks >= usize(1)) && (!(chunk_no_lto) && !(is_target_wasm(target))), {
+  // Chunked emission needs ThinLTO **at -O1 and above**, and there it is NOT an
+  // optional tuning knob (plans/CHUNKED_C_EMISSION.md). Splitting the program
+  // into N translation units externalizes every generated function, so an
+  // optimizing build can no longer internalize or dead-strip them: MEASURED on
+  // an N=4 self-build at -O2, the binary went 9 MB / 3.5k symbols -> 24 MB /
+  // 7.2k symbols and ran 14.2% SLOWER on `check ./src` (102.8s vs 90.0s).
+  // `-flto=thin` gives the linker back the cross-module inlining and the same
+  // build runs 87.4s — slightly FASTER than single-file.
+  //
+  // At -O0 the opposite is true: clang neither inlines nor dead-strips there,
+  // so externalization costs nothing (MEASURED: +12% symbols, and `check ./std`
+  // 40.2s chunked vs 40.7s single-file — identical) while the parallel C phase
+  // is 3.3x faster (5.5s vs 18.2s). Paying for a thin-link at -O0 would spend
+  // that win on nothing, so LTO tracks the OPTIMIZATION LEVEL rather than the
+  // chunk flag. The condition mirrors the -O selection above exactly.
+  // Not for wasm: emcc's LTO story is separate and chunked wasm is out of scope.
+  chunk_lto_wanted := (((optimize == "") && release) || ((optimize != "") && (optimize != "0")));
+  if((emit_chunks >= usize(1)) && (chunk_lto_wanted && (!(chunk_no_lto) && !(is_target_wasm(target)))), {
     cmd.arg(String.from("-flto=thin"));
   });
   if(debug_symbols, {


### PR DESCRIPTION
Follow-up to #234, driven by one measurement that inverts the LTO decision at
`-O0`.

#234 made `--emit-chunks` imply `-flto=thin` unconditionally, because at `-O2`
splitting into N translation units externalizes every generated function and
the C compiler can then neither internalize nor dead-strip them — the binary
went 9 MB / 3,493 symbols → 24 MB / 7,201 symbols and ran **14.2% slower**.
ThinLTO gives the cross-module inlining back and makes it 2.9% *faster* than
single-file, so at `-O2` it is not optional.

**At `-O0` the opposite holds, and it is worth a lot.** clang neither inlines
nor dead-strips there, so the single-file build cannot strip the unused statics
either — the externalization costs almost nothing:

| `-O0` build | C phase | runtime (`check ./std`, 154/154 both) | defined symbols |
|---|---|---|---|
| single-file | 18.25 s | 40.73 s | 6,848 |
| chunked, 4 parallel | **5.49 s (3.3×)** | **40.23 s (identical)** | 7,693 (+12%) |

Compare the `-O2` symbol blow-up of 2.1× against +12% here. Paying for a
thin-link at `-O0` would spend a 3.3× parallel-compile win on nothing, so
`chunk_lto_wanted` now mirrors the `-O` selection exactly: `-O1`+ gets
`-flto=thin`, `-O0` skips it. Verified on both paths (chunked `-O0` and chunked
`--release` each build and run).

This also materially changes the default-on calculus recorded in the plan: at
`-O0` — the default, non-`--release` build — chunking is a pure win, and with
step 3's `.o` cache a no-change rebuild becomes a 0.13 s link.

## Also documented (no behaviour change)

**`issues/io-spawn-in-loop-or-recursion-hangs.md`** — found while prototyping
step 3's parallel fan-out, then root-caused at the C level. `io.spawn` inside a
`while` loop or a recursive call hangs, spinning at 100% CPU. Bisected across
six variants: unrolled spawn, await-in-loop, `ArrayList` of handles, spawn from
a helper fn, and a wave loop all **work**; spawn-in-loop and spawn-in-recursion
**hang**. The cause is that a `JoinHandle` stores a *borrowed* pointer to the
task future and takes no reference, so the loop body's scope-end drop frees the
future under every handle already collected — the refcount reaches 0 when the
task completes and the await then polls freed memory forever. Proof: deleting
the single `__yo_decr_rc(task)` line from the emitted C makes the hanging case
pass, 4/4 concurrent in 507 ms. The complete fix needs `JoinHandle` to own its
future (dup/drop plumbing on what is currently a bare `void*` field); the two
smaller changes both convert the UAF into a leak, which would trip the existing
LSan gates. Not a port error — the TS lowering has the same gap. This is the
blocker for step 3, and it has a verified workaround (unrolled spawns in a
helper, loop over waves of that helper).

**`issues/binding-a-unit-returning-call-emits-invalid-c.md`** — `x := f()`
where `f` returns `unit` emits `void x = ;`. Nine-line repro; `yo check`
accepts it.

**Plan updates** — step 3 is now measured up front rather than designed on
hope: single-file 72.3 s, chunked+one-clang+LTO 65.8 s, 4-parallel+LTO 36.2 s
(11.5 s compile + 24.8 s link), 4-parallel no-LTO 26.4 s. Two consequences
recorded: under LTO the *link* is the bottleneck and is not cacheable, so a
`.o` cache saves at most the 11.5 s compile and the plan's "N=16 C-phase ≤ 20 s"
gate is unreachable with LTO; and raising N past ~4 mostly does not help
because the thin-link/backend phase already parallelizes internally (~1.9×).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
