### PR TITLE
issues: two findings from the D3.4 collect prototype

### DIFF
--- a/issues/comptime-type-argument-alone-does-not-bind-the-generic.md
+++ b/issues/comptime-type-argument-alone-does-not-bind-the-generic.md
@@ -1,0 +1,99 @@
+# A generic bound ONLY by an explicit `comptime(C) : Type` argument leaves the call result under-resolved
+
+**Status:** OPEN
+**Found:** 2026-08-24, prototyping `collect` for STD_API_AUDIT D3.4.
+**Severity:** high for std design — this is the "trait-generic-method
+prototyping" gap the audit named as the reason `collect`/`FromIterator` was
+deferred. It blocks every "pass the target type, get a value of it back" API:
+`collect(C)`, a `parse(T)`, a `zeroed(T)`.
+
+## Symptom
+
+When a function's type parameter is pinned **only** by the explicit comptime
+type argument — no value argument has that type — the call's *result* is
+under-resolved. Method calls on the result then fail to resolve, and if the
+result is discarded the evaluator accepts the call but codegen emits
+"Failed to transpile part of main's body".
+
+An explicit type annotation on the binding does **not** repair it.
+
+## Measured matrix
+
+All four compiled with the same binary, 2026-08-24
+(`yo compile <f> --release`; reproducer: `issues/repros/comptime-type-arg-binding.yo`):
+
+| shape | result |
+| --- | --- |
+| `pick :: (fn(comptime(C) : Type, v : C) -> C)(v)` | ✅ works — C is also pinned by a value argument |
+| `a := (i32 <: Default).default()` (concrete type) | ✅ works — explicit trait dispatch is fine |
+| `dflt2 :: (fn(comptime(C) : Type, hint : C, where(C <: Default)) -> C)((C <: Default).default())` | ✅ works — adding *any* value parameter of type C fixes it |
+| `dflt :: (fn(comptime(C) : Type, where(C <: Default)) -> C)((C <: Default).default())` | ❌ **fails** |
+
+The failing call:
+
+```rust
+dflt :: (fn(comptime(C) : Type, where(C <: Default)) -> C)((C <: Default).default());
+main :: (fn() -> unit)({
+  (a : i32) = dflt(i32);
+  println(a.to_string());     // Error: No matching call found with arguments: (a.to_string)()
+});
+```
+
+and with the result discarded:
+
+```rust
+main :: (fn() -> unit)({
+  dflt(i32);                  // evaluator accepts …
+  println(`ok`);              // … but codegen: "Failed to transpile part of main's body"
+});
+```
+
+## Reading
+
+The working/failing contrast says the type binding for `C` is populated by
+**unifying value arguments against parameter types**, and not by the explicit
+comptime `Type` argument itself — even though the caller wrote `i32` in the call.
+The body can use `C` (the call is accepted), so `C` reaches the callee's
+environment as a *value* binding; what is missing is the *type* binding that the
+declared return type `-> C` and the call-site result stamp consult.
+
+Two consequences worth noting for whoever fixes it:
+
+- the binding annotation `(a : i32) = dflt(i32);` does not stamp `a` as `i32` —
+  the annotated binding adopts the RHS's (unresolved) type, which is itself
+  worth checking.
+- the failure is silent-ish at eval time and only becomes loud in codegen when
+  the value is used, which is the same late-failure signature as the
+  under-resolution family (`issues/varbound-combinator-receiver-impl-match.md`,
+  `issues/iterator-chain-shared-stamp-cross-item-pollution.md`) — but the
+  trigger here is much simpler and reproduces in three lines, so it may be a
+  distinct, more tractable bug.
+
+## Why it matters for std
+
+`collect` cannot be expressed without it. The natural shape is
+
+```rust
+collect : (
+  fn(
+    generic(A : Type),
+    self : Self,
+    comptime(C) : Type,
+    where(Self <: Iterator(Item := A), C <: Default, C <: Extend(A := A))
+  ) -> C
+)( … )
+```
+
+which is exactly the failing shape: `C` is pinned only by the type argument.
+Two shapes were ruled out on the way:
+
+- `FromIterator(A)` with a *generic trait method*
+  (`from_iter : (fn(generic(I : Type), it : I, where(I <: Iterator(Item := Self.A))) -> Self)`)
+  fails earlier, at the bound check itself.
+- The same `collect` written as a free function fails the `I <: Iterator(Item := A)`
+  bound; as a blanket method on `I <: Iterator` the receiver bound resolves fine,
+  which is the shape to keep once this bug is fixed.
+
+Until then, `collect` would have to be a family of concrete methods
+(`collect_list`, `collect_set`, …), which the audit's §1 stability contract makes
+an expensive thing to ship and later replace.

--- a/issues/repros/comptime-type-arg-binding.yo
+++ b/issues/repros/comptime-type-arg-binding.yo
@@ -1,0 +1,29 @@
+// Reproducer for
+// issues/comptime-type-argument-alone-does-not-bind-the-generic.md
+//
+//   yo compile issues/repros/comptime-type-arg-binding.yo --release -o /tmp/x
+//
+// Expected today: fails with
+//   Error: No matching call found with arguments: (a.to_string)()
+// Expected after the fix: prints "0" then "5" then "0".
+open(import("std/string"));
+open(import("std/fmt"));
+// ❌ THE BUG — C is pinned only by the explicit comptime type argument.
+dflt :: (fn(comptime(C) : Type, where(C <: Default)) -> C)((C <: Default).default());
+// ✅ works — C is also pinned by the value parameter `v`.
+pick :: (fn(comptime(C) : Type, v : C) -> C)(v);
+// ✅ works — same as `dflt` plus a dummy value parameter of type C.
+dflt2 :: (fn(comptime(C) : Type, hint : C, where(C <: Default)) -> C)(
+  (C <: Default).default()
+);
+main :: (fn() -> unit)({
+  // ✅ explicit trait dispatch at a concrete type is fine.
+  z := (i32 <: Default).default();
+  println(z.to_string());
+  println(pick(i32, i32(5)).to_string());
+  println(dflt2(i32, i32(0)).to_string());
+  // ❌ the failing line.
+  (a : i32) = dflt(i32);
+  println(a.to_string());
+});
+export(main);

