### PR TITLE
std S1 (chunk 5): ToString for C-interop integers, longdouble, and containers

### DIFF
--- a/issues/inout-unit-receiver-void-ref-spill.md
+++ b/issues/inout-unit-receiver-void-ref-spill.md
@@ -1,0 +1,34 @@
+# Calling an `inout(self)` method on a `unit` value emits an invalid C ref-spill
+
+**Status: OPEN.** Found 2026-08-24 implementing D3.8 (`ToString` for `unit`,
+branch s1-tostring — the impl is DEFERRED because of this).
+
+## Symptom
+
+With `impl(unit, ToString(to_string : (fn(inout(self) : Self) -> String)(...)))`:
+
+```rust
+u := ();
+u.to_string();
+```
+
+emits
+
+```c
+void __yo_ref_spill_61 = ;
+```
+
+("variable has incomplete type 'void'" + "expected expression").
+
+## Root cause
+
+`_apply_ref_amp` (src/codegen/exprs/other_fn_call.yo) spills a
+non-addressable ref argument to a typed temp; for a unit receiver the C
+type renders as `void` and the value expression is empty. Unit-typed
+inout/ref parameters need to be elided (or handed a dummy) at both the
+call site and the callee signature.
+
+## Repro
+
+tmp/fixme scale: the two lines above with the unit ToString impl restored
+(see the s1-tostring branch history).

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -186,6 +186,18 @@ deferred, each needing new machinery: `collect`/`FromIterator`
 D3.5 Range iteration). Tests: 10 new cases in
 tests/iterator_combinators.test.yo (28/28).
 
+**Progress (S1 chunk 5, 2026-08-24, branch s1-tostring, stacked on
+chunk 3):** D3.8 ToString completion — the eight C-interop integers
+(`int`/`uint`/`short`/`ushort`/`long`/`ulong`/`longlong`/`ulonglong`) plus
+`longdouble` (`%Lg`), and containers: `ArrayList(T)`/`Array(T, N)` print as
+`[a, b, c]` where `T <: ToString` (nests through Option/Result's chunk-2
+impls), so `println(list)` compiles. `to_string.yo` now imports ArrayList
+(no cycle — array_list does not import fmt). DEFERRED: `unit` — an
+`inout(self)` receiver of type unit emits an invalid C ref-spill
+(`void __yo_ref_spill_N = ;`,
+issues/inout-unit-receiver-void-ref-spill.md). Tests: 2 new cases in
+tests/fmt.test.yo (5/5).
+
 1. **`Default`** trait + derive. Unblocks `unwrap_or_default`, map `or_default`.
 2. **`From(T)` / `Into(T)`** (the prelude header already *claims* they exist).
 3. **`Ordering` wired in**: `Ord` gains `cmp(self, rhs) -> Ordering` (default

--- a/std/fmt/to_string.yo
+++ b/std/fmt/to_string.yo
@@ -2,6 +2,7 @@
 pragma(Pragma.AllowUnsafe);
 { String, rune } :: import("../string");
 { snprintf } :: import("../libc/stdio");
+{ ArrayList } :: import("../collections/array_list");
 /// Trait for converting values to their `String` representation.
 /// Types implementing this trait can be used with `println`, `print`, and template strings.
 ToString :: trait(
@@ -153,6 +154,107 @@ impl(
     })
   )
 );
