### PR TITLE
codegen: spell `unit` as a one-byte placeholder in C storage positions (D3.8 complete)

### DIFF
--- a/issues/fixed/unit-typed-params-and-fields-emit-c-void.md
+++ b/issues/fixed/unit-typed-params-and-fields-emit-c-void.md
@@ -1,7 +1,33 @@
 # `unit` in parameter or field position is emitted as C `void`
 
-**Status:** OPEN
+**Status: FIXED 2026-08-24** (branch `codegen/unit-storage-byte`).
 **Found:** 2026-08-24, while completing STD_API_AUDIT D3.8 (`ToString` for `unit`).
+
+## The fix
+
+C has no zero-sized object type, so a type whose C spelling is exactly `void` is
+now spelled as a **one-byte placeholder** in every STORAGE position — parameter,
+struct/tuple field, cast target — via `get_storage_type_string`
+(`src/codegen/utils/index.yo`), and the matching empty argument slot is filled
+with `0`. Return position keeps `get_type_string`, where `void` is legal, and
+pointer types spell `void*` rather than `void`, so both are untouched.
+
+The guard therefore fires **only where today's output is already invalid C**
+(`void x`, `void f(void x)`, `void b;`), which is what makes the change
+fixpoint-neutral by construction: the emitted C for every program that compiles
+today is unchanged. Verified — 8 representative corpus files re-emitted after the
+change, all 8 byte-identical (sha256), and the bootstrap fixpoint holds.
+
+Field COUNT and ORDER are preserved rather than erasing unit fields, so struct
+layouts, both constructor parameter lists, and the compound literal all stay
+aligned; a missed site keeps failing loudly at the C compiler instead of
+silently desynchronizing an ABI.
+
+Every shape in the boundary table below now compiles and runs, including
+`println(())`, `ArrayList(unit)` and `HashMap(String, unit)`. Regression test:
+`tests/unit_as_value_type.test.yo`. Remaining deliberately-unfixed shapes are in
+issues/unit-zst-residual-gaps.md.
+
 **Severity:** medium — `unit` is not usable as a value type argument, so
 `ArrayList(unit)`, `HashMap(K, unit)`, tuples containing `unit`, and any
 function taking a `unit` parameter fail at the C compiler.

--- a/issues/unit-zst-residual-gaps.md
+++ b/issues/unit-zst-residual-gaps.md
@@ -1,0 +1,53 @@
+# `unit` as a value type — the shapes still not covered
+
+**Status:** OPEN (deliberate scope boundary, not regressions)
+**Context:** follow-up to issues/fixed/unit-typed-params-and-fields-emit-c-void.md,
+which made `unit` work in parameter, field, tuple and generic-container positions
+by spelling storage positions with a one-byte placeholder
+(`get_storage_type_string`).
+
+Everything below fails **today exactly as it failed before** that change. Each is
+the same one-line recipe — route the site through `get_storage_type_string`
+instead of `get_type_string`, and fill the matching empty argument slot — but
+each needs its own reproducer and test, so they were left out rather than
+changed blind.
+
+## Not covered
+
+| shape | site |
+| --- | --- |
+| `[unit; N]` array element | `src/codegen/types/generation.yo` (array struct declaration) |
+| a `unit` member of a `union` | `src/codegen/types/generation.yo` (union declaration) |
+| `dyn` interface vtable fn-pointer parameters and non-function members | `src/codegen/types/generation.yo`, `src/codegen/functions/dyn.yo` |
+| a module-level `unit` global | module-variable emission |
+| a `unit` local that crosses an `io.await` (async state-machine slot) | `src/codegen/async/` |
+| a `unit` parameter of `main` | `src/codegen/functions/generation.yo` (`_main_call_args` emits `(void){0}`) |
+| parallelism spawn zero-initialization | `src/codegen/parallelism/` |
+
+## Two pre-existing defects surfaced while mapping this
+
+1. **`is_void_type` never matches `.Unit`.** `src/types/guards.yo` defines
+   `is_void_type` (guards.yo:411) to match only `.Void`, while `is_unit_type`
+   (guards.yo:120) matches only `.Unit`. `src/codegen/functions/dyn.yo:483` passes
+   `is_void_type(result)` to the
+   dyn wrapper emitter, so a **unit-returning `dyn` impl method** emits
+   `return impl(...);` inside a C `void` wrapper.
+
+2. **`unit` is zero bits, so `ArrayList(unit)` allocates zero bytes.**
+   `get_size_of_type(.Unit)` is 0 (`src/types/utils.yo:1537`; alignment is 1, :1434), so an
+   `ArrayList(unit)` mallocs `0 * capacity`. It works on macOS/Linux because
+   `malloc(0)` returns a unique non-NULL pointer, but on a platform where
+   `malloc(0)` is NULL, `push` would return `.Err(AllocError.OutOfMemory)`.
+   The unit-store guards in `src/codegen/exprs/assignment.yo` are what keep a
+   one-byte write out of that zero-byte block — **do not remove them**. If a real
+   unit store is ever needed, raise the size to 8 bits first, and note that this
+   is a user-visible change to the `size_of` builtin's comptime value.
+
+## Also worth doing
+
+`is_unit_type` does not walk the SomeT resolution chain while `get_type_string`
+does, so a generic whose type argument RESOLVES to unit is invisible to every
+`is_unit_type` guard in codegen. Four sites in `src/codegen/exprs/return.yo` and
+`src/codegen/exprs/await.yo` compensate with a literal `cty == "void"` string
+test; those are load-bearing and undocumented. Either document them or give
+`is_unit_type` a resolving variant and use it consistently.

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -197,15 +197,19 @@ SHIPS (2026-08-24, branch fix/inout-unit-ref-spill): the invalid C
 ref-spill for an `inout(self)` receiver of type unit is fixed in codegen
 (`((void*)0)` — the callee's `void* self` is never read;
 issues/fixed/inout-unit-receiver-void-ref-spill.md), so `().to_string()`