--- a/issues/std-path-exemptions-are-lexical-so-tmp-symlink-breaks-them.md
+++ b/issues/std-path-exemptions-are-lexical-so-tmp-symlink-breaks-them.md
@@ -1,0 +1,63 @@
+# A symlinked `YO_STD` (e.g. macOS `/tmp`) silently loses the std pragma exemptions
+
+**Status:** OPEN
+**Found:** 2026-08-24, running a scratch battery with `YO_STD=/tmp/yo-unitfix/std`.
+**Severity:** low, but the error message points nowhere near the cause.
+
+## Symptom
+
+With a std tree under a symlinked directory, std's own macro-defining modules
+are rejected as if they were user code:
+
+```
+$ YO_STD=/tmp/yo-unitfix/std yo test ./tests/collections.test.yo
+… macro definition is not allowed here …   (std/collections/hash_map.yo, hash_set.yo)
+```
+
+The same command with `YO_STD=/private/tmp/yo-unitfix/std` — the *same
+directory*, spelled through the resolved path — works.
+
+On macOS `/tmp` is a symlink to `/private/tmp`, so this is easy to hit any time
+a std tree lives in a temp directory (scratch worktrees, CI sandboxes, bootstrap
+staging).
+
+## Root cause
+
+`is_macro_def_capable_file` (src/evaluator/memory_safety.yo:153) grants std files
+an exemption by comparing the module path against the std root as a **lexical**
+string prefix, via `_lex_abs_path` (same file, :136), which explicitly does no
+symlink resolution:
+
+```
+/// Purely lexical — no symlink resolution — matching how the loaders build
+/// std module URIs (a join on the same std root).
+```
+
+That assumption holds only when both sides come from the same spelling. They do
+not: the std root keeps whatever spelling `--std-path`/`YO_STD` was given
+(`/tmp/...`), while a relative module path is absolutized against `cwd()`, which
+returns the **resolved** path (`/private/tmp/...`). The prefix test then fails
+and the file falls through to `file_has_pragma(..., Pragma.AllowMacroDef)`,
+which std files cannot yet carry (the exemption exists precisely because the
+pragma is seed-gated — see plans/MACRO_POLICY.md Part 2).
+
+`is_implicitly_unsafe_capable_file` in the same file shares `_lex_abs_path` and
+therefore the same hazard.
+
+## Fix options
+
+1. Canonicalize the std root once at startup (resolve symlinks when the path is
+   taken from `--std-path`/`YO_STD`), so both sides are in resolved form. This is
+   the smallest change and matches what `cwd()` already returns.
+2. Resolve both sides in `_lex_abs_path`. More robust, but it makes a per-check
+   syscall unless memoized, and the comment above it deliberately avoids that.
+3. Leave the mechanism alone and make the diagnostic say so: when a macro-def or
+   unsafe rejection fires for a file whose *resolved* path is under the resolved
+   std root but whose lexical path is not, report the std-root spelling mismatch.
+
+Option 1 plus the option-3 message is probably the right pair.
+
+## Workaround
+
+Spell `YO_STD` (and `--std-path`) with the resolved path — `/private/tmp/...`
+rather than `/tmp/...` on macOS.


### PR DESCRIPTION
Documentation only — two bugs found while prototyping `collect` for the std audit's D3.4.

### 1. A generic bound ONLY by an explicit `comptime(C) : Type` argument leaves the call result under-resolved

This is the "trait-generic-method prototyping" gap the audit named as the reason
`collect`/`FromIterator` was deferred, now with a three-line reproducer
(`issues/repros/comptime-type-arg-binding.yo`):

| shape | result |
| --- | --- |
| `fn(comptime(C) : Type, v : C) -> C` | works — C also pinned by a value argument |
| `fn(comptime(C) : Type, hint : C, where(C <: Default)) -> C` | works — any value param of type C fixes it |
| `(i32 <: Default).default()` at a concrete type | works |
| `fn(comptime(C) : Type, where(C <: Default)) -> C` | **fails** — result under-resolved |

An explicit annotation on the binding does not rescue it; with the result discarded the
evaluator accepts the call and codegen reports "Failed to transpile part of main's body".
The contrast says the type binding is seeded only by unifying *value* arguments against
parameter types, never by the explicit comptime type argument.

Two `collect` shapes were ruled out on the way and are recorded in the issue: a
`FromIterator(A)` with a generic trait method (fails at the bound check), and `collect` as a
free function (fails the `I <: Iterator(Item := A)` bound — the blanket-method form on
`I <: Iterator` is the one to keep once this is fixed).

### 2. A symlinked `YO_STD` silently loses std's pragma exemptions

`is_macro_def_capable_file` compares module paths against the std root **lexically**, while a
relative module path is absolutized against `cwd()` — which resolves symlinks. On macOS
`/tmp` is a symlink to `/private/tmp`, so `YO_STD=/tmp/…/std` makes std's own macro-defining
modules get rejected as user code. `is_overload_set_capable_file` shares the helper and the
hazard. Three fix options are listed; the workaround is to spell the resolved path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)