### PR TITLE
codegen: GC traversal must not delegate to a trace spec the function emitter skips

### DIFF
--- a/issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md
+++ b/issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md
@@ -1,7 +1,15 @@
 # where-bound IntoIterator generics: a prior instantiation leaves a later one's GC trace calls ABSTRACT-keyed — C compile fails on undeclared trace fn
 
-**Status: OPEN.** Found 2026-08-24 implementing S1 D3.6 (IntoIterator trait
-impls on every collection, branch `s1-intoiter`). Third face of the
+**Status: FIXED 2026-08-24 (the C-compile symptom; branch
+`fix/where-bound-gc-trace`) — the era-copy family root stays OPEN via the
+sibling issues below.** `get_trace_function_for_type`
+(src/codegen/exprs/drop_dup.yo) now refuses to delegate GC traversal to a
+trace spec that `should_skip_function_codegen` will never emit; the phantom
+era-copy identities (zero construction sites, verified in the emitted C)
+fall back to the inert field-walk. Red-first regression test:
+tests/where_clause_fn_inference.test.yo (user-defined IntoIterator-shaped
+trait, independent of the D3.6 std impls). Found 2026-08-24 implementing S1
+D3.6 (IntoIterator trait impls on every collection, branch `s1-intoiter`). Third face of the
 under-resolution family: same root class as
 issues/iterator-chain-shared-stamp-cross-item-pollution.md (face 2) and the
 flat_map residual in issues/varbound-combinator-receiver-impl-match.md

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -230,11 +230,14 @@ and all 394 collections tests are unaffected. DEFERRED: a blanket
 IntoIterator TRAIT impl for every Iterator (so ranges/combinator chains
 satisfy the bound too) — needs assoc-of-assoc (`Item := I.Item`) in a
 blanket impl; the inherent blanket `into_iter` still serves the `for`
