### PR TITLE
evaluator: canonicalize the method-call return stamp so a self-nesting generic keeps one identity

### DIFF
--- a/issues/ctfe-memo-shared-struct-id-fast-path-smell.md
+++ b/issues/ctfe-memo-shared-struct-id-fast-path-smell.md
@@ -1,0 +1,68 @@
+# The CTFE memo's raw-id fast paths rest on a false invariant (NOT reproduced)
+
+**Status:** OPEN as a hardening opportunity — **no reproducer found**. Filed so
+the next person does not re-derive the theory, and does not chase it as a live
+bug either.
+**Found:** 2026-08-25, while fixing
+issues/fixed/nested-same-adaptor-instantiation-identity-split.md.
+
+## The false invariant
+
+Two places in `src/evaluator/calls/comptime_fn.yo` decide two types are the same
+when their struct ids match, without comparing type arguments:
+
+- `_ctfe_types_era_equal` — `if((a_sid.len() > 0) && (a_sid == b_sid), return(true))`
+- `_ctfe_args_equal` — `((a_struct_id.len() > 0) && (a_struct_id == b_struct_id)) => true`
+
+The justifying idea is that a struct id is unique per definition. That is **false**
+for generic instantiations: `substitute()` (`src/types/substitution.yo`) keeps the
+def-era `id` and `constructor_func_id` while rewriting type arguments, so every
+instantiation of one constructor shares a single id and the distinction lives only
+in the rendered type key.
+
+On paper, then, two DIFFERENT instantiations used as memo ARGUMENTS should compare
+equal, and a second lookup should adopt the first's instance.
+
+## Why it is NOT filed as a bug: the predicted trigger works
+
+The predicted trigger — two self-nested chains at different element types in one
+module, so both outer lookups key on an argument carrying the shared id — was
+built and run. It produces correct results:
+
+```rust
+a := (i32(0) .. i32(4)).rev().rev().collect(ArrayList(i32));   // [0, 1, 2, 3]
+b := (i64(0) .. i64(4)).rev().rev().collect(ArrayList(i64));   // [0, 1, 2, 3]
+c := (u8(0)  .. u8(3)).rev().rev().collect(ArrayList(u8));     // [0, 1, 2]
+d := (i32(1) ..= i32(3)).rev().rev().map((x) => (x * i32(10))) // [10, 20, 30]
+       .collect(ArrayList(i32));
+```
+
+`count()` variants of the same shapes are also correct. So either the lookups do
+not collide in practice (something upstream keys the entries more finely than the
+fast paths suggest), or the collision needs a shape not yet found. Three element
+types and a mapped chain were tried.
+
+## If a reproducer ever appears
+
+The smallest sound hardening is to treat equal ids as decisive only when the two
+sides' `type_arguments` are pairwise era-equal (two empty lists being trivially
+equal). That preserves both documented reasons those paths exist:
+
+- a recursive struct's self-shell shares **both** the id and the type arguments,
+  so it still unifies;
+- the enum `__self_shell` strip is untouched — and it is load-bearing: it is what
+  keeps two calls landing in ONE memo entry rather than minting two
+  `ArrayList(MyExpr)` instantiations whose traverse/drop machinery cross-corrupted
+  the heap (`issues/repros/recursive-enum-box-plus-arraylist-self.yo`).
+
+It must be landed alone with its own full battery — it perturbs CTFE memo identity
+globally, and the `Option(Node-era-A)`/`Option(Node-era-B)` convergence and the
+`Bucket`/`ArrayList(u8)` cross-module unification both depend on these paths.
+
+## The real fix for the whole family, for the record
+
+Every repair in this family — #247's operator-arm canonicalization, the
+method-arm twin, and this hardening — patches a stamping or comparison site
+rather than the invariant. A full fix gives `substitute()` instantiation-unique
+ids (or interposes an identity layer that does), so one eval struct id never
+serves many instantiations. That is a campaign, not a patch.

--- a/issues/fixed/nested-same-adaptor-instantiation-identity-split.md
+++ b/issues/fixed/nested-same-adaptor-instantiation-identity-split.md
@@ -1,6 +1,24 @@
 # A generic struct instantiated over ITSELF gets two C type identities
 
