### PR TITLE
evaluator: revert the [bind-T] probe enrichment (5 debug lines cost +11.7 GB seed-compile memory)

### DIFF
--- a/issues/debug-probe-line-costs-gigabytes-at-compile-time.md
+++ b/issues/debug-probe-line-costs-gigabytes-at-compile-time.md
@@ -1,0 +1,74 @@
+# A 5-line debug-probe enrichment in synthesizer.yo cost +11.7 GB / +2.9x wall of SEED-compile memory — compile-time, with the probe never firing
+
+**Status: OPEN (the probe is reverted; the underlying compile-cost mechanism
+is the open part).** Found 2026-08-24 root-causing what was first
+misdiagnosed as "S1 std growth hit a memory wall"
+(issues/std-s1-prelude-growth-tripled-self-emit-memory.md — superseded by
+this doc's finding).
+
+## The numbers (seed v0.2.16, `yo compile src/main.yo --release
+--skip-c-compiler`, peak = `/usr/bin/time -l` peak memory footprint)
+
+2×2 over #242's two src files on the develop tree (full S1 std content):
+
+| impl.yo (cell-chain fix) | synthesizer.yo (probe enrichment) | wall | peak |
+|---|---|---|---|
+| old | old | 140 s | 17.5 GB |
+| NEW | old | 140 s | **17.5 GB** |
+| old | NEW | 410 s | 29.1 GB |
+| NEW | NEW | 390-402 s | 29.1 GB |
+
+So the #242 cell-chain fix is FREE, and the ENTIRE regression is the
+`[bind-T]` probe enrichment in `_bind_some_type`
+(src/evaluator/types/synthesizer.yo) — a block gated behind
+`YO_DEBUG_BIND`, which is UNSET in every one of these runs. The cost is
+paid COMPILING the probe, not running it. Line-level split:
+
+- `slot_str := match(old_var.value.get(usize(0)), .Some(ovv) =>
+  value_to_string(ovv), .None => String.from("-"));`
+  → **+8.7 GB, +220 s** on its own.
+- The remaining enrichment (gate conjunct removal + `slot_id=${…}
+  src_id=${…} selfm=${….to_string()}` template refs) → **+3.0 GB, +45 s**.
+
+For scale: the whole S0+S1 std campaign (5 merged PRs, ~1,000 added prelude
+lines) costs +0.4 GB total (17.1 → 17.5). One probe line cost 22× the
+entire campaign.
+
+## Why this went to CI as a "memory wall"
+
+The 16 GB differential-shard runners swap-thrashed under the 29 GB peak
+(stage-1 build 12.8 → 60.5 min), heavy internal files then tripped the
+600 s evaluator deadline, and all four required shard checks became
+un-passable. The budget patch (#244: shard timeout 210 min +
+`--compile-timeout-ms 1800000`) papered over it — REVERT #244's knobs once
+this revert is on develop and shard times are re-verified normal.
+
+Measurement trap that delayed the diagnosis: an early baseline ran in a
+worktree WITHOUT `vendor/` submodules initialized (the known fresh-worktree
+trap), reading 10.0 GB and manufacturing a phantom "S0 tripled memory"
+jump. All apples-to-apples (with-vendor) numbers: pre-#238 17.1 GB,
+post-S1 17.5 GB.
+
+## Open question — the actual mechanism
+
+Why does compiling ONE gated statement cost gigabytes? The block sits in
+`_bind_some_type`, whose body the seed def-time-evaluates and specializes
+during the self-emit. Suspects, unverified: (a) def-eval descent into
+`value_to_string(<unknown EvalValue>)` from a NEW binding shape exploding
+the trial/specialization graph a generation deeper (the old probe already
+called `value_to_string(val)` on a parameter, which was cheap — the
+difference may be the Option-unwrap match producing a fresh unknown
+lineage); (b) per-interpolation costs in the template string (each extra
+`${…}` measurably GBs). Distill a minimal repro (a gated eprintln with a
+match-unwrapped unknown fed to a large recursive formatter, in a
+module-level fn), attribute with the live census
+(scripts/bootstrap/live_census.py), and fix the underlying evaluator
+behavior — probes must be O(probe size) to compile.
+
+## Rule of thumb until the mechanism is fixed
+
+Debug probes in HOT evaluator files: keep interpolations few and feed them
+PARAMETERS or precomputed strings, not match-unwrapped values routed
+through big recursive formatters. Measure the self-emit peak
+(`/usr/bin/time -l`, with vendor initialized!) before landing any probe in
+src/evaluator/.

--- a/issues/std-s1-prelude-growth-tripled-self-emit-memory.md
+++ b/issues/std-s1-prelude-growth-tripled-self-emit-memory.md
@@ -1,55 +1,25 @@
-# S1 prelude growth TRIPLED self-emit peak memory (10 → 29 GB) — 16 GB CI runners swap-thrash, differential shards time out
+# ~~S1 prelude growth tripled self-emit memory~~ — SUPERSEDED: the regression was a debug-probe line, NOT std growth
 
-**Status: OPEN (mitigated in CI; root fix is the env-sharing campaign).**
-Found 2026-08-24 when PR #243's differential shards died at the 120-min
-budget even UNCONTENDED, after the S1 chunks merged. This is the
-`plans/backlog/YO_SELF_ENV_SHARING.md` pathology hitting its predicted
-wall: def-time body envs COPY what TS shared, so every prelude
-fn/impl/method added costs a copy of an ever-BIGGER prelude frame —
-super-linear growth in both memory and time.
+**Status: SUPERSEDED 2026-08-24 (same day)** by
+issues/debug-probe-line-costs-gigabytes-at-compile-time.md.
 
-## Measurements (seed v0.2.16, `yo compile src/main.yo --release
---skip-c-compiler`, macOS M4; "peak" = `/usr/bin/time -l` peak memory
-footprint — see the footprint-metric memory note for why not RSS)
+The bisect this doc originally recorded was CONFOUNDED twice:
 
-| tree | wall | peak footprint |
-|---|---|---|
-| 644bf2120 (pre-#238, last green shards) | 67 s | 10.0 GB |
-| 7a1a24bb7 (+ S0 #238, chunk 1 #240, chunk 2 #241) | 138 s | 17.4 GB |
-| 9c31ec0f0 (+ chunk 3 #242, #239) | 390 s | 29.2 GB |
+1. The 10.0 GB "pre-#238 baseline" was measured in a worktree with EMPTY
+   `vendor/` submodules (the fresh-worktree trap) — the true with-vendor
+   baseline is **17.1 GB**, so the "S0/chunk-1 jump" never existed.
+2. The real +11.7 GB / +2.9x wall jump came from #242's 5-line `[bind-T]`
+   DEBUG-PROBE enrichment in src/evaluator/types/synthesizer.yo — a
+   compile-time cost of the probe's own code (it never fires), proven by a
+   2x2 over #242's two src files. The S0+S1 std campaign in its entirety
+   costs +0.4 GB (17.1 -> 17.5 GB).
 
-Cumulative — no single culprit PR. The evaluator-only path is UNCHANGED
-(`yo check tests/internal/ast_reflection.test.yo`: 60 s old vs 57 s new) —
-`check` never evaluates fn bodies, so it never pays the def-eval copies;
-full compile does.
+Consequences carried forward:
 
-## CI impact
-
-- The 4 differential shards (16 GB ubuntu runners + 32 G swapfile): the
-  seed stage-1 `yo build` went 12.8 min (green, 2026-08-23) → **60.5 min**
-  (swap thrash), and the heavy internal files then trip the test-runner's
-  DEFAULT 600 s `--compile-timeout-ms` (ast_reflection, build_runner —
-  "Yo compilation exceeded the configured time limit"), so shards fail or
-  hit `timeout-minutes: 120`. Every required shard check on develop is
-  currently un-passable. (The first #243 failures looked like the known
-  two-matrices starvation; the uncontended rerun disproved that.)
-- The other stage-1-building jobs (fixpoint, tier-1 gates, hollow sweep,
-  musl bundle) run 1.2–2 h but pass — bigger budgets, no per-file deadline.
-
-## Mitigation (this change)
-
-`test.yml` differential-shard job: `timeout-minutes` 120 → 210 and
-`--compile-timeout-ms 1800000` on the per-file test invocation. This is a
-BUDGET patch, not a fix — shard wall time is ~2–2.5 h until the root
-lands, and every future prelude addition makes it worse. REVERT both knobs
-when the env-sharing fix lands.
-
-## Root fix
-
-`plans/backlog/YO_SELF_ENV_SHARING.md` — the ranked levers for sharing
-def-time body envs instead of copying (frozen frame membership is the
-prerequisite, see the campaign memory notes). The S1/S2 std campaign is
-BLOCKED-ish on it: chunk 4 (ranges, +570 prelude lines) and chunk 6
-(IntoIterator) are validated locally and will push the peak further; S3+
-additions compound it. Sequence the env-sharing work BEFORE landing more
-prelude surface.
+- The probe revert restores normal CI shard times; **revert #244's budget
+  patch** (shard `timeout-minutes` 210 -> 120, drop
+  `--compile-timeout-ms 1800000`) once verified.
+- std growth is NOT gated on the env-sharing campaign after all — that
+  campaign remains a real (pre-existing) improvement track, not a blocker.
+- The measurement discipline lives in the superseding issue: always init
+  vendor/ submodules and use peak footprint on with-vendor trees.

--- a/src/evaluator/types/synthesizer.yo
+++ b/src/evaluator/types/synthesizer.yo
@@ -347,11 +347,10 @@ _bind_some_type :: (
         return(());
       });
       bind_probe_name := match(synth_dbg_env.get(`YO_DEBUG_BIND`), .Some(bpn) => bpn, .None => String.from(""));
-      if((bind_probe_name.len() > usize(0)) && (name == bind_probe_name), {
+      if(((bind_probe_name.len() > usize(0)) && (name == bind_probe_name)) && !(val_is_self_marker), {
         wrote_lvl := if(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))), env.frames.len() - usize(1), old_var.frame_level);
         wrote_fid := match(env.frames.get(wrote_lvl), .Some(wf) => wf.id, .None => usize(0));
-        slot_str := match(old_var.value.get(usize(0)), .Some(ovv) => value_to_string(ovv), .None => String.from("-"));
-        eprintln(`[bind-T] val=${value_to_string(val)} slot=${slot_str} slot_id=${found_slot_someid} src_id=${source_some_id} selfm=${val_is_self_marker.to_string()} slot_lvl=${old_var.frame_level.to_string()} top=${(env.frames.len() - usize(1)).to_string()} wrote_lvl=${wrote_lvl.to_string()} fid=${wrote_fid.to_string()} inplace=${(!(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))))).to_string()}`);
+        eprintln(`[bind-T] val=${value_to_string(val)} slot_lvl=${old_var.frame_level.to_string()} top=${(env.frames.len() - usize(1)).to_string()} wrote_lvl=${wrote_lvl.to_string()} fid=${wrote_fid.to_string()} inplace=${(!(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))))).to_string()}`);
       });
       if(identity_mismatch || ((env.frames.len() > usize(0)) && (old_var.frame_level != (env.frames.len() - usize(1)))), {
         add_variable_to_env(


### PR DESCRIPTION
The differential-shard collapse was NOT std growth: a 2×2 over #242's two src files pins the entire +11.7 GB / +2.9× wall self-emit regression on the `[bind-T]` debug-probe enrichment in `synthesizer.yo` — pure compile-time cost, probe never fires (`YO_DEBUG_BIND` unset). The chunk-3 cell-chain fix is free, and the whole S0+S1 std campaign costs +0.4 GB (17.1 → 17.5 GB with-vendor baselines).

Measured on the fix branch: **141 s / 17.47 GB** (develop: 390-410 s / 29.1 GB). Records: `issues/debug-probe-line-costs-gigabytes-at-compile-time.md` (open mechanism investigation) and the superseded-in-place memory-wall issue. Follow-up after CI confirms normal shard times: revert #244's budget knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)