### PR TITLE
std: S2 chunk 3 — one MapEntry(K,V) replaces Bucket / BTreeEntry / OrderedMapEntry / Pair

### DIFF
--- a/issues/where-bound-gc-trace-still-fails-when-run-standalone.md
+++ b/issues/where-bound-gc-trace-still-fails-when-run-standalone.md
@@ -1,0 +1,87 @@
+# The `where-bound` GC-trace regression test FAILS when run standalone — the suite's batching hides it
+
+**Status: OPEN.** Found 2026-08-25 on `develop` at `12d226078`, while landing
+the STD_API_AUDIT MapEntry unification (S2 chunk 3). **Not caused by that work
+— it reproduces on unmodified `develop`.**
+
+`tests/where_clause_fn_inference.test.yo` is the red-first regression test for
+`issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md` (fixed
+2026-08-24, `#249`). Run it by itself and it still fails, with the exact symptom
+that issue says was fixed.
+
+## Reproduce
+
+```
+$ git log --oneline -1
+12d226078 std: S2 chunk 2 — the fs and net API renames ... (#273)
+
+$ yo test tests/where_clause_fn_inference.test.yo --parallel 1
+tests/.yo_selftest_batch_1_0.bin.c:2605:3: error: call to undeclared function
+  'yo_id_4260_rtparam0_R_gs_yo_id_4135_gs_yo_id_6511_1923_1924_rtparam1_...__ret_unit'
+... 3 such calls (2605, 2634, 2639), each a different raw-SomeT id pair
+22 warnings and 3 errors generated.
+yo: error: compile: C compiler failed (exit 1)
+```
+
+The full suite passes 2905/2905 — including this file. **The difference is batch
+composition**: the runner packs many `.test.yo` files into one
+`__yo_user_main` batch, and which types get instantiated together in a batch
+decides whether the era-copy identities are minted. Alone, this file is batch
+`1_0` and the trigger fires; inside the suite it lands in a batch where it does
+not.
+
+## Why the existing fix does not cover it
+
+The caller is the GC traverse emitter:
+
+```c
+static void __yo_traverse___yo_t48(void* ptr, void (*visit)(void*)) {
+  yo_id_4260_..._1923_1924_..._ret_unit(obj, (void*)visit);   // never declared
+```
+
+`src/codegen/functions/constructors.yo:343` already routes through
+`get_trace_function_for_type`, and `#249` added the guard there
+(`src/codegen/exprs/drop_dup.yo:118`): refuse to delegate to a spec that
+`should_skip_function_codegen` will never emit. So in this configuration the
+predicate and the emitter DISAGREE — `should_skip_function_codegen` reports the
+spec as emittable, and the function emitter skips it anyway. The guard is
+sound; its oracle is not.
+
+The likely axis is `type_key` (`src/types/type_key.yo:190+`), which keys a
+generic instantiation by `(constructor_func_id, type_arguments)`. For era-copy
+phantoms the type arguments are raw SomeTs, so the trace registration a lookup
+finds can be one minted by a different, hard-generic instantiation.
+
+## Why this matters beyond the one test
+
+**A regression test that cannot fail the suite is not a gate.** This one pins a
+bug class the audit keeps brushing against — it is "face 3" of the era-copy
+under-resolution family, whose root is explicitly still OPEN:
+
+- `issues/iterator-chain-shared-stamp-cross-item-pollution.md` (face 2)
+- `issues/varbound-combinator-receiver-impl-match.md` (face 1, flat_map residual)
+
+Until the root is fixed, the batch-composition dependence means any future
+change can silently re-trigger the C-compile failure and the suite will stay
+green.
+
+## Suggested handling
+
+1. Make the failure visible: this file should be run in a batch where the
+   trigger fires — either pinned as its own single-file case in CI, or with the
+   two `__WbInto` instantiations kept in one batch by construction.
+2. Fix the oracle: reconcile `should_skip_function_codegen` with what the
+   function emitter actually does for hard-generic trace specs, so the `#249`
+   guard fires in this configuration too.
+3. The era-copy root remains the real fix (see the two sibling issues).
+
+## Evidence that it is not the MapEntry unification
+
+The unification (four identical `struct(key, value)` types — `Bucket`,
+`BTreeEntry`, `OrderedMapEntry`, `Pair` — collapsed to one `MapEntry`) was
+suspected first, because sharing one `constructor_func_id` collapses `type_key`
+entries that used to differ. Two checks ruled it out:
+
+- Reverting `btree_map` to its OWN local `MapEntry` constructor (a pure rename,
+  no sharing) still fails identically.
+- Unmodified `develop` fails identically — same `yo_id_4260`, same 3 calls.

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -728,7 +728,33 @@ small number of PRs with tree-wide fixups (compiler + std + tests + docs):
   `into_iter` for values and `iter_ptr` for pointers, exactly D2's split);
   OrderedMap iterators get real `Iterator` impls
 - `?(T)` spelling in btree_map/deque → `Option(T)` (or bless `?(T)` everywhere — pick one)
-- `Bucket`/`BTreeEntry`/`OrderedMapEntry`/`Pair` → one `MapEntry(K,V)`
+- ~~`Bucket`/`BTreeEntry`/`OrderedMapEntry`/`Pair` → one `MapEntry(K,V)`~~
+  **DONE 2026-08-25 (S2 chunk 3)** — all four were literally
+  `struct(key : K, value : V)`, so this was one concept under four names. The
+  shared type lives in a NEW `std/collections/entry.yo` (user approved new
+  `.yo` files, 2026-08-25); it is deliberately NOT in the prelude, where growth
+  has a measured self-emit memory cost
+  (issues/std-s1-prelude-growth-tripled-self-emit-memory.md), and NOT in
+  `hash_map.yo`, which would have made `std/imm/map` depend on a
+  `std/collections` map. Each map module re-exports `MapEntry`, so
+  `{ BTreeMap, MapEntry } :: import("std/collections/btree_map")` still works.
+
+  TWO traps, both of which a textual sweep would have walked into:
+   - **Prelude `IterPair(A, B)` is NOT a map entry.** It is
+     `struct(_0 : A, _1 : B)` — POSITIONAL, produced by `zip` (D3.4). It was
+     left alone; a map entry is NAMED (`key`/`value`).
+   - **Most `\bPair\b` matches are TEST-LOCAL structs of unrelated shape** —
+     `struct(first : i32, second : i32)` (tests/index.test.yo:533),
+     `atomic(ref(struct(a : i32, b : u32)))` (tests/privilege_pragma.test.yo:88),
+     a `ref(...)` (tests/codegen-bootstrap/borrowed_field_return.yo:27). Only
+     two files import std's `Pair`. `Bucket`/`BTreeEntry`/`OrderedMapEntry` are
+     unambiguous and were swept tree-wide; `Pair` was done by explicit file
+     list.
+
+  `Bucket` was additionally referenced in ~35 `src/` COMMENTS documenting
+  type-identity hazards (`tk2/Bucket`, cache collisions). Those were updated
+  too — it is the same type under a new name, and a comment naming a type that
+  no longer exists is not navigable.
 - ~~`canonical`→`canonicalize`; `relative_from`→`strip_prefix`~~ **DONE
   2026-08-25** — the `canonical` FAMILY moved together
   (`canonical_str`/`canonical_cstr` too), since leaving the siblings behind would