-macro. FOUND (pre-existing, OPEN — third face of the under-resolution
+macro. FOUND (pre-existing — third face of the under-resolution
 family): piling several instantiations of one where-bound generic leaves a
 later instantiation's GC trace calls abstract-keyed → C compile failure;
-minimal trigger LinkedList-then-BTreeMap,
-issues/where-bound-intoiterator-gc-trace-abstract-key.md. Tests: 1 new case
+minimal trigger LinkedList-then-BTreeMap. The C-compile symptom is FIXED
+(branch fix/where-bound-gc-trace: traverse emission no longer delegates to
+a never-emitted hard-generic trace spec;
+issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md) — the
+era-copy family root stays open via the flat_map/shared-stamp issues. Tests: 1 new case
 in tests/iterator_combinators.test.yo (33/33), scoped away from the
 landmine with a pointer at the issue.
 

--- a/src/codegen/exprs/drop_dup.yo
+++ b/src/codegen/exprs/drop_dup.yo
@@ -28,6 +28,7 @@ open(import("std/string"));
 { random_id, is_temp_variable_name } :: import("../../utils.yo");
 { MethodEntry, get_type_trait_methods_by_name, type_id_or_empty } :: import("../../evaluator/values/type_trait_methods.yo");
 { FunctionGenerationContext } :: import("../functions/context.yo");
+{ should_skip_function_codegen } :: import("../functions/declarations.yo");
 { _call_generate_expr } :: import("./_expr.yo");
 { get_type_string, get_variable_type_string, get_variable_name_for_codegen, get_deferred_drop_target_atom_name, get_deferred_dup_target_atom_name, is_deferred_drop_for_closure_capture, get_enum_variant_c_name, sanitize_for_c_identifier, can_optimize_as_nullable_pointer, get_runtime_struct_fields, type_key } :: import("../utils/index.yo");
 { resolve_enum_shell, resolve_struct_shell } :: import("../../types/creators.yo");
@@ -105,7 +106,20 @@ get_trace_function_for_type :: (fn(type : TypeValue, context : FunctionGeneratio
         v,
         .FuncVal(__fvd2, _) => match(
           context.base.get_function_entry(__fvd2.*.func_id),
-          .Some(e) => Option(String).Some(e.c_name),
+          // A registry hit whose spec the function emitter SKIPS (hard-generic
+          // — its signature still carries unresolvable SomeTs) must not be
+          // delegated to: the traverse would call a never-emitted C name
+          // ("call to undeclared function ...", raw SomeT ids in the mangled
+          // name). This state is reached by ERA-COPY type identities minted
+          // during failed where-bound generic-impl trials (never constructed
+          // at runtime — the field-walk fallback is inert for them); the
+          // trials themselves are the open under-resolution family,
+          // issues/where-bound-intoiterator-gc-trace-abstract-key.md.
+          .Some(e) => cond(
+            should_skip_function_codegen(__fvd2.*.func_id, e.c_name.clone(), v, context.base) =>
+              Option(String).None,
+            true => Option(String).Some(e.c_name)
+          ),
           .None => Option(String).None
         ),
         _ => Option(String).None

--- a/src/codegen/exprs/drop_dup.yo
+++ b/src/codegen/exprs/drop_dup.yo
@@ -114,7 +114,7 @@ get_trace_function_for_type :: (fn(type : TypeValue, context : FunctionGeneratio
           // during failed where-bound generic-impl trials (never constructed
           // at runtime — the field-walk fallback is inert for them); the
           // trials themselves are the open under-resolution family,
-          // issues/where-bound-intoiterator-gc-trace-abstract-key.md.
+          // issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md.
           .Some(e) => cond(
             should_skip_function_codegen(__fvd2.*.func_id, e.c_name.clone(), v, context.base) =>
               Option(String).None,

--- a/tests/iterator_combinators.test.yo
+++ b/tests/iterator_combinators.test.yo
@@ -379,7 +379,7 @@ test("every integer type forms and iterates a range", {
 // NOTE: kept to single instantiations + a small combo — piling many
 // instantiations of ONE where-bound generic trips the pre-existing
 // under-resolution bug (LinkedList-then-BTreeMap is the minimal trigger):
-// issues/where-bound-intoiterator-gc-trace-abstract-key.md.
+// issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md.
 __ii_sum :: (
   fn(generic(C : Type), c : C, where(C <: IntoIterator(Item := i32))) -> i32
 )(

--- a/tests/where_clause_fn_inference.test.yo
+++ b/tests/where_clause_fn_inference.test.yo
@@ -67,3 +67,56 @@ test("where-clause inference with bool callback return type", {
     .Some(v) => assert(false, "should not produce a value")
   );
 });
+// --- where-bound generic over two collections: GC trace must not go
+// abstract-keyed (issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md).
+// A user IntoIterator-shaped trait (assoc Item/IntoIter + a where-clause tying
+// them) implemented on LinkedList and BTreeMap; instantiating one where-bound
+// generic at LinkedList and then a second at BTreeMap minted ERA-COPY
+// ArrayList(BTreeEntry(K',V')) identities from the failed impl-match trials,
+// whose GC traverse delegated to a never-emitted hard-generic trace spec —
+// "call to undeclared function yo_id_..._<raw SomeT ids>_..." at C compile.
+{ LinkedList, LinkedListIter } :: import("std/collections/linked_list");
+{ BTreeMap, BTreeMapIter, BTreeEntry } :: import("std/collections/btree_map");
+__WbInto :: trait(
+  Item : Type,
+  IntoIter : Type,
+  wb_into : (fn(self : Self) -> Self.IntoIter),
+  where(Self.IntoIter <: Iterator(Item := Self.Item))
+);
+impl(
+  generic(T : Type),
+  LinkedList(T),
+  __WbInto(
+    Item : T,
+    IntoIter : LinkedListIter(T),
+    wb_into : (fn(self : Self) -> LinkedListIter(T))(self.into_iter())
+  )
+);
+impl(
+  generic(K : Type, V : Type),
+  BTreeMap(K, V),
+  __WbInto(
+    Item : BTreeEntry(K, V),
+    IntoIter : BTreeMapIter(K, V),
+    wb_into : (fn(self : Self) -> BTreeMapIter(K, V))(self.into_iter())
+  )
+);
+__wb_sum :: (
+  fn(generic(C : Type), c : C, where(C <: __WbInto(Item := i32))) -> i32
+)(
+  c.wb_into().fold(i32(0), (acc, x) => (acc + x))
+);
+__wb_count :: (
+  fn(generic(C : Type), c : C, where(C <: __WbInto)) -> usize
+)(
+  c.wb_into().count()
+);
+test("where-bound generic over LinkedList then BTreeMap compiles and runs", {
+  ll := LinkedList(i32).new();
+  ll.push_back(i32(10));
+  ll.push_back(i32(20));
+  assert(__wb_sum(ll) == i32(30), "LinkedList through the Item-bound generic");
+  bt := BTreeMap(i32, i32).new();
+  bt.set(i32(1), i32(10));
+  assert(__wb_count(bt) == usize(1), "BTreeMap through the bare bound");
+});


### PR DESCRIPTION
Fixes the C-compile symptom of the where-bound under-resolution family's third face (`issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md`): instantiating one `where(C <: IntoIterator)`-shaped generic at LinkedList and then BTreeMap minted ERA-COPY `ArrayList(BTreeEntry(K',V'))` identities from the failed impl-match trials, whose GC traverse delegated to a hard-generic trace spec codegen never emits — "call to undeclared function yo_id_…_<raw SomeT ids>_…".

`get_trace_function_for_type` now gates the delegation on `should_skip_function_codegen` (the emitter's single source of truth); a skipped spec falls back to the field-walk traversal, inert for these phantom identities (zero construction sites, verified in the emitted C). The era-copy family root stays OPEN via the flat_map/shared-stamp issues.

Red-first regression test in `tests/where_clause_fn_inference.test.yo` with a user-defined IntoIterator-shaped trait (independent of the D3.6 std impls): 3 implicit-function-declaration C errors before, 3/3 green after.

Validation: full battery (check 154+262, suite 2852/2852, cli-diff 51/0/0, tier-1 gates clean, FIXPOINT_HOLDS) + post-#248-rebase revalidation (scorecard 51/0/0, where 3/3, iterator 33/33, collections 394/394).

🤖 Generated with [Claude Code](https://claude.com/claude-code)