### PR TITLE
cc: commit the help-compile golden and issue record #260 left behind

### DIFF
--- a/issues/fixed/release-builds-suppress-all-c-warnings.md
+++ b/issues/fixed/release-builds-suppress-all-c-warnings.md
@@ -1,0 +1,44 @@
+# `--release` passed a bare `-w`, silencing the diagnostics that catch codegen faults
+
+**Status:** FIXED 2026-08-25 (PR #260).
+**Found:** 2026-08-24, while diagnosing
+`issues/fixed/specialized-inout-param-loses-ref-with-comptime-arg.md`.
+
+## Symptom
+
+Warning selection was purely a function of the optimization level: any optimized
+build (`--release`, or `--optimize` at a nonzero level) passed a bare `-w` to the
+C compiler, which disables **every** C diagnostic.
+
+That is defensible for the noise generated C produces — unused temporaries,
+redundant parentheses, pointer-sign on string literals — but it also silenced the
+three diagnostics that can only mean the code **generator** emitted something
+inconsistent with its own prototypes:
+
+- `-Wincompatible-pointer-types`
+- `-Wint-conversion`
+- `-Wimplicit-function-declaration`
+
+## Why it mattered
+
+Not hypothetical. A specialized generic's `inout` parameter lost its by-ref
+binding, so codegen passed a `T**` where its own emitted prototype said `T*`.
+That is exactly `-Wincompatible-pointer-types`. With `-w` in force the build
+looked clean, and the program returned an uninitialised value — a formatted
+string came back as padding with no body, a silent wrong answer rather than a
+crash.
+
+The same class of fault had been invisible in every optimized build the project
+had ever run.
+
+## Fix
+
+`src/main.yo`: warnings are decoupled from the optimization level. Both `-w`
+arms now additionally pass the three diagnostics above, so the noise stays
+suppressed while a generator/prototype mismatch is still reported.
+
+## Verification
+
+A full self-build after the change emitted **zero** hits of the three re-enabled
+diagnostics — so they are not noisy on real generated C, and no other latent
+instance of this class existed in the tree at the time.

--- a/tests/cli-cases/help-compile/expected_stdout
+++ b/tests/cli-cases/help-compile/expected_stdout
@@ -5,8 +5,12 @@ Compile a '.yo' source file to a native executable (via C11).
 
 Options:
   -o <path>                 Output binary path
-  --release                 Optimized build (-O2; default is -O0)
-  --optimize <level>        Explicit C optimization level (0|1|2|3|s|z)
+  --release                 Optimized build (-O2; default is -O0). The usual
+                            way to build for real use.
+  --optimize <level>        Explicit C optimization level (0|1|2|3). --release
+                            is exactly --optimize 2; an explicit --optimize
+                            wins. Any level above 0 also enables the ThinLTO
+                            pairing that --emit-chunks requires.
   -g, --debug-symbols       Emit debug symbols
   -s, --strip               Strip the output binary
   --cc, --c-compiler <cc>   C compiler to use (clang|gcc|zig|emcc)


### PR DESCRIPTION
#260 rewrote `yo compile --help` but landed **without** the golden that pins that text, so the `help-compile` CLI case has been failing on develop since that merge. My mistake — the battery recorded the golden in its worktree and I merged without staging it.

- `tests/cli-cases/help-compile/expected_stdout` — the recorded golden, verified against the live binary's `compile --help` output (the only remaining diffs were the harness's own normalization: the `$ yo …` header, the `<TARGET>` placeholder, and the `rc=` footer).
- `issues/fixed/release-builds-suppress-all-c-warnings.md` — the record of the defect #260 fixed, which was likewise never staged.

No source change; this is repairing the merge, not altering behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)