+// === C-interop Integer Implementations (plans/STD_API_AUDIT.md D3.8) ===
+impl(
+  int,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _INT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      unsafe(snprintf(*(char)(buffer_ptr), _INT_BUFFER_SIZE, "%d", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
+impl(
+  uint,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _INT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      unsafe(snprintf(*(char)(buffer_ptr), _INT_BUFFER_SIZE, "%u", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
+impl(
+  short,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _INT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      unsafe(snprintf(*(char)(buffer_ptr), _INT_BUFFER_SIZE, "%hd", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
+impl(
+  ushort,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _INT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      unsafe(snprintf(*(char)(buffer_ptr), _INT_BUFFER_SIZE, "%hu", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
+impl(
+  long,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _INT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      unsafe(snprintf(*(char)(buffer_ptr), _INT_BUFFER_SIZE, "%ld", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
+impl(
+  ulong,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _INT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      unsafe(snprintf(*(char)(buffer_ptr), _INT_BUFFER_SIZE, "%lu", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
+impl(
+  longlong,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _INT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      unsafe(snprintf(*(char)(buffer_ptr), _INT_BUFFER_SIZE, "%lld", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
+impl(
+  ulonglong,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _INT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      unsafe(snprintf(*(char)(buffer_ptr), _INT_BUFFER_SIZE, "%llu", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
+impl(
+  longdouble,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      buffer := Array(u8, _FLOAT_BUFFER_SIZE).fill(0);
+      buffer_ptr := (&(buffer(0)));
+      // Use %Lg for general format (removes trailing zeros)
+      unsafe(snprintf(*(char)(buffer_ptr), _FLOAT_BUFFER_SIZE, "%Lg", self));
+      String.from_cstr(buffer_ptr).unwrap()
+    })
+  )
+);
 // === Boolean Implementation ===
 impl(
   bool,
@@ -281,7 +383,54 @@ impl(
     )
   )
 );
-// TODO: Array to_string implementation?
+// === Container Implementations (plans/STD_API_AUDIT.md D3.8) ===
+/// `ArrayList(T)` prints as `[a, b, c]`, so `println(list)` compiles.
+impl(
+  generic(T : Type),
+  where(T <: ToString),
+  ArrayList(T),
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      (out : String) = `[`;
+      (i : usize) = usize(0);
+      n := self.len();
+      while(i < n, {
+        cond(
+          (i > usize(0)) => {
+            out = `${out}, `;
+          },
+          true => ()
+        );
+        out = `${out}${self(i)}`;
+        i = (i + usize(1));
+      });
+      `${out}]`
+    })
+  )
+);
+/// `Array(T, N)` prints as `[a, b, c]`.
+impl(
+  generic(T : Type, N : usize),
+  where(T <: ToString),
+  Array(T, N),
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      (out : String) = `[`;
+      (i : usize) = usize(0);
+      while(i < N, {
+        cond(
+          (i > usize(0)) => {
+            out = `${out}, `;
+          },
+          true => ()
+        );
+        out = `${out}${self(i)}`;
+        i = (i + usize(1));
+      });
+      `${out}]`
+    })
+  )
+);
 // --- derive_rule for ToString ---
 // Local helpers (not exported from prelude, so defined locally)
 __ts_s2 :: (fn(comptime(a) : comptime_str, comptime(b) : comptime_str) -> comptime(comptime_str))(a + b);

--- a/tests/fmt.test.yo
+++ b/tests/fmt.test.yo
@@ -103,3 +103,32 @@ test("Test template strings", {
   assert(escaped7 == "${a} and ${b} with 42".to_string());
   println("All template string tests passed!");
 });
+test("C-interop integers, longdouble, and unit stringify (D3.8)", {
+  assert(int(42).to_string() == `42`, "int");
+  assert(uint(7).to_string() == `7`, "uint");
+  assert(short(-3).to_string() == `-3`, "short");
+  assert(ushort(9).to_string() == `9`, "ushort");
+  assert(long(-100).to_string() == `-100`, "long");
+  assert(ulong(100).to_string() == `100`, "ulong");
+  assert(longlong(-5).to_string() == `-5`, "longlong");
+  assert(ulonglong(5).to_string() == `5`, "ulonglong");
+  assert(longdouble(1.5).to_string() == `1.5`, "longdouble");
+  // unit's ToString is DEFERRED: an inout(self) receiver of type unit emits
+  // an invalid C ref-spill (issues/inout-unit-receiver-void-ref-spill.md).
+});
+test("ArrayList and Array stringify as bracketed lists (D3.8)", {
+  { ArrayList } :: import("std/collections/array_list");
+  list := ArrayList(i32).new();
+  assert(list.to_string() == `[]`, "empty list");
+  list.push(i32(1));
+  list.push(i32(2));
+  list.push(i32(3));
+  assert(list.to_string() == `[1, 2, 3]`, "three elements");
+  assert(`${list}` == `[1, 2, 3]`, "interpolates in templates");
+  arr := Array(u8, usize(3)).fill(7);
+  assert(arr.to_string() == `[7, 7, 7]`, "array fill");
+  nested := ArrayList(Option(i32)).new();
+  nested.push(Option(i32).Some(i32(4)));
+  nested.push(Option(i32).None);
+  assert(nested.to_string() == `[Some(4), None]`, "nests through Option's ToString");
+});


### PR DESCRIPTION
Stacked on #242 (s1-iterators). Fifth S1 chunk of plans/STD_API_AUDIT.md — D3.8, the ToString completion.

## What

- **C-interop integers**: `int`/`uint`/`short`/`ushort`/`long`/`ulong`/`longlong`/`ulonglong` via snprintf (`%d`/`%u`/`%hd`/`%hu`/`%ld`/`%lu`/`%lld`/`%llu`), plus `longdouble` via `%Lg` — every numeric type now prints.
- **Containers**: `ArrayList(T)` and `Array(T, N)` print as `[a, b, c]` where `T <: ToString`, nesting through Option/Result's chunk-2 impls — `println(list)` compiles. `to_string.yo` imports ArrayList (no cycle: array_list does not import fmt).
- **Deferred**: `unit` — calling an `inout(self)` method on a unit value emits an invalid C ref-spill (`void __yo_ref_spill_N = ;`); filed as issues/inout-unit-receiver-void-ref-spill.md.

## Validation (local, aarch64-macos, full battery on this exact stack)

- `yo check ./std` 154/154, `yo check ./src` 262/262
- Full language suite under this stage-1: **2847/2847** (fmt 5/5, 2 new cases)
- gates_fast: **failures=0**; no golden drift (fmt-only change)
- **FIXPOINT_HOLDS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)