### PR TITLE
docs: fix 60 verified staleness defects across the user-facing docs

### DIFF
--- a/docs/en-US/ALGEBRAIC_EFFECTS.md
+++ b/docs/en-US/ALGEBRAIC_EFFECTS.md
@@ -18,7 +18,7 @@ function pointers are passed as extra C parameters.
 | Evidence passing       | Handler fn pointers as C params                          |
 | One-shot continuations | `return` resumes, `unwind` discards                      |
 | Handler type           | `ctl(args) -> ret` parallel to `fn(args) -> ret`         |
-| Escape discipline      | Type-level check via `typeIsControlBound`                |
+| Escape discipline      | Type-level check via `type_is_control_bound`                |
 | Effect polymorphism    | `generic(E : Type.Struct)` + `e : E`                     |
 | Effect bundling        | Anonymous structs `{ raise, log }` or named struct types |
 
@@ -229,7 +229,7 @@ locally installed.
 7. **Control-bound types.** A type is _control-bound_ iff it
    transitively contains a `ctl(...) -> ret` (directly, or as a
    struct/tuple/enum/union field, or as an array/slice element, or as
-   a pointer pointee). The predicate is `typeIsControlBound(T)`.
+   a pointer pointee). The predicate is `type_is_control_bound(T)`.
 
 8. **Escape boundaries.** Control-bound types are rejected as:
 
@@ -237,7 +237,7 @@ locally installed.
      install frame.
    - **Module-level binding type** — module scope outlives every call
      frame.
-   - **`Box(T)` / `Rc(T)` / any heap-allocation type parameter** —
+   - **`Box(T)` / `Arc(T)` / any heap-allocating type constructor** —
      heap outlives every stack frame.
    - **Closure capture type** (covered by rule 4).
    - **Pointer pointee type** — `*(Raise)` is rejected so a handler
@@ -293,7 +293,7 @@ top_handler :: (raise : Raise) = ((msg) -> { unwind(i32(0)); });
 P :: *(Raise);  // rejected
 
 // ❌ Storing in a Box — heap outlives the install frame.
-b := Box(Raise).new((msg) -> { unwind(i32(0)); });
+b := box((msg) -> { unwind(i32(0)); });
 
 // ❌ Closure capturing a handler — closure escapes; handler with it.
 (r : Raise) = ((msg) -> { unwind(i32(0)); });
