### PR TITLE
cc: keep codegen-defect diagnostics under -w; collapse --release into --optimize; fix the broken pkg-config include path

### DIFF
--- a/issues/build-release-small-is-identical-to-release-safe.md
+++ b/issues/build-release-small-is-identical-to-release-safe.md
@@ -1,0 +1,44 @@
+# `ReleaseSmall` builds exactly like `ReleaseSafe`, and `std/build.yo` documents `-g` that is never passed
+
+**Status:** OPEN
+**Found:** 2026-08-25, auditing the `yo compile` optimization flags.
+**Severity:** low-but-dishonest — the build system advertises two optimization
+modes that produce identical output, and documents a debug flag it never passes.
+
+## 1. `release-small` and `release-safe` emit identical flags
+
+`src/build_runner.yo` maps the artifact optimization level to `--optimize`:
+
+```rust
+release-safe  -> "2"
+release-fast  -> "3"
+release-small -> "2"      // <-- same as release-safe
+```
+
+So `ReleaseSmall` and `ReleaseSafe` produce byte-identical `cc` argv.
+`std/build.yo` spends six comment lines justifying when to choose `ReleaseSmall`
+over `ReleaseSafe`, on a distinction that does not exist in the emitted build.
+
+The natural mapping is `-Os` (or `-Oz`), but `yo compile --optimize` **rejects**
+`s` and `z`: its validator accepts only `0|1|2|3`. (Its help text used to
+advertise `s|z` anyway — that lie is fixed in the same change as this filing.)
+
+Fixing it properly means deciding what `s`/`z` mean across the toolchain's C
+compilers: clang has both `-Os` and `-Oz`; gcc has `-Os` but no `-Oz`. So
+accepting `s` is straightforward, `z` needs either a clang-only gate or a
+documented fallback to `-Os`.
+
+## 2. `std/build.yo` documents `-g` that is never passed
+
+`std/build.yo` documents the levels as, in effect, `Debug -> -O0 -g` and
+`ReleaseSafe -> -O2 -g`. `build_runner` never emits `-g` for any level — debug
+symbols come only from an explicit `yo compile -g`. Either the build system
+should pass `-g` for the levels that promise it, or the doc comment should stop
+promising it.
+
+## Why this was not fixed in the same change
+
+Both are behaviour changes to build output, not documentation slips:
+adding `-Os` changes what `ReleaseSmall` produces, and adding `-g` changes
+artifact size for every debug build. They deserve their own change and their own
+battery, rather than riding along with a CLI flag collapse.