-compiles and returns `"()"`. D3.8 is otherwise complete, with ONE
-carve-out found while landing it: `unit` in a *declaration* position is
-still emitted as C `void`, so a by-value `unit` parameter — and therefore
-`println(())` — a `unit` struct field, and `ArrayList(unit)` do not
-compile. Whole boundary measured and filed in
-issues/unit-typed-params-and-fields-emit-c-void.md (enum payloads like
-`Option(unit)`/`Result(unit, E)` already work; the fix is a codegen
-decision between full ZST erasure and a 1-byte representation). Tests:
-2 chunk-5 cases + 1 unit case in tests/fmt.test.yo (6/6).
+compiles and returns `"()"`. **D3.8 is COMPLETE**: the carve-out found
+while landing it — `unit` in a C *declaration* position was emitted as
+`void`, so a by-value `unit` parameter (hence `println(())`), a `unit`
+struct field, a tuple containing `unit` and `ArrayList(unit)` all failed to
+compile — is fixed too (branch codegen/unit-storage-byte,
+issues/fixed/unit-typed-params-and-fields-emit-c-void.md). Storage
+positions now spell a type whose C rendering is exactly `void` as a
+one-byte placeholder (`get_storage_type_string`), and the matching empty
+argument slot is filled; return position keeps `void`, so the guard fires
+only where today's C is already invalid and the emitted C for every
+compiling program is byte-identical (verified: 8/8 corpus files, same
+sha256). Tests: 2 chunk-5 cases + 1 unit case in tests/fmt.test.yo (6/6)
+plus tests/unit_as_value_type.test.yo (6/6).
 
 **Progress (S1 chunk 4, 2026-08-24, branch fix/range-op-era-split —
 UNPARKED, compiler fix + std landed together):** D3.5 implemented on the

--- a/src/codegen/exprs/comptime_value.yo
+++ b/src/codegen/exprs/comptime_value.yo
@@ -369,7 +369,12 @@ generate_comptime_value :: (fn(value : EvalValue, ty : TypeValue, context : Code
           out.push_str("._");
           out.push_string(i.to_string());
           out.push_str(" = ");
-          match(fields.get(i), .Some(fv) => out.push_string(recur(fv, fty, context)), .None => ());
+          // A `unit` element has no comptime C value (it falls through the
+          // dispatch's catch-all to a skip marker) and its field is now a
+          // one-byte placeholder, so initialize it with the dead byte. Done
+          // here rather than as a `.UnitVal` arm on the dispatch: other callers
+          // key off that skip-marker string.
+          match(fields.get(i), .Some(fv) => out.push_string(if(is_unit_type(fty), String.from("0"), recur(fv, fty, context))), .None => ());
           i = (i + usize(1));
         });
         out.push_str(" }");

--- a/src/codegen/exprs/other_fn_call.yo
+++ b/src/codegen/exprs/other_fn_call.yo
@@ -1687,8 +1687,8 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
                 match(
                   vs_args.get(rfi),
                   .Some(a) => {
-                    fv := emit_deferred_dup_or_code(a, _call_generate_expr(a, indent.clone(), context), indent.clone(), context);
-                    cl_out.push_string(if(fv.len() == usize(0), String.from("0"), fv));
+                    vs_fv := emit_deferred_dup_or_code(a, _call_generate_expr(a, indent.clone(), context), indent.clone(), context);
+                    cl_out.push_string(if(vs_fv.len() == usize(0), String.from("0"), vs_fv));
                   },
                   .None => ()
                 );

