### PR TITLE
instructions: encode the D1/D2 std conventions (S1); sharpen the nested-instantiation diagnosis

### DIFF
--- a/.github/instructions/yo-design.instructions.md
+++ b/.github/instructions/yo-design.instructions.md
@@ -471,6 +471,61 @@ Key semantics:
 - Mixed GADT/regular variants: some variants can have `-> recur(...)` while others remain unconstrained
 - For full design document, see `plans/GADTS.md` and `docs/en-US/GADTS.md`
 
+## std error handling: three blessed styles, no fourth
+
+Decided in `plans/STD_API_AUDIT.md` D1. Before this, std shipped four styles,
+sometimes inside one file. When you add or change a fallible std API, pick from
+exactly these three — and if none fits, that is a design discussion, not a
+licence to invent a fourth.
+
+| Situation | Style |
+| --- | --- |
+| I/O, and anything on the `io` path (fs, net, http, process) | **effects** — `exn : Exception` / `IoExn` |
+| pure fallible transforms: parsing, decoding, conversion | **`Result(T, TypedError)`** |
+| lookups where absence is not an error | **`Option(T)`** |
+
+Rules that follow from it:
+
+- **`Result(_, String)` is banned.** An error type is a real enum implementing
+  `Error()`. A string error cannot be matched on, downcast, or wrapped, and it
+  forces every caller into prose comparison.
+- **Never drop the payload on failure.** `Channel.send` returning
+  `Result(unit, unit)` discarded the value the caller still owned; return it.
+- A fallible constructor that cannot fail should not be fallible — do not add a
+  `Result` "for symmetry".
+- Absence and failure are different: do not model a missing key as an error, and
+  do not model an I/O failure as `None`.
+
+## std naming conventions
+
+Decided in `plans/STD_API_AUDIT.md` D2. One name per concept, across the whole
+tree. Use these when adding an API; a new module that invents a synonym is a
+review defect, not a style preference.
+
+| Concept | Blessed name | Do not use |
+| --- | --- | --- |
+| element count | `len()`, plus `is_empty()` on EVERY container | a public `size` field |
+| map insert | `insert(k, v) -> Option(V)` (returns the old value) | `set` |
+| set insert | `insert(v) -> bool` | `add` |
+| sequence append | `push` / `push_front` / `push_back` | — |
+| membership | `contains` (sequence/set), `contains_key` (map) | — |
+| value iterator | `into_iter()` | — |
+| pointer iterator | `iter()` | `iter_ptr` |
+| accessors | a bare noun | a `get_` prefix |
+| byte codecs | `encode` / `decode` | `to_ascii` / `to_unicode` |
+| text formats | `parse` / `stringify` | `decode_html`-style verb-first names |
+| conversion | `from_` / `to_` / `into_`, with Rust's discipline (`into_` consumes) | two spellings of one conversion (`to_cstr` vs `to_c_str`) |
+| comptime twins | `Comptime` prefix on the trait, `comptime_` prefix on the method | an infix `_comptime_` |
+
+Two conventions that are easy to miss:
+
+- **`sys/` is plumbing, `std/*` is the product.** Every user-relevant syscall
+  gets a typed wrapper, and an underscore-private name must never appear in an
+  `export(...)` list.
+- **Traits are the API.** An inherent method that duplicates a trait method
+  becomes a trait impl, so generic code can dispatch on it. Types that should
+  compose get `Eq` / `Ord` / `Hash` / `Clone` / `ToString`.
+
 ## Standard library module organization (`std/`)
 
 ## Function-type re-evaluation during impl specialization

--- a/issues/nested-same-adaptor-instantiation-identity-split.md
+++ b/issues/nested-same-adaptor-instantiation-identity-split.md
@@ -57,6 +57,45 @@ repair was to canonicalize the *result* through the constructor memo
 (`canonicalize_instantiation_via_ctfe_memo`); the fix here is likely to
 canonicalize each concrete type ARGUMENT before keying the memo.
 