-**Status:** OPEN
+**Status: FIXED 2026-08-25** — one statement in the method-dispatch arm of
+`evaluate_function_call` now canonicalizes the stamped return type through the
+CTFE constructor memo, the twin of the trait-operator arm #247 fixed the same
+way. `.rev().rev()` compiles and returns source order; three levels, the
+variable-bound receiver form, `take` of `take`, `skip` of `skip`, and a
+self-nested chain composed with `collect` and with `map` are all covered in
+tests/iterator_combinators.test.yo (49 passing).
+
+**Root cause (measured, after two refuted hypotheses):** the MINT half of a call
+re-evaluates the declared return-type expression under its era-suspect trigger,
+routing `IterRev(Self)` through the constructor memo and adopting the CANONICAL
+instance. The CALLER half has no such trigger — its gate fires only on leftover
+SomeTs, and the substituted return is already SomeT-free — so the call site kept
+the substitution copy. Because `substitute()` KEEPS the def-era struct id, that
+copy is self-nesting (its own id sits in its type arguments), and `type_key`'s
+cycle guard is keyed on the bare struct id, so it read that argument as a
+back-edge and rendered it as the bare id. Codegen keys C types by that string,
+so one logical type became two.
+
 **Found:** 2026-08-25, implementing `rev` for STD_API_AUDIT D3.4.
 **Pre-existing:** yes — reproduced identically with the previous compiler
 (develop before the D3.4 branch), so it is not caused by the routing-gate fix

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -6433,6 +6433,20 @@ Fix: wrap the call:
             ),
             .None => ()
           );
+          // Recursive-instantiation era repair, METHOD-dispatch arm — the twin
+          // of the trait-operator arm above. A declared return like
+          // `-> IterRev(Self)` is resolved per call by substitution, and
+          // `substitute()` KEEPS the def-era struct id (types/substitution.yo).
+          // For an adaptor instantiated over ITSELF that means the outer
+          // instance and its own type ARGUMENT carry ONE id, so `type_key`'s
+          // id-keyed cycle guard reads the argument as a back-edge and renders
+          // it as the bare sid — splitting the call site from the
+          // specialization, whose own era repair had already adopted the ctor
+          // memo's CANONICAL instance. The mint half has an era-suspect
+          // trigger; this caller-side path has none, so adopt the canonical
+          // instantiation here. AFTER the receiver adopt, never before.
+          // issues/fixed/nested-same-adaptor-instantiation-identity-split.md
+          m_out_ty = canonicalize_instantiation_via_ctfe_memo(m_out_ty);
           out_m := new_expr_info(call_result_m.caller_env, m_out_ty);
           out_m.value = m_result_val;
           out_m.runtime_arg_exprs_in_order = Option(ArrayList(AstExpr)).Some(call_result_m.runtime_arg_exprs_in_order);

--- a/tests/iterator_combinators.test.yo
+++ b/tests/iterator_combinators.test.yo
@@ -422,10 +422,45 @@ test("rev on an ArrayList and on an Array", {
   });
   assert(arr_out.to_string() == `[0, 8, 7]`, "Array backwards");
 });