--- a/src/codegen/exprs/closures.yo
+++ b/src/codegen/exprs/closures.yo
@@ -170,7 +170,7 @@ generate_closure_construction :: (fn(expr : AstExpr, indent : String, context : 
     // Look up by the FULL type_key, not the bare struct id: the registry is
     // keyed by type_key(t), and for a cfid-empty struct with field types the
     // key is now STRUCTURAL (sid + field keys) — bare-sid lookup only worked
-    // while type_key collapsed such structs to their sid (the Bucket visit-fn
+    // while type_key collapsed such structs to their sid (the MapEntry visit-fn
     // collision). TS looks up by struct id because TS ids are per-instantiation
     // AND are the registry key; type_key is yo-self's equivalent identity.
     capture_c_name := match(context.base.get_type_c_name(type_key(capture_ty)), .Some(n) => n, .None => return(codegen_fatal_expr(String.from("Capture type not found for closure"))));

--- a/src/codegen/exprs/drop_dup.yo
+++ b/src/codegen/exprs/drop_dup.yo
@@ -395,7 +395,7 @@ generate_drop_code_for_value :: (fn(value_code : String, value_type : TypeValue,
     // INLINE — the same rationale as the value-enum arm above (yo-self lowers
     // RC ops directly instead of synthesizing per-type ___drop methods; TS
     // calls the synthesized fn_..___drop here). Previously the missing-method
-    // case silently emitted NOTHING, so value-struct locals (e.g. Bucket(K, V)
+    // case silently emitted NOTHING, so value-struct locals (e.g. MapEntry(K, V)
     // in HashMap.set) never released their RC fields at scope end.
     is_struct_type(concrete_type) => match(
       get_drop_function_for_type(concrete_type, context),

--- a/src/codegen/exprs/gc.yo
+++ b/src/codegen/exprs/gc.yo
@@ -45,7 +45,7 @@ generate_yo_gc_trace_child :: (fn(expr : AstExpr, indent : String, context : Fun
           // function's C SIGNATURE resolves to — NOT the slot expr's own
           // ExprInfo type. The two are different TypeValue COPIES of the same
           // logical instantiation: the visit fn's declared param carries a
-          // cfid-EMPTY Bucket copy (type_key → the shared merged key →
+          // cfid-EMPTY MapEntry copy (type_key → the shared merged key →
           // whichever instantiation registered that key FIRST), while the
           // slot expr's ExprInfo carries a cfid-CARRYING copy (type_key → the
           // precise `gs_…` key → a DIFFERENT C type). Walking the ExprInfo

--- a/src/codegen/functions/collection.yo
+++ b/src/codegen/functions/collection.yo
@@ -1030,7 +1030,7 @@ _specialize_and_register_trace :: (
         find_function_calls_in_expr(spec_body, base, info);
       });
       // Key by type_key(ct), NOT the raw struct id: shared-id generics (every
-      // Bucket/ArrayList instantiation shares ONE eval struct id, differing
+      // MapEntry/ArrayList instantiation shares ONE eval struct id, differing
       // only in type_arguments) would all register under the same id and
       // get_trace_function_for_type would return whichever instantiation
       // registered FIRST (HashMap iteration order → flaky) — the GC-tracer

--- a/src/codegen/types/collection.yo
+++ b/src/codegen/types/collection.yo
@@ -385,7 +385,7 @@ collect_type :: (fn(type_in : TypeValue, context : CodeGenContext) -> unit)({
 /// Collect any pointer POINTEE found directly in `ft` or one level inside an
 /// enum variant of `ft`. Covers `*(T)` and the nullable-pointer `?(*(T))` (=
 /// `Option(*(T))`) shapes used by container `data` fields. One level only (no
-/// deep enum recursion) — sufficient for `data : ?(*(Bucket))` / `?(*(T))` and
+/// deep enum recursion) — sufficient for `data : ?(*(MapEntry))` / `?(*(T))` and
 /// guaranteed terminating; `collect_type`'s already-collected guard handles the
 /// rest. (Defined before collect_pointer_pointees — Yo has no forward refs.)
 _collect_field_pointees :: (fn(ft : TypeValue, context : CodeGenContext) -> unit)(
@@ -416,13 +416,13 @@ _collect_field_pointees :: (fn(ft : TypeValue, context : CodeGenContext) -> unit
 );
 /// SECOND PASS (run after collect_required_types, before generate_type_
 /// declarations): register the pointee types behind pointer FIELDS of
-/// already-registered structs. A container like `HashMap.data : ?(*(Bucket(K,V)))`
+/// already-registered structs. A container like `HashMap.data : ?(*(MapEntry(K,V)))`
 /// or `ArrayList.data : ?(*(T))` lowers to `T*`, so emitting the OWNER struct's
 /// typedef calls get_type_string(T) and REQUIRES `T` registered. The main
 /// collection reaches `T` only via the container's generated dup/drop bodies; for
 /// the async/effect-codegen value types whose dup/drop involve recursive members
 /// (AstExpr / Box(Self) self-shells), that path does NOT fire in the self-compile,
-/// leaving e.g. `Bucket(usize, WhileLoopInfo)` unregistered → "type not collected
+/// leaving e.g. `MapEntry(usize, WhileLoopInfo)` unregistered → "type not collected
 /// before lowering" panic. Running as a SEPARATE pass (not inline in collect_type)
 /// leaves the MAIN collection ORDER untouched, so it cannot perturb the
 /// order-sensitive lazy array-struct registration. Fixpoint loop handles

--- a/src/evaluator/calls/comptime_fn.yo
+++ b/src/evaluator/calls/comptime_fn.yo
@@ -88,7 +88,7 @@ _(env : ctfe_dbg_env) :: import("std/env");
 /// diverging one level up (the imm_sorted_map/imm_threading caller-arg
 /// struct-to-struct casts). Enums carry no type_arguments; their cfid match
 /// falls back to pairwise era-equal variant FIELD lists. Concrete same-shape
-/// but different-ctor types still take the EXACT fallback (the Bucket/ME
+/// but different-ctor types still take the EXACT fallback (the MapEntry/ME
 /// cache-collision hazard).
 _ctfe_types_era_equal :: (fn(aty : TypeValue, bty : TypeValue, d : usize) -> bool)({
   if(d > usize(6), {
@@ -226,8 +226,8 @@ _ctfe_args_equal :: (
           // compatibility. Mirrors TS comptime-fn.ts:159-164 (`requireExactMatch
           // =true`). Lenient `are_types_compatible` treats two distinct
           // same-shaped structs as equal (e.g. a user `object(name, kind)` vs
-          // `Bucket(key, value)`), causing a CACHE COLLISION: a later
-          // `(?*)(Bucket(String, ArrayList(ME)))` wrongly hit a cached
+          // `MapEntry(key, value)`), causing a CACHE COLLISION: a later
+          // `(?*)(MapEntry(String, ArrayList(ME)))` wrongly hit a cached
           // `(?*)(ME)` entry and returned `Option(*(ME))` — making
           // `HashMap(.., ArrayList(<RC>)).new()`'s data field `?(*(ME))` and
           // failing method resolution. See

--- a/src/evaluator/calls/helper.yo
+++ b/src/evaluator/calls/helper.yo
@@ -1204,7 +1204,7 @@ value_to_signature_string :: (fn(value : EvalValue) -> String)(
     // instantiation produced the SAME specialization signature and collapsed
     // onto one specialized function (param typed from one instantiation,
     // return from another — arc.test.yo's per-test `Counter :: struct(...)`;
-    // previously also the shared-GcTracer-visit Bucket class). yo-self has no
+    // previously also the shared-GcTracer-visit MapEntry class). yo-self has no
     // numeric `type.id`; `type_key` is its instantiation-precise identity.
     // (Re-applied 2026-07-17: the 2026-07-15 revert's crash verdicts came
     // from an invalidated bisect — the startup corruption was the since-fixed

--- a/src/evaluator/context.yo
+++ b/src/evaluator/context.yo
@@ -229,7 +229,7 @@ EvalContext :: ref(
     /// the C-type registry across generations (SomeT surgery slice 2). Inside
     /// CTFE (> 0), ids stay eval-fresh: generic INSTANTIATIONS (Option(i32)
     /// vs Option(String) evaluate the same enum body via the constructor's
-    /// ctfe) must NOT share ids — the recorded tk2/Bucket failure of the
+    /// ctfe) must NOT share ids — the recorded tk2/MapEntry failure of the
     /// naive ast-id swap, and the ctfe memo's same-enum-id rule would
     /// conflate instantiations.
     ctfe_depth : usize,

--- a/src/evaluator/exprs/begin.yo
+++ b/src/evaluator/exprs/begin.yo
@@ -1282,7 +1282,7 @@ _schedule_scope_end_drops :: (
       .Some(v) => {
         // Mirrors TS getVariablesNeedingDrop (src/env.ts): any owning local
         // whose type CONTAINS an RC-managed type needs a scope-end drop —
-        // including value-structs with RC fields (e.g. Bucket(K, V) locals in
+        // including value-structs with RC fields (e.g. MapEntry(K, V) locals in
         // HashMap.set; their ___drop decrements the field). The earlier "M1"
         // narrowing to direct ref-struct/ref-enum handles under-dropped those
         // locals: the compound-literal dup + dup-on-store then over-counted

--- a/src/evaluator/types/enum.yo
+++ b/src/evaluator/types/enum.yo
@@ -211,7 +211,7 @@ evaluate_enum_type :: (
   // construct+drop heap corruption). Inside CTFE (generic constructor
   // instantiation), ids stay eval-fresh: Option(i32) vs Option(String)
   // evaluate the same enum body and must NOT share identity (the recorded
-  // tk2/Bucket failure of the unconditional ast-id swap).
+  // tk2/MapEntry failure of the unconditional ast-id swap).
   enum_id := if(
     ctx.ctfe_depth == usize(0),
     `enum_decl_${ast_expr_id(expr).to_string()}_${env.module_path.replace(String.from("/"), String.from("_")).replace(String.from("."), String.from("_")).replace(String.from(":"), String.from("_"))}`,

--- a/src/evaluator/types/struct.yo
+++ b/src/evaluator/types/struct.yo
@@ -77,7 +77,7 @@ evaluate_struct_type :: (
   // twin (see there for the full rationale): re-evaluation generations of a
   // module-level struct declaration share one identity; CTFE instantiations
   // (generic constructors) keep eval-fresh ids so distinct instantiations
-  // never share (the recorded tk2/Bucket hazard of the unconditional swap).
+  // never share (the recorded tk2/MapEntry hazard of the unconditional swap).
   struct_id := if(
     ctx.ctfe_depth == usize(0),
     `struct_decl_${ast_expr_id(expr).to_string()}_${env.module_path.replace(String.from("/"), String.from("_")).replace(String.from("."), String.from("_")).replace(String.from(":"), String.from("_"))}`,

--- a/src/evaluator/types/synthesizer.yo
+++ b/src/evaluator/types/synthesizer.yo
@@ -1596,7 +1596,7 @@ _synthesize_types_impl :: (
     // funcIds directly. Unscoped, two ANONYMOUS same-shaped ctors unified:
     // HashMapIter(K,V) vs HashMapIterPtr(K,V) (both name="", both fields
     // `(_map, _index)`) let the Clone-impl trial's `it.next()` bind the
-    // BY-VALUE iterator's `next : -> Option(Bucket(K,V))` for a
+    // BY-VALUE iterator's `next : -> Option(MapEntry(K,V))` for a
     // HashMapIterPtr receiver, so `bucket_ptr` lost its pointer type and
     // the trial swallowed "Cannot unify u64 and unit" (hash_map:714,
     // issues/fixed/def-eval-swallow-remaining-roots.md corpus phase).

--- a/src/evaluator/values/impl.yo
+++ b/src/evaluator/values/impl.yo
@@ -1388,7 +1388,7 @@ MethodCandidate :: struct(
 /// instantiation env (`func.$.env`) at dispatch: impl methods carry no
 /// `generic` of their own (the `generic(K, V)` lives on the impl block), so the
 /// regular call path — which only binds a method's *own* generic params — would
-/// otherwise leave `K`/`V` abstract and break e.g. `sizeof(Bucket(K, V))`.
+/// otherwise leave `K`/`V` abstract and break e.g. `sizeof(MapEntry(K, V))`.
 ///
 /// Only `FuncVal` methods are affected; associated-type and other field shapes
 /// pass through unchanged. The existing capture arrays are COPIED (never

--- a/src/types/compatibility.yo
+++ b/src/types/compatibility.yo
@@ -636,7 +636,7 @@ _compat_impl :: (
     // STRUCTURALLY (equal field labels + recursively-exact field types), with a
     // cycle guard. All yo-self structs carry an empty `name` (struct.yo sets
     // `""`), so name-only would treat ALL anonymous structs as equal — that
-    // caused a comptime-fn cache collision where `(?*)(Bucket(String,
+    // caused a comptime-fn cache collision where `(?*)(MapEntry(String,
     // ArrayList(ME)))` hit a cached `(?*)(ME)` entry (both name=""), collapsing
     // HashMap's `data` field to `?(*(ME))`. Structural exact comparison
     // distinguishes them (e.g. labels `[key, value]` vs `[name, kind]`).

--- a/src/types/type_key.yo
+++ b/src/types/type_key.yo
@@ -159,7 +159,7 @@ _type_key_at :: (fn(t : TypeValue, depth : usize) -> String)(
       // #30: a reference-semantics struct (`ref(struct …)` → emitted as a pointer
       // field) and a value struct with the SAME fields have DIFFERENT C layouts
       // and MUST NOT share a C type id. `type_key` historically omitted this, so
-      // two `Bucket(K,V)` instantiations — one with a ref `value` field, one with
+      // two `MapEntry(K,V)` instantiations — one with a ref `value` field, one with
       // a value `value` field — collapsed onto one id; the GC traverse fn built for
       // the ref layout was then emitted for the value layout (`if(struct){…}` — a
       // clang scalar-type error, main.yo-only). Prefix ref-semantics struct keys so
@@ -196,8 +196,8 @@ _type_key_at :: (fn(t : TypeValue, depth : usize) -> String)(
         // a depth cap made every generic nested deeper than the cap fall back
         // to the g_struct_cfid_keys[sid] single slot, which is
         // first-registration-wins and thus WRONG for shared-id generics like
-        // Bucket(K,V) (all instantiations share one eval struct id) — the
-        // flaky GC-tracer .label/.ty cluster: a deep Bucket keyed as the
+        // MapEntry(K,V) (all instantiations share one eval struct id) — the
+        // flaky GC-tracer .label/.ty cluster: a deep MapEntry keyed as the
         // FIRST-seen instantiation, collapsing two different layouts onto one
         // C name, order-dependent per emit. Long keys are ugly but correct.
         ((scfid.len() > usize(0)) && (stas.len() > usize(0))) => {
@@ -249,12 +249,12 @@ _type_key_at :: (fn(t : TypeValue, depth : usize) -> String)(
           // Record the cfid-key for this struct id so cfid-empty copies use
           // it — but ONLY while the sid maps to ONE instantiation key. When a
           // SECOND different key arrives (shared-id generics: every
-          // Bucket(K,V) instantiation shares one eval struct id), POISON the
+          // MapEntry(K,V) instantiation shares one eval struct id), POISON the
           // slot: a cfid-empty copy can then no longer be attributed to any
           // single instantiation and must key STRUCTURALLY (below). The old
           // first-registration-wins slot pinned every cfid-empty copy to the
-          // FIRST instantiation — one specialized Bucket tracer served 36
-          // different Bucket layouts (the flaky GC-tracer .label/.ty cluster),
+          // FIRST instantiation — one specialized MapEntry tracer served 36
+          // different MapEntry layouts (the flaky GC-tracer .label/.ty cluster),
           // with registration order deciding the winner per emit.
           if(sid.len() > usize(0), {
             match(
@@ -275,11 +275,11 @@ _type_key_at :: (fn(t : TypeValue, depth : usize) -> String)(
         // with different layouts get different, DETERMINISTIC keys (the enum
         // analogue: g_enum_sig_keys). A NEVER-REGISTERED sid (.None) with
         // known field types ALSO keys structurally: shared-id generics whose
-        // instantiations are all cfid-empty (Bucket(K,V) — created by the
+        // instantiations are all cfid-empty (MapEntry(K,V) — created by the
         // with_capacity Type(1) path, so NO instantiation ever records a gs_
         // key) otherwise render bare-sid everywhere and every layout collapses
-        // onto ONE key — one GcTracer visit specialization served all Bucket
-        // layouts and walked the wrong fields (TS emits 47 distinct Bucket
+        // onto ONE key — one GcTracer visit specialization served all MapEntry
+        // layouts and walked the wrong fields (TS emits 47 distinct MapEntry
         // visit fns, one per instantiation). Unpoisoned REGISTERED sids
         // (.Some non-poison) behave exactly as before.
         (sid.len() > usize(0)) => {

--- a/std/collections/btree_map.yo
+++ b/std/collections/btree_map.yo
@@ -12,13 +12,10 @@
 //! ```
 pragma(Pragma.AllowUnsafe);
 { ArrayList } :: import("./array_list");
+{ MapEntry } :: import("./entry.yo");
+export(MapEntry);
 { assert } :: import("../assert");
 open(import("../string"));
-/// Key-value pair entry stored in a BTreeMap.
-BTreeEntry :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
-  struct(key : K, value : V)
-);
-export(BTreeEntry);
 // Internal result from binary search.
 _FindResult :: struct(idx : usize, found : bool);
 /// Sorted map maintaining entries in key order.
@@ -26,7 +23,7 @@ _FindResult :: struct(idx : usize, found : bool);
 BTreeMap :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
   ref(
     struct(
-      _entries : ArrayList(BTreeEntry(K, V))
+      _entries : ArrayList(MapEntry(K, V))
     )
   )
 );
@@ -35,7 +32,7 @@ impl(
   BTreeMap(K, V),
   // Create an empty map.
   new : (fn() -> Self)(
-    Self(_entries : ArrayList(BTreeEntry(K, V)).new())
+    Self(_entries : ArrayList(MapEntry(K, V)).new())
   ),
   // Number of entries.
   len : (fn(self : Self) -> usize)(
@@ -82,11 +79,11 @@ impl(
     cond(
       r.found => {
         entry := self._entries(r.idx);
-        &(self._entries(r.idx)).* = BTreeEntry(K, V)(key : entry.key, value : v);
+        &(self._entries(r.idx)).* = MapEntry(K, V)(key : entry.key, value : v);
       },
       true => {
         // Append new entry then bubble left to sorted position
-        self._entries.push(BTreeEntry(K, V)(key : k, value : v));
+        self._entries.push(MapEntry(K, V)(key : k, value : v));
         pos := (self._entries.len() - usize(1));
         while(pos > r.idx, pos = (pos - usize(1)), {
           curr := self._entries(pos);
@@ -110,14 +107,14 @@ impl(
     )
   }),
   // Return the entry with the smallest key, or .None.
-  min : (fn(self : Self) -> ?(BTreeEntry(K, V)))(
+  min : (fn(self : Self) -> ?(MapEntry(K, V)))(
     cond(
       (self._entries.len() == usize(0)) => .None,
       true => .Some(self._entries(usize(0)))
     )
   ),
   // Return the entry with the largest key, or .None.
-  max : (fn(self : Self) -> ?(BTreeEntry(K, V)))(
+  max : (fn(self : Self) -> ?(MapEntry(K, V)))(
     cond(
       (self._entries.len() == usize(0)) => .None,
       true => .Some(self._entries(self._entries.len() - usize(1)))
@@ -125,11 +122,11 @@ impl(
   )
 );
 /**
-* Value iterator for BTreeMap - yields BTreeEntry(K, V) in sorted key order
+* Value iterator for BTreeMap - yields MapEntry(K, V) in sorted key order
 */
 BTreeMapIter :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
   struct(
-    _entries : ArrayList(BTreeEntry(K, V)),
+    _entries : ArrayList(MapEntry(K, V)),
     _index : usize
   )
 );
@@ -137,8 +134,8 @@ impl(
   generic(K : Type, V : Type),
   BTreeMapIter(K, V),
   Iterator(
-    Item : BTreeEntry(K, V),
-    next : (fn(inout(self) : Self) -> Option(BTreeEntry(K, V)))(
+    Item : MapEntry(K, V),
+    next : (fn(inout(self) : Self) -> Option(MapEntry(K, V)))(
       cond(
         (self._index >= self._entries.len()) => .None,
         true => {
@@ -154,7 +151,7 @@ impl(
   generic(K : Type, V : Type),
   BTreeMap(K, V),
   IntoIterator(
-    Item : BTreeEntry(K, V),
+    Item : MapEntry(K, V),
     IntoIter : BTreeMapIter(K, V),
     into_iter : (fn(self : Self) -> BTreeMapIter(K, V))(
       BTreeMapIter(K, V)(_entries : self._entries, _index : usize(0))
@@ -162,11 +159,11 @@ impl(
   )
 );
 /**
-* Pointer iterator for BTreeMap - yields pointers to BTreeEntry(K, V) in sorted key order
+* Pointer iterator for BTreeMap - yields pointers to MapEntry(K, V) in sorted key order
 */
 BTreeMapIterPtr :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
   struct(
-    _entries : ArrayList(BTreeEntry(K, V)),
+    _entries : ArrayList(MapEntry(K, V)),
     _index : usize
   )
 );
@@ -174,8 +171,8 @@ impl(
   generic(K : Type, V : Type),
   BTreeMapIterPtr(K, V),
   Iterator(
-    Item : *(BTreeEntry(K, V)),
-    next : (fn(inout(self) : Self) -> Option(*(BTreeEntry(K, V))))(
+    Item : *(MapEntry(K, V)),
+    next : (fn(inout(self) : Self) -> Option(*(MapEntry(K, V))))(
       cond(
         (self._index >= self._entries.len()) => .None,
         true =>

--- a/std/collections/entry.yo
+++ b/std/collections/entry.yo
@@ -1,0 +1,29 @@
+//! The key/value entry shared by every map in the standard library.
+//!
+//! `HashMap`, `BTreeMap`, `OrderedMap` and `imm.Map` each used to declare their
+//! own identical `struct(key, value)` under a different name — `Bucket`,
+//! `BTreeEntry`, `OrderedMapEntry` and `Pair` respectively. One concept with
+//! four names meant an entry could not move between maps, and a reader could
+//! not tell from a signature whether two of them were the same shape. They are
+//! now this one type (plans/STD_API_AUDIT.md D2, §5).
+//!
+//! Not to be confused with the prelude's `IterPair(A, B)`, which is
+//! `struct(_0, _1)` — a POSITIONAL pair produced by `zip`. A map entry is
+//! named: it has a `key` and a `value`.
+//!
+//! # Example
+//!
+//! ```rust
+//! { MapEntry } :: import("std/collections/entry");
+//!
+//! e := MapEntry(String, i32)(key : `hits`, value : i32(3));
+//! println(e.value);
+//! ```
+/// A single key/value entry in a map.
+MapEntry :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
+  struct(
+    key : K,
+    value : V
+  )
+);
+export(MapEntry);

--- a/std/collections/hash_map.yo
+++ b/std/collections/hash_map.yo
@@ -1,6 +1,7 @@
 //! Hash map using SwissTable algorithm with SIMD-accelerated lookup.
 pragma(Pragma.AllowUnsafe);
 { GlobalAllocator, AllocError } :: import("../allocator.yo");
+{ MapEntry } :: import("./entry.yo");
 { malloc, calloc, realloc, free } :: GlobalAllocator;
 /// Error variants for HashMap operations.
 HashMapError :: enum(
@@ -20,13 +21,6 @@ DEFAULT_CAPACITY :: usize(16);
 /// Maximum load factor numerator (7/8 = 0.875). Resize when `size > capacity * 7 / 8`.
 MAX_LOAD_FACTOR_NUMERATOR :: usize(7);
 MAX_LOAD_FACTOR_DENOMINATOR :: usize(8);
-/// Key-value pair stored in a hash map bucket.
-Bucket :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
-  struct(
-    key : K,
-    value : V
-  )
-);
 /// Extract H2 hash (lower 7 bits) from full hash for control byte comparison.
 h2_hash :: (fn(hash : u64) -> u8)(u8(hash & u64(127)));
 /// Avalanche-mix a 64-bit hash (murmur3 fmix64 finalizer) so that weakly-
@@ -58,7 +52,7 @@ HashMap :: (
   ref(
     struct(
       ctrl : ?(*(u8)),
-      data : ?(*(Bucket(K, V))),
+      data : ?(*(MapEntry(K, V))),
       capacity : usize,
       size : usize
     )
@@ -73,7 +67,7 @@ impl(
   * Initializes all control bytes to EMPTY
   */
   _alloc_with_capacity : (fn(capacity : usize) -> Result(Self, HashMapError))({
-    bucket_size :: sizeof(Bucket(K, V));
+    bucket_size :: sizeof(MapEntry(K, V));
     ctrl_size := capacity;
     data_size := (capacity * bucket_size);
     ctrl_result := malloc(ctrl_size);
@@ -90,7 +84,7 @@ impl(
             .Err(.AllocError(error : .OutOfMemory))
           },
           .Some(data_void_ptr) => {
-            data_ptr := *(Bucket(K, V))(data_void_ptr);
+            data_ptr := *(MapEntry(K, V))(data_void_ptr);
             i := usize(0);
             while(i < capacity, i = (i + usize(1)), {
               (ctrl_ptr.add(i)).* = CTRL_EMPTY;
@@ -157,7 +151,7 @@ impl(
   /**
   * Get data pointer (unwrapped for internal use)
   */
-  _data_ptr : (fn(self : Self) -> *(Bucket(K, V)))(
+  _data_ptr : (fn(self : Self) -> *(MapEntry(K, V)))(
     match(
       self.data,
       .Some(ptr) => ptr,
@@ -308,12 +302,12 @@ impl(
         data_ptr := Self._data_ptr(self);
         old_bucket := (data_ptr.add(index)).*;
         old_value := old_bucket.value;
-        new_bucket := Bucket(K, V)(key : key, value : value);
+        new_bucket := MapEntry(K, V)(key : key, value : value);
         // Don't use consume here - we want to drop the old bucket at memory
         // Note: old_bucket already duped it, so dropping here decrements to RC=1
         // Then old_bucket goes out of scope and drops again to RC=0
         // But wait - we return old_value which was duped from old_bucket...
-        // Actually the Bucket struct contains RC types, so assignment drops old + dups new
+        // Actually the MapEntry struct contains RC types, so assignment drops old + dups new
         (data_ptr.add(index)).* = new_bucket;
         .Ok(.Some(old_value))
       },
@@ -334,7 +328,7 @@ impl(
             ctrl_ptr := Self._ctrl_ptr(self);
             data_ptr := Self._data_ptr(self);
             (ctrl_ptr.add(index)).* = h2;
-            new_bucket := Bucket(K, V)(key : key, value : value);
+            new_bucket := MapEntry(K, V)(key : key, value : value);
             consume((data_ptr.add(index)).* = new_bucket);
             self.size = (self.size + usize(1));
             .Ok(.None)
@@ -494,7 +488,7 @@ impl(
   )
 );
 /**
-* Value iterator for HashMap - yields Bucket(K, V) by value
+* Value iterator for HashMap - yields MapEntry(K, V) by value
 * Scans ctrl bytes to find occupied slots.
 */
 HashMapIter :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
@@ -508,14 +502,14 @@ impl(
   where(K <: (Eq(K), Hash)),
   HashMapIter(K, V),
   Iterator(
-    Item : Bucket(K, V),
-    next : (fn(inout(self) : Self) -> Option(Bucket(K, V)))(
+    Item : MapEntry(K, V),
+    next : (fn(inout(self) : Self) -> Option(MapEntry(K, V)))(
       cond(
         (self._map.capacity == usize(0)) => .None,
         true => {
           ctrl_ptr := self._map.ctrl.unwrap();
           data_ptr := self._map.data.unwrap();
-          result := Option(Bucket(K, V)).None;
+          result := Option(MapEntry(K, V)).None;
           while((self._index < self._map.capacity) && result.is_none(), self._index = (self._index + usize(1)), {
             ctrl_byte := (ctrl_ptr.add(self._index)).*;
             cond(
@@ -536,7 +530,7 @@ impl(
   where(K <: (Eq(K), Hash)),
   HashMap(K, V),
   IntoIterator(
-    Item : Bucket(K, V),
+    Item : MapEntry(K, V),
     IntoIter : HashMapIter(K, V),
     into_iter : (fn(self : Self) -> HashMapIter(K, V))(
       HashMapIter(K, V)(_map : self, _index : usize(0))
@@ -544,7 +538,7 @@ impl(
   )
 );
 /**
-* Pointer iterator for HashMap - yields pointers to Bucket(K, V)
+* Pointer iterator for HashMap - yields pointers to MapEntry(K, V)
 * Pointers are valid as long as the map is not modified during iteration.
 */
 HashMapIterPtr :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
@@ -558,14 +552,14 @@ impl(
   where(K <: (Eq(K), Hash)),
   HashMapIterPtr(K, V),
   Iterator(
-    Item : *(Bucket(K, V)),
-    next : (fn(inout(self) : Self) -> Option(*(Bucket(K, V))))(
+    Item : *(MapEntry(K, V)),
+    next : (fn(inout(self) : Self) -> Option(*(MapEntry(K, V))))(
       cond(
         (self._map.capacity == usize(0)) => .None,
         true => {
           ctrl_ptr := self._map.ctrl.unwrap();
           data_ptr := self._map.data.unwrap();
-          result := Option(*(Bucket(K, V))).None;
+          result := Option(*(MapEntry(K, V))).None;
           while((self._index < self._map.capacity) && result.is_none(), self._index = (self._index + usize(1)), {
             ctrl_byte := (ctrl_ptr.add(self._index)).*;
             cond(
@@ -585,7 +579,7 @@ impl(
   generic(K : Type, V : Type),
   where(K <: (Eq(K), Hash)),
   HashMap(K, V),
-  /// Pointer iterator — yields `*(Bucket(K, V))` for each occupied bucket.
+  /// Pointer iterator — yields `*(MapEntry(K, V))` for each occupied bucket.
   /// For privileged/unsafe internal use; value iteration goes through
   /// `into_iter()`.
   iter : (fn(self : Self) -> HashMapIterPtr(K, V))(
@@ -752,7 +746,7 @@ impl(
     * Cycle-GC tracing. Buckets live in a malloc'd open-addressing buffer the
     * compiler's auto-derived field walk cannot reach, so trace each FULL slot
     * (its control byte is neither EMPTY nor DELETED). `tracer.visit` takes the
-    * `Bucket(K, V)` slot POINTER; the per-value traversal descends inline through
+    * `MapEntry(K, V)` slot POINTER; the per-value traversal descends inline through
     * the value struct, tracing BOTH the key and the value, WITHOUT touching any
     * reference count (a by-value managed handle would be dup'd then dropped,
     * freeing a live element mid-collection). Mirrors the ArrayList `Trace` impl +
@@ -787,7 +781,7 @@ impl(
 export(
   HashMap,
   HashMapError,
-  Bucket,
+  MapEntry,
   HashMapIter,
   HashMapIterPtr,
   HashMapKeys,

--- a/std/collections/ordered_map.yo
+++ b/std/collections/ordered_map.yo
@@ -32,6 +32,7 @@
 //!   );
 //! };
 //! ```
+{ MapEntry } :: import("./entry.yo");
 open(import("./array_list"));
 open(import("./hash_map"));
 /// Ordered map preserving insertion order of keys.
@@ -196,18 +197,6 @@ impl(
     );
   })
 );
-/// Key-value pair yielded by `OrderedMapIter`.
-OrderedMapEntry :: (
-  fn(
-    comptime(K) : Type,
-    comptime(V) : Type
-  ) -> comptime(Type)
-)(
-  struct(
-    key : K,
-    value : V
-  )
-);
 /// Iterator over `(key, value)` pairs of an `OrderedMap` in insertion order.
 OrderedMapIter :: (
   fn(
@@ -227,7 +216,7 @@ impl(
   generic(K : Type, V : Type),
   where(K <: (Eq(K), Hash)),
   OrderedMapIter(K, V),
-  next : (fn(inout(self) : Self) -> Option(OrderedMapEntry(K, V)))({
+  next : (fn(inout(self) : Self) -> Option(MapEntry(K, V)))({
     cond(
       (self._index >= self._map._order.len()) => {
         return(.None);
@@ -241,7 +230,7 @@ impl(
         match(
           self._map._map.get(k),
           .Some(v) => {
-            return(.Some(OrderedMapEntry(K, V)(key : k, value : v)));
+            return(.Some(MapEntry(K, V)(key : k, value : v)));
           },
           .None => {
             return(.None);
@@ -273,7 +262,7 @@ impl(
 );
 export(
   OrderedMap,
-  OrderedMapEntry,
+  MapEntry,
   OrderedMapKeys,
   OrderedMapValues,
   OrderedMapIter

--- a/std/imm/map.yo
+++ b/std/imm/map.yo
@@ -29,6 +29,7 @@
 pragma(Pragma.AllowUnsafe);
 { GlobalAllocator } :: import("../allocator.yo");
 { ArrayList } :: import("../collections/array_list.yo");
+{ MapEntry } :: import("../collections/entry.yo");
 { malloc, free } :: GlobalAllocator;
 /// Number of bits per HAMT level.
 BITS :: usize(5);
@@ -41,10 +42,6 @@ popcount :: (fn(x : u32) -> u32)({
   v = ((v & u32(858993459)) + ((v >> u32(2)) & u32(858993459)));
   (((v + (v >> u32(4))) & u32(252645135)) * u32(16843009)) >> u32(24)
 });
-/// Key-value pair used in collision nodes and entries.
-Pair :: (fn(comptime(K) : Type, comptime(V) : Type) -> comptime(Type))(
-  struct(key : K, value : V)
-);
 /// HAMT leaf node -- single key-value entry.
 MapLeaf :: (
   fn(
@@ -75,7 +72,7 @@ MapCollision :: (
     ref(
       struct(
         hash : u64,
-        _pairs_ptr : *(Pair(K, V)),
+        _pairs_ptr : *(MapEntry(K, V)),
         _pairs_len : usize
       )
     )
@@ -243,11 +240,11 @@ _branch_without_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : Ma
   MapBranch(K, V)(bitmap : (branch.bitmap & (~(bit))), _children_ptr : new_ptr, _children_len : new_len)
 });
 // -- MapCollision helpers --
-_alloc_pairs :: (fn(comptime(K) : Type, comptime(V) : Type, count : usize, where(K <: (Eq(K), Hash, Send), V <: Send)) -> *(Pair(K, V)))({
-  sz := (sizeof(Pair(K, V)) * count);
+_alloc_pairs :: (fn(comptime(K) : Type, comptime(V) : Type, count : usize, where(K <: (Eq(K), Hash, Send), V <: Send)) -> *(MapEntry(K, V)))({
+  sz := (sizeof(MapEntry(K, V)) * count);
   match(
     malloc(sz),
-    .Some(p) => *(Pair(K, V))(p),
+    .Some(p) => *(MapEntry(K, V))(p),
     .None => __yo_panic("imm.Map: collision allocation failed")
   )
 });
@@ -265,8 +262,8 @@ _copy_pairs :: (
   fn(
     comptime(K) : Type,
     comptime(V) : Type,
-    dst : *(Pair(K, V)),
-    src : *(Pair(K, V)),
+    dst : *(MapEntry(K, V)),
+    src : *(MapEntry(K, V)),
     dst_offset : usize,
     src_offset : usize,
     count : usize,
@@ -284,14 +281,14 @@ _coll_with_pair :: (fn(comptime(K) : Type, comptime(V) : Type, coll : MapCollisi
     .Some(idx) => {
       new_ptr := _alloc_pairs(K, V, coll._pairs_len);
       _copy_pairs(K, V, new_ptr, coll._pairs_ptr, usize(0), usize(0), coll._pairs_len);
-      (new_ptr.add(idx)).* = Pair(K, V)(key : k, value : v);
+      (new_ptr.add(idx)).* = MapEntry(K, V)(key : k, value : v);
       return(MapCollision(K, V)(hash : coll.hash, _pairs_ptr : new_ptr, _pairs_len : coll._pairs_len));
     },
     .None => {
       new_len := (coll._pairs_len + usize(1));
       new_ptr := _alloc_pairs(K, V, new_len);
       _copy_pairs(K, V, new_ptr, coll._pairs_ptr, usize(0), usize(0), coll._pairs_len);
-      consume((new_ptr.add(coll._pairs_len)).* = Pair(K, V)(key : k, value : v));
+      consume((new_ptr.add(coll._pairs_len)).* = MapEntry(K, V)(key : k, value : v));
       return(MapCollision(K, V)(hash : coll.hash, _pairs_ptr : new_ptr, _pairs_len : new_len));
     }
   )
@@ -400,8 +397,8 @@ _node_insert :: (
           );
         });
         pairs_ptr := _alloc_pairs(K, V, usize(2));
-        consume(pairs_ptr.* = Pair(K, V)(key : leaf.key, value : leaf.value));
-        consume((pairs_ptr.add(usize(1))).* = Pair(K, V)(key : k, value : v));
+        consume(pairs_ptr.* = MapEntry(K, V)(key : leaf.key, value : leaf.value));
+        consume((pairs_ptr.add(usize(1))).* = MapEntry(K, V)(key : k, value : v));
         return(
           InsertResult(K, V)(
             node : .Collision(MapCollision(K, V)(hash : hash, _pairs_ptr : pairs_ptr, _pairs_len : usize(2))),
@@ -702,15 +699,15 @@ _collect_entries :: (
     comptime(K) : Type,
     comptime(V) : Type,
     node : MapNode(K, V),
-    acc : List(Pair(K, V)),
+    acc : List(MapEntry(K, V)),
     where(K <: (Eq(K), Hash, Send), V <: Send)
-  ) -> List(Pair(K, V))
+  ) -> List(MapEntry(K, V))
 )(
   match(
     node,
-    .Leaf(leaf) => acc.prepend(Pair(K, V)(key : leaf.key, value : leaf.value)),
+    .Leaf(leaf) => acc.prepend(MapEntry(K, V)(key : leaf.key, value : leaf.value)),
     .Branch(branch) => {
-      (result : List(Pair(K, V))) = acc;
+      (result : List(MapEntry(K, V))) = acc;
       i := u8(0);
       while(i < branch._children_len, i = (i + u8(1)), {
         result = recur(K, V, _branch_child_at(K, V, branch, i), result);
@@ -718,7 +715,7 @@ _collect_entries :: (
       result
     },
     .Collision(coll) => {
-      (result : List(Pair(K, V))) = acc;
+      (result : List(MapEntry(K, V))) = acc;
       i := usize(0);
       while(i < coll._pairs_len, i = (i + usize(1)), {
         result = result.prepend((coll._pairs_ptr.add(i)).*);
@@ -760,7 +757,7 @@ _map_values_node :: (
       i := usize(0);
       while(i < coll._pairs_len, i = (i + usize(1)), {
         old_pair := (coll._pairs_ptr.add(i)).*;
-        consume((new_ptr.add(i)).* = Pair(K, U)(key : old_pair.key, value : f(old_pair.value)));
+        consume((new_ptr.add(i)).* = MapEntry(K, U)(key : old_pair.key, value : f(old_pair.value)));
       });
       .Collision(
         MapCollision(K, U)(
@@ -936,11 +933,11 @@ impl(
     )
   ),
   /// Collect all entries into a list of pairs.
-  entries : (fn(self : Self) -> List(Pair(K, V)))(
+  entries : (fn(self : Self) -> List(MapEntry(K, V)))(
     match(
       self._root,
-      .Some(root) => _collect_entries(K, V, root, List(Pair(K, V)).new()),
-      .None => List(Pair(K, V)).new()
+      .Some(root) => _collect_entries(K, V, root, List(MapEntry(K, V)).new()),
+      .None => List(MapEntry(K, V)).new()
     )
   ),
   /// Apply a function to each value, producing a new map.
@@ -964,7 +961,7 @@ impl(
     result
   }),
   /// Create a map from a slice of key-value pairs.
-  from_entries : (fn(pairs : ArrayList(Pair(K, V))) -> Self)({
+  from_entries : (fn(pairs : ArrayList(MapEntry(K, V))) -> Self)({
     (result : Self) = Self.new();
     i := usize(0);
     plen := pairs.len();
@@ -995,4 +992,4 @@ impl(
     })
   )
 );
-export(Map, MapNode, MapBranch, MapLeaf, MapCollision, Pair, InsertResult, RemoveResult);
+export(Map, MapNode, MapBranch, MapLeaf, MapCollision, MapEntry, InsertResult, RemoveResult);

--- a/std/imm/sorted_map.yo
+++ b/std/imm/sorted_map.yo
@@ -20,7 +20,7 @@
 pragma(Pragma.AllowUnsafe);
 { List } :: import("./list.yo");
 { ArrayList } :: import("../collections/array_list.yo");
-{ Pair } :: import("./map.yo");
+{ MapEntry } :: import("./map.yo");
 /// Color of a red-black tree node.
 Color :: enum(Red, Black);
 /// Internal LLRB tree node — an `atomic object` for thread-safe sharing.
@@ -617,7 +617,7 @@ impl(
     _collect_values(K, V, self._root, List(V).new())
   ),
   /// Create a sorted map from a slice of key-value pairs.
-  from_entries : (fn(pairs : ArrayList(Pair(K, V))) -> Self)({
+  from_entries : (fn(pairs : ArrayList(MapEntry(K, V))) -> Self)({
     (result : Self) = Self.new();
     i := usize(0);
     plen := pairs.len();

--- a/std/prelude.yo
+++ b/std/prelude.yo
@@ -8119,7 +8119,7 @@ export(IntoIterator);
 /// registry is keyed by (type id, label) with no trait discrimination, so an
 /// `Item` here would collide with the collection's own `IntoIterator.Item` and
 /// resolve first-wins by load order — benign for `ArrayList`, but genuinely
-/// divergent for `HashMap`, whose `IntoIterator.Item` is `Bucket(K, V)`.
+/// divergent for `HashMap`, whose `IntoIterator.Item` is `MapEntry(K, V)`.
 ///
 /// `from_iter_add` RETURNS the accumulator instead of mutating it so that one
 /// signature covers reference collections (mutate `acc`, return it — the return

--- a/tests/codegen-bootstrap/hashmap_self_cycle.yo
+++ b/tests/codegen-bootstrap/hashmap_self_cycle.yo
@@ -1,8 +1,8 @@
 // Regression: cycle collection through a `HashMap(_, Self)` field. The managed
-// references live in the map's malloc'd Bucket buffer, which the auto-derived
+// references live in the map's malloc'd MapEntry buffer, which the auto-derived
 // field walk cannot reach — so HashMap's hand-written `Trace` impl
 // (std/collections/hash_map.yo) must visit each full bucket slot, and
-// `can_type_form_rc_cycle` must see THROUGH the `?(*(Bucket(K, V)))` buffer to V to
+// `can_type_form_rc_cycle` must see THROUGH the `?(*(MapEntry(K, V)))` buffer to V to
 // mark the type cyclic. a <-> b reference each other through their maps; on return
 // the pair is unreachable and must be fully reclaimed (after == before). Both
 // compilers must agree.

--- a/tests/codegen-bootstrap/imm_map_entries_shell.yo
+++ b/tests/codegen-bootstrap/imm_map_entries_shell.yo
@@ -1,5 +1,5 @@
 { assert } :: import("std/assert");
-{ Map, Pair } :: import("std/imm/map");
+{ Map, MapEntry } :: import("std/imm/map");
 { List } :: import("std/imm/list");
 main :: (fn() -> unit)({
   m := Map(i32, i32).new();

--- a/tests/codegen-bootstrap/ptr_deref_copy_rc_struct.yo
+++ b/tests/codegen-bootstrap/ptr_deref_copy_rc_struct.yo
@@ -26,22 +26,22 @@ Krate :: ref(
   )
 );
 
-Bucket :: struct(k : Krate, n : i32);
+MapEntry :: struct(k : Krate, n : i32);
 
 // Repeatedly deref-copy a bucket out of a malloc'd buffer (the
 // HashMap._find_bucket shape) — each copy must +1 the RC field so the
 // local's scope drop cannot steal the buffer's reference.
-probe :: (fn(data_ptr : *(Bucket), i : usize) -> i32)({
+probe :: (fn(data_ptr : *(MapEntry), i : usize) -> i32)({
   bucket := (data_ptr.add(i)).*;
   bucket.n
 });
 
 main :: (fn() -> unit)({
   kk := Krate(v : 7);
-  m := unsafe(GlobalAllocator.calloc(usize(2), sizeof(Bucket)));
+  m := unsafe(GlobalAllocator.calloc(usize(2), sizeof(MapEntry)));
   pv := match(m, .Some(p2) => p2, .None => __yo_panic("alloc failed"));
-  data_ptr := unsafe((*(Bucket))(pv));
-  (data_ptr.add(usize(0))).* = Bucket(k : kk, n : 1);
+  data_ptr := unsafe((*(MapEntry))(pv));
+  (data_ptr.add(usize(0))).* = MapEntry(k : kk, n : 1);
   print(rc(kk));
   print(" ");
   (j : i32) = i32(0);

--- a/tests/collections/hash_map.test.yo
+++ b/tests/collections/hash_map.test.yo
@@ -501,7 +501,7 @@ test("HashMap for (b) => body iterates occupied buckets by value", {
   assert(val_sum == i32(30));
 });
 test("HashMap value-form bucket is a copy — writes do not reach the map", {
-  // The value form yields `Bucket(K, V)` STRUCT COPIES; in-place value
+  // The value form yields `MapEntry(K, V)` STRUCT COPIES; in-place value
   // mutation goes through `set` (or `iter_ptr` in privileged code).
   map := HashMap(i32, i32).new();
   map.insert(i32(1), i32(10));

--- a/tests/collections/ordered_map.test.yo
+++ b/tests/collections/ordered_map.test.yo
@@ -1,5 +1,5 @@
 { assert } :: import("std/assert");
-{ OrderedMap, OrderedMapEntry } :: import("std/collections/ordered_map");
+{ OrderedMap, MapEntry } :: import("std/collections/ordered_map");
 open(import("std/collections/array_list"));
 open(import("std/string"));
 test("OrderedMap empty new", {

--- a/tests/imm_map.test.yo
+++ b/tests/imm_map.test.yo
@@ -1,5 +1,5 @@
 { assert } :: import("std/assert");
-{ Map, Pair } :: import("std/imm/map");
+{ Map, MapEntry } :: import("std/imm/map");
 { List } :: import("std/imm/list");
 { String } :: import("std/imm/string");
 CollisionKey :: struct(id : i32);

--- a/tests/where_clause_fn_inference.test.yo
+++ b/tests/where_clause_fn_inference.test.yo
@@ -72,11 +72,11 @@ test("where-clause inference with bool callback return type", {
 // A user IntoIterator-shaped trait (assoc Item/IntoIter + a where-clause tying
 // them) implemented on LinkedList and BTreeMap; instantiating one where-bound
 // generic at LinkedList and then a second at BTreeMap minted ERA-COPY
-// ArrayList(BTreeEntry(K',V')) identities from the failed impl-match trials,
+// ArrayList(MapEntry(K',V')) identities from the failed impl-match trials,
 // whose GC traverse delegated to a never-emitted hard-generic trace spec —
 // "call to undeclared function yo_id_..._<raw SomeT ids>_..." at C compile.
 { LinkedList, LinkedListIter } :: import("std/collections/linked_list");
-{ BTreeMap, BTreeMapIter, BTreeEntry } :: import("std/collections/btree_map");
+{ BTreeMap, BTreeMapIter, MapEntry } :: import("std/collections/btree_map");
 __WbInto :: trait(
   Item : Type,
   IntoIter : Type,
@@ -96,7 +96,7 @@ impl(
   generic(K : Type, V : Type),
   BTreeMap(K, V),
   __WbInto(
-    Item : BTreeEntry(K, V),
+    Item : MapEntry(K, V),
     IntoIter : BTreeMapIter(K, V),
     wb_into : (fn(self : Self) -> BTreeMapIter(K, V))(self.into_iter())
   )


### PR DESCRIPTION
`plans/STD_API_AUDIT.md` §5's entry-type unification. All four types were literally `struct(key : K, value : V)` — one concept wearing four names, so an entry could not move between maps and a reader could not tell from a signature whether two of them were the same shape.

| was | where | sites |
| --- | --- | --- |
| `Bucket` | `hash_map.yo` | 19 |
| `BTreeEntry` | `btree_map.yo` | 15 |
| `OrderedMapEntry` | `ordered_map.yo` | 3 |
| `Pair` | `imm/map.yo` | 21 |

## Where the shared type lives

A new `std/collections/entry.yo`. Deliberately **not** the prelude, where growth has a measured self-emit memory cost (`issues/std-s1-prelude-growth-tripled-self-emit-memory.md`), and deliberately **not** `hash_map.yo`, which would have made `std/imm/map` depend on a `std/collections` map. Each map module re-exports `MapEntry`, so `{ BTreeMap, MapEntry } :: import("std/collections/btree_map")` still works and no consumer learns a new import path.

## Two traps a textual sweep walks straight into

**Prelude `IterPair(A, B)` is not a map entry.** It is `struct(_0 : A, _1 : B)` — *positional*, produced by `zip` (D3.4). Folding it in would have merged two genuinely different concepts. A map entry is *named*.

**Most `\bPair\b` matches are test-local structs of unrelated shape:**

| file | actual shape |
| --- | --- |
| `tests/index.test.yo:533` | `struct(first : i32, second : i32)` |
| `tests/privilege_pragma.test.yo:88` | `atomic(ref(struct(a : i32, b : u32)))` |
| `tests/codegen-bootstrap/borrowed_field_return.yo:27` | `ref(...)` |

Exactly **two** files import std's `Pair`. So `Bucket`/`BTreeEntry`/`OrderedMapEntry` were swept tree-wide (unambiguous names) while `Pair` was done by explicit file list. `TypePair` in the evaluator is unrelated and word-boundary-safe.

`check ./std` caught one the sweep could not: `std/imm/sorted_map.yo` imports `Pair` *through* `imm/map`.

## The `src/` comment churn

`Bucket` appeared in ~35 `src/` comments documenting type-identity hazards (`tk2/Bucket`, comptime-fn cache collisions, `type_key` shared-eval-id notes). Those moved too — it is the same type under a new name, and a comment naming a type that no longer exists is not navigable. **Every `src/` change here is inside a comment: 27 insertions, 27 deletions, zero executable lines.**

## Also filed — not caused by this work

`issues/where-bound-gc-trace-still-fails-when-run-standalone.md`.

`tests/where_clause_fn_inference.test.yo` — the red-first regression test for `issues/fixed/where-bound-intoiterator-gc-trace-abstract-key.md` (#249) — **fails when run standalone**, with the exact `call to undeclared function yo_id_..._<raw SomeT ids>` symptom that issue says was fixed. It reproduces on unmodified develop at `12d226078`.

The suite stays green only because the runner's **batch composition** differs: alone the file is batch `1_0` and the era-copy trigger fires; inside the suite it lands in a batch where it does not. A regression test that cannot fail the suite is not a gate.

I suspected this unification first — sharing one `constructor_func_id` collapses `type_key` entries that used to differ. Two checks ruled it out:

- reverting `btree_map` to its **own local** `MapEntry` constructor (pure rename, no sharing) fails identically;
- **unmodified develop** fails identically — same `yo_id_4260`, same three calls.

## Verification

| gate | result |
| --- | --- |
| `yo check ./std` | 153/153 |
| `yo check ./src` | 262/262 |
| `yo build` | rc=0 |
| full suite | **2905 / 2905** |
| CLI scorecard | PASS 51, **zero golden drift** |
| `gates_fast.sh` | `T1_DONE failures=0` |
| `fixpoint_only.sh` | `STAGE3_RC=0 FIXPOINT_HOLDS` |
| `hollow_sweep69.sh` | `SWEEP_GATE_OK` (0 allowlisted known-failing) |

`FIXPOINT_HOLDS` is the load-bearing one here: collapsing four constructors into one directly affects `type_key`, and the self-compile fixpoint is what proves it did not perturb type identity.

Targeted runs: `tests/collections` 391/391, `imm_map` 21/21, `imm_sorted_map` 17/17, plus `index` 49/49 and `privilege_pragma` 7/7 — the last two carry the test-local `Pair`s that must **not** move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