+## Measured evidence (2026-08-25)
+
+From the emitted C of the reproducer:
+
+```c
+struct __yo_t9_struct  { __yo_t10 _inner; };  //  : <struct:struct_yo_id_3978>
+struct __yo_t19_struct { __yo_t9  _inner; };  //  : <struct:struct_yo_id_3978>
+struct __yo_t11_struct { __yo_t9  _inner; };  //  : <struct:struct_yo_id_6252>
+```
+
+`t19` and `t11` are structurally IDENTICAL — both `IterRev(IterRev(Range(i32)))`
+— but carry DIFFERENT eval struct ids. `struct_yo_id_6252` appears exactly ONCE
+in the whole emitted C: as that one struct definition, used only as the `rev`
+function's return type. So one logical type was minted twice, and the call site
+holds the other instance.
+
+`3978` is the shared def-era `IterRev` id — `substitute()` keeps `id` and
+`constructor_func_id` while rewriting type arguments, so EVERY `IterRev`
+instantiation shares it and the distinction lives in the rendered type key.
+`6252` is a genuinely separate instantiation.
+
+Two hypotheses were tested and REFUTED:
+
+1. *The constructor memo key misses on a non-canonical copy.* No —
+   `_ctfe_args_equal` compares struct arguments by id first (a copy hits
+   trivially) and then by constructor fid plus recursive era-equality, so a copy
+   or an era instance unifies.
+2. *The return-type re-evaluation path (`rre_era_suspect`) mints it.* No —
+   running the reproducer with `YO_DEBUG_RRE=1` prints seven `[rre]` lines and
+   NONE of them is for `rev`. That path is never entered for this call, so it
+   cannot be the source.
+
+What remains: the two instances are produced by two different mechanisms — one
+substitution-derived (`3978` + rewritten arguments) for the call site, one a real
+constructor instantiation (`6252`) for the callee's return — and nothing
+reconciles them. #247 added exactly such a reconciliation
+(`canonicalize_instantiation_via_ctfe_memo`) but wired it to the trait-OPERATOR
+dispatch path only; a method call never reaches it.
+
 ## Impact
 
 Any generic type applied to an instance of itself: `.rev().rev()`,

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -94,6 +94,12 @@ otherwise COMPLETE.
 
 ### D1 — Error handling: three blessed styles, no fourth
 
+**ADR WRITTEN 2026-08-25** — D1 and D2 are now encoded as conventions in
+`.github/instructions/yo-design.instructions.md` ("std error handling: three
+blessed styles, no fourth" and "std naming conventions"), so a future std change
+is told the rule without having to read this plan. The *enforcement* — migrating
+the existing violations — is still the S2 sweep.
+
 - **Effects (`exn : Exception` / `IoExn`)** for I/O and anything on the `io` path
   (fs, net, http, process). Already dominant; bufio's `Future(Result(_, IoError), Io)`
   and env's `Result(_, String)` migrate to it.


### PR DESCRIPTION
Docs only — no code change, so no local battery applies.

## 1. The D1/D2 conventions ADR (an S1 deliverable)

`plans/STD_API_AUDIT.md` decided both in §3, and §9 lists "conventions ADR" as
part of S1 — but nothing told future work to follow them.
`.github/instructions/yo-design.instructions.md` had **no** error-style or naming
guidance at all, so the conventions existed only in a plan document that a std
change is not required to read.

**D1 — three blessed error styles, no fourth:** effects (`exn : Exception` /
`IoExn`) for I/O and anything on the `io` path; `Result(T, TypedError)` for pure
fallible transforms; `Option(T)` only where absence is not an error. With the
corollaries that made the audit file bugs: `Result(_, String)` is banned (a
string error cannot be matched, downcast or wrapped), and a failure must not drop
a payload the caller still owns (the `Channel.send` defect).

**D2 — one name per concept:** the full table — `len()`/`is_empty()`,
`insert` for both map and set, `push`/`push_front`/`push_back`,
`contains`/`contains_key`, `into_iter()` vs `iter()`, bare-noun accessors,
`encode`/`decode`, `parse`/`stringify`, `from_`/`to_`/`into_` with Rust's
discipline, and the `Comptime`/`comptime_` twins — plus the two conventions
easiest to miss: `sys/` is plumbing and traits are the API.

Enforcement (migrating the existing violations) remains the S2 sweep; this PR is
the rule, not the migration.

## 2. A sharper diagnosis for the nested-instantiation bug

`issues/nested-same-adaptor-instantiation-identity-split.md` (filed with #253)
now carries measured evidence and **two refuted hypotheses**, so the next
attempt does not repeat them:

- The emitted C shows `__yo_t19` and `__yo_t11` structurally identical — both
  `IterRev(IterRev(Range(i32)))` — under **different** eval struct ids (3978 vs
  6252), and `6252` appears exactly once in the whole file, as that function's
  return type. One logical type minted twice.
- *Refuted:* "the constructor memo key misses on a non-canonical copy" —
  `_ctfe_args_equal` compares struct arguments by id first and then by
  constructor fid plus recursive era-equality, so a copy unifies.
- *Refuted:* "the return-type re-evaluation path mints it" — `YO_DEBUG_RRE=1`
  prints seven `[rre]` lines on the reproducer and **none** is for `rev`, so that
  path is never entered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)