@@ -358,12 +358,28 @@ log_and_check :: (fn(x : i32, logger : Logger) -> i32)({
 result := log_and_check(42, my_logger);
 ```
 
+## Handler Functions Are Not Closures
+
+Effect handler functions — both the struct-record and the `fn`-type forms — are
+compiled as standalone C functions via evidence passing. They are **not**
+closures: no capture struct is generated, and a handler body cannot read a local
+from the scope that installed it. This is by design.
+
+If a handler needs state, pass it explicitly:
+
+- take it as an argument to the effect function, so the caller supplies it at
+  the `ctl` call site; or
+- allocate a `Box` outside the handler and pass its address in.
+
+(`.github/instructions/c-codegen.instructions.md` § "Handler functions are
+standalone, not closures" is the implementation-side statement of the same rule.)
+
 ## Semantics
 
-- Handler bodies run in their install frame's stack — they can
-  reference outer-frame locals (sibling handlers, surrounding
-  variables) directly. The codegen achieves this by inlining handlers
-  / threading them through state machines.
+- Handler bodies are compiled as **standalone C functions** via evidence
+  passing, so they can NOT reference variables from the enclosing scope —
+  no closure/capture struct is generated. See
+  [Handler Functions Are Not Closures](#handler-functions-are-not-closures).
 - `return(value)` is **one-shot** — the captured continuation can be
   resumed at most once.
 - Handler types are enforced at the type level via `ctl(...)`. The

--- a/docs/en-US/ARC.md
+++ b/docs/en-US/ARC.md
@@ -4,19 +4,19 @@
 It is **not** a compiler built-in anymore. In the current design, `Arc` is defined
 in `std/prelude.yo` as a thin `atomic(ref(struct(...)))` wrapper, so `Arc` and
 `arc(...)` are available everywhere through the prelude. `Arc(T)` itself requires
-`T <: Send`, which keeps `Arc` from laundering non-thread-safe values into a
+`T <: (Send, Acyclic)`, which keeps `Arc` from laundering non-thread-safe values into a
 thread-shareable wrapper.
 
 ## Current definition
 
 ```rust
-Arc :: (fn(comptime(V) : Type, where(V <: Send)) -> comptime(Type))
+Arc :: (fn(comptime(V) : Type, where(V <: (Send, Acyclic))) -> comptime(Type))
   atomic(ref(struct(
     (*) : V
   )))
 ;
 
-arc :: (fn(generic(V : Type), own(value) : V, where(V <: Send)) -> Arc(V))
+arc :: (fn(generic(V : Type), own(value) : V, where(V <: (Send, Acyclic))) -> Arc(V))
   Arc(V)(value)
 ;
 ```
@@ -71,7 +71,7 @@ assert((b.(*) == c.(*)), "same shared value");
 ### Cross-thread sharing
 
 ```rust
-{ Thread } :: import "std/thread";
+{ Thread } :: import("std/thread");
 
 shared := arc(i32(42));
 

--- a/docs/en-US/ASYNC_AWAIT.md
+++ b/docs/en-US/ASYNC_AWAIT.md
@@ -4,7 +4,7 @@
 
 Yo uses **async/await with state machine transformation** via **algebraic effects** for efficient **single-threaded concurrency**. This is a stackless coroutine model similar to JavaScript's event loop - all async code runs on the **same thread** as the caller.
 
-**Key Insight**: `io.async`/`io.await` provides **concurrency** (interleaved execution), not **parallelism** (simultaneous execution). For parallelism, see `PARALLELISM.md` which describes the `Task.spawn` API for isolated multi-threaded execution.
+**Key Insight**: `io.async`/`io.await` provides **concurrency** (interleaved execution), not **parallelism** (simultaneous execution). For parallelism, see `PARALLELISM.md`, which describes `Thread.spawn` (std/thread) and the worker pool for isolated multi-threaded execution.
 
 ```rust
 { yield } :: import "std/async";
@@ -34,7 +34,7 @@ export main;
 | Concept         | Mechanism             | Description                                |
 | --------------- | --------------------- | ------------------------------------------ |
 | **Concurrency** | `io.async`/`io.await` | Multiple tasks interleaved on ONE thread   |
-| **Parallelism** | `Task.spawn`          | Multiple tasks running on SEPARATE threads |
+| **Parallelism** | `Thread.spawn`        | Multiple tasks running on SEPARATE threads |
 
 ```rust
 // Concurrency: Same thread, interleaved execution
@@ -48,10 +48,12 @@ main :: (fn(io : Io) -> unit)({
 });
 
 // Parallelism: Different threads, true simultaneous execution
-task := Task(i32, bool).spawn((parent) -> {
-  // Runs on a DIFFERENT thread!
-  // Completely isolated - no shared memory
+thread := Thread.spawn((io) => {
+  // Runs on a DIFFERENT thread, with its own independent event loop.
+  // Isolated: only Send values cross the boundary.
+  ()
 });
+thread.join();
 ```
 
 ## Execution Model: Lazy Start via Algebraic Effects
@@ -128,7 +130,7 @@ Multi-threaded async (like Rust's tokio) adds complexity:
 - Need cross-thread synchronization
 - Work-stealing adds overhead
 
-Yo's approach: Keep async simple (single-threaded), use `Task.spawn` for parallelism (isolated threads).
+Yo's approach: Keep async simple (single-threaded), use `Thread.spawn` for parallelism (isolated threads).
 
 ## Language Syntax
 
@@ -181,11 +183,15 @@ test "my test", {
 
 ```rust
 io.async(fn)                  // Create a cold Future (lazy, doesn't start)
-io.await(future)              // Start if cold, wait for completion, return result
+io.await(future, e)           // Start if cold, wait for completion, return result
 io.state(future)              // Query the current state of a Future (returns FutureState)
-io.spawn(future)              // Start a cold Future without waiting, returns JoinHandle(T)
-handle.await(io)       // Wait for spawned task, returns Option(T) (.None on unwind)
-yield()                       // Create a pre-completed Future (yields control to event loop)
+io.spawn(future, e)           // Start a cold Future without waiting, returns JoinHandle(T)
+handle.await(io)              // Wait for spawned task, returns Option(T) (.None on unwind)
+yield(io)                     // Create a pre-completed Future (yields control to event loop)
+
+// `e` is the EFFECT RECORD the future needs. For a pure-Io task that is just
+// `io`, e.g. `io.await(fut, io)`. For a future needing several effects, bundle
+// them in a struct and pass that one value.
 ```
 
 **Important Rules**:
@@ -300,7 +306,7 @@ provides:
 Io :: struct(
   async : (fn(generic(T : Type, E : Type.Struct), action : Impl(Fn(e : E) -> T)) -> Impl(Future(T, E))),
   await : (fn(generic(T : Type, E : Type.Struct), fut : Impl(Future(T, E)), e : E) -> T),
-  state : (fn(generic(T : Type, E : Type.Struct), fut : Impl(Future(T, E))) -> FutureState),
+  state : (fn(generic(T : Type, E : Type), fut : Impl(Future(T, E))) -> FutureState),
   spawn : (fn(generic(T : Type, E : Type.Struct), fut : Impl(Future(T, E)), e : E) -> JoinHandle(T))
 );
 ```
@@ -349,8 +355,11 @@ main :: (fn(io : Io) -> unit) {
     return i32(42);
   });
 
-  (raise : Raise) = (msg) -> { unwind (); };
-  handle := io.spawn(task, io, raise);
+  (raise : Raise) = (msg) -> { unwind(()); };
+  // `spawn`/`await` take ONE effect argument. With more than one effect,
+  // bundle them into a struct and pass that.
+  Ctx :: struct(io : Io, raise : Raise);
+  handle := io.spawn(task, Ctx(io : io, raise : raise));
   result := handle.await(io);
   // result is Option(i32).None — the task was aborted
   assert(result.is_none(), "aborted task returns None");
@@ -553,7 +562,7 @@ static _Thread_local struct io_uring __yo_io_ring;
 This means:
 
 - **Main thread**: Has its own event loop for `io.async`/`io.await` tasks
-- **Worker threads** (from `Task.spawn`): Each gets an independent event loop
+- **Worker threads** (from `Thread.spawn`): Each gets an independent event loop
 - **Multiple workers per thread**: Workers on the same OS thread cooperatively share that thread's event loop
 - **No cross-thread task migration**: Tasks always run on the thread that created them
 - **No locking needed**: Queue operations are single-threaded by design
@@ -580,16 +589,16 @@ int main(int argc, char** argv) {
 
 Similarly, the **parallelism runtime** (thread pool, worker spawn, hardware detection) is only emitted when the program uses `Thread.spawn` or `worker.spawn`. Non-parallel programs save ~450 lines of generated C code.
 
-**Synchronous system helpers** (stat/dirent accessors, sendfile/copyfile, sync file operations, mmap/madvise, fcntl, flock, socket address helpers, signal handlers, TTY) are always emitted via `generateSysRuntime()` which includes both cross-platform helpers and platform-specific sync helpers (`generatePlatformSysRuntime{MacOS,Linux,Windows}`). These have **no IoFuture dependency**. All functions are `static`, so unused ones are stripped by the C compiler's dead-code elimination. This ensures non-async programs that use signals, stat, mmap, TTY, etc. compile without pulling in the full async runtime.
+**Synchronous system helpers** (stat/dirent accessors, sendfile/copyfile, sync file operations, mmap/madvise, fcntl, flock, socket address helpers, signal handlers, TTY) are always emitted via `generate_sys_runtime()` which includes both cross-platform helpers and platform-specific sync helpers (`generate_platform_sys_runtime_{macos,linux,windows,wasm}`). These have **no IoFuture dependency**. All functions are `static`, so unused ones are stripped by the C compiler's dead-code elimination. This ensures non-async programs that use signals, stat, mmap, TTY, etc. compile without pulling in the full async runtime.
 
 ### Platform-Specific I/O Backends
 
 | Platform | Backend                                         | File                    |
 | -------- | ----------------------------------------------- | ----------------------- |
-| Linux    | `io_uring` (via liburing)                       | `runtime-io-linux.ts`   |
-| macOS    | `kqueue` (kevent readiness + sync pread/pwrite) | `runtime-io-macos.ts`   |
-| Windows  | I/O Completion Ports (IOCP)                     | `runtime-io-windows.ts` |
-| WASM     | POSIX I/O (NODERAWFS) + timer queue             | `runtime-io-wasm.ts`    |
+| Linux    | `io_uring` (via liburing)                       | `src/codegen/async/runtime_io_linux.yo`   |
+| macOS    | `kqueue` (kevent readiness + sync pread/pwrite) | `src/codegen/async/runtime_io_macos.yo`   |
+| Windows  | I/O Completion Ports (IOCP)                     | `src/codegen/async/runtime_io_windows.yo` |
+| WASM     | POSIX I/O (NODERAWFS) + timer queue             | `src/codegen/async/runtime_io_wasm.yo`    |
 
 #### WASM Async Support
 
@@ -699,7 +708,7 @@ void fn_id12345___drop(async_block_state_t* self) {
 
 **Type System Integration:**
 
-The evaluator's `getMethodsByNameFromEnv` function has special handling for Future types - it does NOT use the `resolvedConcreteType` for method lookup. This ensures that when calling `task.___drop()`, it uses the SomeType's own `___drop` method which calls `__yo_sometype_drop`, rather than using the capture struct's drop function.
+The evaluator's `get_receiver_methods_by_name_from_env` function has special handling for Future types - it does NOT use the `resolved_concrete` for method lookup. This ensures that when calling `task.___drop()`, it uses the SomeType's own `___drop` method which calls `__yo_sometype_drop`, rather than using the capture struct's drop function.
 
 ### State Machine Lifecycle
 
@@ -894,7 +903,7 @@ export main;
 - ✅ No atomic RC overhead
 - ✅ Familiar to web developers
 
-For parallelism, use `Task.spawn` (see `PARALLELISM.md`).
+For parallelism, use `Thread.spawn` (see `PARALLELISM.md`).
 
 ## Effect Injection (Runtime Effect Binding)
 
@@ -1001,29 +1010,27 @@ parameters via `e : E`, and callers inject handlers at `io.await` or
    functions and cannot capture variables from the enclosing scope. Pass state
    via explicit parameters or `Box`. See `docs/en-US/ALGEBRAIC_EFFECTS.md`.
 
-2. **Async unwind RC double-decrement** — when a future is passed as a
-   parameter to a function that escapes during `io.await`, the future's RC is
-   decremented twice (once in the await abort path, once in unwind cleanup),
-   causing use-after-free. Workaround: create the future inside the escaping
-   function. See `issues/async-unwind-rc-double-decrement.md`.
+2. **Async unwind RC double-decrement** — reported as: a future passed as a
+   parameter to a function that escapes during `io.await` has its RC decremented
+   twice, causing use-after-free. **Status unverified** — the tracking issue this
+   used to cite (`issues/async-unwind-rc-double-decrement.md`) has never existed
+   in the repository, so there is no record to check it against. Several
+   neighbouring async RC defects WERE fixed in v0.2.17 (the never-dropped future
+   result and the stale `cond_branch` cleanup over-release), which may or may not
+   cover this.
 
-3. **3-argument while loop in async** — the async SM codegen only handles the
-   2-argument form `while condition, body`. The 3-argument form
-   `while condition, step, body` emits broken C code. Workaround: put the step
-   expression inside the loop body. See `issues/async-while-3arg-form.md`.
-
-4. **Binary expression as async return value** — when the last expression in an
-   async closure is a binary operation (e.g., `(a + b)`), the SM struct gets
-   `void* result` instead of the correct type. Workaround: assign to a variable
-   first. See `issues/async-sm-result-type-binary-expr.md`.
+Limitations 3 and 4 in earlier revisions of this document — the 3-argument
+`while` in async, and a binary expression as an async return value — are FIXED.
+See `issues/fixed/async-while-3arg-form.md` and
+`issues/fixed/async-sm-result-type-binary-expr.md`.
 
 ## Summary
 
 Yo's async/await provides:
 
-1. **Lazy execution** — `io.async(fn)` creates cold Futures that don't start until `io.await` or `io.spawn`
+1. **Lazy execution** — `io.async(fn)` creates cold Futures that don't start until `io.await(f, e)` or `io.spawn(f, e)`
 2. **Single-threaded concurrency** — all async runs on one thread
-3. **Concurrent spawn** — `io.spawn(f)` starts a cold Future without waiting, returns `JoinHandle(T)`
+3. **Concurrent spawn** — `io.spawn(f, e)` starts a cold Future without waiting, returns `JoinHandle(T)`
 4. **No thread safety concerns** — no data races possible
 5. **Algebraic effects** — Io capabilities explicit via `io : Io`
 6. **State machine transformation** — zero-cost abstraction
@@ -1073,7 +1080,7 @@ r2 := handle2.await(io);  // Option(T)
 | ------------------------------ | --------------------------------- |
 | Io-bound concurrent tasks      | `io.async`/`io.await`             |
 | Running multiple tasks at once | `io.spawn` + `handle.await`       |
-| CPU-bound parallel computation | `Task.spawn` (see PARALLELISM.md) |
-| Background processing          | `Task.spawn` (see PARALLELISM.md) |
+| CPU-bound parallel computation | `Thread.spawn` (see PARALLELISM.md) |
+| Background processing          | `Thread.spawn` (see PARALLELISM.md) |
 | Waiting for multiple IOs       | `io.spawn` + `handle.await`       |
-| Utilizing multiple CPU cores   | `Task.spawn` (see PARALLELISM.md) |
+| Utilizing multiple CPU cores   | `Thread.spawn` (see PARALLELISM.md) |

--- a/docs/en-US/CYCLE_COLLECTION.md
+++ b/docs/en-US/CYCLE_COLLECTION.md
@@ -226,15 +226,15 @@ Yo uses **complete thread isolation** - spawned tasks run on separate threads wi
 x := 42;
 node := Node(1, .None);  // Cycle-forming type, stays on this thread
 
-// Spawn isolated task - runs on different thread
-task := Task(i32, unit).spawn((parent) -> async {
-  // ❌ CANNOT access node here - completely isolated!
-  // ✅ Can only receive copies of value types
-  value := await parent.recv();
+// Spawn an isolated OS thread — `Thread.spawn` from std/thread.
+// (There is no `Task` type; the async API is `io.async` / `io.await` / `io.spawn`,
+// which are single-threaded and do NOT create threads.)
+handle := Thread.spawn((io) => {
+  // The plain ref(...) `node` above is thread-local and cannot be captured here.
+  // Only Send values cross: value types, Arc(T), and the std/imm structures.
+  ()
 });
-
-await task.send(x);  // Send COPY of x (value type)
-// Cannot send node - reference types stay on their thread
+handle.join();
 ```
 
 **What can be sent between threads (value types only):**
@@ -247,9 +247,9 @@ await task.send(x);  // Send COPY of x (value type)
 | Enums with value payloads        | ✅ Yes    | Value type, copied              |
 | `ref(struct(...))`               | ❌ No     | Reference counted, thread-local |
 | Closures                         | ❌ No     | May capture references          |
-| `*T` (pointers)                  | ❌ No     | Not safe across threads         |
+| `*(T)` (pointers)                | ❌ No     | Not safe across threads         |
 
-**Key Design Decision:** Reference types (`ref(struct(...))`) **never** cross thread boundaries. This means:
+**Key Design Decision:** PLAIN (non-atomic) reference types (`ref(struct(...))`) are thread-local and never cross thread boundaries. The ATOMIC forms — `atomic(ref(...))`, i.e. `Arc`, `std/sync` and `std/imm` — are `Send` and are shared across threads with atomic RC (and are therefore not cycle-collected). This means:
 
 - Each thread's GC only tracks objects created on that thread
 - No cross-thread GC coordination needed
@@ -259,31 +259,28 @@ await task.send(x);  // Send COPY of x (value type)
 **Common patterns:**
 
 ```rust
-// ✅ Message passing with value types
-task := Task(Message, Response).spawn((parent) -> async {
-  msg := await parent.recv();  // Receives COPY of Message
-  await parent.send(Response(ok: true));
+{ Thread } :: import("std/thread");
+{ Channel } :: import("std/sync/channel");
+
+// ✅ Message passing with Send values, over a channel
+main :: (fn(io : Io) -> unit)({
+  // The main thread owns the cycle-forming structure; it stays here.
+  tree := ComplexTree();
+
+  ch := Channel(i32).new();
+  worker := Thread.spawn((io) => {
+    // Only Send values cross: value types, Arc(T), std/imm structures.
+    ch.send(expensive_computation());
+    ()
+  });
+
+  match(ch.recv(), .Some(result) => tree.update(result), .None => ());
+  worker.join();
 });
-
-// ✅ Each thread owns its complex data
-main :: (fn() -> unit) {
-  // Main thread owns complex data structures
-  tree := ComplexTree();  // Has cycles, stays on main thread
-
-  async {
-    // Spawn worker for CPU-intensive computation
-    task := Task(Array(i32), i32).spawn((parent) -> async {
-      data := await parent.recv();
-      result := expensive_computation(data);
-      await parent.send(result);
-    });
-
-    await task.send([1, 2, 3, 4, 5]);  // Send value array
-    result := await task.recv();       // Receive value result
-    tree.update(result);               // Update local data
-  };
-};
 ```
+
+Each thread runs its own independent event loop, so a spawned thread can still
+use `io.async` / `io.await` without contention. See `PARALLELISM.md`.
 
 **GC Collection Process:**
 
@@ -353,18 +350,20 @@ Global impact: Zero (other threads continue running)
 ## API
 
 ```rust
-// Runtime cycle collection control
-gc_collect :: (fn() -> unit);  // Trigger immediate collection
-gc_set_threshold :: (fn(threshold: usize) -> unit);  // Set collection frequency
-gc_get_stats :: (fn() -> GCStats);  // Get collection statistics
+{ collect, tracked_count } :: import("std/gc");
 
-GCStats :: struct(
-  collections: usize,
-  objects_collected: usize,
-  objects_tracked: usize,
-  last_pause_ns: u64,
-);
+collect();          // Trigger an immediate cycle collection
+tracked_count();    // u64 — objects currently tracked by the collector
 ```
+
+That is the whole surface (`std/gc.yo`). There is no statistics struct and no
+threshold-setting function; collection frequency is tuned with environment
+variables read by the emitted runtime:
+
+| Variable | Effect |
+|---|---|
+| `YO_GC_THRESHOLD` | Raises the allocation threshold that triggers a collection — or DISABLES the collector entirely |
+| `YO_GC_FULL_PCT` | Full-scan growth factor, as a percent of post-collection live set (default 200, i.e. 2x-live). Lower to cap peak memory; raise for fewer but larger scans |
 
 ## Compiler Support
 

--- a/docs/en-US/DESIGN.md
+++ b/docs/en-US/DESIGN.md
@@ -304,9 +304,13 @@ y :: 14;
 // or
 (3 + 4) - 5;
 
-// Operators in Yo are combination of the following characters:
-// = + - * / < > @ $ ~ & % | ! ? ^ . : \\ #
-// They can be used as infix operators with two arguments
+// Yo has a CLOSED operator set (plans/OPERATOR_SET_AND_PRECEDENCE.md).
+// A run of operator characters is split greedily against two fixed tables;
+// anything not in them is a LEX ERROR, not a user-defined operator.
+//   two-char: != && -> :: := <: << <= == => >= >> ?= ||
+//   one-char: ! # % & * + - / : < = > ? ^ | ~
+//   dot family: . .. ..= ... ...#
+// Infix operators are translated to a dot method call:
 // But they will be translated as dot method call:
 (3 + 4) * 5; // is the same as
 3.(+)(4).(*)(5);
@@ -585,9 +589,7 @@ p2 := BoolPoint(true, false);
 Named arguments in Yo must be provided in the same order as they are defined in the function signature:
 
 ```rust
-add :: (fn(x : i32, y : i32) -> i32)
-  (x + y)
-;
+add :: (fn(x : i32, y : i32) -> i32)((x + y));
 
 add(3, 4);        // OK: Positional arguments
 add(x: 3, y: 4);  // OK: Named arguments in correct order
@@ -603,9 +605,9 @@ Default parameter values can be defined using `?=` syntax:
 create_user :: (fn(
     name: String,
     (age: i32) ?= 18,
-  ) -> User)
+  ) -> User)(
   User(name: name, age: age)
-;
+);
 
 create_user(name: "Alice");  // Uses defaults: age=18
 create_user(name: "Bob", age: 30);  // Explicit age
@@ -618,9 +620,7 @@ create_user(name: "Bob", age: 30);  // Explicit age
 You can use `generic` to define generic functions:
 
 ```rust
-identity :: (fn(generic(T : Type), arg : T) -> T)
-  arg
-;
+identity :: (fn(generic(T : Type), arg : T) -> T)(arg);
 
 x := identity(12);     // Type inferred: x: i32
 y := identity(true);   // Type inferred: y: bool
@@ -631,9 +631,7 @@ y := identity(true);   // Type inferred: y: bool
 You can use `where` clause to add type constraints on generic parameters:
 
 ```rust
-add :: (fn(generic(T : Type), x: T, y: T, where(T <: Add(T))) -> T)
-  (x + y)
-;
+add :: (fn(generic(T : Type), x: T, y: T, where(T <: Add(T))) -> T)((x + y));
 ```
 
 `where` clause can specify multiple constraints:
@@ -946,11 +944,12 @@ For more pointer examples, see [ptr.test.yo](../tests/ptr.test.yo).
 Yo uses `Option(*(T))` for nullable pointers:
 
 ```rust
-// malloc returns Option(*(T))
+// malloc returns Option(*(void)) — it is NOT generic, so cast before use.
 some_ptr := malloc(sizeof(i32));
 match(some_ptr,
-  .Some(ptr) => {
-    ptr.* = 42;
+  .Some(vp) => {
+    ptr := *(i32)(vp);
+    ptr.* = i32(42);
     printf("value: %d\n", ptr.*);
     free(some_ptr);
   },
@@ -968,7 +967,7 @@ Yo's safety model is layered (the design plan is [plans/MEMORY_SAFETY.md](../../
 
 - **Reference-semantics types** (`ref(struct(...))` / `ref(enum(...))`, and the `atomic(ref(...))` variants) are reference-counted and automatically freed (RC + cycle removal). Memory-safe by construction.
 - **`Iso(T)` / `Arc(T)`** provide affine and atomic-RC ownership for transfer and thread-shared cases.
-- **`*(T)` raw pointers** require an explicit `unsafe(...)` wrap around operations that dereference, do arithmetic on, or consume-through a pointer. Without the wrap, those operations are compile errors.
+- **`*(T)` raw pointers** are available only in a file that declares `pragma(Pragma.AllowUnsafe);`. Inside such a file the `unsafe(...)` wrap is the per-operation AUDIT MARKER that `yo unsafe-report` keys on — and the convention `std/`, `src/` and `tests/` follow — not a second compiler gate: a bare `p.*` in a pragma'd file compiles. In a file WITHOUT the pragma the whole raw-pointer surface is rejected, including the `*(T)` type itself.
 
 `unsafe(...)` is a regular builtin call that takes exactly one expression. It is purely a compile-time marker — at codegen time it lowers to its inner expression, no runtime cost.
 
@@ -992,7 +991,7 @@ write_and_read :: (fn(p : *(i32), v : i32) -> i32)(unsafe({
 
 **What requires `unsafe(...)`**: pointer dereference (`.*`), pointer arithmetic (`.add(n)`, `.sub(n)`, `.offset_from(q)`), and `consume(p.* = v)`.
 
-**What stays safe**: taking an address (`&(x)`), passing/storing/returning pointers, pointer comparison (`<`, `==`, etc.), pointer-type casts (`*(u8)(p)`), and `asm(...)` (already implicitly unsafe).
+**What needs no additional `unsafe(...)` wrap** (inside a file that already declares `pragma(Pragma.AllowUnsafe);`): taking an address (`&(x)`), passing/storing/returning pointers, pointer comparison (`<`, `==`, etc.), pointer-type casts (`*(u8)(p)`), and `asm(...)` (already implicitly unsafe). None of these are available in SAFE code — without the pragma, `&(x)` is rejected at the construction site and a `*(T)` type in any signature is rejected outright.
 
 The unsafe surface is greppable: every `unsafe(` token marks a place where raw memory ops happen. A file must declare `pragma(Pragma.AllowUnsafe);` at the top before it can use `unsafe(...)` or perform raw pointer operations. `std/`, `src/`, and `tests/` files declare this pragma explicitly; user code (`main.yo`, the rest of your project) defaults to safe mode and gets a compile error if it tries to use `unsafe(...)`.
 
@@ -1081,24 +1080,26 @@ my_unit := (); // my_unit: unit.
 
 my_i32_tuple := (12);  // my_i32_tuple: i32
 // Needs extra comma to make it a tuple
-my_i32_tuple := (12,); // my_i32_tuple: (i32,). Free type
+my_i32_tuple := (12,); // my_i32_tuple: (i32;). Free type
 
-(i32_tuple: (i32, i32, i32)) = (1, 2, 3); // tuple: (i32, i32, i32). Free type
+// NOTE the separator: tuple VALUES use commas, tuple TYPES use SEMICOLONS.
+(i32_tuple : (i32; i32; i32)) = (1, 2, 3);
 
-mixed_tuple := (1, true, "Hello"); // mixed_tuple: (i32, bool, *u8[6,'\0']). Free type
+mixed_tuple := (1, true, "Hello"); // mixed_tuple: (i32; bool; str)
 
-(a, b, c) := mixed_tuple; // a: i32, b: bool, c: *u8[6,'\0']. Free type
+(a, b, c) := mixed_tuple; // a: i32, b: bool, c: str
 
 a := mixed_tuple.0;
 b := mixed_tuple.1;
 c := mixed_tuple.2;
 
-// NOTE: For a tuple that has only 1 element, we need to add a comma to make it a tuple.
-MyTuple := (i32)
+// NOTE: a 1-element tuple TYPE still needs the separator, or it is just the
+// element type itself.
+MyTuple :: (i32);
 // is equivalent to
-MyTuple := i32;
-// to make it a tuple, we need to add a comma
-MyTuple := (i32,);
+MyTuple :: i32;
+// to make it a 1-element tuple type:
+MyTuple :: (i32;);
 ```
 
 ## Array & Ranges
@@ -1138,7 +1139,7 @@ part := list(usize(1)..usize(3));   // [2, 3]
 part2 := list(usize(1)..=usize(3)); // [2, 3, 4]
 
 // Mutating the copy does not affect the source
-part.set(usize(0), i32(99));
+part(usize(0)) = i32(99);
 assert(list(usize(1)) == i32(2));
 ```
 
@@ -1151,7 +1152,9 @@ Arrays in Yo come with useful methods:
 Create an array filled with a value:
 
 ```rust
-// Fill at runtime
+// `fill` requires a COMPILE-TIME value (it is defined under `where(T <: Comptime)`
+// and takes a `comptime(val)`), so there is no runtime fill. The two forms below
+// differ only in binding the comptime result to a runtime (`:=`) or comptime (`::`) name.
 zeros := Array(i32, 10).fill(0);  // [0,0,0,0,0,0,0,0,0,0]
 
 // Fill at compile-time
@@ -1164,12 +1167,11 @@ Get the length of an array:
 
 ```rust
 arr := [1, 2, 3, 4, 5];
-len := arr.len();  // 5 (compile-time known for fixed-size arrays)
+len := arr.len();  // 5 (a runtime value; the length is in the TYPE, reachable
+                   //    at compile time via Type.get_info([i32; 5]) -> .Array(_, n))
 
 // Works with generic arrays
-generic_len :: (fn(comptime(T) : Type, comptime(n) : usize, arr : [T; n]) -> usize)
-  arr.len()  // Returns n
-;
+generic_len :: (fn(comptime(T) : Type, comptime(n) : usize, arr : [T; n]) -> usize)(arr.len());  // Returns n
 ```
 
 ### Array Length Inference
@@ -1277,12 +1279,11 @@ main :: (fn() -> unit)({
   // If no return type, it is unit
   number := 3;
 
-  if number < 5, then: {
+  if(number < 5, then: {
     println("condition was true");
-  },
-  else: {
+  }, else: {
     println("condition was false");
-  };
+  });
 
   if(number < 5, println("condition was true"), println("condition was false"));
 });
@@ -1290,8 +1291,8 @@ main :: (fn() -> unit)({
 
 ### while
 
-`while(condition, do: body)` or
-`while(condition, steps, do: body)`
+`while(condition, body)` or
+`while(condition, step, body)`
 
 ```rust
 factorial :: (fn(n: i32) -> i32)({
@@ -1646,26 +1647,26 @@ newtype(
 
 ```rust
 rune :: newtype(
-  c : u32
+  char : u32
 );
 impl(rune,
   // Constructor with validation
-  from_u32 : ((fn(value: u32) -> Option(Self))
+  from_u32 : (fn(value : u32) -> Option(Self))(
     cond(
-      ((value <= u32(0x10FFFF)) && (((value < 0xD800) || (value > 0xDFFF)))) => .Some(Self(c: value)),
+      ((value <= u32(0x10FFFF)) && ((value < 0xD800) || (value > 0xDFFF))) => .Some(Self(char : value)),
       true => .None
     )
   ),
 
-  to_u32 : ((fn(self: Self) -> u32) self.c),
+  to_u32 : (fn(self : Self) -> u32)(self.char),
 
-  is_ascii : ((fn(self: Self) -> bool) (self.c <= 0x7F)),
+  is_ascii : (fn(self : Self) -> bool)(self.char <= u32(0x7F)),
 
   // Constants
-  NUL        : Self(c: 0x00),
-  TAB        : Self(c: 0x09),
-  NEWLINE    : Self(c: 0x0A),
-  SPACE      : Self(c: 0x20)
+  NUL        : Self(char : 0x00),
+  TAB        : Self(char : 0x09),
+  NEWLINE    : Self(char : 0x0A),
+  SPACE      : Self(char : 0x20)
 );
 ```
 
@@ -1688,7 +1689,7 @@ UserId :: newtype(value : i32);
 ## C union
 
 ```rust
-MyNumber := union(
+MyNumber :: union(
   i : i32,
   j : f32
 );
@@ -1710,11 +1711,11 @@ union MyNumber {
 It's the same as the ADT, but all variants have no fields.
 
 ```rust
-State := enum(
+State :: enum(
   Working,
   Failed
 );
-Week := enum(
+Week :: enum(
   Monday, // 0
   Tuesday, // 1
   Wednesday // 2
@@ -1910,7 +1911,7 @@ list.push(i32(42));
 list.push(i32(100));
 list.push(i32(200));
 
-printf("Length: %zu\n", list.length());
+printf("Length: %zu\n", list.len());
 printf("Capacity: %zu\n", list.capacity());
 
 // Get elements by index
@@ -1921,7 +1922,7 @@ match(first,
 );
 
 // Set an element
-list.set(usize(1), i32(150));
+list(usize(1)) = i32(150);
 
 // Pop an element
 popped := list.pop();
@@ -1967,7 +1968,7 @@ match(value_opt,
 
 // Check if key exists
 cond(
-  (map.has(i32(1))) => printf("Contains key 1\n"),
+  (map.contains_key(i32(1))) => printf("Contains key 1\n"),
   true => printf("Does not contain key 1\n")
 );
 
@@ -1979,7 +1980,7 @@ match(removed,
 );
 
 // Check length and empty
-printf("Length: %zu\n", map.length());
+printf("Length: %zu\n", map.len());
 cond(
   (map.is_empty()) => printf("Map is empty\n"),
   true => printf("Map is not empty\n")
@@ -2011,7 +2012,7 @@ match(result,
 
 // Check if has
 cond(
-  (set.has(i32(42))) => printf("Contains 42\n"),
+  (set.contains(i32(42))) => printf("Contains 42\n"),
   true => printf("Does not contain 42\n")
 );
 
@@ -2037,14 +2038,14 @@ set2.add(i32(4));
 // Union
 union_result := set1.union(set2);
 match(union_result,
-  .Ok(union_set) => printf("Union size: %zu\n", union_set.length()),
+  .Ok(union_set) => printf("Union size: %zu\n", union_set.len()),
   .Error(_) => printf("Union failed\n")
 );
 
 // Intersection
 inter_result := set1.intersection(set2);
 match(inter_result,
-  .Ok(inter_set) => printf("Intersection size: %zu\n", inter_set.length()),
+  .Ok(inter_set) => printf("Intersection size: %zu\n", inter_set.len()),
   .Error(_) => printf("Intersection failed\n")
 );
 
@@ -2102,7 +2103,7 @@ match(list.get(usize(0)),
 );
 
 // Insert at index
-match(list.set(usize(1), i32(20)),
+match(list.insert(usize(1), i32(20)),
   .Ok(_) => printf("Inserted at index 1\n"),
   .Error(err) => match(err,
     .IndexOutOfBounds => printf("Index out of bounds\n"),
@@ -2118,7 +2119,7 @@ match(list.remove(usize(0)),
 
 // Check if has
 cond(
-  (list.has(i32(20))) => printf("Contains 20\n"),
+  (list.contains(i32(20))) => printf("Contains 20\n"),
   true => printf("Does not contain 20\n")
 );
 
@@ -2398,11 +2399,22 @@ RetI32 :: trait(
   return_i32 : (fn(inout(self) : Self) -> i32)
 );
 
+// `Impl(Trait)` is STATIC dispatch: every path must return the SAME concrete
+// type, which the compiler infers. Returning `bool` from one arm and `i32` from
+// another does not compile.
 get_value :: (fn(use_bool : bool) -> Impl(RetI32))({
   cond(
-    use_bool => return(true),   // bool implements RetI32
-    true => return(i32(42))      // i32 implements RetI32
-  )
+    use_bool => return(i32(1)),
+    true => return(i32(42))
+  );
+});
+
+// To return DIFFERENT concrete types from different arms, erase to `Dyn`:
+get_any :: (fn(use_bool : bool) -> Dyn(RetI32))({
+  cond(
+    use_bool => return(dyn(true)),
+    true => return(dyn(i32(42)))
+  );
 });
 ```
 
@@ -2476,9 +2488,7 @@ DogRun :: impl(Dog, Run(
 ));
 
 // Dyn type is reference counted - no & needed
-act :: (fn(s: Dyn(Speak, Run)) -> i32)
-  (s.speak() + s.run())
-;
+act :: (fn(s: Dyn(Speak, Run)) -> i32)((s.speak() + s.run()));
 
 main :: (fn() -> i32)({
   dog := Dog();
@@ -2626,7 +2636,7 @@ safe_divide :: (fn(x: i32, y: i32, exn : Exception) -> i32)(
   )
 );
 
-result := safe_divide(6, 3);     // result = 2
+result := safe_divide(6, 3, exn);     // result = 2
 safe_divide(10, 0, exn);         // handler fires, unwinds — code after this is unreached
 ```
 
@@ -2670,15 +2680,15 @@ Yo uses **async/await with state machine transformation** for efficient **single
 
 main :: (fn(io : Io) -> unit)({
   task1 := io.async((io : Io)=> {
-    io.await(yield());
+    io.await(yield(io), io);
     return(i32(1));
   });
   task2 := io.async((io : Io)=> {
-    io.await(yield());
+    io.await(yield(io), io);
     return(i32(2));
   });
-  handle1 := io.spawn(task1);  // start task1, returns JoinHandle(i32)
-  handle2 := io.spawn(task2);  // start task2, returns JoinHandle(i32)
+  handle1 := io.spawn(task1, io);  // start task1, returns JoinHandle(i32)
+  handle2 := io.spawn(task2, io);  // start task2, returns JoinHandle(i32)
   r1 := handle1.await(io);  // wait → Option(i32)
   r2 := handle2.await(io);
 });
@@ -2688,8 +2698,8 @@ export(main);
 Key properties:
 
 - `io.async(fn)` creates a **cold Future** — the body does NOT execute until awaited or spawned
-- `io.await(future)` starts a cold future and runs it to completion; can be called **multiple times** on the same Future
-- `io.spawn(future)` starts a cold future without waiting, returns `JoinHandle(T)`
+- `io.await(future, e)` starts a cold future and runs it to completion; can be called **multiple times** on the same Future (`e` is the effect record — just `io` for pure-Io tasks)
+- `io.spawn(future, e)` starts a cold future without waiting, returns `JoinHandle(T)`
 - `handle.await(io)` waits for a spawned task, returns `Option(T)` — `.None` on unwind (abort)
 - All async code runs on the **same thread** (no thread spawning, no data races)
 
@@ -2707,7 +2717,7 @@ Please check [ISOLATED.md](./ISOLATED.md) for details on isolated types in Yo.
 
 `Arc(T)` provides **shared ownership** with atomic reference counting. It is no longer
 a compiler built-in; it is defined in `std/prelude.yo` as a thin
-`atomic(ref(struct(...)))` wrapper. `Arc(T)` requires `T <: Send`, so it only wraps
+`atomic(ref(struct(...)))` wrapper. `Arc(T)` requires `T <: (Send, Acyclic)` — thread-shareable AND unable to form a reference cycle (atomic RC is not cycle-collected) — so it only wraps
 thread-shareable values. Use `Arc(T)` when you want to share a single value.
 Use `atomic(ref(struct(...)))` when defining your own shared types.
 
@@ -2843,7 +2853,7 @@ test("Test description", {
 
 // Io is implicitly available via `io` in all test bodies
 test("With effects", {
-  io.await(sleep(u64(1000)));
+  io.await(sleep(u64(1000)), io);
 });
 ```
 
@@ -2898,7 +2908,7 @@ test("Compile-time assertions", {
 
   // Type-level assertions
   T :: i32;
-  comptime_assert(Type.to_string(T) == "i32");
+  comptime_assert(Type.to_comptime_string(T) == "i32");
 });
 ```
 
@@ -3081,11 +3091,11 @@ Yo supports automatic trait derivation similar to Rust's `#[derive(...)]`, but u
 
 ### Built-in derives
 
-Five traits have built-in derive support: `Eq`, `Hash`, `Clone`, `Ord`, and `ToString`. They work for both structs and enums:
+Six traits have built-in derive support: `Eq`, `Hash`, `Clone`, `Ord`, `Default`, and `ToString`. They work for both structs and enums:
 
 ```rust
 Point :: struct(x : i32, y : i32);
-derive(Point, Eq, Hash, Clone, Ord, ToString);
+derive(Point, Eq(Point), Hash, Clone, Ord(Point), ToString);
 
 // Now Point supports ==, !=, hashing, cloning, comparison, and string conversion
 main :: (fn() -> unit)({
@@ -3243,9 +3253,7 @@ len :: arr.len();          // 5 (compile-time)
 zeros :: Array(i32, 10).fill(0);  // [0,0,0,0,0,0,0,0,0,0]
 
 // Generic array function
-create_array :: (fn(comptime(T) : Type, comptime(n) : usize, value : T) -> [T; n])
-  Array(T, n).fill(value)
-;
+create_array :: (fn(comptime(T) : Type, comptime(n) : usize, value : T) -> [T; n])(Array(T, n).fill(value));
 
 int_array :: create_array(i32, 5, 42);  // [42,42,42,42,42]
 ```
@@ -3263,7 +3271,7 @@ test("Compile-time assertions", {
 
   // Compile-time type checks
   T :: i32;
-  comptime_assert(Type.to_string(T) == "i32");
+  comptime_assert(Type.to_comptime_string(T) == "i32");
 });
 ```
 
@@ -3352,7 +3360,7 @@ For the full design, syntax reference, and C codegen details, see [INLINE_ASSEMB
 
 Yo provides a unified `Index` trait for custom indexing on any type. Types that implement `Index(Idx)` can use function-call syntax `value(index)` for element access, pointer access via `&(value(index))`, and mutation via the call-syntax assignment `value(index) = new_value`.
 
-The standard library implements `Index` for `ArrayList`, `HashMap`, `BTreeMap`, `Deque`, and `String`. Fixed-size arrays and `str` use built-in indexing with the same syntax; `..` and `..=` ranges on collections produce owned copies (`slice_copy`), while ranges on `str` are zero-copy static windows.
+The standard library implements `Index` for its collection types, including `ArrayList`, `HashMap`, `BTreeMap`, `Deque`, `LinkedList` and `String`. Fixed-size arrays and `str` use built-in indexing with the same syntax; `..` and `..=` ranges on collections produce owned copies (`slice_copy`), while ranges on `str` are zero-copy static windows.
 
 For the full design, trait definition, and implementation details, see [INDEX_TRAIT.md](./INDEX_TRAIT.md).
 

--- a/docs/en-US/MEMORY_SAFETY.md
+++ b/docs/en-US/MEMORY_SAFETY.md
@@ -20,7 +20,7 @@ Everything you'd expect from a modern general-purpose language:
 
 - **Value types.** `i32`, `bool`, `str` (a view of STATIC string bytes — immortal backing), structs, enums, tuples, `Array(T, N)`.
 - **Heap-managed collections.** `ArrayList(T)`, `HashMap(K, V)`, `HashSet(T)`, `Deque(T)`, `LinkedList(T)`, `String`, immutable variants in `std/imm/*`.
-- **Shared ownership.** `object` types (single-threaded Rc), `Arc(T)` (atomic Rc for cross-thread sharing), `Iso(T)` (ownership transfer).
+- **Shared ownership.** Reference-semantics types — `ref(struct(...))` / `ref(enum(...))` (single-threaded Rc) — `Arc(T)` (atomic Rc for cross-thread sharing), `Iso(T)` (ownership transfer).
 - **Sum / option / result types.** `Option(T)`, `Result(T, E)`, your own `enum`s.
 - **Closures and higher-order functions** over safe types.
 - **Generics, traits, GADTs.** All of Yo's type-system features.
@@ -46,7 +46,7 @@ main :: (fn() -> unit)({
 });
 ```
 
-The `for` macro iterates by value (`(item) => …` calls `.into_iter()` under the hood). Object elements are handles, so mutating `item` in the body mutates the element in place; for struct/scalar elements, write back with index assignment (`coll(i) = v`). The old borrow form `for(coll, inout(item) => …)` was removed and produces a compile error with this recipe.
+The `for` macro iterates by value (`(item) => …` calls `.into_iter()` under the hood). Reference-semantics elements are handles, so mutating `item` in the body mutates the element in place; for struct/scalar elements, write back with index assignment (`coll(i) = v`). The old borrow form `for(coll, inout(item) => …)` was removed and produces a compile error with this recipe.
 
 ## What Safe Code Cannot Do
 
@@ -54,7 +54,7 @@ Each of the following is a compile error in a file without `pragma(Pragma.AllowU
 
 | Construct                                                    | Diagnostic (short)                                                               | Safe alternative                                                                                   |
 | ------------------------------------------------------------ | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `*(T)` type expression in a parameter, field, or return      | "raw pointer types are not available in safe code"                               | owned collections (`ArrayList`/`String`), `inout(name) : T`, an `object` type, or a stdlib wrapper |
+| `*(T)` type expression in a parameter, field, or return      | "raw pointer types are not available in safe code"                               | owned collections (`ArrayList`/`String`), `inout(name) : T`, a reference-semantics type, or a stdlib wrapper |
 | `&(expr)` address-of                                         | "this expression has type `*(T)`, which is not available in safe code"           | `inout(name) : T` parameter, or pass the owned collection                                          |
 | `unsafe(...)` call                                           | "`unsafe(...)` is not available in safe code"                                    | Use the stdlib's safe API, or add `pragma(Pragma.AllowUnsafe);` if you genuinely need raw ops      |
 | `asm(...)` block                                             | "inline assembly is not available in safe code"                                  | Same                                                                                               |
@@ -103,7 +103,7 @@ The language also closes the **dangling-view hole** that other languages with ra
 
 - `str` is the only built-in view type, and it can only refer to **static** string data (literals, `comptime_str`) — it is never backed by a heap buffer that could be freed under it.
 - **Range operations on collections copy.** `list(usize(1)..usize(3))` and `String` ranges produce an owned value, not a window into the source buffer — there is no heap-backed slice type to dangle.
-- **Element access hands out values, never interior pointers.** `xs.get(i)` returns the element — for object elements that is a handle to the element _object_ (it mutates in place and survives the container's growth/realloc); for struct elements it is a copy, written back with `xs(i) = v`. No safe expression yields a pointer into a container's buffer, so growth invalidation is inexpressible.
+- **Element access hands out values, never interior pointers.** `xs.get(i)` returns the element — for reference-semantics elements that is a handle to the element _object_ (it mutates in place and survives the container's growth/realloc); for struct elements it is a copy, written back with `xs(i) = v`. No safe expression yields a pointer into a container's buffer, so growth invalidation is inexpressible.
 
 The walkthrough of these rules is in [FLOWABILITY.md](./FLOWABILITY.md); you don't need to know them to write safe code — the compiler rejects the dangerous shapes.
 
@@ -135,7 +135,7 @@ copy_bytes :: (fn(dst : *(u8), src : *(u8), n : usize) -> unit)({
 
 ## `unsafe(...)`: the Per-Op Audit Marker
 
-Inside a privileged file, every UB-capable operation must appear inside an `unsafe(...)` call:
+Inside a privileged file the compiler ENFORCES the `unsafe(...)` wrap on `extern "c"` call sites. Wrapping pointer deref/write/arithmetic is a stdlib CONVENTION that `yo unsafe-report` keys off — not a compile error — so the wrap is how the unsafe surface stays greppable rather than a second gate:
 
 | Operation                   | Example                                                            |
 | --------------------------- | ------------------------------------------------------------------ |


### PR DESCRIPTION
Markdown only. Every finding was **verified against the current tree** before being applied — most by running `yo check` / `yo compile` on the documented snippet. These are not wording preferences: the majority are code samples that **do not compile**.

### DESIGN.md — 36

- **The operator alphabet was wrong.** Documented as an open set including `@`, `$`, `\`. Yo has a *closed* operator token set; `x := (1 @ 2)` is a lex error. Replaced with the actual two-char / one-char / dot tables.
- **Eight function definitions don't parse** — body separated from the `fn` type by a newline, which Yo rejects as a paren-less call. The same file says so 300 lines earlier.
- **Tuple *types* use semicolons**: `(i32; i32; i32)`. Verified both forms; the comma form fails to evaluate.
- **`malloc` is not generic** — it returns `?(*(void))`, so the worked example never type-checked without a cast.
- **The unsafe story was backwards.** The gate is `pragma(Pragma.AllowUnsafe)` at *file* level; inside such a file a bare `p.*` compiles, and `unsafe(...)` is the audit marker `yo unsafe-report` keys on. The "what stays safe" list was also wrong — none of it is available without the pragma.
- **`Impl(Trait)` as a return type is static dispatch**, so the two-different-types example could never compile. Added the `Dyn(Trait)` form that does.
- Wrong method names throughout (`length()`→`len()`, `has()`→`contains`/`contains_key`, `set()`→index assignment or `insert`), `if`/`while` keyword-arg syntax that doesn't exist, `union`/`enum` defined with `:=`, `rune`'s field is `char` not `c`, `Type.to_string`→`to_comptime_string`, five derivable traits→six, and `derive(Point, Eq)` where `Eq`/`Ord` are parametric.

### ASYNC_AWAIT.md — 9

`io.await`/`io.spawn`/`yield` all take the effect record, which the API block and every example omitted. **`Task.spawn` does not exist anywhere in std** — it's `Thread.spawn`. `io.spawn(task, io, raise)` isn't the multi-effect form. The platform-runtime table and evaluator function names were still TypeScript (`runtime-io-linux.ts`, `getMethodsByNameFromEnv`) from the retired compiler.

Limitations 3 and 4 are **fixed** (issues now in `issues/fixed/`). Limitation 2 cites a tracking issue that **has never existed in the repo** — now marked unverified rather than presented as fact.

### ALGEBRAIC_EFFECTS.md — 5

The doc claimed handler bodies *"can reference outer-frame locals directly"*. They cannot — handlers compile to standalone C functions via evidence passing, with no capture struct. The doc contradicted itself, and `c-codegen.instructions.md` cross-referenced a "Handler Functions Are Not Closures" section that **didn't exist**. Corrected the claim and added the missing section so the cross-reference resolves.

### CYCLE_COLLECTION.md — 4

The documented GC API (`gc_collect`, `gc_set_threshold`, `gc_get_stats`, `GCStats`) is **entirely fictional**. `std/gc` exports exactly `collect` and `tracked_count`; tuning is via `YO_GC_THRESHOLD` / `YO_GC_FULL_PCT`. Thread-isolation examples rewritten against `Thread.spawn`/`Channel`. Also: plain `ref(...)` is thread-local but `atomic(ref(...))` **is** `Send`, which the "never cross thread boundaries" claim flattened.

### ARC.md / MEMORY_SAFETY.md — 4

`Arc(T)` requires `T <: (Send, Acyclic)`, not just `Send` — atomic RC isn't cycle-collected, so a cycle through an `Arc` leaks silently. Plus residual `object` terminology and the same unsafe-gate overstatement.

---

All seven files verify **zero** broken internal anchors against GitHub's real anchor rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)