### PR TITLE
std: S2 chunk 2 — the fs and net API renames (symmetric read/write, Shutdown enum, usize byte counts)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1416,7 +1416,7 @@ jobs:
       # liburing the emitter silently swaps the whole async runtime for stubs
       # (src/codegen/async/runtime_io_linux.yo:1465) whose init prints
       # "liburing not available, async I/O disabled" — and since the compiler
-      # reads every source file through io.await(read_file(...)), such a binary
+      # reads every source file through io.await(read(...)), such a binary
       # links, ships, and then compiles NOTHING. So io_uring presence is
       # asserted explicitly, not assumed.
       - name: Assert the bundle is static AND has working async I/O

--- a/docs/en-US/ASYNC_AWAIT.md
+++ b/docs/en-US/ASYNC_AWAIT.md
@@ -471,7 +471,7 @@ whole loop cycle through one state.
 
 ```rust
 // ✓ supported
-cond(needs_write => { io.await(write_file(p, data, io), io); }, true => ());
+cond(needs_write => { io.await(write_string(p, data, io), io); }, true => ());
 if(io.await(exists(p, io), io), { ... });
 cond(io.await(ready(io), io) => ..., true => ...);
 match(io.await(num(io), io), 42 => ..., _ => ...);

--- a/docs/zh-CN/ASYNC_AWAIT.md
+++ b/docs/zh-CN/ASYNC_AWAIT.md
@@ -459,7 +459,7 @@ task := io.async((io : Io)=> {
 
 ```rust
 // ✓ 支持
-cond(needs_write => { io.await(write_file(p, data, io), io); }, true => ());
+cond(needs_write => { io.await(write_string(p, data, io), io); }, true => ());
 if(io.await(exists(p, io), io), { ... });
 cond(io.await(ready(io), io) => ..., true => ...);
 match(io.await(num(io), io), 42 => ..., _ => ...);

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -564,6 +564,24 @@ reflects is exactly what the `ImmString` rename above is for.
 
 ### D5 — Async I/O traits + the fd problem
 
+**Byte-count carry-over from S2 chunk 2 (2026-08-25).** Chunk 2 moved the NET
+byte counts to `usize` (TcpStream read/write_str/write_string/write_bytes,
+UdpSocket send_to/recv/recv_from/send), which is the shape this section
+specifies. The FILE and BUFIO sides were deliberately NOT converted with them,
+and must land here rather than as a stray rename, because they are not merely a
+different integer type — they are three different error models:
+
+| | returns | error style |
+| --- | --- | --- |
+| `TcpStream.read` | `Future(usize, IoExn)` | throws (DONE) |
+| `File.read` | `Future(i32, IoExn)` | throws |
+| `BufReader.read` | `Future(Result(i32, IoError), Io)` | Result + `IoError` + `Io` effect |
+
+Converting `File.read` alone would still leave bufio split three ways, so the
+`usize` change rides with this section's `IoExn` adoption and the
+`std/sys/bufio` → `std/io` move. Until then `TcpStream.read` and `File.read`
+disagree on their count type — a KNOWN transient, tracked here.
+
 `std/io.Reader`/`Writer` are sync, orphaned (zero implementors), and
 incompatible with the async model. Redesign: async `Reader`/`Writer` traits
 (`read(buf, io) -> Future(usize, IoExn)`), implemented by `File`, `TcpStream`,
@@ -699,8 +717,13 @@ small number of PRs with tree-wide fixups (compiler + std + tests + docs):
   missing it — btree_map, deque, hash_map, hash_set, linked_list, ordered_map,
   priority_queue and String all already had one, so D2's "is_empty on EVERY
   container" was a one-method gap, landed additively ahead of the breaking
