### PR TITLE
issues: derive(ToString) on a generic struct emits invalid C

### DIFF
--- a/issues/derive-tostring-on-a-generic-struct-emits-invalid-c.md
+++ b/issues/derive-tostring-on-a-generic-struct-emits-invalid-c.md
@@ -1,0 +1,59 @@
+# `derive(ToString)` on a generic struct emits invalid C (`&(self.field)` on a pointer)
+
+**Status:** OPEN
+**Found:** 2026-08-25, completeness-checking the fix for
+issues/fixed/derive-rules-name-types-through-a-display-renderer.md — i.e. asking
+which OTHER derive rules break on a generic struct.
+**Severity:** medium. Hard C error, so it is loud, not silent.
+
+## Symptom
+
+```rust
+TSBox :: (fn(comptime(T) : Type) -> comptime(Type))(struct(value : T));
+derive(generic(T), TSBox(T), where(T <: ToString), ToString);
+
+TSBox(i32)(i32(5)).to_string();
+```
+
+```
+error: member reference type '__yo_t9 *' (aka 'struct __yo_t9_struct *') is a pointer;
+       did you mean to use '->'?
+ 1875 |   __yo_t4 _file____User_temp_5830 = yo_id_4896((&(self.value)));
+      |                                                   ~~~~^
+      |                                                       ->
+```
+
+`derive(ToString)` on a NON-generic struct is fine (`Plain(5)`), so genericity is
+the trigger.
+
+## Root cause
+
+The emitted C takes the address of a field on an `inout(self)` receiver without
+dereferencing it: `&(self.value)` where `self` is `__yo_t9*`. It must be
+`&(self->value)`.
+
+That is the `Variable.is_ref` channel again — the same family as
+issues/fixed/specialized-inout-param-loses-ref-with-comptime-arg.md (#258) and
+issues/generic-trait-method-reads-primitive-inout-self-as-pointer.md — but a
+third distinct site: the ADDRESS-OF-A-FIELD path rather than a plain scalar read.
+It is why `derive(Clone)` on a generic struct is fine after its own fix while
+this one still fails: Clone's body reads fields as values, ToString's takes their
+address to pass them on to the nested `to_string`.
+
+Note this is NOT the display-renderer bug. That one is also present here but is
+harmless: `type_name` lands inside a STRING LITERAL, so a generic struct would
+merely PRINT `<struct:struct_yo_id_N>(5)` instead of `TSBox(5)` once the C error
+is fixed. Both halves need fixing for the output to be right, and they are
+independent.
+
+## Reproducer
+
+`issues/repros/derive-tostring-generic-struct.yo`
+
+## Suggested order
+
+Fix with the sibling `inout(self)` pointer bugs — all three are the same channel
+and a single repair to the ref-ness propagation may cover them. Add a
+`derive(ToString)`-on-a-generic-struct case to `tests/derive.test.yo` at that
+point; the existing generic-derive coverage there is Eq/Clone/Default only,
+which is exactly why this went unnoticed.

--- a/issues/repros/derive-tostring-generic-struct.yo
+++ b/issues/repros/derive-tostring-generic-struct.yo
@@ -1,0 +1,11 @@
+open(import("std/string"));
+open(import("std/fmt"));
+TSBox :: (fn(comptime(T) : Type) -> comptime(Type))(
+  struct(value : T)
+);
+derive(generic(T), TSBox(T), where(T <: ToString), ToString);
+main :: (fn() -> unit)({
+  println(`generic : ${TSBox(i32)(i32(5)).to_string()}`);
+  ();
+});
+export(main);


### PR DESCRIPTION
Docs + reproducer only — no source change.

Found by **completeness-checking my own fix**: after repairing `derive(Clone)` and `derive(FromJson)`, I asked which *other* derive rules break on a generic struct rather than stopping at the two the Hasher work happened to surface. `derive(ToString)` is the third, and it fails differently — a hard C error rather than a silent wrong answer:

```c
yo_id_4896((&(self.value)))   // self is __yo_t9*, needs self->value
```

So this is **not** the display-renderer bug — it is the `Variable.is_ref` channel again, a third site in that family after #258 (scalar read in a folded-const specialization) and #263 (generic trait method reading a primitive `inout(self)`). This one is the *address-of-a-field* path, which is precisely why `derive(Clone)` on a generic struct is fine after its fix while this still fails: Clone reads fields as values; ToString takes their address to hand to the nested `to_string`.

The renderer bug is also present here but harmlessly — `type_name` lands inside a string literal, so once the C error is fixed a generic struct would still *print* `<struct:struct_yo_id_N>(5)`. Both halves are needed for correct output, and they are independent.

`derive(ToString)` on a non-generic struct is unaffected (`Plain(5)`).

The existing generic-derive coverage in `tests/derive.test.yo` is Eq/Clone/Default only — which is why this went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)