--- a/src/codegen/exprs/other_fn_call.yo
+++ b/src/codegen/exprs/other_fn_call.yo
@@ -27,7 +27,7 @@ open(import("std/string"));
 { Environment, get_variables_from_env, find_innermost_frame_with_given_variable, Variable } :: import("../../env.yo");
 { is_builtin_yo_inline_function } :: import("../constants.yo");
 { FunctionGenerationContext } :: import("../functions/context.yo");
-{ get_type_string, get_variable_type_string, get_variable_name_for_codegen, sanitize_for_c_identifier, is_function_value_with_only_builtin_yo_inline_function_call, type_key, get_runtime_struct_fields, RuntimeStructField, can_optimize_as_nullable_pointer, can_optimize_as_simple_enum, get_enum_variant_c_name, ImplClosureCallInfo, scope_stack_contains } :: import("../utils/index.yo");
+{ get_type_string, get_storage_type_string, get_variable_type_string, get_variable_name_for_codegen, sanitize_for_c_identifier, is_function_value_with_only_builtin_yo_inline_function_call, type_key, get_runtime_struct_fields, RuntimeStructField, can_optimize_as_nullable_pointer, can_optimize_as_simple_enum, get_enum_variant_c_name, ImplClosureCallInfo, scope_stack_contains } :: import("../utils/index.yo");
 { resolve_some_type_to_concrete } :: import("./closures.yo");
 { extract_fn_trait_from_type, type_implements_future } :: import("../../evaluator/trait_checking.yo");
 { CapturedVariable } :: import("../../evaluator/async/await_analysis_types.yo");
@@ -474,6 +474,15 @@ _materialize_arg :: (fn(arg : AstExpr, param_is_ref : bool, expr : AstExpr, inde
             .None => ()
           );
         });
+        // A `unit`-valued argument generates NO C code at all (the unit rvalue
+        // emitters return ""). Never materialize that into `<T> name = ;` — an
+        // invalid declaration. Hand back the empty marker and let the argument
+        // loop fill the C slot with the dead byte that now matches the callee's
+        // placeholder parameter. Twin of the three local-declaration guards in
+        // exprs/init_assignment.yo.
+        if(arg_code.len() == usize(0), {
+          return(String.from(""));
+        });
         is_comptime_only := _last_is_comptime_only(arg_ei.env, vname.clone());
         is_sm := arg_code.starts_with("sm->");
         sanitized := get_variable_name_for_codegen(vname.clone(), Option(Environment).Some(arg_ei.env));