-// `.rev().rev()` is NOT covered: instantiating a generic struct over ITSELF
-// mints two C type identities, a pre-existing bug (same failure on the previous
-// compiler) that IterRev is simply the first std adaptor able to trigger —
-// issues/nested-same-adaptor-instantiation-identity-split.md.
+// Self-nesting adaptors — a generic struct instantiated over ITSELF. These used
+// to mint two C type identities for one logical type and fail at the C compiler;
+// issues/fixed/nested-same-adaptor-instantiation-identity-split.md.
+test("rev of rev is the identity", {
+  out := array_list(i32(0));
+  (i32(0) .. i32(4)).rev().rev().for_each((x) => {
+    out.push(x);
+  });
+  assert(out.to_string() == `[0, 0, 1, 2, 3]`, "double rev restores source order");
+});
+test("three levels of rev", {
+  out := array_list(i32(0));
+  (i32(0) .. i32(4)).rev().rev().rev().for_each((x) => {
+    out.push(x);
+  });
+  assert(out.to_string() == `[0, 3, 2, 1, 0]`, "triple rev reverses again");
+});
+test("self-nesting through a VARIABLE-BOUND receiver", {
+  // The chained form re-specializes on demand; the variable-bound form keeps
+  // the stamp, and only the stamp was repaired — so both are covered.
+  it := (i32(0) .. i32(4)).rev().rev();
+  out := array_list(i32(0));
+  it.for_each((x) => {
+    out.push(x);
+  });
+  assert(out.to_string() == `[0, 0, 1, 2, 3]`, "variable-bound double rev");
+});
+test("self-nesting on adaptors other than rev", {
+  assert((i32(0) .. i32(9)).take(usize(5)).take(usize(2)).count() == usize(2), "take of take");
+  assert((i32(0) .. i32(9)).skip(usize(1)).skip(usize(1)).count() == usize(7), "skip of skip");
+});
+test("a self-nested chain still composes with collect and map", {
+  got := (i32(0) .. i32(4)).rev().rev().collect(ArrayList(i32));
+  assert(got.to_string() == `[0, 1, 2, 3]`, "collect after a self-nested chain");
+  // `.map` puts a closure type in the adaptor's type arguments, which the
+  // canonicalizer deliberately declines to touch — keep that path exercised.
+  doubled := (i32(0) .. i32(3)).rev().rev().map((x) => (x * i32(2))).collect(ArrayList(i32));
+  assert(doubled.to_string() == `[0, 2, 4]`, "map after a self-nested chain");
+});
 test("next and next_back meet in the middle", {
   it := (i32(0) .. i32(4)).into_iter();
   a := it.next();


### PR DESCRIPTION
Fixes the bug filed with #253: a generic struct instantiated over **itself** got
two C type identities, so `.rev().rev()` failed at the C compiler.

```
error: initializing '__yo_t19' with an expression of incompatible type '__yo_t11'
```

Both structs are `IterRev(IterRev(Range(i32)))`, structurally identical, under two
different eval struct ids — and the second appeared exactly once in the emitted C,
as that function's return type.

## Root cause

`substitute()` KEEPS the def-era struct `id` and `constructor_func_id` while
rewriting type arguments, so **every** `IterRev` instantiation shares one eval id
and the distinction lives in the rendered type key. Two halves of one call then
disagree:

- The **mint** half (specialization) re-evaluates the declared return-type
  expression under its era-suspect trigger, which routes `IterRev(Self)` through
  the CTFE constructor memo and adopts the **canonical** instance.
- The **caller** half has no such trigger — its gate fires only on leftover
  SomeTs, and the substituted return is already SomeT-free — so the call site
  keeps the substitution copy, which for a self-nesting adaptor holds *its own
  id* in its type arguments. `type_key`'s cycle guard is keyed on the bare struct
  id, so it reads that argument as a back-edge and renders it as the bare id.

Result: `gs_<ctor>_struct_<sid>` at the call site versus
`gs_<ctor>_gs_<ctor>_gs_<range>_i32` at the callee. Codegen keys C types by that
string, so one logical type became two.

Two hypotheses were tested and refuted on the way, and are recorded in the issue
so nobody repeats them: the memo key does **not** miss (arguments compare by id
first, then by constructor fid plus recursive era-equality), and the
`rre`/return-type re-evaluation path is **never entered** for `rev`
(`YO_DEBUG_RRE=1` prints seven lines, none for it).

## The fix

One statement in the method-dispatch arm of `evaluate_function_call`, making it
the twin of the trait-operator arm that #247 already fixed the same way:

```rust
m_out_ty = canonicalize_instantiation_via_ctfe_memo(m_out_ty);
```

Placed **after** the receiver adopt, never before. By the time this arm stamps,
the specialization has already registered the canonical instance in the memo, so
the call site adopts exactly what the callee returns.

Why the existing repairs did not cover it: `adopt_receiver_struct_instance` bails
when the return and receiver share an id — always true for a self-nesting adaptor
— and `canonicalize_instantiation_via_ctfe_memo` had exactly one call site, on
the trait-operator path, which a dot-method call never reaches.

## Why nothing else changes

- **Single `.rev()`** — the lookup either finds the canonical instance, whose type
  key is *identical* to the copy's (at one nesting level no id repeats, so the
  cycle guard never fires), or finds nothing and returns the input untouched.
- **Closure-carrying adaptors** (`map`, `filter`, `filter_map`, `flat_map`,
  `take_while`) — their type arguments include the closure type as a top-level
  bare SomeT, and the canonicalizer early-returns on such an argument. Those
  returns are never touched, so closure-capture identity is preserved.
- **Closure-free adaptors** (`take`, `skip`, `enumerate`, `zip`, `chain`) are
  canonicalized, but only ever onto the instance the callee itself registered —
  i.e. toward agreement, the direction #247 established.

## Tests

`tests/iterator_combinators.test.yo`: double `rev`, **triple** `rev` (the guard
against level collapse), the variable-bound receiver form as well as the chained
one, self-nesting on adaptors other than `rev` (`take` of `take`, `skip` of
`skip`), and a self-nested chain composed with `collect` and with `map` — the last
one keeps the closure-SomeT bail exercised on the same shape.

## A residual I could NOT reproduce, recorded with its negative evidence

The memo's identity rules have two raw-id fast paths whose justifying comment
("a struct id is unique per definition") is false for exactly the shared-id
generics `substitute()` creates, so on paper two *different* instantiations used
as memo arguments should compare equal.

I built the predicted trigger — self-nested chains at three different element
types in one module, plus a mapped one — and **it produces correct results**:

```rust
(i32(0) .. i32(4)).rev().rev().collect(ArrayList(i32))   // [0, 1, 2, 3]
(i64(0) .. i64(4)).rev().rev().collect(ArrayList(i64))   // [0, 1, 2, 3]
(u8(0)  .. u8(3)).rev().rev().collect(ArrayList(u8))     // [0, 1, 2]
(i32(1) ..= i32(3)).rev().rev().map((x) => (x * i32(10))).collect(ArrayList(i32))
                                                          // [10, 20, 30]
```

So it is filed as `issues/ctfe-memo-shared-struct-id-fast-path-smell.md` — an
OPEN *hardening opportunity* carrying its negative evidence and the smallest
sound hardening, explicitly **not** a live bug. I would rather record what was
tried than leave a theory in the tree that reads like a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