--- a/src/build_runner.yo
+++ b/src/build_runner.yo
@@ -625,7 +625,7 @@ compile_artifact :: (
     i = usize(0);
     n = artifact.include_paths.len();
     while(i < n, {
-      cmd.arg(String.from("--include"));
+      cmd.arg(String.from("-I"));
       cmd.arg(artifact.include_paths(i));
       i = (i + usize(1));
     });
@@ -635,10 +635,10 @@ compile_artifact :: (
     // every level except debug/release-safe, `mapOptimize` sends
     // release-safe/-small to -O2 and release-fast to -O3, allocator is passed
     // unconditionally, sanitize only when not "none".
-    is_release := ((artifact.optimize != "debug") && (artifact.optimize != "release-safe"));
-    if(is_release, {
-      cmd.arg(String.from("--release"));
-    });
+    // NOTE: no `--release` is emitted. Every level that would have set it
+    // (release-fast, release-small) also emits an explicit `--optimize` below,
+    // which supersedes it — so the flag never changed a single argv. `yo compile`
+    // now collapses `--release` into `--optimize` anyway.
     optimize_num := cond(
       (artifact.optimize == "release-safe") => String.from("2"),
       (artifact.optimize == "release-fast") => String.from("3"),

--- a/src/main.yo
+++ b/src/main.yo
@@ -1796,13 +1796,39 @@ run_compile :: (
   // Optimization + warnings: explicit --optimize wins over --release; the
   // default and explicit `--optimize 0` use -O0 with the noisy warnings
   // suppressed (mirrors the TS option logic).
+  //
+  // WARNINGS ARE NOT PURELY A FUNCTION OF THE OPTIMIZATION LEVEL. Generated C is
+  // full of harmless noise (unused temporaries, redundant parens, pointer-sign
+  // on string literals), so an optimized build passes `-w` to silence it. But a
+  // few diagnostics can ONLY mean the code GENERATOR emitted something
+  // inconsistent with its own prototypes, and those are re-enabled AFTER `-w`
+  // (clang and gcc honour the later flag, so exactly those come back).
+  //
+  // This is not hypothetical: a specialized generic's `inout` parameter lost its
+  // by-ref binding, so codegen passed a `T**` where its own prototype said `T*`.
+  // That is only -Wincompatible-pointer-types, `-w` swallowed it, and the
+  // program silently returned an uninitialised value — a formatted string came
+  // back as padding with no body. See
+  // issues/fixed/specialized-inout-param-loses-ref-with-comptime-arg.md and
+  // issues/release-builds-suppress-all-c-warnings.md. A pointer-type mismatch
+  // between generated code and its own generated prototype is never noise:
+  // both sides are written by this compiler.
+  //
+  // The -O0 arm below needs no such re-enabling — `-Wall` and clang's
+  // defaults already include all three.
   cond(
     ((optimize == "") && release) => {
       cmd.arg(String.from("-w"));
+      cmd.arg(String.from("-Wincompatible-pointer-types"));
+      cmd.arg(String.from("-Wint-conversion"));
+      cmd.arg(String.from("-Wimplicit-function-declaration"));
       cmd.arg(String.from("-O2"));
     },
     ((optimize != "") && (optimize != "0")) => {
       cmd.arg(String.from("-w"));
+      cmd.arg(String.from("-Wincompatible-pointer-types"));
+      cmd.arg(String.from("-Wint-conversion"));
+      cmd.arg(String.from("-Wimplicit-function-declaration"));
       cmd.arg(`-O${optimize}`);
     },
     true => {
@@ -3588,8 +3614,13 @@ Compile a '.yo' source file to a native executable (via C11).
 
 Options:
   -o <path>                 Output binary path
-  --release                 Optimized build (-O2; default is -O0)
-  --optimize <level>        Explicit C optimization level (0|1|2|3|s|z)
+  --release                 Optimized build (-O2; default is -O0). The usual
+                            way to build for real use.
+  --optimize <level>        Explicit C optimization level (0|1|2|3|s|z), for a
+                            level --release does not give you. Takes precedence
+                            over --release; any level above 0 optimizes exactly
+                            as --release does, including the ThinLTO pairing
+                            that --emit-chunks requires.
   -g, --debug-symbols       Emit debug symbols
   -s, --strip               Strip the output binary
   --cc, --c-compiler <cc>   C compiler to use (clang|gcc|zig|emcc)

--- a/src/main.yo
+++ b/src/main.yo
@@ -1497,6 +1497,16 @@ run_compile :: (
   if((optimize != "") && (((optimize != "0") && (optimize != "1")) && ((optimize != "2") && (optimize != "3"))), {
     exn.throw(dyn(`compile: invalid --optimize "${optimize}". Choices: 0, 1, 2, 3`));
   });
+  // `--release` is an ALIAS for `--optimize 2` — it selects no profile, gates
+  // nothing semantic, and never reaches `compile_module`, so the emitted C is
+  // identical with or without it. Collapse it into `optimize` HERE, so exactly
+  // ONE mechanism reaches the flag emission and the LTO gate below and the
+  // "explicit --optimize wins" precedence rule stops being a special case that
+  // every reader has to reconstruct. An explicit `--optimize` still wins simply
+  // by already being set.
+  if(release && (optimize == ""), {
+    optimize = String.from("2");
+  });
   if((sanitize != "") && (((sanitize != "address") && (sanitize != "leak")) && (sanitize != "thread")), {
     exn.throw(dyn(`compile: invalid --sanitize "${sanitize}". Choices: address, leak, thread`));
   });
@@ -1793,9 +1803,9 @@ run_compile :: (
   if(get_needs_intel_asm_syntax() && !(is_target_wasm(target)), {
     cmd.arg(String.from("-masm=intel"));
   });
-  // Optimization + warnings: explicit --optimize wins over --release; the
-  // default and explicit `--optimize 0` use -O0 with the noisy warnings
-  // suppressed (mirrors the TS option logic).
+  // Optimization + warnings. `--release` was already collapsed into `optimize`
+  // above, so there is ONE mechanism here: an empty or "0" level means the -O0
+  // default, anything else is an optimized build.
   //
   // WARNINGS ARE NOT PURELY A FUNCTION OF THE OPTIMIZATION LEVEL. Generated C is
   // full of harmless noise (unused temporaries, redundant parens, pointer-sign
@@ -1817,13 +1827,6 @@ run_compile :: (
   // The -O0 arm below needs no such re-enabling — `-Wall` and clang's
   // defaults already include all three.
   cond(
-    ((optimize == "") && release) => {
-      cmd.arg(String.from("-w"));
-      cmd.arg(String.from("-Wincompatible-pointer-types"));
-      cmd.arg(String.from("-Wint-conversion"));
-      cmd.arg(String.from("-Wimplicit-function-declaration"));
-      cmd.arg(String.from("-O2"));
-    },
     ((optimize != "") && (optimize != "0")) => {
       cmd.arg(String.from("-w"));
       cmd.arg(String.from("-Wincompatible-pointer-types"));
@@ -1860,7 +1863,7 @@ run_compile :: (
   // that win on nothing, so LTO tracks the OPTIMIZATION LEVEL rather than the
   // chunk flag. The condition mirrors the -O selection above exactly.
   // Not for wasm: emcc's LTO story is separate and chunked wasm is out of scope.
-  chunk_lto_wanted := (((optimize == "") && release) || ((optimize != "") && (optimize != "0")));
+  chunk_lto_wanted := ((optimize != "") && (optimize != "0"));
   if((emit_chunks >= usize(1)) && (chunk_lto_wanted && (!(chunk_no_lto) && !(is_target_wasm(target)))), {
     cmd.arg(String.from("-flto=thin"));
   });
@@ -3616,11 +3619,10 @@ Options:
   -o <path>                 Output binary path
   --release                 Optimized build (-O2; default is -O0). The usual
                             way to build for real use.
-  --optimize <level>        Explicit C optimization level (0|1|2|3|s|z), for a
-                            level --release does not give you. Takes precedence
-                            over --release; any level above 0 optimizes exactly
-                            as --release does, including the ThinLTO pairing
-                            that --emit-chunks requires.
+  --optimize <level>        Explicit C optimization level (0|1|2|3). --release
+                            is exactly --optimize 2; an explicit --optimize
+                            wins. Any level above 0 also enables the ThinLTO
+                            pairing that --emit-chunks requires.
   -g, --debug-symbols       Emit debug symbols
   -s, --strip               Strip the output binary
   --cc, --c-compiler <cc>   C compiler to use (clang|gcc|zig|emcc)


### PR DESCRIPTION
Three related cleanups behind one question the repo owner asked — "should
`--release`/`--debug` go away, since we can just pass `-Ox`?"

**The answer was no, and `--debug` never existed** (debug symbols are `-g`,
stripping is `-s`, both orthogonal). But auditing it turned up three real
defects, and the owner's instinct about confusion was right — just aimed at the
wrong flag.

## 1. Warnings no longer ride on the optimization level

Any optimized build passed a bare `-w`, disabling **every** C diagnostic. That is
reasonable for the noise generated C makes (unused temporaries, redundant parens,
pointer-sign on string literals) — but it also silenced the diagnostics that can
only mean the code **generator** contradicted its own prototypes.

Not hypothetical: #258's bug passed a `T**` where its own prototype said `T*`.
That is only `-Wincompatible-pointer-types`, `-w` swallowed it, the build looked
clean, and the program returned an **uninitialised value**. Three diagnostics are
now re-enabled after `-w` (clang and gcc honour the later flag, so only these
come back and the noise stays suppressed):

```
-Wincompatible-pointer-types  -Wint-conversion  -Wimplicit-function-declaration
```

The `-O0` arm is untouched — `-Wall` plus clang's defaults already include all
three.

## 2. One optimization mechanism instead of two

`--release` was a pure alias for `--optimize 2`: read in exactly two places, both
treating them identically, emitting byte-identical `cc` argv, and never passed to
`compile_module` — so the emitted C is the same either way. There is no profile
behind the name (no `debug_assertions` analogue, no NDEBUG, no `-g`, no contract
erasure; `-fwrapv` is unconditional and contracts key off `Pragma.NoContracts`).

It now collapses at parse time — `--release` sets `optimize = "2"` when
`--optimize` was not given — and the flag emission and ThinLTO gate key on
`optimize` alone. **No invocation changes**; what disappears is the
"explicit `--optimize` wins over `--release`" precedence rule that every reader
had to reconstruct from two three-armed conds.

`--release` stays, deliberately: it is the only name the project teaches
(`--optimize` appears in zero user-facing docs), and it is the right name to
carry release-conditional semantics if Yo ever gains them.

Also fixes the help, which advertised `--optimize (0|1|2|3|s|z)` while the
validator rejects `s` and `z` outright.

## 3. The pkg-config build path was broken

`build_runner` emitted `--include <path>` for artifact include paths, but
`yo compile` parses only `-I <dir>` and attached `-I<dir>` — and the attached form
explicitly excludes `--`-prefixed arguments. Unknown options are a hard throw, so
**any** artifact with include paths died with
`compile: unknown option '--include'`. Those paths come from pkg-config, so that
whole path was unusable. `--extern`, emitted three lines earlier, IS parsed — a
single-flag slip. Now `-I`.

The `--release` emitted next to it is also removed: it fired only for
release-fast and release-small, and both also emit an explicit `--optimize` right
below, which superseded it — it never changed a single argv.

## Filed, not bundled

`issues/build-release-small-is-identical-to-release-safe.md`: `ReleaseSmall` maps
to `-O2` exactly like `ReleaseSafe` (the natural `-Os` is rejected by
`--optimize`, and gcc has no `-Oz`), and `std/build.yo` documents `-g` for levels
that never receive it. Both change build *output*, so they deserve their own
change and battery.

## Validation

Full battery running, including a deliberate probe: whether the re-enabled
diagnostics surface anything while the compiler compiles **itself**. The
`help-compile` CLI golden is re-recorded (the help text changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)