@@ -649,8 +658,14 @@ _per_arg_cast :: (fn(args_list : String, param_types : ArrayList(TypeValue), par
         if(i > usize(0), {
           out.push_str(", ");
         });
-        base_str := match(param_types.get(i), .Some(t) => get_type_string(t, context.base), .None => String.from("void*"));
         pref := match(param_is_ref.get(i), .Some(r) => r, .None => false);
+        // A BY-VALUE `unit` parameter is spelled as the one-byte placeholder in
+        // the prototype, so its cast must agree; a REF one stays `void` + `*`.
+        base_str := match(
+          param_types.get(i),
+          .Some(t) => if(pref, get_type_string(t, context.base), get_storage_type_string(t, context.base)),
+          .None => String.from("void*")
+        );
         out.push_str("(");
         out.push_string(base_str);
         if(pref, {
@@ -1194,6 +1209,11 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
               ),
               .None => ArrayList(bool).new()
             );
+            // Resolved BEFORE the argument loop (they only need `method_fv`)
+            // so the loop can tell whether an empty — i.e. `unit` — argument
+            // has a real C parameter slot to fill with the dead byte.
+            cm_mft := match(method_fv, .Some(mv) => get_func_type(_func_val_id(mv)), .None => TypeValue.Unit);
+            cm_ptypes := match(cm_mft, .Func({ param_types : cpt }) => cpt, _ => ArrayList(TypeValue).new());
             cm_arg_list := ArrayList(String).new();
             cnma := dm_runtime.len();
             (cmi : usize) = usize(0);
@@ -1201,7 +1221,11 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
               match(
                 dm_runtime.get(cmi),
                 .Some(a) => {
-                  _cmp := cm_arg_list.push(_call_generate_expr(a, indent.clone(), context));
+                  _cmp := cm_arg_list.push({
+                    mc := _call_generate_expr(a, indent.clone(), context);
+                    hs := match(cm_ptypes.get(cmi), .Some(_) => true, .None => false);
+                    if((mc.len() == usize(0)) && hs, String.from("0"), mc)
+                  });
                 },
                 .None => ()
               );
@@ -1221,8 +1245,6 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
             // deep inside a method, the caller CONTINUED with a garbage
             // result (stage-2 prelude-eval SIGSEGV; see
             // issues/retired/yo-self-stage2-unwind-check-coverage.md).
-            cm_mft := match(method_fv, .Some(mv) => get_func_type(_func_val_id(mv)), .None => TypeValue.Unit);
-            cm_ptypes := match(cm_mft, .Func({ param_types : cpt }) => cpt, _ => ArrayList(TypeValue).new());
             // Method dispatch: the callee is a property access, not an atom —
             // TS's exprIsAtom(expr.func) fallback is false here.
             cm_may_unwind := _call_may_unwind(method_fv, cm_mft, cm_ptypes, false, context);
@@ -1312,6 +1334,11 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
           .Some(rmcn) => {
             rm_runtime := match(ei.runtime_arg_exprs_in_order, .Some(ra) => ra, .None => ArrayList(AstExpr).new());
             rm_pir := match(get_func_type(rm_fid.clone()), .Func({ meta : __fmrm }) => __fmrm.*.param_is_ref, _ => ArrayList(bool).new());
+            // Resolved BEFORE the argument loop (they only need `rm_fid`) so an
+            // empty — i.e. `unit` — argument can be filled with the dead byte
+            // when the callee actually has a C parameter at that index.
+            rm_mft := get_func_type(rm_fid.clone());
+            rm_ptypes := match(rm_mft, .Func({ param_types : cpt }) => cpt, _ => ArrayList(TypeValue).new());
             rm_args := ArrayList(String).new();
             rm_n := rm_runtime.len();
             (rmi : usize) = usize(0);
@@ -1319,7 +1346,11 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
               match(
                 rm_runtime.get(rmi),
                 .Some(a) => {
-                  _rmp := rm_args.push(_call_generate_expr(a, indent.clone(), context));
+                  _rmp := rm_args.push({
+                    mc := _call_generate_expr(a, indent.clone(), context);
+                    hs := match(rm_ptypes.get(rmi), .Some(_) => true, .None => false);
+                    if((mc.len() == usize(0)) && hs, String.from("0"), mc)
+                  });
                 },
                 .None => ()
               );
@@ -1330,8 +1361,6 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
             rm_call.push_str("(");
             rm_call.push_string(_join_args(rm_args));
             rm_call.push_str(")");
-            rm_mft := get_func_type(rm_fid.clone());
-            rm_ptypes := match(rm_mft, .Func({ param_types : cpt }) => cpt, _ => ArrayList(TypeValue).new());
             rm_may_unwind := _call_may_unwind(Option(EvalValue).Some(rmv), rm_mft, rm_ptypes, false, context);
             rm_install_ei := new_expr_info(ei.env, rm_mft);
             rm_install_ei.value = Option(EvalValue).Some(rmv);
@@ -1518,7 +1547,17 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
             if(ci > usize(0), {
               ctor_list.push_str(", ");
             });
-            match(ctor_args.get(ci), .Some(ca) => ctor_list.push_string(emit_deferred_dup_or_code(ca, _call_generate_expr(ca, indent.clone(), context), indent.clone(), context)), .None => ());
+            // A `unit` field argument generates no C; the constructor parameter
+            // it feeds is now a one-byte placeholder, so pass the dead byte
+            // instead of emitting `__yo_new_T(1, )`. Arity is preserved.
+            match(
+              ctor_args.get(ci),
+              .Some(ca) => {
+                cc := emit_deferred_dup_or_code(ca, _call_generate_expr(ca, indent.clone(), context), indent.clone(), context);
+                ctor_list.push_string(if(cc.len() == usize(0), String.from("0"), cc));
+              },
+              .None => ()
+            );
             ci = (ci + usize(1));
           });
           ctor_call := String.from("__yo_new_");
@@ -1642,7 +1681,17 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
                 // expression evaluated `code` TWICE (a fresh `N(...)` ctor
                 // arg allocated two objects: one leaked incr'd, one stored
                 // un-incr'd) and over-counted moves that need no incr at all.
-                match(vs_args.get(rfi), .Some(a) => cl_out.push_string(emit_deferred_dup_or_code(a, _call_generate_expr(a, indent.clone(), context), indent.clone(), context)), .None => ());
+                // Same as the constructor call: a `unit` field initializer has
+                // no C value, and the field is now a one-byte placeholder, so
+                // fill `.b = 0` rather than emitting `.b = `.
+                match(
+                  vs_args.get(rfi),
+                  .Some(a) => {
+                    fv := emit_deferred_dup_or_code(a, _call_generate_expr(a, indent.clone(), context), indent.clone(), context);
+                    cl_out.push_string(if(fv.len() == usize(0), String.from("0"), fv));
+                  },
+                  .None => ()
+                );
                 rfi = (rfi + usize(1));
               });
               cl_out.push_str(" }");
