### PR TITLE
ci: revert the shard budget patch — obsolete after #245, and its yo-test flag was invalid

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1225,12 +1225,7 @@ jobs:
     # the ruleset's required check changed from the single name to the four
     # shard names in the same change — the swap must land in the ruleset
     # BEFORE this merges (see the issue's ordering trap).
-    # BUDGET PATCH 2026-08-24 (was 120): the S1 prelude growth tripled
-    # self-emit peak memory (10 -> 29 GB), so the seed stage-1 build swap-
-    # thrashes on these 16 GB runners (12.8 -> 60.5 min measured) and the
-    # heavy files slow proportionally. REVERT to 120 when the env-sharing
-    # root fix lands — issues/std-s1-prelude-growth-tripled-self-emit-memory.md.
-    timeout-minutes: 210
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -1318,10 +1313,7 @@ jobs:
           failed=""
           for f in $files; do
             echo "::group::$f"
-            # --compile-timeout-ms 1800000: the default 600 s evaluator
-            # deadline trips on the heavy files while the runner swaps (same
-            # budget patch as timeout-minutes above; revert together).
-            if /tmp/yo-stage1 test "$f" --parallel 1 --verbose --compile-timeout-ms 1800000; then
+            if /tmp/yo-stage1 test "$f" --parallel 1 --verbose; then
               echo "::endgroup::"
             else
               echo "::endgroup::"

--- a/issues/debug-probe-line-costs-gigabytes-at-compile-time.md
+++ b/issues/debug-probe-line-costs-gigabytes-at-compile-time.md
@@ -39,9 +39,12 @@ entire campaign.
 The 16 GB differential-shard runners swap-thrashed under the 29 GB peak
 (stage-1 build 12.8 → 60.5 min), heavy internal files then tripped the
 600 s evaluator deadline, and all four required shard checks became
-un-passable. The budget patch (#244: shard timeout 210 min +
-`--compile-timeout-ms 1800000`) papered over it — REVERT #244's knobs once
-this revert is on develop and shard times are re-verified normal.
+un-passable. The budget patch (#244) papered over it and was REVERTED right after the
+probe fix: the probe fix restored fast builds (shard build back to minutes
+on the first post-fix run), and #244's `--compile-timeout-ms` flag was
+INVALID anyway — `yo test` has no such option (the 600 s deadline is
+hardcoded on the runner's CHILD compile, src/main.yo ~2506), so every
+shard file failed instantly on 'unknown option'.
 
 Measurement trap that delayed the diagnosis: an early baseline ran in a
 worktree WITHOUT `vendor/` submodules initialized (the known fresh-worktree

--- a/issues/std-s1-prelude-growth-tripled-self-emit-memory.md
+++ b/issues/std-s1-prelude-growth-tripled-self-emit-memory.md
@@ -16,9 +16,9 @@ The bisect this doc originally recorded was CONFOUNDED twice:
 
 Consequences carried forward:
 
-- The probe revert restores normal CI shard times; **revert #244's budget
-  patch** (shard `timeout-minutes` 210 -> 120, drop
-  `--compile-timeout-ms 1800000`) once verified.
+- The probe revert restores normal CI shard times; #244's budget patch is
+  REVERTED (and its `--compile-timeout-ms` flag was invalid for `yo test` —
+  it broke every shard file with 'unknown option').
 - std growth is NOT gated on the env-sharing campaign after all — that
   campaign remains a real (pre-existing) improvement track, not a blocker.
 - The measurement discipline lives in the superseding issue: always init


### PR DESCRIPTION
Full revert of #244: the probe fix (#245) restored fast shard builds, and #244's `--compile-timeout-ms` was never a `yo test` option (the 600 s deadline is hardcoded on the runner's child compile) — every shard file failed instantly with 'unknown option', which is what failed #243's post-fix run. Restores the exact pre-#244 job text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)