-  sweep); `remove(start,count)`→`drain(range)`, add single-`remove(idx) -> T`;
-  `iter()` pointer iterator for symmetry
+  sweep); `remove(start,count)`→`drain(range)`, add single-`remove(idx) -> T`,
+  and `iter()` pointer iterator for symmetry — **deferred to S2 chunk 3** (the
+  collections chunk) rather than chunk 2: `remove` is a name shared with
+  `HashMap.remove`/`HashSet.remove`, so it needs the compiler-as-oracle
+  treatment rather than a textual sweep, and it changes the return type from
+  `Result(usize, ArrayListError)` to an element — a different blast radius from
+  chunk 2's fs/net renames
 - ~~`HashMap.iter_ptr`→`iter`~~ **DONE 2026-08-25** (no collision: HashMap had
   `into_iter` for values and `iter_ptr` for pointers, exactly D2's split);
   OrderedMap iterators get real `Iterator` impls
@@ -710,18 +733,64 @@ small number of PRs with tree-wide fixups (compiler + std + tests + docs):
   2026-08-25** — the `canonical` FAMILY moved together
   (`canonical_str`/`canonical_cstr` too), since leaving the siblings behind would
   have created exactly the split-vocabulary D2 exists to prevent;
-  `created_time`→`status_changed_time` + real `created_time` (btime) still open
+  ~~`created_time`→`status_changed_time`~~ **DONE 2026-08-25 (S2 chunk 2)** — it
+  returned `ctime_sec()`, which on POSIX is the status-change time, so the old
+  name was actively wrong (ctime moves on chmod/rename/link-count changes and can
+  postdate mtime); the method's own comment already said "Status change time".
+  Zero call sites. A real `created_time` (btime) is **still open** and is a
+  feature, not a rename: `Statx` requests `STATX_BASIC_STATS` (0x7ff), which
+  excludes `STATX_BTIME` (0x800), and there is no `btime_sec()` accessor — plus
+  it needs per-platform work (statx btime / `st_birthtime` / Windows
+  CreationTime)
 - ~~`File.read_string`/free `read_string`→`read_to_string`~~ **DONE 2026-08-25**
-  (family: `read_string_str`/`read_string_cstr` moved with it); `read_file`→`read`
-  (bytes) mirroring `write_file`→`write` moves to S2 chunk 2 — its **collision
-  check is now DONE and clean**: `std/sys/file.yo` does export free `read`/`write`
-  at the fd level and `File.read` is a method, but nothing in std/, src/ or tests/
-  uses a glob `open(import(...))` on either module (every import is
-  destructuring), so there is no ambient collision — and it matches
-  `std::fs::read` in Rust
+  (family: `read_string_str`/`read_string_cstr` moved with it)
+- ~~`read_file`→`read` / `write_file`→`write`~~ **DONE 2026-08-25 (S2 chunk 2)**,
+  but NOT as this list originally specified. Writing it out exposed a flaw in the
+  spec: `read_file` returns BYTES while `write_file` takes a `String`, so
+  `read_file`→`read` + `write_file`→`write` would have produced a `read` that
+  returns bytes and a `write` that takes a String — leaving the actual byte
+  counterpart of `read` named `write_bytes`. That is precisely the split
+  vocabulary D2 exists to prevent. **Decision (user, 2026-08-25): symmetric
+  pairs.**
+
+  | new name | was | payload |
+  | --- | --- | --- |
+  | `read` | `read_file` | bytes |
+  | `write` | `write_bytes` | bytes |
+  | `read_to_string` | (unchanged) | String |
+  | `write_string` | `write_file` | String |
+
+  `read_str`/`read_cstr` and `write_string_str`/`write_string_cstr` moved with
+  their families. This matches `std::fs::read` / `std::fs::write` exactly (Rust
+  needs no `write_string` only because `AsRef<[u8]>` covers `&str`; Yo has no
+  such coercion, so the String half is a named function). 150 occurrences across
+  25 files.
+
+  Collision check, done before the rename and clean: `std/sys/file.yo` does
+  export free `read`/`write` at the fd level and `File.read` is a method, but
+  nothing in std/, src/ or tests/ uses a glob `open(import(...))` on either
+  module (every import is destructuring); no file imports both `fs/file` and
+  `sys/file`; neither name is in the prelude; and `std/fmt` (glob-imported by
+  `fs/file.yo`) exports only Alignment/Format/FormatSpec/ToString/Writer/
+  eprint/eprintln/print/println.
+
+  Method note: `write_bytes` and `write_string` are ALSO method names on four
+  writer types (File, TcpStream, Writer, BufWriter). Only the free functions
+  moved — the method vocabulary is deliberately shared and stays put.
 - `min()`/`max()` naming: maps `first_entry`/`last_entry`, sets keep `min`/`max`
-- `Http` inherent `to_string`→`ToString` impl; `TcpStream.shutdown(i32)`→
-  `shutdown(Shutdown)`; net `read/write` return `usize`
+- `Http` inherent `to_string`→`ToString` impl; ~~`TcpStream.shutdown(i32)`→
+  `shutdown(Shutdown)`~~ **DONE 2026-08-25 (S2 chunk 2)** — new `Shutdown` enum
+  (`Read`/`Write`/`Both`, matching `std::net::Shutdown`) plus a private
+  `_shutdown_to_how` mapping to SHUT_RD/SHUT_WR/SHUT_RDWR, following the existing
+  `SeekFrom`/`_seek_from_to_whence` idiom; the sys layer keeps its `i32` `how`,
+  since that IS the syscall boundary; ~~net `read/write` return `usize`~~ **DONE
+  2026-08-25 (S2 chunk 2)** — 8 methods (TcpStream `read`/`write_str`/
+  `write_string`/`write_bytes`, UdpSocket `send_to`/`recv`/`recv_from`/`send`).
+  `NetError.check` itself stays `i32`: it is also used for file descriptors
+  (`fd := NetError.check(raw_fd, ...)`), so the conversion is at the eight
+  byte-count call sites. This also SHARPENED `std/http/client.yo`, whose read
+  loop tested `n <= i32(0)` — conflating "error" with EOF. Errors throw, so a
+  count is never negative; the test is now `n == usize(0)`, i.e. EOF only
 - `punycode.to_ascii`/`to_unicode`→`domain_to_ascii`/`domain_to_unicode`
 - two `sleep`s → `time.sleep(Duration, io)` async + `time.sleep_blocking(Duration)`
 - `str.join(items)` receiver-as-separator: keep (Python style is fine) but

--- a/src/build_runner.yo
+++ b/src/build_runner.yo
@@ -17,7 +17,7 @@ open(import("std/fmt"));
 // Imported under an alias: `args` collides with the `args` parameter/field used
 // throughout this file (`run_step.args`). Same rename form main.yo uses for `env`.
 _(args : proc_args) :: import("std/env");
-{ exists, read_file, write_file } :: import("std/fs/file");
+{ exists, read, write_string } :: import("std/fs/file");
 { read_dir } :: import("std/fs/dir");
 { sha256_hex } :: import("std/crypto/sha256");
 { CURRENT_YO_VERSION } :: import("./version.yo");
@@ -429,7 +429,7 @@ _cache_collect_yo_files :: (
 /// disables the cache for this artifact rather than mis-stamping it.
 _cache_read_file :: (fn(path : String, io : Io) -> Option(ArrayList(u8)))({
   rd_exn := Exception(throw : ((_e) -> unwind(Option(ArrayList(u8)).None)));
-  bytes := io.await(read_file(Path.new(path.clone()), io), IoExn(io : io, exn : rd_exn));
+  bytes := io.await(read(Path.new(path.clone()), io), IoExn(io : io, exn : rd_exn));
   Option(ArrayList(u8)).Some(bytes)
 });
 /// The artifact's input stamp, or "" when stamping failed (cache disabled).
@@ -480,13 +480,13 @@ _artifact_input_stamp :: (
 /// Read the recorded stamp next to an output, `.None` when absent.
 _read_stamp :: (fn(path : String, io : Io) -> Option(String))({
   st_exn := Exception(throw : ((_e) -> unwind(Option(String).None)));
-  bytes := io.await(read_file(Path.new(path.clone()), io), IoExn(io : io, exn : st_exn));
+  bytes := io.await(read(Path.new(path.clone()), io), IoExn(io : io, exn : st_exn));
   Option(String).Some(String.from_bytes(bytes))
 });
 /// Record the stamp; failures are silent (the cache is an optimization).
 _write_stamp :: (fn(path : String, stamp : String, io : Io) -> unit)({
   wr_exn := Exception(throw : ((_e) -> unwind(())));
-  io.await(write_file(Path.new(path.clone()), stamp.clone(), io), IoExn(io : io, exn : wr_exn));
+  io.await(write_string(Path.new(path.clone()), stamp.clone(), io), IoExn(io : io, exn : wr_exn));
 });
 compile_artifact :: (
   fn(

--- a/src/codegen/exprs/async.yo
+++ b/src/codegen/exprs/async.yo
@@ -1481,7 +1481,7 @@ _build_async_capture_struct_literal :: (
               // RECORDED atom expr here (async.ts:330-335); yo-self
               // capture-struct fields carry no per-field exprs, so the C name
               // of the same-named variable at the io.async call site is the
-              // faithful equivalent for the std-internal shapes (read_file's
+              // faithful equivalent for the std-internal shapes (read's
               // `.path = path, .io = io` — enclosing-fn params). The RC +1
               // for the whole struct comes from the dup wrap below
               // (used_deferred_dups stays false), mirroring TS's

--- a/src/doc/render_html.yo
+++ b/src/doc/render_html.yo
@@ -19,7 +19,7 @@ open(import("std/fmt"));
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 { Path } :: import("std/path");
-{ write_file } :: import("std/fs/file");
+{ write_string } :: import("std/fs/file");
 { create_dir_all } :: import("std/fs/dir");
 { Exception, IoExn } :: import("std/error");
 {
@@ -1640,7 +1640,7 @@ render_doc_site :: (
   index_content := _render_index_content(model);
   index_sidebar := _render_sidebar(model, Option(String).None);
   index_page := _wrap_page(`${model.name} — Documentation`, index_content, index_sidebar, _search_index_json(search_idx), css_text, js_text);
-  io.await(write_file(Path.new(`${output_dir}/index.html`), index_page, io), ioexn);
+  io.await(write_string(Path.new(`${output_dir}/index.html`), index_page, io), ioexn);
   (mi : usize) = usize(0);
   while(mi < model.modules.len(), {
     m := match(
@@ -1655,7 +1655,7 @@ render_doc_site :: (
     mod_content := _render_module_content(m, symbol_links);
     mod_search := _fix_search_index_for_module_page(search_idx);
     mod_page := _wrap_page(`${m.name} — ${model.name}`, mod_content, mod_sidebar, _search_index_json(mod_search), css_text, js_text);
-    io.await(write_file(Path.new(`${module_dir}/${fname}.html`), mod_page, io), ioexn);
+    io.await(write_string(Path.new(`${module_dir}/${fname}.html`), mod_page, io), ioexn);
     mi = (mi + usize(1));
   });
 });

--- a/src/doc_command.yo
+++ b/src/doc_command.yo
@@ -14,7 +14,7 @@ open(import("std/fmt"));
 { ArrayList } :: import("std/collections/array_list");
 { Path } :: import("std/path");
 { Exception, IoExn } :: import("std/error");
-{ read_file, write_file, exists } :: import("std/fs/file");
+{ read, write_string, exists } :: import("std/fs/file");
 { metadata } :: import("std/fs/metadata");
 { read_dir, create_dir_all } :: import("std/fs/dir");
 { Command } :: import("std/process");
@@ -268,7 +268,7 @@ _infer_project_name :: (
   pkg_path := Path.new(base_path.clone()).join(Path.new(String.from("package.json")));
   pkg_exists := io.await(exists(pkg_path, io), io);
   if(pkg_exists, {
-    pkg_bytes := io.await(read_file(Path.new(base_path.clone()).join(Path.new(String.from("package.json"))), io), IoExn(io : io, exn : exn));
+    pkg_bytes := io.await(read(Path.new(base_path.clone()).join(Path.new(String.from("package.json"))), io), IoExn(io : io, exn : exn));
     content := String.from_bytes(pkg_bytes);
     match(
       _scan_quoted_value_after(content, `"name"`, `:`),
@@ -281,7 +281,7 @@ _infer_project_name :: (
   build_path := Path.new(base_path.clone()).join(Path.new(String.from("build.yo")));
   build_exists := io.await(exists(build_path, io), io);
   if(build_exists, {
-    build_bytes := io.await(read_file(Path.new(base_path.clone()).join(Path.new(String.from("build.yo"))), io), IoExn(io : io, exn : exn));
+    build_bytes := io.await(read(Path.new(base_path.clone()).join(Path.new(String.from("build.yo"))), io), IoExn(io : io, exn : exn));
     content := String.from_bytes(build_bytes);
     match(
       _scan_quoted_value_after(content, `.name`, `=`),
@@ -315,7 +315,7 @@ _document_file :: (
   if(verbose, {
     println(`  Documenting: ${module_name}`);
   });
-  src_bytes := io.await(read_file(Path.new(file_path.clone()), io), IoExn(io : io, exn : exn));
+  src_bytes := io.await(read(Path.new(file_path.clone()), io), IoExn(io : io, exn : exn));
   src := String.from_bytes(src_bytes);
   // A lexer failure is caught locally so the walk continues (TS's
   // try/tokenize → warn → null).
@@ -356,7 +356,7 @@ _render_markdown_site :: (
   io.await(create_dir_all(Path.new(out_dir.clone()), io), ioexn);
   io.await(create_dir_all(Path.new(out_dir.clone()).join(Path.new(String.from("module"))), io), ioexn);
   io.await(
-    write_file(Path.new(out_dir.clone()).join(Path.new(String.from("README.md"))), render_index_md(model), io),
+    write_string(Path.new(out_dir.clone()).join(Path.new(String.from("README.md"))), render_index_md(model), io),
     ioexn
   );
   (i : usize) = usize(0);
@@ -376,7 +376,7 @@ _render_markdown_site :: (
           },
           .None => ()
         );
-        io.await(write_file(target, page, io), ioexn);
+        io.await(write_string(target, page, io), ioexn);
       },
       .None => ()
     );
@@ -459,7 +459,7 @@ run_doc :: (
       io.await(create_dir_all(Path.new(abs_output_dir.clone()), io), IoExn(io : io, exn : exn));
       json := render_doc_json_string(model, true);
       io.await(
-        write_file(Path.new(abs_output_dir.clone()).join(Path.new(String.from("doc.json"))), json, io),
+        write_string(Path.new(abs_output_dir.clone()).join(Path.new(String.from("doc.json"))), json, io),
         IoExn(io : io, exn : exn)
       );
       output_file = String.from("doc.json");

--- a/src/evaluator/calls/function_type.yo
+++ b/src/evaluator/calls/function_type.yo
@@ -1492,7 +1492,7 @@ try_to_implement_function_by_function_type :: (
           // declaration's type object here; the cell is that object's
           // value-semantics surrogate) plus the id-keyed eval→codegen
           // bridge. For a body that is itself a resolved SomeT (delegation
-          // wrappers, e.g. write_file_cstr → write_file, both returning
+          // wrappers, e.g. write_string_cstr → write_string, both returning
           // Impl(Future(...))), propagate its resolution instead.
           match(
             result_box,

--- a/src/fetch.yo
+++ b/src/fetch.yo
@@ -10,7 +10,7 @@ open(import("std/string"));
 { AnyError, Exception, IoExn } :: import("std/error");
 { ArrayList } :: import("std/collections/array_list");
 { Path } :: import("std/path");
-{ read_file, write_file, write_bytes, exists } :: import("std/fs/file");
+{ read, write_string, write, exists } :: import("std/fs/file");
 {
   DirEntry,
   FileType,
@@ -342,7 +342,7 @@ compute_content_hash :: (
           abs_file := item.abs_path.clone();
           abs_file.push_str("/");
           abs_file.push_string(entry_name);
-          content := e.io.await(read_file(Path.new(abs_file), e.io), e);
+          content := e.io.await(read(Path.new(abs_file), e.io), e);
           normalized := normalize_line_endings(content);
           hasher = hasher.update(normalized);
         });
@@ -375,7 +375,7 @@ write_sidecar_hash :: (
     sidecar := Path.new(cached_path).join(Path.new(String.from(SIDECAR_FILENAME)));
     sidecar_content := content_hash.clone();
     sidecar_content.push_str("\n");
-    e.io.await(write_file(sidecar, sidecar_content, e.io), e);
+    e.io.await(write_string(sidecar, sidecar_content, e.io), e);
   })
 );
 /// Read the sidecar hash file, returning None if it doesn't exist or can't be read.
@@ -390,7 +390,7 @@ read_sidecar_hash :: (
     sidecar := Path.new(cached_path).join(Path.new(String.from(SIDECAR_FILENAME)));
     sidecar_exists := e.io.await(exists(sidecar, e.io), e.io);
     if(!(sidecar_exists), Option(String).None, {
-      content := e.io.await(read_file(sidecar, e.io), e);
+      content := e.io.await(read(sidecar, e.io), e);
       text := String.from_bytes(content).trim();
       Option(String).Some(text)
     })

--- a/src/fetch_command.yo
+++ b/src/fetch_command.yo
@@ -8,7 +8,7 @@ open(import("std/fmt"));
 { Path } :: import("std/path");
 { env } :: import("std/env");
 { cwd } :: import("std/env");
-{ exists, read_file, write_file } :: import("std/fs/file");
+{ exists, read, write_string } :: import("std/fs/file");
 { BuildGitDependency, get_build_registry, clear_build_registry } :: import("./evaluator/builtins/build.yo");
 { FetchResult, fetch_all_deps } :: import("./fetch.yo");
 { mm_load_yo_file, mm_reset } :: import("./module_manager.yo");
@@ -51,16 +51,16 @@ ensure_gitignore :: (
     already := e.io.await(exists(Path.new(gitignore_str.clone()), e.io), e.io);
     cond(
       already => {
-        content := String.from_bytes(e.io.await(read_file(Path.new(gitignore_str.clone()), e.io), e));
+        content := String.from_bytes(e.io.await(read(Path.new(gitignore_str.clone()), e.io), e));
         cond(
           (content.contains(entry.clone())) => (),
           true => {
-            e.io.await(write_file(Path.new(gitignore_str.clone()), `${content}\n${entry}\n`, e.io), e);
+            e.io.await(write_string(Path.new(gitignore_str.clone()), `${content}\n${entry}\n`, e.io), e);
           }
         );
       },
       true => {
-        e.io.await(write_file(Path.new(gitignore_str.clone()), `${entry}\n`, e.io), e);
+        e.io.await(write_string(Path.new(gitignore_str.clone()), `${entry}\n`, e.io), e);
       }
     );
   })

--- a/src/formatter.yo
+++ b/src/formatter.yo
@@ -15,7 +15,7 @@ open(import("std/fmt"));
 { ArrayList } :: import("std/collections/array_list");
 { HashSet } :: import("std/collections/hash_set");
 { Path } :: import("std/path");
-{ read_file, write_file, is_file, is_dir, exists } :: import("std/fs/file");
+{ read, write_string, is_file, is_dir, exists } :: import("std/fs/file");
 { DirEntry, FileType, read_dir } :: import("std/fs/dir");
 { HashMap } :: import("std/collections/hash_map");
 { Token, TokenKind } :: import("./token.yo");
@@ -2647,13 +2647,13 @@ format_yo_files :: (
       files.get(fi),
       .None => (),
       .Some(file) => {
-        bytes := io.await(read_file(Path.new(file), io), IoExn(io : io, exn : exn));
+        bytes := io.await(read(Path.new(file), io), IoExn(io : io, exn : exn));
         original := String.from_bytes(bytes);
         formatted := format_yo_source(original, file, exn);
         if(formatted != original, {
           _r := changed.push(file);
           if(!(options.check), {
-            io.await(write_file(Path.new(file), formatted, io), IoExn(io : io, exn : exn));
+            io.await(write_string(Path.new(file), formatted, io), IoExn(io : io, exn : exn));
           });
         });
       }

--- a/src/init.yo
+++ b/src/init.yo
@@ -12,7 +12,7 @@ open(import("std/fmt"));
 { AnyError, Exception, IoExn } :: import("std/error");
 { ArrayList } :: import("std/collections/array_list");
 { cwd } :: import("std/env");
-{ exists, write_file } :: import("std/fs/file");
+{ exists, write_string } :: import("std/fs/file");
 { create_dir_all } :: import("std/fs/dir");
 // ---------------------------------------------------------------------------
 // Data types
@@ -181,13 +181,13 @@ init_project :: (
       },
       true => ()
     );
-    e.io.await(write_file(build_yo_path, generate_build_yo(project_name), e.io), e);
+    e.io.await(write_string(build_yo_path, generate_build_yo(project_name), e.io), e);
     // deps.yo
     deps_yo_path := project_dir.join(Path.new(String.from("deps.yo")));
     deps_yo_exists := e.io.await(exists(deps_yo_path, e.io), e.io);
     cond(
       !(deps_yo_exists) => {
-        e.io.await(write_file(deps_yo_path, String.from(generate_deps_yo()), e.io), e);
+        e.io.await(write_string(deps_yo_path, String.from(generate_deps_yo()), e.io), e);
       },
       true => ()
     );
@@ -196,7 +196,7 @@ init_project :: (
     main_exists := e.io.await(exists(main_path, e.io), e.io);
     cond(
       !(main_exists) => {
-        e.io.await(write_file(main_path, String.from(generate_main_source()), e.io), e);
+        e.io.await(write_string(main_path, String.from(generate_main_source()), e.io), e);
       },
       true => ()
     );
@@ -205,7 +205,7 @@ init_project :: (
     lib_exists := e.io.await(exists(lib_path, e.io), e.io);
     cond(
       !(lib_exists) => {
-        e.io.await(write_file(lib_path, String.from(generate_lib_source()), e.io), e);
+        e.io.await(write_string(lib_path, String.from(generate_lib_source()), e.io), e);
       },
       true => ()
     );
@@ -214,7 +214,7 @@ init_project :: (
     test_exists := e.io.await(exists(test_path, e.io), e.io);
     cond(
       !(test_exists) => {
-        e.io.await(write_file(test_path, String.from(generate_test_file()), e.io), e);
+        e.io.await(write_string(test_path, String.from(generate_test_file()), e.io), e);
       },
       true => ()
     );
@@ -223,7 +223,7 @@ init_project :: (
     gitignore_exists := e.io.await(exists(gitignore_path, e.io), e.io);
     cond(
       !(gitignore_exists) => {
-        e.io.await(write_file(gitignore_path, String.from(generate_gitignore()), e.io), e);
+        e.io.await(write_string(gitignore_path, String.from(generate_gitignore()), e.io), e);
       },
       true => ()
     );
@@ -232,7 +232,7 @@ init_project :: (
     readme_exists := e.io.await(exists(readme_path, e.io), e.io);
     cond(
       !(readme_exists) => {
-        e.io.await(write_file(readme_path, generate_readme(project_name), e.io), e);
+        e.io.await(write_string(readme_path, generate_readme(project_name), e.io), e);
       },
       true => ()
     );

--- a/src/install_command.yo
+++ b/src/install_command.yo
@@ -14,7 +14,7 @@ open(import("std/fmt"));
 { AnyError, Exception, IoExn } :: import("std/error");
 { ArrayList } :: import("std/collections/array_list");
 { Command } :: import("std/process/command");
-{ exists, read_file, write_file } :: import("std/fs/file");
+{ exists, read, write_string } :: import("std/fs/file");
 { BuildGitDependency, fetch_all_deps } :: import("./fetch.yo");
 { generate_deps_yo } :: import("./init.yo");
 { exit } :: import("std/libc/stdlib");
@@ -457,16 +457,16 @@ append_dep_to_deps_file :: (
     // Create deps.yo from template if it does not exist yet
     file_exists := e.io.await(exists(deps_path, e.io), e.io);
     if(!(file_exists), {
-      e.io.await(write_file(deps_path, String.from(generate_deps_yo()), e.io), e);
+      e.io.await(write_string(deps_path, String.from(generate_deps_yo()), e.io), e);
     });
-    bytes := e.io.await(read_file(deps_path, e.io), e);
+    bytes := e.io.await(read(deps_path, e.io), e);
     content := String.from_bytes(bytes);
     if(dependency_exists_in_deps_file(content, dep_name), {
       println(`Dependency "${dep_name}" already exists in deps.yo. Update it manually if needed.`);
       return(false);
     });
     updated := _append_dep_to_content(content, dep_line);
-    e.io.await(write_file(deps_path, updated, e.io), e);
+    e.io.await(write_string(deps_path, updated, e.io), e);
     true
   })
 );

--- a/src/lock_file.yo
+++ b/src/lock_file.yo
@@ -15,7 +15,7 @@ open(import("std/string"));
 { ArrayList } :: import("std/collections/array_list");
 { Path } :: import("std/path");
 { AnyError, Exception, IoExn } :: import("std/error");
-{ exists, read_to_string, write_file } :: import("std/fs/file");
+{ exists, read_to_string, write_string } :: import("std/fs/file");
 // ---------------------------------------------------------------------------
 // Data types
 // ---------------------------------------------------------------------------
@@ -208,7 +208,7 @@ save_lock_file :: (
   io.async((e) => {
     lock_path := project_dir.join(Path.new(String.from("yo.lock")));
     content := write_lock_file_content(lock);
-    e.io.await(write_file(lock_path, content, e.io), e);
+    e.io.await(write_string(lock_path, content, e.io), e);
   })
 );
 // ---------------------------------------------------------------------------

--- a/src/main.yo
+++ b/src/main.yo
@@ -29,7 +29,7 @@ _(env : proc_env) :: import("std/env");
 { Regex } :: import("std/regex");
 { run_lsp_server } :: import("./lsp/server.yo");
 { Path } :: import("std/path");
-{ read_file, write_file, exists } :: import("std/fs/file");
+{ read, write_string, exists } :: import("std/fs/file");
 { sha256_hex } :: import("std/crypto/sha256");
 { metadata } :: import("std/fs/metadata");
 { read_dir, FileType, remove_file, create_dir_all } :: import("std/fs/dir");
@@ -399,7 +399,7 @@ collect_module_deps :: (
     .Some(p) => p.to_string()
   );
   // Read and parse the imported module
-  src_bytes := io.await(read_file(Path.new(abs_path.clone()), io), IoExn(io : io, exn : exn));
+  src_bytes := io.await(read(Path.new(abs_path.clone()), io), IoExn(io : io, exn : exn));
   src := String.from_bytes(src_bytes);
   mod_exprs := parse(src, mod_base_dir.clone(), exn);
   // Recursively collect dependencies of this module first (post-order DFS)
@@ -970,7 +970,7 @@ _asan_runtime_is_usable :: (fn(base : String, io : Io) -> bool)({
   );
   probe_src := `${base}.asan_probe.c`;
   probe_bin := `${base}.asan_probe`;
-  io.await(write_file(Path.new(probe_src.clone()), String.from("int main(void) { return 0; }\n"), io), IoExn(io : io, exn : probe_exn));
+  io.await(write_string(Path.new(probe_src.clone()), String.from("int main(void) { return 0; }\n"), io), IoExn(io : io, exn : probe_exn));
   cc_cmd := Command.new(String.from("cc"));
   cc_cmd.arg(String.from("-x"));
   cc_cmd.arg(String.from("c"));
@@ -1060,7 +1060,7 @@ _sh_quote :: (fn(s : String) -> String)({
 /// Read a file's bytes, or `.None` when unreadable.
 _chunk_read :: (fn(path : String, io : Io) -> Option(ArrayList(u8)))({
   rd_exn := Exception(throw : ((_e) -> unwind(Option(ArrayList(u8)).None)));
-  bytes := io.await(read_file(Path.new(path.clone()), io), IoExn(io : io, exn : rd_exn));
+  bytes := io.await(read(Path.new(path.clone()), io), IoExn(io : io, exn : rd_exn));
   Option(ArrayList(u8)).Some(bytes)
 });
 /// Recorded stamp beside an object file, `.None` when absent.
@@ -1070,7 +1070,7 @@ _chunk_read_stamp :: (fn(path : String, io : Io) -> Option(String))(
 /// Record a stamp; failures are silent (the cache is only an optimization).
 _chunk_write_stamp :: (fn(path : String, stamp : String, io : Io) -> unit)({
   wr_exn := Exception(throw : ((_e) -> unwind(())));
-  io.await(write_file(Path.new(path.clone()), stamp.clone(), io), IoExn(io : io, exn : wr_exn));
+  io.await(write_string(Path.new(path.clone()), stamp.clone(), io), IoExn(io : io, exn : wr_exn));
 });
 /// Compile the chunk `.c` files to `.o` in PARALLEL and return the object
 /// paths, honouring a content-addressed cache.
@@ -1189,7 +1189,7 @@ _compile_chunks_parallel :: (
       });
       script.push_str("for p in $pids; do wait $p || rc=1; done\nexit $rc\n");
       script_path := `${out_base}_chunks_compile.sh`;
-      io.await(write_file(Path.new(script_path.clone()), script, io), IoExn(io : io, exn : exn));
+      io.await(write_string(Path.new(script_path.clone()), script, io), IoExn(io : io, exn : exn));
       shcmd := Command.new(String.from("sh"));
       shcmd.arg(script_path.clone());
       shst := io.await(shcmd.status(io), IoExn(io : io, exn : exn));
@@ -1673,7 +1673,7 @@ run_compile :: (
     // Quiet: `compile` has no `check:` chatter.
     mm_preload_prelude(std_path.clone(), false, io, exn);
     // Read + parse the input module.
-    src_bytes := io.await(read_file(Path.new(input_path.clone()), io), IoExn(io : io, exn : exn));
+    src_bytes := io.await(read(Path.new(input_path.clone()), io), IoExn(io : io, exn : exn));
     src := String.from_bytes(src_bytes);
     exprs := parse(src, input_path.clone(), exn);
     // Demand-driven module loading. The entry module's eval context reuses the
@@ -1746,7 +1746,7 @@ run_compile :: (
         shared_h := `${c_base}_shared.h`;
         shared_h_base := match(Path.new(shared_h.clone()).file_name(), .Some(bn) => bn, .None => shared_h.clone());
         io.await(
-          write_file(Path.new(shared_h.clone()), match(chunk_parts.get(usize(0)), .Some(x) => x, .None => String.new()), io),
+          write_string(Path.new(shared_h.clone()), match(chunk_parts.get(usize(0)), .Some(x) => x, .None => String.new()), io),
           IoExn(io : io, exn : exn)
         );
         (pi2 : usize) = usize(1);
@@ -1757,7 +1757,7 @@ run_compile :: (
           cbody.push_string(shared_h_base.clone());
           cbody.push_str("\"\n");
           cbody.push_string(match(chunk_parts.get(pi2), .Some(x) => x, .None => String.new()));
-          io.await(write_file(Path.new(cf.clone()), cbody.clone(), io), IoExn(io : io, exn : exn));
+          io.await(write_string(Path.new(cf.clone()), cbody.clone(), io), IoExn(io : io, exn : exn));
           chunk_c_files.push(cf);
           chunk_text_hashes.push(sha256_hex(cbody.as_bytes()));
           pi2 = (pi2 + usize(1));
@@ -1765,7 +1765,7 @@ run_compile :: (
         c_path = match(chunk_c_files.get(usize(0)), .Some(x) => x.clone(), .None => c_path.clone());
       },
       true => {
-        io.await(write_file(Path.new(c_path.clone()), c_src, io), IoExn(io : io, exn : exn));
+        io.await(write_string(Path.new(c_path.clone()), c_src, io), IoExn(io : io, exn : exn));
       }
     );
   };
@@ -2337,7 +2337,7 @@ run_test :: (
     while(sfi < files.len(), {
       sf := match(files.get(sfi), .Some(f) => f, .None => String.from(""));
       sfi = (sfi + usize(1));
-      sf_bytes := io.await(read_file(Path.new(sf.clone()), io), IoExn(io : io, exn : exn));
+      sf_bytes := io.await(read(Path.new(sf.clone()), io), IoExn(io : io, exn : exn));
       sf_src := String.from_bytes(sf_bytes);
       sf_lines := sf_src.split("\n");
       (skip_this : bool) = false;
@@ -2377,7 +2377,7 @@ run_test :: (
     fi = (fi + usize(1));
     println(``);
     println(`${file}`);
-    src_bytes := io.await(read_file(Path.new(file.clone()), io), IoExn(io : io, exn : exn));
+    src_bytes := io.await(read(Path.new(file.clone()), io), IoExn(io : io, exn : exn));
     src := String.from_bytes(src_bytes);
     prog := parse(src, file.clone(), exn);
     tests := ArrayList(TestDecl).new();
@@ -2485,7 +2485,7 @@ run_test :: (
         // that was never written throws `file or directory not found` and
         // aborts the rest of the cleanup with it.
         tmp_c := if(run_is_wasi || run_is_emcc, `${batch_base}.c`, `${tmp_bin}.c`);
-        io.await(write_file(Path.new(tmp_yo.clone()), prog_src.clone(), io), IoExn(io : io, exn : exn));
+        io.await(write_string(Path.new(tmp_yo.clone()), prog_src.clone(), io), IoExn(io : io, exn : exn));
         // Compile the batch in a CHILD PROCESS, not in-process.
         //
         // WHY: `run_compile` creates a fresh ExprInfoTable, but compiler state lives
@@ -2609,7 +2609,7 @@ run_test :: (
           // (getMacOSLsanSuppressions, compiler-utils.ts:334-341).
           if(is_target_macos(host_ti), {
             lsan_supp_file = `${tmp_bin}.lsan_supp.txt`;
-            io.await(write_file(Path.new(lsan_supp_file.clone()), String.from("leak:libobjc\nleak:libdyld\nleak:libxpc\nleak:libsystem_malloc\nleak:dyld"), io), IoExn(io : io, exn : exn));
+            io.await(write_string(Path.new(lsan_supp_file.clone()), String.from("leak:libobjc\nleak:libdyld\nleak:libxpc\nleak:libsystem_malloc\nleak:dyld"), io), IoExn(io : io, exn : exn));
             _sv_lsan := proc_env.set(String.from("LSAN_OPTIONS"), `suppressions=${lsan_supp_file}`);
           });
           // Windows + clang: the ASan runtime DLL directory must be on PATH
@@ -3445,7 +3445,7 @@ run_version_cmd :: (
           exn.throw(dyn(`Error: Yo version ${version_to_pin} is not available. Run \`yo version list --remote\` to see the published releases.`));
         });
       });
-      io.await(write_file(Path.new(`${version_cwd}/.yo-version`), `${version_to_pin}\n`, io), IoExn(io : io, exn : exn));
+      io.await(write_string(Path.new(`${version_cwd}/.yo-version`), `${version_to_pin}\n`, io), IoExn(io : io, exn : exn));
       println(`Pinned Yo version to ${version_to_pin} in .yo-version`);
     },
     (action == "install") => {

--- a/src/module_manager.yo
+++ b/src/module_manager.yo
@@ -31,7 +31,7 @@ open(import("std/string"));
 open(import("std/error"));
 open(import("std/fmt"));
 { Path } :: import("std/path");
-{ read_file } :: import("std/fs/file");
+{ read } :: import("std/fs/file");
 { ArrayList } :: import("std/collections/array_list");
 { getenv } :: import("std/libc/stdlib");
 { current_exe } :: import("std/env");
@@ -399,7 +399,7 @@ _load_module_at_abs :: (fn(abs : String) -> Option(String))({
   std_path := match(g_loader_std_path, .Some(s) => s, .None => String.from(""));
   exn := match(g_loader_exn, .Some(e) => e, .None => return(Option(String).None));
   fs_path := abs.replace(String.from("file://"), String.from(""));
-  src_bytes := io.await(read_file(Path.new(fs_path.clone()), io), IoExn(io : io, exn : exn));
+  src_bytes := io.await(read(Path.new(fs_path.clone()), io), IoExn(io : io, exn : exn));
   (src : String) = String.from_bytes(src_bytes);
   // Open-buffer overlay (Phase B1): the editor's text wins over the disk
   // read above. The read still ALWAYS runs — the await stays a top-level
@@ -678,7 +678,7 @@ mm_load_file :: (
   if(verbose, {
     println(`check: parsing ${input_path}`);
   });
-  src_bytes := io.await(read_file(Path.new(input_path.clone()), io), IoExn(io : io, exn : exn));
+  src_bytes := io.await(read(Path.new(input_path.clone()), io), IoExn(io : io, exn : exn));
   src := String.from_bytes(src_bytes);
   exprs := parse(src, input_path.clone(), local_exn);
   if(verbose, {

--- a/std/fs/file.yo
+++ b/std/fs/file.yo
@@ -6,11 +6,11 @@
 //! # Example
 //!
 //! ```rust
-//! { File, read_to_string, write_file, OpenMode } :: import "std/fs/file";
+//! { File, read_to_string, write_string, OpenMode } :: import "std/fs/file";
 //!
 //! main :: (fn(io : Io, exn : Exception) -> unit)({
 //!   // Write a file
-//!   io.await(write_file(Path.new(`test.txt`), `hello world`, io), { io, exn });
+//!   io.await(write_string(Path.new(`test.txt`), `hello world`, io), { io, exn });
 //!
 //!   // Read it back
 //!   content := io.await(read_to_string(Path.new(`test.txt`), io), { io, exn });
@@ -263,7 +263,7 @@ read_to_string_cstr :: (fn(path : *(u8), io : Io) -> Impl(Future(String, IoExn))
   read_to_string(Path.from_cstr(path), io)
 );
 /// Read an entire file into a byte list (`ArrayList(u8)`).
-read_file :: (fn(path : Path, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))(
+read :: (fn(path : Path, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))(
   io.async((e) => {
     file := e.io.await(File.open(path, .Read, io), e);
     content := e.io.await(file.read_bytes(io), e);
@@ -272,15 +272,15 @@ read_file :: (fn(path : Path, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))(
   })
 );
 /// Read an entire file into bytes (`str` path variant).
-read_file_str :: (fn(path : str, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))(
-  read_file(Path.new(String.from(path)), io)
+read_str :: (fn(path : str, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))(
+  read(Path.new(String.from(path)), io)
 );
 /// Read an entire file into bytes (C string path variant).
-read_file_cstr :: (fn(path : *(u8), io : Io) -> Impl(Future(ArrayList(u8), IoExn)))(
-  read_file(Path.from_cstr(path), io)
+read_cstr :: (fn(path : *(u8), io : Io) -> Impl(Future(ArrayList(u8), IoExn)))(
+  read(Path.from_cstr(path), io)
 );
 /// Write a `String` to a file, creating or truncating it.
-write_file :: (fn(path : Path, data : String, io : Io) -> Impl(Future(unit, IoExn)))(
+write_string :: (fn(path : Path, data : String, io : Io) -> Impl(Future(unit, IoExn)))(
   io.async((e) => {
     file := e.io.await(File.open(path, .Write, io), e);
     e.io.await(file.write_string(data, io), e);
@@ -288,15 +288,15 @@ write_file :: (fn(path : Path, data : String, io : Io) -> Impl(Future(unit, IoEx
   })
 );
 /// Write a `str` to a file, creating or truncating it (`str` path variant).
-write_file_str :: (fn(path : str, data : str, io : Io) -> Impl(Future(unit, IoExn)))(
-  write_file(Path.new(String.from(path)), String.from(data), io)
+write_string_str :: (fn(path : str, data : str, io : Io) -> Impl(Future(unit, IoExn)))(
+  write_string(Path.new(String.from(path)), String.from(data), io)
 );
 /// Write a `str` to a file, creating or truncating it (C string path variant).
-write_file_cstr :: (fn(path : *(u8), data : str, io : Io) -> Impl(Future(unit, IoExn)))(
-  write_file(Path.from_cstr(path), String.from(data), io)
+write_string_cstr :: (fn(path : *(u8), data : str, io : Io) -> Impl(Future(unit, IoExn)))(
+  write_string(Path.from_cstr(path), String.from(data), io)
 );
 /// Write bytes to a file, creating or truncating it.
-write_bytes :: (fn(path : Path, data : ArrayList(u8), io : Io) -> Impl(Future(unit, IoExn)))(
+write :: (fn(path : Path, data : ArrayList(u8), io : Io) -> Impl(Future(unit, IoExn)))(
   io.async((e) => {
     file := e.io.await(File.open(path, .Write, io), e);
     e.io.await(file.write_bytes(data, io), e);
@@ -436,13 +436,13 @@ export(
   read_to_string,
   read_to_string_str,
   read_to_string_cstr,
-  read_file,
-  read_file_str,
-  read_file_cstr,
-  write_file,
-  write_file_str,
-  write_file_cstr,
-  write_bytes,
+  read,
+  read_str,
+  read_cstr,
+  write_string,
+  write_string_str,
+  write_string_cstr,
+  write,
   append_file,
   append_file_str,
   exists,

--- a/std/fs/metadata.yo
+++ b/std/fs/metadata.yo
@@ -59,8 +59,15 @@ impl(
   accessed_time : (fn(self : Self) -> i64)(
     self._statx.atime_sec()
   ),
-  // Status change time (seconds since epoch).
-  created_time : (fn(self : Self) -> i64)(
+  // Status change time (seconds since epoch) — POSIX ctime.
+  //
+  // This is NOT the file's creation time: ctime moves whenever the inode's
+  // metadata changes (chmod, rename, link count), so it can be LATER than the
+  // modification time. A real creation time (statx btime / st_birthtime /
+  // Windows CreationTime) is not exposed yet — Statx requests
+  // STATX_BASIC_STATS (0x7ff), which does not include STATX_BTIME (0x800),
+  // and there is no btime_sec() accessor. See plans/STD_API_AUDIT.md §5.
+  status_changed_time : (fn(self : Self) -> i64)(
     self._statx.ctime_sec()
   ),
   // True if the file is read-only (no write permission for anyone).

--- a/std/http/client.yo
+++ b/std/http/client.yo
@@ -190,12 +190,15 @@ _read_http_response :: (fn(stream : TcpStream, e : IoExn) -> String)({
   while(runtime(!(done)), {
     n := e.io.await(stream.read(buf, buf_size, e.io), e);
     cond(
-      (n <= i32(0)) => {
+      // 0 bytes means the peer closed the connection. A negative count is
+      // no longer representable: NetError.check throws on error, so read()
+      // only ever returns a real byte count.
+      (n == usize(0)) => {
         done = true;
       },
       true => {
         i := usize(0);
-        while(runtime(i < usize(n)), {
+        while(runtime(i < n), {
           result.push((buf.add(i)).*);
           i = (i + usize(1));
         });

--- a/std/net/tcp.yo
+++ b/std/net/tcp.yo
@@ -27,7 +27,7 @@ open(import("../fmt"));
 { Error, AnyError, Exception, IoExn } :: import("../error");
 IO_tcp :: import("../sys/tcp");
 SockInfo :: import("../sys/sockinfo");
-{ AF_INET, AF_INET6, SOCK_STREAM, SOL_SOCKET, SO_REUSEADDR, IPPROTO_TCP, TCP_NODELAY, SO_KEEPALIVE } :: import("../sys/socket");
+{ AF_INET, AF_INET6, SOCK_STREAM, SOL_SOCKET, SO_REUSEADDR, IPPROTO_TCP, TCP_NODELAY, SO_KEEPALIVE, SHUT_RD, SHUT_WR, SHUT_RDWR } :: import("../sys/socket");
 // ============================================================================
 // Internal helpers
 // ============================================================================
@@ -100,6 +100,26 @@ TcpStream :: ref(
 // ============================================================================
 // TcpListener
 // ============================================================================
+/// Which half of a TCP connection to shut down — the argument to
+/// `TcpStream.shutdown`.
+Shutdown :: enum(
+  /// Further receives are disallowed (SHUT_RD).
+  Read,
+  /// Further sends are disallowed (SHUT_WR).
+  Write,
+  /// Both further sends and receives are disallowed (SHUT_RDWR).
+  Both
+);
+// Convert Shutdown to the POSIX `how` argument.
+_shutdown_to_how :: (fn(how : Shutdown) -> i32)(
+  match(
+    how,
+    .Read => SHUT_RD,
+    .Write => SHUT_WR,
+    .Both => SHUT_RDWR
+  )
+);
+export(Shutdown);
 /// A TCP socket that listens for incoming connections.
 TcpListener :: ref(
   struct(
@@ -270,41 +290,41 @@ impl(
   ),
   /// Read bytes from the stream into `buf`.
   /// Returns the number of bytes read, or 0 if the peer closed the connection.
-  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(i32, IoExn)))({
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async((e) => {
       r := e.io.await(IO_tcp.recv(fd, buf, size, i32(0)), e.io);
-      NetError.check(r, e.exn)
+      usize(NetError.check(r, e.exn))
     })
   }),
   /// Write a `str` to the stream.
   /// Returns the number of bytes written.
-  write_str : (fn(self : Self, data : str, io : Io) -> Impl(Future(i32, IoExn)))({
+  write_str : (fn(self : Self, data : str, io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     s := String.from(data);
     s_bytes := s.as_bytes();
     io.async((e) => {
       r := e.io.await(IO_tcp.send(fd, s_bytes.ptr().unwrap(), s_bytes.len(), i32(0)), e.io);
-      NetError.check(r, e.exn)
+      usize(NetError.check(r, e.exn))
     })
   }),
   /// Write a `String` to the stream.
   /// Returns the number of bytes written.
-  write_string : (fn(self : Self, data : String, io : Io) -> Impl(Future(i32, IoExn)))({
+  write_string : (fn(self : Self, data : String, io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     data_bytes := data.as_bytes();
     io.async((e) => {
       r := e.io.await(IO_tcp.send(fd, data_bytes.ptr().unwrap(), data_bytes.len(), i32(0)), e.io);
-      NetError.check(r, e.exn)
+      usize(NetError.check(r, e.exn))
     })
   }),
   /// Write raw bytes from an `ArrayList(u8)` to the stream.
   /// Returns the number of bytes written.
-  write_bytes : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(i32, IoExn)))({
+  write_bytes : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async((e) => {
       r := e.io.await(IO_tcp.send(fd, data.ptr().unwrap(), data.len(), i32(0)), e.io);
-      NetError.check(r, e.exn)
+      usize(NetError.check(r, e.exn))
     })
   }),
   /// Read all available data from the stream into a byte list.
@@ -340,11 +360,11 @@ impl(
     })
   }),
   /// Shut down part or all of the connection.
-  /// `how`: 0 = read, 1 = write, 2 = both.
-  shutdown : (fn(self : Self, how : i32, io : Io) -> Impl(Future(unit, IoExn)))({
+  shutdown : (fn(self : Self, how : Shutdown, io : Io) -> Impl(Future(unit, IoExn)))({
     fd := self._fd;
+    raw_how := _shutdown_to_how(how);
     io.async((e) => {
-      r := e.io.await(IO_tcp.shutdown(fd, how), e.io);
+      r := e.io.await(IO_tcp.shutdown(fd, raw_how), e.io);
       cond(
         (r < i32(0)) => {
           _throw_io(i32(0) - r, e.exn);

--- a/std/net/udp.yo
+++ b/std/net/udp.yo
@@ -89,39 +89,39 @@ impl(
   ),
   /// Send a datagram to a specific address.
   /// Returns the number of bytes sent.
-  send_to : (fn(self : Self, data : ArrayList(u8), addr : SocketAddr, io : Io) -> Impl(Future(i32, IoExn)))({
+  send_to : (fn(self : Self, data : ArrayList(u8), addr : SocketAddr, io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async((e) => {
       saddr := _make_sockaddr(addr);
       r := e.io.await(IO_udp.sendto(fd, data.ptr().unwrap(), data.len(), i32(0), saddr.buf, saddr.len), e.io);
       IO_tcp.free_sockaddr(saddr);
-      NetError.check(r, e.exn)
+      usize(NetError.check(r, e.exn))
     })
   }),
   /// Receive a datagram into the provided buffer.
   /// Returns the number of bytes received.
-  recv : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(i32, IoExn)))({
+  recv : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async((e) => {
       r := e.io.await(IO_udp.recv(fd, buf, size, i32(0)), e.io);
-      NetError.check(r, e.exn)
+      usize(NetError.check(r, e.exn))
     })
   }),
   /// Receive a datagram and retrieve the sender's address.
   /// Returns the number of bytes received.
-  recv_from : (fn(self : Self, buf : *(u8), size : usize, src_addr : *(u8), src_addr_len : *(u32), io : Io) -> Impl(Future(i32, IoExn)))({
+  recv_from : (fn(self : Self, buf : *(u8), size : usize, src_addr : *(u8), src_addr_len : *(u32), io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async((e) => {
       r := e.io.await(IO_udp.recvfrom(fd, buf, size, i32(0), src_addr, src_addr_len), e.io);
-      NetError.check(r, e.exn)
+      usize(NetError.check(r, e.exn))
     })
   }),
   /// Send data on a connected socket (requires prior connect).
-  send : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(i32, IoExn)))({
+  send : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async((e) => {
       r := e.io.await(IO_udp.send(fd, data.ptr().unwrap(), data.len(), i32(0)), e.io);
-      NetError.check(r, e.exn)
+      usize(NetError.check(r, e.exn))
     })
   }),
   /// Close the socket.

--- a/tests/fs/dir.test.yo
+++ b/tests/fs/dir.test.yo
@@ -154,7 +154,7 @@ test("remove_file removes a file", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_dir_rm_file.txt`));
-  io.await(fs_file.write_file(fpath, String.from("to remove"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("to remove"), io), IoExn(io : io, exn : exn));
   io.await(fs_dir.remove_file(fpath, io), IoExn(io : io, exn : exn));
   unsafe(printf("  remove_file ok\n"));
   // Verify gone
@@ -195,7 +195,7 @@ test("rename moves a file", {
     },
     true => ()
   );
-  io.await(fs_file.write_file(old_path, String.from("rename me"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(old_path, String.from("rename me"), io), IoExn(io : io, exn : exn));
   io.await(fs_dir.rename(old_path, new_path, io), IoExn(io : io, exn : exn));
   unsafe(printf("  rename ok\n"));
   // Old should not exist
@@ -232,7 +232,7 @@ test("hard_link creates a link", {
     },
     true => ()
   );
-  io.await(fs_file.write_file(src, String.from("link data"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(src, String.from("link data"), io), IoExn(io : io, exn : exn));
   io.await(fs_dir.hard_link(src, dst, io), IoExn(io : io, exn : exn));
   unsafe(printf("  hard_link ok\n"));
   // Read via link
@@ -268,7 +268,7 @@ test("symlink creates a symbolic link", {
     },
     true => ()
   );
-  io.await(fs_file.write_file(src, String.from("symlink data"), io), IoExn(io : io, exn : setup_exn));
+  io.await(fs_file.write_string(src, String.from("symlink data"), io), IoExn(io : io, exn : setup_exn));
   // Symlink may fail with PermissionDenied on Windows
   sym_exn := Exception(
     throw : (
@@ -334,7 +334,7 @@ test("read_dir survives directories larger than one getdents buffer", {
   io.await(fs_dir.create_dir_all(dpath, io), IoExn(io : io, exn : exn));
   (i : usize) = usize(0);
   while(runtime(i < usize(200)), {
-    io.await(fs_file.write_file(Path.new(path_join(dname.clone(), `file_with_a_reasonably_long_name_${i}.txt`)), String.from("x"), io), IoExn(io : io, exn : exn));
+    io.await(fs_file.write_string(Path.new(path_join(dname.clone(), `file_with_a_reasonably_long_name_${i}.txt`)), String.from("x"), io), IoExn(io : io, exn : exn));
     i = (i + usize(1));
   });
   entries := io.await(fs_dir.read_dir(dpath, io), IoExn(io : io, exn : exn));
@@ -361,8 +361,8 @@ test("read_dir lists directory entries", {
   dpath := Path.new(path_join(tmp, `yo_fs_read_dir`));
   io.await(fs_dir.create_dir_all(dpath, io), IoExn(io : io, exn : exn));
   // Create some files inside
-  io.await(fs_file.write_file(Path.new(path_join(path_join(tmp, `yo_fs_read_dir`), `a.txt`)), String.from("a"), io), IoExn(io : io, exn : exn));
-  io.await(fs_file.write_file(Path.new(path_join(path_join(tmp, `yo_fs_read_dir`), `b.txt`)), String.from("b"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(Path.new(path_join(path_join(tmp, `yo_fs_read_dir`), `a.txt`)), String.from("a"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(Path.new(path_join(path_join(tmp, `yo_fs_read_dir`), `b.txt`)), String.from("b"), io), IoExn(io : io, exn : exn));
   // Create a subdirectory
   io.await(fs_dir.create_dir(Path.new(path_join(path_join(tmp, `yo_fs_read_dir`), `subdir`)), io), IoExn(io : io, exn : exn));
   entries := io.await(fs_dir.read_dir(dpath, io), IoExn(io : io, exn : exn));

--- a/tests/fs/file.test.yo
+++ b/tests/fs/file.test.yo
@@ -14,7 +14,7 @@ open(import("std/fmt"));
 // ============================================================================
 // Convenience function tests
 // ============================================================================
-test("write_file and read_to_string round-trip", {
+test("write_string and read_to_string round-trip", {
   exn := Exception(
     throw : (
       (err) -> {
@@ -26,7 +26,7 @@ test("write_file and read_to_string round-trip", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_file_write_read.txt`));
-  io.await(fs_file.write_file(fpath, String.from("hello world"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("hello world"), io), IoExn(io : io, exn : exn));
   unsafe(printf("  write ok\n"));
   s := io.await(fs_file.read_to_string(fpath, io), IoExn(io : io, exn : exn));
   unsafe(printf("  read: %s\n", s.to_cstr().ptr().unwrap()));
@@ -34,7 +34,7 @@ test("write_file and read_to_string round-trip", {
   // Cleanup
   io.await(fs_dir.remove_file(fpath, io), IoExn(io : io, exn : exn));
 });
-test("write_file_cstr and read_to_string_cstr", {
+test("write_string_cstr and read_to_string_cstr", {
   exn := Exception(
     throw : (
       (err) -> {
@@ -47,14 +47,14 @@ test("write_file_cstr and read_to_string_cstr", {
   fpath_s := path_join(tmp, `yo_fs_file_str_test.txt`);
   fpath_cstr := fpath_s.to_cstr();
   fpath_c := fpath_cstr.ptr().unwrap();
-  io.await(fs_file.write_file_cstr(fpath_c, "str path test", io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string_cstr(fpath_c, "str path test", io), IoExn(io : io, exn : exn));
   unsafe(printf("  write ok\n"));
   s := io.await(fs_file.read_to_string_cstr(fpath_c, io), IoExn(io : io, exn : exn));
   unsafe(printf("  read: %s\n", s.to_cstr().ptr().unwrap()));
   assert(s == `str path test`, "content mismatch");
   io.await(fs_dir.remove_file(Path.new(fpath_s), io), IoExn(io : io, exn : exn));
 });
-test("read_file returns bytes", {
+test("read returns bytes", {
   exn := Exception(
     throw : (
       (err) -> {
@@ -65,8 +65,8 @@ test("read_file returns bytes", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_file_read_bytes.txt`));
-  io.await(fs_file.write_file(fpath, String.from("ABC"), io), IoExn(io : io, exn : exn));
-  bytes := io.await(fs_file.read_file(fpath, io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("ABC"), io), IoExn(io : io, exn : exn));
+  bytes := io.await(fs_file.read(fpath, io), IoExn(io : io, exn : exn));
   unsafe(printf("  bytes len = %lld\n", i64(bytes.len())));
   assert(bytes.len() == usize(3), "expected 3 bytes");
   assert(bytes(usize(0)) == u8(65), "A=65");
@@ -85,7 +85,7 @@ test("append_file appends to existing content", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_file_append.txt`));
-  io.await(fs_file.write_file(fpath, String.from("first"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("first"), io), IoExn(io : io, exn : exn));
   io.await(fs_file.append_file(fpath, String.from(" second"), io), IoExn(io : io, exn : exn));
   s := io.await(fs_file.read_to_string(fpath, io), IoExn(io : io, exn : exn));
   unsafe(printf("  read: %s\n", s.to_cstr().ptr().unwrap()));
@@ -103,7 +103,7 @@ test("exists returns true for existing file", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_file_exists.txt`));
-  io.await(fs_file.write_file(fpath, String.from("exists"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("exists"), io), IoExn(io : io, exn : exn));
   e := io.await(fs_file.exists(fpath, io), io);
   unsafe(printf("  exists = %d\n", cond(e => i32(1), true => i32(0))));
   assert(e, "file should exist");
@@ -175,7 +175,7 @@ test("File.size returns correct size", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_file_size.txt`));
-  io.await(fs_file.write_file(fpath, String.from("twelve chars"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("twelve chars"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   sz := f.size();
   unsafe(printf("  size = %lld\n", sz));
@@ -194,7 +194,7 @@ test("File.path returns correct path", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_file_path.txt`));
-  io.await(fs_file.write_file(fpath, String.from("x"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("x"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   p := f.path().to_string();
   expected := fpath.to_string();
@@ -215,7 +215,7 @@ test("OpenMode.CreateNew fails if file exists", {
       }
     )
   );
-  io.await(fs_file.write_file(fpath, String.from("first"), io), IoExn(io : io, exn : setup_exn));
+  io.await(fs_file.write_string(fpath, String.from("first"), io), IoExn(io : io, exn : setup_exn));
   // Try CreateNew on existing file - should fail
   exn := Exception(
     throw : (
@@ -264,7 +264,7 @@ test("File.open_cstr convenience", {
   fpath := Path.new(path_join(tmp, `yo_fs_file_open_str.txt`));
   fpath_cstr := fpath.to_string().to_cstr();
   fpath_c := fpath_cstr.ptr().unwrap();
-  io.await(fs_file.write_file(fpath, String.from("open_str test"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("open_str test"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open_cstr(fpath_c, .Read, io), IoExn(io : io, exn : exn));
   s := io.await(f.read_to_string(io), IoExn(io : io, exn : exn));
   unsafe(printf("  read: %s\n", s.to_cstr().ptr().unwrap()));

--- a/tests/fs/fs_convenience.test.yo
+++ b/tests/fs/fs_convenience.test.yo
@@ -25,7 +25,7 @@ test("is_file returns true for a regular file", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_conv_is_file.txt`));
-  io.await(fs_file.write_file(fpath, String.from("hello"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("hello"), io), IoExn(io : io, exn : exn));
   r := io.await(fs_file.is_file(fpath, io), io);
   unsafe(printf("  is_file = %d\n", cond(r => i32(1), true => i32(0))));
   assert(r, "should be a file");
@@ -85,7 +85,7 @@ test("is_dir returns false for a file", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_conv_is_dir_file.txt`));
-  io.await(fs_file.write_file(fpath, String.from("test"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("test"), io), IoExn(io : io, exn : exn));
   r := io.await(fs_file.is_dir(fpath, io), io);
   unsafe(printf("  is_dir on file = %d\n", cond(r => i32(1), true => i32(0))));
   assert(!(r), "file should not be a directory");
@@ -112,7 +112,7 @@ test("canonical resolves a real path", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_conv_canonical.txt`));
-  io.await(fs_file.write_file(fpath, String.from("canonical"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("canonical"), io), IoExn(io : io, exn : exn));
   resolved := io.await(fs_file.canonicalize(fpath, io), IoExn(io : io, exn : exn));
   resolved_str := resolved.to_string();
   unsafe(printf("  canonical = %s\n", resolved_str.to_cstr().ptr().unwrap()));
@@ -135,7 +135,7 @@ test("canonical resolves dot-dot segments", {
   file_path := Path.new(path_join(tmp, `yo_fs_conv_canonical_dir/target.txt`));
   io.await(fs_dir.create_dir(dir_path, io), IoExn(io : io, exn : exn));
   io.await(fs_dir.create_dir(sub_path, io), IoExn(io : io, exn : exn));
-  io.await(fs_file.write_file(file_path, String.from("data"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(file_path, String.from("data"), io), IoExn(io : io, exn : exn));
   // Path with .. segment: dir/sub/../target.txt should resolve to dir/target.txt
   dotdot_path := Path.new(path_join(path_join(path_join(tmp, `yo_fs_conv_canonical_dir`), `sub`), `../target.txt`));
   resolved := io.await(fs_file.canonicalize(dotdot_path, io), IoExn(io : io, exn : exn));

--- a/tests/fs/metadata.test.yo
+++ b/tests/fs/metadata.test.yo
@@ -25,7 +25,7 @@ test("metadata returns file info", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_meta_file.txt`));
-  io.await(fs_file.write_file(fpath, String.from("metadata test"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("metadata test"), io), IoExn(io : io, exn : exn));
   m := io.await(fs_metadata.metadata(fpath, io), IoExn(io : io, exn : exn));
   unsafe(printf("  size = %lld\n", m.size()));
   assert(m.size() == i64(13), "size should be 13");
@@ -88,7 +88,7 @@ test("metadata_str works with str path", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_meta_str.txt`));
-  io.await(fs_file.write_file(fpath, String.from("str meta"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("str meta"), io), IoExn(io : io, exn : exn));
   m := io.await(fs_metadata.metadata(fpath, io), IoExn(io : io, exn : exn));
   unsafe(printf("  size = %lld\n", m.size()));
   assert(m.size() == i64(8), "size should be 8");
@@ -138,7 +138,7 @@ test("symlink_metadata on symlink reports symlink", {
     },
     true => ()
   );
-  io.await(fs_file.write_file(src, String.from("symlink meta test"), io), IoExn(io : io, exn : setup_exn));
+  io.await(fs_file.write_string(src, String.from("symlink meta test"), io), IoExn(io : io, exn : setup_exn));
   // Symlink may fail with PermissionDenied on Windows
   sym_exn := Exception(
     throw : (
@@ -199,7 +199,7 @@ test("File.metadata returns correct info", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_fs_meta_file_method.txt`));
-  io.await(fs_file.write_file(fpath, String.from("file meta"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("file meta"), io), IoExn(io : io, exn : exn));
   { File } :: import("std/fs/file");
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   m := io.await(f.metadata(io), IoExn(io : io, exn : exn));

--- a/tests/fs/walker.test.yo
+++ b/tests/fs/walker.test.yo
@@ -30,10 +30,10 @@ _setup_walk_tree :: (fn(root : String, io : Io, exn : Exception) -> unit)({
   io.await(fs_dir.create_dir_all(Path.new(sub), io), IoExn(io : io, exn : exn));
   deep := path_join(sub, `deep`);
   io.await(fs_dir.create_dir_all(Path.new(deep), io), IoExn(io : io, exn : exn));
-  io.await(fs_file.write_file(Path.new(path_join(root, `a.txt`)), String.from("a"), io), IoExn(io : io, exn : exn));
-  io.await(fs_file.write_file(Path.new(path_join(root, `b.txt`)), String.from("b"), io), IoExn(io : io, exn : exn));
-  io.await(fs_file.write_file(Path.new(path_join(sub, `c.txt`)), String.from("c"), io), IoExn(io : io, exn : exn));
-  io.await(fs_file.write_file(Path.new(path_join(deep, `d.txt`)), String.from("d"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(Path.new(path_join(root, `a.txt`)), String.from("a"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(Path.new(path_join(root, `b.txt`)), String.from("b"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(Path.new(path_join(sub, `c.txt`)), String.from("c"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(Path.new(path_join(deep, `d.txt`)), String.from("d"), io), IoExn(io : io, exn : exn));
 });
 _cleanup_walk_tree :: (fn(root : String, io : Io, exn : Exception) -> unit)({
   sub := path_join(root, `sub`);
@@ -182,7 +182,7 @@ test("walk_cstr works with C string path", {
   root_cstr := root.to_cstr();
   root_c := root_cstr.ptr().unwrap();
   io.await(fs_dir.create_dir_all(Path.new(root), io), IoExn(io : io, exn : exn));
-  io.await(fs_file.write_file(Path.new(path_join(root, `x.txt`)), String.from("x"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(Path.new(path_join(root, `x.txt`)), String.from("x"), io), IoExn(io : io, exn : exn));
   entries := io.await(fs_walker.walk_cstr(root_c, io), IoExn(io : io, exn : exn));
   unsafe(printf("  walk_cstr entries = %lld\n", i64(entries.len())));
   assert(entries.len() == usize(1), "expected 1 entry");
@@ -233,7 +233,7 @@ test("walk_with follow_symlinks descends through directory symlinks", {
         true => ()
       );
       io.await(fs_dir.create_dir_all(Path.new(real), io), IoExn(io : io, exn : exn));
-      io.await(fs_file.write_file(Path.new(path_join(real, `inner.txt`)), String.from("x"), io), IoExn(io : io, exn : exn));
+      io.await(fs_file.write_string(Path.new(path_join(real, `inner.txt`)), String.from("x"), io), IoExn(io : io, exn : exn));
       io.await(fs_dir.symlink(Path.new(real), Path.new(lnk), io), IoExn(io : io, exn : exn));
       opts := WalkOptions(max_depth : .None, follow_symlinks : true, include_dirs : true);
       entries := io.await(fs_walker.walk_with(Path.new(root), opts, io), IoExn(io : io, exn : exn));

--- a/tests/internal/check_watch.test.yo
+++ b/tests/internal/check_watch.test.yo
@@ -9,7 +9,7 @@ open(import("std/error"));
 { assert } :: import("std/assert");
 { Path } :: import("std/path");
 { create_dir_all } :: import("std/fs/dir");
-{ write_file } :: import("std/fs/file");
+{ write_string } :: import("std/fs/file");
 { watch_round } :: import("../../src/check_watch.yo");
 { mm_load_file, mm_invalidate_document, resolve_std_path } :: import("../../src/module_manager.yo");
 { type_trait_methods_entry_count } :: import("../../src/evaluator/values/type_trait_methods.yo");
@@ -41,8 +41,8 @@ test("Phase C: watch_round rechecks the reverse closure, error -> fix -> clean",
   io.await(create_dir_all(Path.new(dir.clone()), io), ioexn);
   lib_path := `${dir}/lib.yo`;
   app_path := `${dir}/app.yo`;
-  io.await(write_file(Path.new(lib_path.clone()), String.from(_LIB_OK), io), ioexn);
-  io.await(write_file(Path.new(app_path.clone()), String.from(_APP), io), ioexn);
+  io.await(write_string(Path.new(lib_path.clone()), String.from(_LIB_OK), io), ioexn);
+  io.await(write_string(Path.new(app_path.clone()), String.from(_APP), io), ioexn);
   std_path := resolve_std_path();
   // Drop any earlier state for these paths (suite processes are reused).
   _pre1 := mm_invalidate_document(lib_path.clone());
@@ -55,11 +55,11 @@ test("Phase C: watch_round rechecks the reverse closure, error -> fix -> clean",
   assert(mm_load_file(lib_path.clone(), std_path.clone(), true, io, exn).ok, "initial lib check should pass");
   // 1. Break lib on DISK (rename the export) -> the round must recheck the
   //    reverse closure and fail exactly the importer.
-  io.await(write_file(Path.new(lib_path.clone()), String.from(_LIB_RENAMED), io), ioexn);
+  io.await(write_string(Path.new(lib_path.clone()), String.from(_LIB_RENAMED), io), ioexn);
   failed1 := _round(lib_path.clone(), files, std_path.clone(), io, exn);
   assert(failed1 == usize(1), `broken lib: expected 1 failed, got ${failed1.to_string()}`);
   // 2. Fix lib on disk -> the next round is clean again.
-  io.await(write_file(Path.new(lib_path.clone()), String.from(_LIB_OK), io), ioexn);
+  io.await(write_string(Path.new(lib_path.clone()), String.from(_LIB_OK), io), ioexn);
   failed2 := _round(lib_path.clone(), files, std_path.clone(), io, exn);
   assert(failed2 == usize(0), `fixed lib: expected 0 failed, got ${failed2.to_string()}`);
   // 3. Long-lived-process guarantee: repeated rounds keep the registry

--- a/tests/internal/module_invalidation.test.yo
+++ b/tests/internal/module_invalidation.test.yo
@@ -18,7 +18,7 @@ open(import("std/error"));
 { assert } :: import("std/assert");
 { Path } :: import("std/path");
 { create_dir_all } :: import("std/fs/dir");
-{ write_file } :: import("std/fs/file");
+{ write_string } :: import("std/fs/file");
 { analyze_document, AnalyzeOutcome } :: import("../../src/lsp/diagnostics.yo");
 {
   mm_set_open_document,
@@ -65,8 +65,8 @@ test("B1: imported-file edit visible after overlay + invalidation", {
   io.await(create_dir_all(Path.new(dir.clone()), io), ioexn);
   lib_path := `${dir}/lib.yo`;
   app_path := `${dir}/app.yo`;
-  io.await(write_file(Path.new(lib_path.clone()), String.from(_LIB_V1), io), ioexn);
-  io.await(write_file(Path.new(app_path.clone()), String.from(_APP), io), ioexn);
+  io.await(write_string(Path.new(lib_path.clone()), String.from(_LIB_V1), io), ioexn);
+  io.await(write_string(Path.new(app_path.clone()), String.from(_APP), io), ioexn);
   std_path := resolve_std_path();
   // Make sure no earlier state for these paths leaks between runs.
   mm_forget_open_document(lib_path.clone());
@@ -116,7 +116,7 @@ test("B2: repeated re-analysis keeps registry entry counts stable", {
   dir := `/tmp/yo_b1_invalidation_fixture`;
   io.await(create_dir_all(Path.new(dir.clone()), io), ioexn);
   doc_path := `${dir}/impl_doc.yo`;
-  io.await(write_file(Path.new(doc_path.clone()), String.from(_IMPL_DOC), io), ioexn);
+  io.await(write_string(Path.new(doc_path.clone()), String.from(_IMPL_DOC), io), ioexn);
   std_path := resolve_std_path();
   // Round 1 establishes the doc's registry generation; every later round
   // purges it (via the invalidation) before re-registering an identical

--- a/tests/internal/version.test.yo
+++ b/tests/internal/version.test.yo
@@ -177,7 +177,7 @@ test("find_yo_version_file: finds .yo-version in current directory", {
   base := path_join(temp_dir(), `yo_ver_cur`);
   io.await(fs_dir.create_dir_all(Path.new(base.clone()), io), ioexn);
   vfile := path_join(base.clone(), `.yo-version`);
-  io.await(fs_file.write_file(Path.new(vfile.clone()), String.from("0.1.12\n"), io), ioexn);
+  io.await(fs_file.write_string(Path.new(vfile.clone()), String.from("0.1.12\n"), io), ioexn);
   found := io.await(find_yo_version_file(Path.new(base.clone()), io), io);
   match(
     found,
@@ -202,7 +202,7 @@ test("find_yo_version_file: finds .yo-version in parent directory", {
   child := path_join(base.clone(), `child`);
   io.await(fs_dir.create_dir_all(Path.new(child.clone()), io), ioexn);
   vfile := path_join(base.clone(), `.yo-version`);
-  io.await(fs_file.write_file(Path.new(vfile.clone()), String.from("0.1.12\n"), io), ioexn);
+  io.await(fs_file.write_string(Path.new(vfile.clone()), String.from("0.1.12\n"), io), ioexn);
   found := io.await(find_yo_version_file(Path.new(child.clone()), io), io);
   match(
     found,
@@ -229,8 +229,8 @@ test("find_yo_version_file: picks nearest .yo-version in directory hierarchy", {
   io.await(fs_dir.create_dir_all(Path.new(inner.clone()), io), ioexn);
   outer_v := path_join(base.clone(), `.yo-version`);
   inner_v := path_join(inner.clone(), `.yo-version`);
-  io.await(fs_file.write_file(Path.new(outer_v.clone()), String.from("0.1.1\n"), io), ioexn);
-  io.await(fs_file.write_file(Path.new(inner_v.clone()), String.from("0.1.2\n"), io), ioexn);
+  io.await(fs_file.write_string(Path.new(outer_v.clone()), String.from("0.1.1\n"), io), ioexn);
+  io.await(fs_file.write_string(Path.new(inner_v.clone()), String.from("0.1.2\n"), io), ioexn);
   found := io.await(find_yo_version_file(Path.new(inner.clone()), io), io);
   match(
     found,
@@ -273,7 +273,7 @@ test("read_yo_version: reads and parses .yo-version", {
   base := path_join(temp_dir(), `yo_ver_read`);
   io.await(fs_dir.create_dir_all(Path.new(base.clone()), io), ioexn);
   vfile := path_join(base.clone(), `.yo-version`);
-  io.await(fs_file.write_file(Path.new(vfile.clone()), String.from("v0.1.12\n"), io), ioexn);
+  io.await(fs_file.write_string(Path.new(vfile.clone()), String.from("v0.1.12\n"), io), ioexn);
   got := io.await(read_yo_version(Path.new(base.clone()), io, exn), ioexn);
   match(
     got,
@@ -314,7 +314,7 @@ test("read_yo_version: throws on invalid content", {
   base := path_join(temp_dir(), `yo_ver_bad`);
   io.await(fs_dir.create_dir_all(Path.new(base.clone()), io), cleanup_ioexn);
   vfile := path_join(base.clone(), `.yo-version`);
-  io.await(fs_file.write_file(Path.new(vfile.clone()), String.from("not-a-version\n"), io), cleanup_ioexn);
+  io.await(fs_file.write_string(Path.new(vfile.clone()), String.from("not-a-version\n"), io), cleanup_ioexn);
   // The throw handler unwinds the test body, skipping the trailing
   // assert(false) — reaching it means read_yo_version accepted bad content.
   throw_exn := Exception(

--- a/tests/net/tcp.test.yo
+++ b/tests/net/tcp.test.yo
@@ -8,10 +8,9 @@ open(import("std/libc/stdio"));
 { ArrayList } :: import("std/collections/array_list");
 open(import("std/string"));
 open(import("std/fmt"));
-{ TcpListener, TcpStream } :: import("std/net/tcp");
+{ TcpListener, TcpStream, Shutdown } :: import("std/net/tcp");
 { SocketAddr, IpAddr } :: import("std/net/addr");
 { NetError } :: import("std/net/errors");
-{ SHUT_RDWR } :: import("std/sys/socket");
 { Error, AnyError, Exception, IoExn } :: import("std/error");
 // ============================================================================
 // TcpListener tests
@@ -85,13 +84,13 @@ test("TCP echo with write_str and read", {
   server_stream := io.await(listener.accept(io), IoExn(io : io, exn : exn));
   // Client sends
   n := io.await(client.write_str("Hello Net!", io), IoExn(io : io, exn : exn));
-  unsafe(printf("  sent = %d\n", n));
-  assert(n == i32(10), "should send 10 bytes");
+  unsafe(printf("  sent = %zu\n", n));
+  assert(n == usize(10), "should send 10 bytes");
   // Server reads
   recv_buf := *(u8)(malloc(usize(256)).unwrap());
   nr := io.await(server_stream.read(recv_buf, usize(256), io), IoExn(io : io, exn : exn));
-  unsafe(printf("  received = %d\n", nr));
-  assert(nr == i32(10), "should receive 10 bytes");
+  unsafe(printf("  received = %zu\n", nr));
+  assert(nr == usize(10), "should receive 10 bytes");
   assert((recv_buf.add(usize(0))).* == u8(72), "H");
   assert((recv_buf.add(usize(1))).* == u8(101), "e");
   assert((recv_buf.add(usize(2))).* == u8(108), "l");
@@ -118,13 +117,13 @@ test("TCP echo with write String", {
   // Write using String
   msg := `Hello String!`;
   n := io.await(client.write_string(msg, io), IoExn(io : io, exn : exn));
-  unsafe(printf("  sent = %d\n", n));
-  assert(n == i32(13), "should send 13 bytes");
+  unsafe(printf("  sent = %zu\n", n));
+  assert(n == usize(13), "should send 13 bytes");
   // Server reads
   recv_buf := *(u8)(malloc(usize(256)).unwrap());
   nr := io.await(server_stream.read(recv_buf, usize(256), io), IoExn(io : io, exn : exn));
-  unsafe(printf("  received = %d\n", nr));
-  assert(nr == i32(13), "should receive 13 bytes");
+  unsafe(printf("  received = %zu\n", nr));
+  assert(nr == usize(13), "should receive 13 bytes");
   free(.Some(*(void)(recv_buf)));
   io.await(server_stream.close(io), IoExn(io : io, exn : exn));
   io.await(client.close(io), IoExn(io : io, exn : exn));
@@ -150,13 +149,13 @@ test("TCP write_bytes", {
   data.push(u8(3));
   data.push(u8(4));
   n := io.await(client.write_bytes(data, io), IoExn(io : io, exn : exn));
-  unsafe(printf("  sent = %d\n", n));
-  assert(n == i32(4), "should send 4 bytes");
+  unsafe(printf("  sent = %zu\n", n));
+  assert(n == usize(4), "should send 4 bytes");
   // Server reads
   recv_buf := *(u8)(malloc(usize(256)).unwrap());
   nr := io.await(server_stream.read(recv_buf, usize(256), io), IoExn(io : io, exn : exn));
-  unsafe(printf("  received = %d\n", nr));
-  assert(nr == i32(4), "should receive 4 bytes");
+  unsafe(printf("  received = %zu\n", nr));
+  assert(nr == usize(4), "should receive 4 bytes");
   assert((recv_buf.add(usize(0))).* == u8(1), "byte 0");
   assert((recv_buf.add(usize(1))).* == u8(2), "byte 1");
   assert((recv_buf.add(usize(2))).* == u8(3), "byte 2");
@@ -198,7 +197,7 @@ test("TCP shutdown", {
   listener := io.await(TcpListener.bind(addr, io), IoExn(io : io, exn : exn));
   client := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : exn));
   server_stream := io.await(listener.accept(io), IoExn(io : io, exn : exn));
-  io.await(client.shutdown(SHUT_RDWR, io), IoExn(io : io, exn : exn));
+  io.await(client.shutdown(Shutdown.Both, io), IoExn(io : io, exn : exn));
   unsafe(printf("  shutdown ok\n"));
   io.await(server_stream.close(io), IoExn(io : io, exn : exn));
   io.await(client.close(io), IoExn(io : io, exn : exn));
@@ -238,7 +237,7 @@ test("TCP read_bytes gets all data", {
   server_stream := io.await(listener.accept(io), IoExn(io : io, exn : exn));
   // Client sends data then closes write side
   io.await(client.write_str("ABCDE", io), IoExn(io : io, exn : exn));
-  io.await(client.shutdown(i32(1), io), IoExn(io : io, exn : exn));
+  io.await(client.shutdown(Shutdown.Write, io), IoExn(io : io, exn : exn));
   // Server reads all
   data := io.await(server_stream.read_bytes(io), IoExn(io : io, exn : exn));
   unsafe(printf("  read_bytes len = %lld\n", i64(data.len())));

--- a/tests/net/udp.test.yo
+++ b/tests/net/udp.test.yo
@@ -67,13 +67,13 @@ test("UdpSocket send_to and recv", {
   data.push(u8(108)); // l
   data.push(u8(111)); // o
   n := io.await(client.send_to(data, server_addr, io), IoExn(io : io, exn : exn));
-  unsafe(printf("  sent = %d\n", n));
-  assert(n == i32(5), "should send 5 bytes");
+  unsafe(printf("  sent = %zu\n", n));
+  assert(n == usize(5), "should send 5 bytes");
   // Server receives
   recv_buf := *(u8)(malloc(usize(256)).unwrap());
   nr := io.await(server.recv(recv_buf, usize(256), io), IoExn(io : io, exn : exn));
-  unsafe(printf("  received = %d\n", nr));
-  assert(nr == i32(5), "should receive 5 bytes");
+  unsafe(printf("  received = %zu\n", nr));
+  assert(nr == usize(5), "should receive 5 bytes");
   assert((recv_buf.add(usize(0))).* == u8(72), "H");
   assert((recv_buf.add(usize(1))).* == u8(101), "e");
   assert((recv_buf.add(usize(2))).* == u8(108), "l");
@@ -107,8 +107,8 @@ test("UdpSocket recv_from gets source address", {
   src_addr_len := *(u32)(malloc(usize(4)).unwrap());
   src_addr_len.* = u32(128);
   nr := io.await(server.recv_from(recv_buf, usize(256), src_addr_buf, src_addr_len, io), IoExn(io : io, exn : exn));
-  unsafe(printf("  received = %d\n", nr));
-  assert(nr == i32(2), "should receive 2 bytes");
+  unsafe(printf("  received = %zu\n", nr));
+  assert(nr == usize(2), "should receive 2 bytes");
   assert((recv_buf.add(usize(0))).* == u8(65), "A");
   assert((recv_buf.add(usize(1))).* == u8(66), "B");
   // Verify source address family

--- a/tests/sys/bufio.test.yo
+++ b/tests/sys/bufio.test.yo
@@ -41,7 +41,7 @@ test("BufReader read_line reads single line", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_readline_single.txt`));
-  io.await(fs_file.write_file(fpath, String.from("hello world\n"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("hello world\n"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -74,7 +74,7 @@ test("BufReader read_line reads multiple lines", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_readline_multi.txt`));
-  io.await(fs_file.write_file(fpath, String.from("line1\nline2\nline3\n"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("line1\nline2\nline3\n"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -152,7 +152,7 @@ test("BufReader read_line handles line without trailing newline", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_readline_notrail.txt`));
-  io.await(fs_file.write_file(fpath, String.from("no newline at end"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("no newline at end"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -200,7 +200,7 @@ test("BufReader read_line on empty file returns None", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_readline_empty.txt`));
-  io.await(fs_file.write_file(fpath, String.from(""), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from(""), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -232,7 +232,7 @@ test("BufReader read_bytes reads entire file", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_readall.txt`));
-  io.await(fs_file.write_file(fpath, String.from("all data here"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("all data here"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -260,7 +260,7 @@ test("BufReader read_to_string reads entire file as String", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_readtostring.txt`));
-  io.await(fs_file.write_file(fpath, String.from("string content"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("string content"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -455,7 +455,7 @@ test("BufReader read returns bytes from file", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_read_bytes.txt`));
-  io.await(fs_file.write_file(fpath, String.from("abcde"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("abcde"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -486,7 +486,7 @@ test("BufReader read on empty file returns zero", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_read_empty.txt`));
-  io.await(fs_file.write_file(fpath, String.from(""), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from(""), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -515,7 +515,7 @@ test("BufReader read partial then remaining", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_read_partial.txt`));
-  io.await(fs_file.write_file(fpath, String.from("hello world"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("hello world"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -566,7 +566,7 @@ test("BufReader with small buffer reads multiple chunks", {
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_small_buf.txt`));
   // Write data larger than small buffer
-  io.await(fs_file.write_file(fpath, String.from("abcdefghijklmnopqrstuvwxyz"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("abcdefghijklmnopqrstuvwxyz"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   // Use a small buffer (8 bytes) to force multiple refills
@@ -595,7 +595,7 @@ test("BufReader with small buffer reads lines across chunks", {
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_small_buf_lines.txt`));
   // Lines that span multiple 8-byte buffer fills
-  io.await(fs_file.write_file(fpath, String.from("hello world\ngoodbye world\n"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("hello world\ngoodbye world\n"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.with_capacity(fd, usize(8));
@@ -646,7 +646,7 @@ test("BufReader read_line with only newlines", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_only_newlines.txt`));
-  io.await(fs_file.write_file(fpath, String.from("\n\n\n"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("\n\n\n"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   fd := f.fd();
   reader := BufReader.new(fd);
@@ -802,7 +802,7 @@ test("BufReader read_exact reads exactly n bytes and leaves the rest", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_read_exact.txt`));
-  io.await(fs_file.write_file(fpath, String.from("HEAD\nabcdefghijTAIL\n"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("HEAD\nabcdefghijTAIL\n"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   reader := BufReader.new(f.fd());
   // A header line, then a fixed-size payload, then the remainder — the shape a
@@ -846,7 +846,7 @@ test("BufReader read_exact reports EOF when short", {
   );
   tmp := temp_dir();
   fpath := Path.new(path_join(tmp, `yo_bufio_read_exact_short.txt`));
-  io.await(fs_file.write_file(fpath, String.from("tiny"), io), IoExn(io : io, exn : exn));
+  io.await(fs_file.write_string(fpath, String.from("tiny"), io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   reader := BufReader.new(f.fd());
   // Asking for more than exists must be distinguishable from a clean read, so a


### PR DESCRIPTION
`plans/STD_API_AUDIT.md` §5's fs and net items. Each change was verified by **running** the code — chunk 1 established that a green `yo check` proves nothing for this class of edit.

## fs read/write — as symmetric pairs, not as §5 specified

Writing the rename out exposed a flaw in the spec. `read_file` returns **bytes** while `write_file` takes a **String**, so `read_file`→`read` + `write_file`→`write` would have produced a `read` returning bytes and a `write` taking a String — leaving the actual byte counterpart of `read` named `write_bytes`. That is exactly the split vocabulary D2 exists to prevent.

Decision (user): symmetric pairs.

| new | was | payload |
| --- | --- | --- |
| `read` | `read_file` | bytes |
| `write` | `write_bytes` | bytes |
| `read_to_string` | *(unchanged)* | String |
| `write_string` | `write_file` | String |

`read_str`/`read_cstr` and `write_string_str`/`write_string_cstr` moved with their families. This matches `std::fs::read` / `std::fs::write` exactly — Rust needs no `write_string` only because `AsRef<[u8]>` covers `&str`, and Yo has no such coercion. **150 occurrences across 25 files.**

The collision check that deferred this from chunk 1 was completed first and is clean: `std/sys/file.yo` does export free `read`/`write` at the fd level and `File.read` is a method, but nothing uses a glob `open(import(...))` on either module; no file imports both `fs/file` and `sys/file`; neither name is in the prelude; and `std/fmt` (glob-imported by `fs/file.yo`) exports only `Alignment Format FormatSpec ToString Writer eprint eprintln print println`.

`write_bytes` and `write_string` are **also method names** on four writer types (File, TcpStream, Writer, BufWriter). Only the free functions moved — the shared method vocabulary stays put. `src/fetch.yo` imported the free `write_bytes` without ever calling it; that dead import is renamed in place, not removed.

## `created_time` was lying, not just misnamed

It returned `ctime_sec()`. POSIX ctime is the **status change** time — it moves on chmod, rename and link-count changes, and can postdate mtime. The method's own comment already said "Status change time" while the name promised creation. Now `status_changed_time`; zero call sites.

A real `created_time` stays **open** and is a feature, not a rename: `Statx` requests `STATX_BASIC_STATS` (0x7ff), which excludes `STATX_BTIME` (0x800), there is no `btime_sec()` accessor, and it needs per-platform work (statx btime / `st_birthtime` / Windows CreationTime). The new doc comment says all of that at the call site so nobody re-adds a lying name.

## `TcpStream.shutdown(i32)` → `shutdown(Shutdown)`

New `Shutdown` enum (`Read`/`Write`/`Both`, matching `std::net::Shutdown`) plus a private `_shutdown_to_how` mapping to `SHUT_RD`/`SHUT_WR`/`SHUT_RDWR`, following the existing `SeekFrom`/`_seek_from_to_whence` idiom. The sys layer keeps its `i32` `how` — that *is* the syscall boundary.

The two existing test call sites passed `SHUT_RDWR` and a bare `i32(1)`; both now name what they mean.

## Net byte counts return `usize`

Eight methods: `TcpStream` read/write_str/write_string/write_bytes and `UdpSocket` send_to/recv/recv_from/send. `NetError.check` itself stays `i32` because it is also used for file descriptors (`fd := NetError.check(raw_fd, ...)`), so the conversion sits at the eight byte-count sites.

This **sharpened a real ambiguity** in `std/http/client.yo`, whose read loop tested `n <= i32(0)` — conflating "error" with EOF. Errors throw, so the count is never negative; the test is now `n == usize(0)`, EOF only. Nine `printf("%d", n)` sites in the net tests became `%zu`, a genuine varargs mismatch once `n` widened to 64-bit.

This is also exactly the shape D5 specifies (`read(buf, io) -> Future(usize, IoExn)`), so that section starts with the net side already done.

## Known transient, tracked in D5

`File.read` still returns `i32` while `TcpStream.read` now returns `usize`. Converting `File` alone would be half a job — the three readers use three different error models:

| | returns | error style |
| --- | --- | --- |
| `TcpStream.read` | `Future(usize, IoExn)` | throws ✅ |
| `File.read` | `Future(i32, IoExn)` | throws |
| `BufReader.read` | `Future(Result(i32, IoError), Io)` | Result + `IoError` + `Io` effect |

D5 already specifies the real fix (bufio moves to `std/io` and adopts `IoExn`), so the `usize` change rides with it. Recorded in that section rather than left as an unexplained wart.

## Deferred to chunk 3

`ArrayList.remove(start,count)`→`drain(range)` plus a single `remove(idx) -> T`. `remove` is a name shared with `HashMap.remove`/`HashSet.remove`, so it needs the compiler-as-oracle treatment rather than a textual sweep, and it changes a return type from `Result(usize, ArrayListError)` to an element — a different blast radius from these renames.

## Verification

| gate | result |
| --- | --- |
| `yo check ./std` | 152/152 |
| `yo check ./src` | 262/262 |
| `yo build` | rc=0 |
| full suite | **2905 / 2905** |
| CLI scorecard | PASS 51, GOLDEN-DIFF 0, **NO golden drift at all** |
| `gates_fast.sh` | `T1_DONE failures=0` |
| `fixpoint_only.sh` | `STAGE3_RC=0 FIXPOINT_HOLDS` |
| `hollow_sweep69.sh` | `SWEEP_GATE_OK` (0 allowlisted known-failing) |

`tests/net` was additionally run on its own (45/45, including `TCP shutdown`) to exercise the new enum through the `io.async` body that `check` cannot see.

Zero golden drift is itself meaningful here: the `public-safe-report`/`unsafe-report` goldens still read `raw-pointer leaks: 2`, confirming directory traversal is intact — the exact thing chunk 1 silently broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
