### PR TITLE
ci: shard budget patch — S1 prelude growth tripled self-emit memory (10→29 GB)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1225,7 +1225,12 @@ jobs:
     # the ruleset's required check changed from the single name to the four
     # shard names in the same change — the swap must land in the ruleset
     # BEFORE this merges (see the issue's ordering trap).
-    timeout-minutes: 120
+    # BUDGET PATCH 2026-08-24 (was 120): the S1 prelude growth tripled
+    # self-emit peak memory (10 -> 29 GB), so the seed stage-1 build swap-
+    # thrashes on these 16 GB runners (12.8 -> 60.5 min measured) and the
+    # heavy files slow proportionally. REVERT to 120 when the env-sharing
+    # root fix lands — issues/std-s1-prelude-growth-tripled-self-emit-memory.md.
+    timeout-minutes: 210
     strategy:
       fail-fast: false
       matrix:
@@ -1313,7 +1318,10 @@ jobs:
           failed=""
           for f in $files; do
             echo "::group::$f"
-            if /tmp/yo-stage1 test "$f" --parallel 1 --verbose; then
+            # --compile-timeout-ms 1800000: the default 600 s evaluator
+            # deadline trips on the heavy files while the runner swaps (same
+            # budget patch as timeout-minutes above; revert together).
+            if /tmp/yo-stage1 test "$f" --parallel 1 --verbose --compile-timeout-ms 1800000; then
               echo "::endgroup::"
             else
               echo "::endgroup::"

--- a/issues/std-s1-prelude-growth-tripled-self-emit-memory.md
+++ b/issues/std-s1-prelude-growth-tripled-self-emit-memory.md
@@ -1,0 +1,55 @@
+# S1 prelude growth TRIPLED self-emit peak memory (10 → 29 GB) — 16 GB CI runners swap-thrash, differential shards time out
+
+**Status: OPEN (mitigated in CI; root fix is the env-sharing campaign).**
+Found 2026-08-24 when PR #243's differential shards died at the 120-min
+budget even UNCONTENDED, after the S1 chunks merged. This is the
+`plans/backlog/YO_SELF_ENV_SHARING.md` pathology hitting its predicted
+wall: def-time body envs COPY what TS shared, so every prelude
+fn/impl/method added costs a copy of an ever-BIGGER prelude frame —
+super-linear growth in both memory and time.
+
+## Measurements (seed v0.2.16, `yo compile src/main.yo --release
+--skip-c-compiler`, macOS M4; "peak" = `/usr/bin/time -l` peak memory
+footprint — see the footprint-metric memory note for why not RSS)
+
+| tree | wall | peak footprint |
+|---|---|---|
+| 644bf2120 (pre-#238, last green shards) | 67 s | 10.0 GB |
+| 7a1a24bb7 (+ S0 #238, chunk 1 #240, chunk 2 #241) | 138 s | 17.4 GB |
+| 9c31ec0f0 (+ chunk 3 #242, #239) | 390 s | 29.2 GB |
+
+Cumulative — no single culprit PR. The evaluator-only path is UNCHANGED
+(`yo check tests/internal/ast_reflection.test.yo`: 60 s old vs 57 s new) —
+`check` never evaluates fn bodies, so it never pays the def-eval copies;
+full compile does.
+
+## CI impact
+
+- The 4 differential shards (16 GB ubuntu runners + 32 G swapfile): the
+  seed stage-1 `yo build` went 12.8 min (green, 2026-08-23) → **60.5 min**
+  (swap thrash), and the heavy internal files then trip the test-runner's
+  DEFAULT 600 s `--compile-timeout-ms` (ast_reflection, build_runner —
+  "Yo compilation exceeded the configured time limit"), so shards fail or
+  hit `timeout-minutes: 120`. Every required shard check on develop is
+  currently un-passable. (The first #243 failures looked like the known
+  two-matrices starvation; the uncontended rerun disproved that.)
+- The other stage-1-building jobs (fixpoint, tier-1 gates, hollow sweep,
+  musl bundle) run 1.2–2 h but pass — bigger budgets, no per-file deadline.
+
+## Mitigation (this change)
+
+`test.yml` differential-shard job: `timeout-minutes` 120 → 210 and
+`--compile-timeout-ms 1800000` on the per-file test invocation. This is a
+BUDGET patch, not a fix — shard wall time is ~2–2.5 h until the root
+lands, and every future prelude addition makes it worse. REVERT both knobs
+when the env-sharing fix lands.
+
+## Root fix
+
+`plans/backlog/YO_SELF_ENV_SHARING.md` — the ranked levers for sharing
+def-time body envs instead of copying (frozen frame membership is the
+prerequisite, see the campaign memory notes). The S1/S2 std campaign is
+BLOCKED-ish on it: chunk 4 (ranges, +570 prelude lines) and chunk 6
+(IntoIterator) are validated locally and will push the peak further; S3+
+additions compound it. Sequence the env-sharing work BEFORE landing more
+prelude surface.


### PR DESCRIPTION
The S0+S1 std merges cumulatively tripled self-emit peak memory (measured 10.0 → 17.4 → 29.2 GB across the merge points; bisect table in `issues/std-s1-prelude-growth-tripled-self-emit-memory.md`). The 16 GB differential-shard runners now swap-thrash: the seed stage-1 build went 12.8 → 60.5 min and the heavy internal files trip the default 600 s evaluator deadline — so all four required shard checks are un-passable on develop (proven by an uncontended rerun of #243's shards; not runner starvation).

This is the minimal unblock: `timeout-minutes` 120 → 210 and `--compile-timeout-ms 1800000` on the shard test invocations, both marked REVERT-when-root-fix-lands. The root fix is the env-sharing campaign (`plans/backlog/YO_SELF_ENV_SHARING.md`), which now gates further prelude growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)