@@ -1711,10 +1760,17 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
   (ai : usize) = usize(0);
   while(ai < na, {
     pref := match(param_is_ref.get(ai), .Some(r) => r, .None => false);
+    // A `unit` argument materializes to "" (see _materialize_arg). If the callee
+    // has a real C parameter at this index it is now a one-byte placeholder, so
+    // pass the dead byte rather than leaving `f(xs, )`. With NO matching
+    // parameter slot — a reconstructed argument list — leave the slot empty,
+    // which is today's behaviour.
+    has_slot := match(param_types.get(ai), .Some(_) => true, .None => false);
     match(
       runtime_args.get(ai),
       .Some(arg) => {
-        _p := args.push(_materialize_arg(arg, pref, expr, indent.clone(), context));
+        mc := _materialize_arg(arg, pref, expr, indent.clone(), context);
+        _p := args.push(if((mc.len() == usize(0)) && has_slot, String.from("0"), mc));
       },
       .None => ()
     );
@@ -1840,7 +1896,15 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
             return(Option(String).Some(`// Failed to transpile ${ast_expr_to_string(expr)}`));
           });
           casted := _per_arg_cast(args_list.clone(), param_types, param_is_ref, context);
-          if(is_unit_type(result_type), {
+          // `is_unit_type` does not walk the SomeT resolution chain, but
+          // `get_type_string` does — and the normalization above deliberately
+          // leaves `result_type` as a SomeT when the expression's own type is
+          // unit. Consult the SPELLING in that case so a generic result that
+          // RESOLVES to unit takes the statement form instead of declaring a
+          // `void` temp. Only for a SomeT: get_type_string panics on the
+          // Fn/Future trait arms.
+          rt_void := if(is_some_type(result_type), get_type_string(result_type, context.base) == `void`, is_unit_type(result_type));
+          if(rt_void, {
             // Clear __yo_effect_escaped before the call so a stale flag from
             // a previous unwind (already handled by a higher-level handler)
             // doesn't leak into this call's escape check.
@@ -2008,7 +2072,10 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
           if(pi > usize(0), {
             cast.push_str(", ");
           });
-          cast.push_string(match(param_types.get(pi), .Some(t) => get_type_string(t, context.base), .None => String.from("void*")));
+          // Must match the callee's PROTOTYPE, where a by-value `unit` parameter
+          // is the one-byte placeholder. The return slot above keeps
+          // get_type_string — `void` is legal there.
+          cast.push_string(match(param_types.get(pi), .Some(t) => get_storage_type_string(t, context.base), .None => String.from("void*")));
           pi = (pi + usize(1));
         });
         cast.push_str("))");
@@ -2028,7 +2095,8 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
               if(fa_i > usize(0), {
                 fa_out.push_str(", ");
               });
-              fa_pt := match(param_types.get(fa_i), .Some(t) => get_type_string(t, context.base), .None => String.from("void*"));
+              // In lockstep with the fn-pointer cast above.
+              fa_pt := match(param_types.get(fa_i), .Some(t) => get_storage_type_string(t, context.base), .None => String.from("void*"));
               fa_part := match(fa_parts.get(fa_i), .Some(x) => x, .None => String.new());
               fa_out.push_str("(");
               fa_out.push_string(fa_pt);

--- a/src/codegen/exprs/tuple_fn.yo
+++ b/src/codegen/exprs/tuple_fn.yo
@@ -71,7 +71,10 @@ _build_tuple :: (fn(arg_exprs : ArrayList(AstExpr), c_name : String, expr : AstE
           .None => ()
         );
         if(!(used_dup_temp), {
-          args_list.push_string(arg_code);
+          // Twin of the comptime tuple literal: a `unit` element generates no C
+          // and its field is now a one-byte placeholder, so fill the dead byte
+          // rather than emitting `(__yo_t0){ 1,  }`.
+          args_list.push_string(if(arg_code.len() == usize(0), String.from("0"), arg_code));
         });
       },
       .None => ()

--- a/src/codegen/functions/constructors.yo
+++ b/src/codegen/functions/constructors.yo
@@ -20,7 +20,7 @@ open(import("std/string"));
 { TypeValue } :: import("../../types/definitions.yo");
 { is_reference_struct_type, is_atomic_reference_struct_type, is_reference_enum_type, is_atomic_reference_enum_type, is_enum_type, is_struct_type, is_newtype_type, is_tuple_type, is_array_type, is_unit_type } :: import("../../types/guards.yo");
 { type_contains_some_type, type_contains_rc_type, can_type_form_rc_cycle, type_uses_small_rc_header, _type_refs_back_to_cyclic } :: import("../../types/utils.yo");
-{ get_type_string, get_runtime_struct_fields, sanitize_for_c_identifier, get_enum_variant_c_name, can_optimize_as_nullable_pointer, can_optimize_as_simple_enum, RuntimeStructField } :: import("../utils/index.yo");
+{ get_type_string, get_storage_type_string, get_runtime_struct_fields, sanitize_for_c_identifier, get_enum_variant_c_name, can_optimize_as_nullable_pointer, can_optimize_as_simple_enum, RuntimeStructField } :: import("../utils/index.yo");
 { FunctionGenerationContext } :: import("./context.yo");
 { get_dispose_function_for_type, get_trace_function_for_type } :: import("../exprs/drop_dup.yo");
 /// True if any runtime field of `struct_type` contains a SomeType (generic).
@@ -60,7 +60,7 @@ _generate_one_constructor :: (fn(type : TypeValue, c_name : String, context : Fu
         if(pi > usize(0), {
           params.push_str(", ");
         });
-        params.push_string(get_type_string(field.ty, context.base));
+        params.push_string(get_storage_type_string(field.ty, context.base));
         params.push_str(" ");
         params.push_string(sanitize_for_c_identifier(field.label.clone(), false));
       },

--- a/src/codegen/functions/declarations.yo
+++ b/src/codegen/functions/declarations.yo
@@ -15,7 +15,7 @@ open(import("std/string"));
 { lookup_some_resolved_concrete, expr_info_effect_analysis, expr_info_async_state_machine_struct_name } :: import("../../expr_info.yo");
 { EvalValue } :: import("../../value.yo");
 { get_func_type, is_effect_record_member, is_closure_fn, is_io_async_sm_closure, is_fn_unemittable } :: import("../../function_value.yo");
-{ CodeGenContext, get_type_string, sanitize_for_c_identifier, get_runtime_struct_fields, RuntimeStructField, is_function_value_with_only_builtin_yo_inline_function_call, find_returned_async_block, type_key } :: import("../utils/index.yo");
+{ CodeGenContext, get_type_string, get_storage_type_string, sanitize_for_c_identifier, get_runtime_struct_fields, RuntimeStructField, is_function_value_with_only_builtin_yo_inline_function_call, find_returned_async_block, type_key } :: import("../utils/index.yo");
 /// One evidence parameter threaded into a function that uses effect-record
 /// evidence passing. Mirrors the `EvidenceParameter` interface.
 EvidenceParameter :: ref(
@@ -185,11 +185,17 @@ generate_function_prototype :: (
             params.push_string(recur(pt, callee, context, Option(String).None, false));
           },
           true => {
-            pts := get_type_string(pt, context);
             is_ref := match(param_is_ref.get(i), .Some(b) => b, .None => false);
-            if(is_ref, {
-              pts.push_str("*");
-            });
+            // A BY-VALUE `unit` parameter has no C object type, so it is spelled
+            // as a dead byte (get_storage_type_string). A REF/`inout` unit
+            // parameter keeps `void*` — that is the pointer the call site hands
+            // it as `((void*)0)`
+            // (issues/fixed/inout-unit-receiver-void-ref-spill.md).
+            pts := if(is_ref, {
+              p0 := get_type_string(pt, context);
+              p0.push_str("*");
+              p0
+            }, get_storage_type_string(pt, context));
             params.push_string(pts);
             params.push_str(" ");
             params.push_string(pname.clone());
@@ -326,7 +332,7 @@ generate_object_constructor_declarations :: (fn(context : CodeGenContext) -> uni
                 if(pi > usize(0), {
                   params.push_str(", ");
                 });
-                params.push_string(get_type_string(field.ty, context));
+                params.push_string(get_storage_type_string(field.ty, context));
                 params.push_str(" ");
                 params.push_string(sanitize_for_c_identifier(field.label.clone(), false));
               },

--- a/src/codegen/types/generation.yo
+++ b/src/codegen/types/generation.yo
@@ -21,6 +21,7 @@ open(import("std/string"));
   CodeGenContext,
   RuntimeStructField,
   get_type_string,
+  get_storage_type_string,
   get_runtime_struct_fields,
   sanitize_for_c_identifier,
   can_optimize_as_nullable_pointer,
@@ -121,7 +122,11 @@ _emit_runtime_fields :: (fn(fields : ArrayList(RuntimeStructField), context : Co
     match(
       fields.get(i),
       .Some(field) => {
-        fts := get_type_string(field.ty, context);
+        // A `unit` field is spelled as a dead byte rather than `void` — C has
+        // no zero-sized object type. Field COUNT and ORDER are preserved, so
+        // both constructor parameter lists and the compound literal stay
+        // aligned with the layout.
+        fts := get_storage_type_string(field.ty, context);
         fname := sanitize_for_c_identifier(field.label.clone(), false);
         context.emitter.emit_declaration_string_line(`  ${fts} ${fname};`);
       },
@@ -187,7 +192,10 @@ generate_tuple_declaration :: (fn(tuple_type : TypeValue, c_name : String, conte
             match(
               field_types.get(i),
               .Some(ft) => {
-                fts := get_type_string(ft, context);
+                // As for struct fields: a `unit` element becomes a dead byte.
+                // The zero-field branch above keeps its own `_dummy` marker —
+                // with placeholders a NON-empty tuple can never render empty.
+                fts := get_storage_type_string(ft, context);
                 context.emitter.emit_declaration_string_line(`  ${fts} _${i.to_string()};`);
               },
               .None => ()

--- a/src/codegen/utils/index.yo
+++ b/src/codegen/utils/index.yo
@@ -1219,6 +1219,24 @@ get_type_string :: (fn(t : TypeValue, context : CodeGenContext) -> String)(
     }
   )
 );
+/// C type string in a STORAGE position — a parameter, a struct/tuple/union
+/// field, a local, or a cast target. C has no zero-sized object type, so a type
+/// whose spelling is exactly `void` (`unit`, `void`, or a SomeT that RESOLVES to
+/// either — `get_type_string` walks the resolution chain, `is_unit_type` does
+/// not) is spelled as a one-byte placeholder that is declared and never read.
+/// RETURN position keeps `get_type_string`, where `void` is legal, and pointer
+/// types spell `void*` rather than `void`, so both are untouched.
+///
+/// The guard fires only where today's output is already invalid C
+/// (`void x` / `void f(void x)` / `void b;`), which is what keeps the emitted C
+/// for every currently-compiling program byte-identical. See
+/// issues/unit-typed-params-and-fields-emit-c-void.md; the existing 1-byte
+/// precedents are `generate_future_trait_declaration` (types/generation.yo) and
+/// the await result slot (exprs/await.yo).
+get_storage_type_string :: (fn(t : TypeValue, context : CodeGenContext) -> String)({
+  s := get_type_string(t, context);
+  if(s == `void`, String.from("uint8_t"), s)
+});
 /// True iff `cn` appears in the emitter-maintained block-scope stack
 /// (`CodeGenContext.declared_scopes`) — i.e. its C variable was declared before
 /// this emission point AND its enclosing C block is still open (a closed
@@ -1540,6 +1558,7 @@ export(
   get_runtime_struct_fields,
   type_key,
   get_type_string,
+  get_storage_type_string,
   get_variable_type_string,
   get_enum_variant_c_name,
   sanitize_for_c_identifier,

--- a/tests/fmt.test.yo
+++ b/tests/fmt.test.yo
@@ -137,10 +137,9 @@ test("ArrayList and Array stringify as bracketed lists (D3.8)", {
   assert(nested.to_string() == `[Some(4), None]`, "nests through Option's ToString");
 });
 test("Test unit ToString", {
-  // The last D3.8 primitive: an inout(self) receiver of type unit used to
-  // emit invalid C (issues/fixed/inout-unit-receiver-void-ref-spill.md).
-  // The receiver is `inout(self) : Self` at Self = unit, which used to emit an
-  // invalid C ref-spill (`void __yo_ref_spill_N = ;`) —
+  // The last D3.8 primitive: the receiver is `inout(self) : Self` at
+  // Self = unit, which used to emit an invalid C ref-spill
+  // (`void __yo_ref_spill_N = ;`) —
   // issues/fixed/inout-unit-receiver-void-ref-spill.md.
   assert(().to_string() == "()", "unit prints as ()");
   // The unit argument's C code is EMPTY (the call is emitted as a statement),
@@ -148,8 +147,7 @@ test("Test unit ToString", {
   // side-effecting unit receiver must still run.
   assert(_unit_mark(i32(1)).to_string() == "()", "unit receiver from a call");
   assert(_unit_side_effects == i32(1), "the receiver call's side effect still ran");
-  // NOTE: `unit` in a *declaration* position — a by-value parameter (so
-  // `println(())`), a struct field, or a container element (`ArrayList(unit)`)
-  // — still emits C `void` and does not compile. Tracked separately in
-  // issues/unit-typed-params-and-fields-emit-c-void.md.
+  // `unit` in a declaration position (a by-value parameter, so `println(())`,
+  // a struct field, a container element) is covered by
+  // tests/unit_as_value_type.test.yo.
 });

--- a/tests/unit_as_value_type.test.yo
+++ b/tests/unit_as_value_type.test.yo
@@ -1,0 +1,43 @@
+{ assert } :: import("std/assert");
+open(import("std/string"));
+open(import("std/fmt"));
+open(import("std/collections/array_list"));
+// `unit` in a C DECLARATION position — a by-value parameter, a struct field, a
+// tuple element, a generic instantiated at T = unit — used to be emitted as C
+// `void`, which is not an object type: "argument may not have 'void' type",
+// "field has incomplete type 'void'". Codegen now spells those positions with a
+// one-byte placeholder (get_storage_type_string) and fills the matching empty
+// argument slot. See issues/fixed/unit-typed-params-and-fields-emit-c-void.md.
+_takes_unit :: (fn(x : unit) -> i32)(i32(7));
+_generic_id :: (fn(generic(T : Type), x : T) -> i32)(i32(9));
+_UnitField :: struct(a : i32, b : unit);
+test("unit as a by-value parameter", {
+  assert(_takes_unit(()) == i32(7), "non-generic unit parameter");
+  assert(_generic_id(()) == i32(9), "generic instantiated at T = unit");
+});
+test("unit as a struct field", {
+  s := _UnitField(a : i32(1), b : ());
+  assert(s.a == i32(1), "the non-unit field survives");
+});
+test("unit inside a tuple", {
+  p := (i32(3), ());
+  assert(p.0 == i32(3), "the non-unit element survives");
+});
+test("unit as a generic container element", {
+  xs := ArrayList(unit).new();
+  xs.push(());
+  xs.push(());
+  assert(xs.len() == usize(2), "ArrayList(unit) stores elements");
+});
+test("unit printing (D3.8)", {
+  assert(().to_string() == "()", "unit stringifies");
+  println(());
+});
+test("unit as an enum payload still works", {
+  // The enum path already erased unit payloads before this change — this is the
+  // no-regression witness, not new behaviour.
+  o := Option(unit).Some(());
+  assert(o.is_some(), "Option(unit)");
+  r := Result(unit, String).Ok(());
+  assert(r.is_ok(), "Result(unit, E)");
+});


### PR DESCRIPTION
## The bug

C has no zero-sized object type, but the Yo→C type mapping renders `unit` as
`void` unconditionally. That is legal in **return** position and harmless where
the value is erased — but nothing stopped it reaching a **declaration**:

| shape | emitted C |
| --- | --- |
| `fn(x : unit) -> i32` | `int32_t f(void x)` → *argument may not have 'void' type* |
| `struct(a : i32, b : unit)` | `void b;` → *field has incomplete type 'void'* |
| `(i32, unit)` | same |
| generic at `T = unit` | `void` param + `void` local + `f(xs, )` → *expected expression* |

So `ArrayList(unit)`, `HashMap(K, unit)` and `println(())` — whose parameter is
`value : T` — did not compile. Enum payloads (`Option(unit)`, `Result(unit, E)`)
already worked, because the enum emitter counts non-unit fields and skips the
rest.

## The fix

`get_storage_type_string` spells a type whose C rendering is exactly `void` as a
one-byte placeholder, in **storage positions only** — parameters, struct/tuple
fields, cast targets — and the matching empty argument slot is filled with `0`.
Return position keeps `get_type_string`; pointer types spell `void*`, not
`void`, so both are untouched, and a ref/`inout` unit parameter still takes
`void*` with the `((void*)0)` argument from #250.

The guard therefore fires **only where today's output is already invalid C**,
which makes this fixpoint-neutral *by construction*. Verified rather than
assumed: 8 representative corpus files re-emitted after the change are
**byte-identical** to their pre-change sha256.

Field count and order are preserved rather than erasing unit fields, so struct
layouts, both constructor parameter lists and the compound literal stay aligned
— a missed site fails loudly at the C compiler instead of silently
desynchronizing an ABI. (Full erasure was considered and rejected for exactly
that reason: it changes the parameter ABI of every function, closure, dyn
wrapper and async state machine, where a mask divergence at an indirect call is
silent UB rather than a diagnostic.)

## Result

All nine measured shapes compile **and run**, including `println(())`,
`ArrayList(unit)` and `HashMap(String, unit)`. This closes the D3.8 carve-out in
`plans/STD_API_AUDIT.md`.

Red-first regression test: `tests/unit_as_value_type.test.yo` (6 cases, with an
`Option(unit)`/`Result(unit, E)` no-regression witness).

## Deliberately not fixed

`[unit; N]`, unions, dyn vtables, module-level unit globals, async state-machine
slots, and a `unit` parameter of `main` — each fails today exactly as it did
before, each takes the same one-line recipe. Filed with two pre-existing defects
found while mapping (`is_void_type` never matches `.Unit`, so a unit-returning
`dyn` method emits `return` inside a `void` wrapper; and `unit` is zero bits, so
`ArrayList(unit)` mallocs 0 bytes) in `issues/unit-zst-residual-gaps.md`.

## Validation

Local battery in progress at PR time: `check ./src` 262/262, build, repro gate
9/9 (rc=0, ftt=0, run=0), byte-identity 8/8 identical, `tests/fmt.test.yo` 6/6,
`tests/unit_as_value_type.test.yo` 6/6. Full suite + gates + bootstrap fixpoint
running; I'll confirm before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)