### PR TITLE
docs: fix a double-replacement introduced in #269

### DIFF
--- a/docs/en-US/DESIGN.md
+++ b/docs/en-US/DESIGN.md
@@ -885,7 +885,7 @@ float_ptr := *(f32)(ptr);  // Cast pointer to *(f32)
 
 ### Pointer Arithmetic and Comparison
 
-Pointer arithmetic uses methods — `p.add(n)`, `p.sub(n)`, `p.offset_from(q)` — which require `unsafe(...)`. Pointer comparison uses the ordinary operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) via the `Eq`/`Ord` impls on `*(T)` and stays safe — comparing addresses can't violate memory safety. Note that `*(T) ==` compares ADDRESSES (identity), while reference-semantics reference-semantics types compare VALUES via their own `Eq` impls.
+Pointer arithmetic uses methods — `p.add(n)`, `p.sub(n)`, `p.offset_from(q)` — which require `unsafe(...)`. Pointer comparison uses the ordinary operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) via the `Eq`/`Ord` impls on `*(T)` and stays safe — comparing addresses can't violate memory safety. Note that `*(T) ==` compares ADDRESSES (identity), while reference-semantics types compare VALUES via their own `Eq` impls.
 
 ```rust
 test("Pointer arithmetic", {


### PR DESCRIPTION
My `object types` → `reference-semantics types` sweep in #269 matched inside text that *already* read "reference-semantics object types", producing **"reference-semantics reference-semantics types"** at `docs/en-US/DESIGN.md:888`.

Caught while scoping the S2 rename's doc impact. One occurrence tree-wide — the sweep's other 47 replacements are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)