### PR TITLE
codegen: release builds silently discarded every C diagnostic, and untranspiled bodies shipped as UB

### DIFF
--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -125,6 +125,8 @@ masked := ((A | B) | C);
 - Yo has no operator precedence: a chain of the SAME operator left-associates (`a + b + c` ⇒ `(a + b) + c`, no parens needed); adjacent DIFFERENT operators require parentheses (`(a + b) * c`, not `a + b * c`)
 - An operator RHS that itself contains a different top-level operator must be parenthesized: `true => (x / y)`, `value := (x + y)`, `(x : T) = ((v) -> { ... })`, `next : (fn(...) -> T)`
 - The rule also applies on the LEFT of a `cond` arm's `=>`: a same-operator chain like `a || b || c` is fine alone, but `a || b || c => v` mixes `||` with `=>` — wrap the whole condition: `(a || b || c) => v` ("Adjacent different operators need parentheses")
+- …and on the RIGHT of an arm's `=>` too, in BOTH `cond` and `match`. An arm body that is a bare infix expression mixes the operator with `=>`: `.Some(qv) => qv != u8(34)` is rejected, `.Some(qv) => (qv != u8(34))` is accepted. Same for `+`, `==`, `&&`, … in arm-body position.
+- **`yo fmt` does NOT catch either form.** `yo fmt` and `yo fmt --check` both pass on the unparenthesised version; only the evaluator rejects it. A clean `fmt` is not evidence the file parses — run `yo check` on the file after editing arms.
 - Source layout does NOT affect grouping — there is no newline-based associativity
 - Prefix operators (`-` `!` `~` `&` `*` `?` `^`) bind ONE postfix expression (plans/PREFIX_OPERATOR_OPERAND_RULE.md): `-1`, `!ready`, `&s`, `?*T`, `3 - -3` are valid; an INFIX operand still needs parens (`-(1 + 2)`). SEED CONSTRAINT: keep parenthesized forms (`-(1)`, `!(x)`) in `src/` and `std/` until a rule-bearing release becomes the seed.
 - Tight special forms also require immediate parentheses: `#(expr)`, `?(*(u8))`, `T <: !(Runtime)`

--- a/issues/fixed/release-builds-suppress-all-c-warnings.md
+++ b/issues/fixed/release-builds-suppress-all-c-warnings.md
@@ -1,6 +1,29 @@
 # `--release` passes `-w`, hiding warnings that mean the compiler miscompiled
 
-**Status:** FIXED 2026-08-25 (PR #260).
+**Status:** FIXED 2026-08-25 (PR #260) — **but that fix was a NO-OP until
+2026-08-25 (`fix/ftt-silent-stub`), which is when it actually started working.**
+
+PR #260 re-enabled three diagnostics AFTER `-w`. Measured on clang 21.1.7, `-w`
+is ABSOLUTE — nothing later can bring a diagnostic back, not even `-Werror=`:
+
+| flags (two-line file passing `char *` to an `int *` parameter) | result |
+| --- | --- |
+| `-Wincompatible-pointer-types` | warning |
+| `-w -Wincompatible-pointer-types` | **SILENT** |
+| `-w -Werror=incompatible-pointer-types` | **SILENT** |
+| `-Wno-everything -Wincompatible-pointer-types` | warning (comes back) |
+
+So the exact diagnostic this issue was written to preserve — the one that turned
+the `inout` miscompile into a silent wrong answer — was STILL suppressed in
+release builds after the "fix". The other two entries
+(`-Wint-conversion`, `-Wimplicit-function-declaration`) appeared to work only
+because clang 16+ makes them errors BY DEFAULT and `-w` cannot suppress an
+error; they fired with or without the list.
+
+The real fix is one word: the blanket flag is now `-Wno-everything`, which later
+`-W…` flags DO override. Found while adding `-Werror=return-type` for
+issues/ftt-stub-in-live-closure-falls-off-non-void-function.md — that flag was
+also silently doing nothing behind `-w`.
 **Found:** 2026-08-25, while fixing
 issues/fixed/specialized-inout-param-loses-ref-with-comptime-arg.md, where `-w`
 is precisely what turned a miscompile into a silent wrong answer.

--- a/issues/ftt-stub-in-live-closure-falls-off-non-void-function.md
+++ b/issues/ftt-stub-in-live-closure-falls-off-non-void-function.md
@@ -128,15 +128,27 @@ Independently, clang ALREADY detects this exact shape:
 a.out.c:4124:1: warning: non-void function does not return a value [-Wreturn-type]
 ```
 
-`src/main.yo` suppresses it. Optimized builds pass `-w` and then re-enable a
-short list of diagnostics that "can ONLY mean the code GENERATOR emitted
-something inconsistent with its own prototypes" — currently
-`-Wincompatible-pointer-types`, `-Wint-conversion`,
-`-Wimplicit-function-declaration`. `-Wreturn-type` meets that stated criterion
-verbatim and belongs on the list. That is a backstop, not the fix: it should be
-added *in addition to* the gate, exactly as the pointer-type warning was added
-after `issues/fixed/specialized-inout-param-loses-ref-with-comptime-arg.md`.
-See also `issues/release-builds-suppress-all-c-warnings.md`.
+`src/main.yo` suppresses it — and investigating WHY exposed a second bug.
+
+Optimized builds passed `-w` and then "re-enabled" a short list of diagnostics.
+Measured on clang 21.1.7, that never worked: **`-w` is absolute.** No later
+`-W…`, and not even `-Werror=…`, can bring a diagnostic back once `-w` is on
+the command line. `-Wno-everything` behaves differently — later flags DO
+override it.
+
+| flags | on the FTT file above |
+| --- | --- |
+| `-w -Wincompatible-pointer-types -Wint-conversion -Wimplicit-function-declaration` (shipped) | rc=0 — ships the UB |
+| `-Wno-everything <same three> -Werror=return-type` | rc=1 — `error: non-void function does not return a value` |
+
+So the backstop needs BOTH: the blanket flag changed to `-Wno-everything`, and
+`-Werror=return-type` (a bare `-W` would only warn and still build). That also
+makes the three flags from
+`issues/fixed/release-builds-suppress-all-c-warnings.md` effective for the
+first time — see that issue.
+
+The flag is still a backstop, not the cure: it catches the invalid C, but the
+evaluator swallow that produced it remains the root.
 
 ## Regression test
 

--- a/issues/ftt-stub-in-live-closure-falls-off-non-void-function.md
+++ b/issues/ftt-stub-in-live-closure-falls-off-non-void-function.md
@@ -150,6 +150,40 @@ first time — see that issue.
 The flag is still a backstop, not the cure: it catches the invalid C, but the
 evaluator swallow that produced it remains the root.
 
+## A SECOND bug, found while fixing the first: the marker scan is unanchored
+
+`src/codegen/functions/generation.yo` decides whether a function body contains a
+marker by scanning the emitted C for the raw bytes `// Failed to transpile`.
+That text is not only a marker — it is also **data inside this compiler**:
+
+- `src/codegen/exprs/generation.yo` builds the marker with
+  `String.from("// Failed to transpile ")`, and
+- the `codegen_fatal` message a few lines below the scan itself contains
+  "Failed to transpile part of main's body".
+
+So on any SELF-compile the scan matches the compiler's own source text.
+**Measured on stage-2's emitted C: 14 hits, none of them a stub** — every one a
+string literal of the form
+
+```c
+__yo_t0 tmp = yo_id_4576((__yo_str){ .ptr = (const uint8_t*)"// Failed to transpile", .len = 22 });
+```
+
+This was latent because the two consumers were narrowly scoped: the fatal gate
+only fires for `__yo_user_main`, and the rewrite only for
+`fid_fully_specialized` originals. It stops being latent the moment either
+widens — generalizing the rewrite to non-void functions replaced **7 substantial
+emitter functions** (`expr, indent, context`) with `abort()`, ~950 KB of deleted
+bodies, and stage 3 died with `STAGE3_RC=134` (SIGABRT).
+
+It is also reachable WITHOUT any change: a user program whose `main` contains the
+literal text `// Failed to transpile` — a Yo program that generates C, say —
+trips `codegen_fatal` today for no reason.
+
+**Fix:** line-anchor the match. A genuine marker is a comment that starts its own
+line; a string literal is always mid-line inside an expression. Walk back over
+spaces/tabs and require a newline (or buffer start).
+
 ## Regression test
 
 `issues/repros/ftt-stub-in-async-closure-returns-garbage.yo` must fail to compile

--- a/src/codegen/functions/generation.yo
+++ b/src/codegen/functions/generation.yo
@@ -626,7 +626,30 @@ generate_function :: (fn(function_value : EvalValue, c_function_name : String, c
               mi = (mi + usize(1));
             });
             if(all_eq, {
-              stub_found_ftt = true;
+              // REJECT STRING-LITERAL MATCHES. The needle is not only a marker,
+              // it is also DATA inside this compiler: several files build or
+              // compare it with `"// Failed to transpile"` (codegen/exprs/
+              // generation.yo, inline_fns.yo, assignment.yo, dyn.yo, return.yo,
+              // other_fn_call.yo). On a SELF-compile an unanchored scan matches
+              // that source text and mistakes working emitter functions for
+              // stubs — measured: generalizing the rewrite without this check
+              // replaced 7 substantial `(expr, indent, context)` functions with
+              // abort() and stage 3 died with SIGABRT.
+              //
+              // The discriminator is the byte BEFORE the match. Every literal
+              // occurrence in emitted C is preceded by the opening quote
+              // (`(const uint8_t*)"// Failed to transpile"`), and a real marker
+              // never is. Do NOT line-anchor instead: a genuine marker can sit
+              // mid-line, as in `return // Failed to transpile x * i32(2);`,
+              // which anchoring would miss — and that one produces a `return`
+              // with no expression, i.e. C that does not even parse.
+              prev_ok := cond(
+                (si == usize(0)) => true,
+                true => match(sb.get(si - usize(1)), .Some(qv) => (qv != u8(34)), .None => true)
+              );
+              if(prev_ok, {
+                stub_found_ftt = true;
+              });
             });
             si = (si + usize(1));
           });
@@ -641,21 +664,35 @@ generate_function :: (fn(function_value : EvalValue, c_function_name : String, c
       // hollow-sweep detector calls HOLLOW (a batch `__yo_user_main` that is a
       // marker reports every test as passed while running no assertions).
       //
-      // Markers elsewhere are NOT gated here: the degrade guards keep the C
-      // valid, and the stub rewrite just below deletes the ones that land on
-      // dead superseded originals. Gating those too was tried and reverted — it
-      // failed tests/fn.test.yo and tests/algebraic_effects.test.yo, whose
-      // markers are exactly that dead code.
+      // Markers elsewhere are NOT made FATAL here: gating those was tried and
+      // reverted — it failed tests/fn.test.yo and tests/algebraic_effects.test.yo,
+      // whose markers are dead superseded-generic code that never runs.
+      //
+      // But "never runs" does not make the C VALID. A marker in a NON-VOID
+      // function leaves a value-returning C function with no return statement,
+      // and falling off the end of one is undefined behaviour whether or not
+      // anything calls it — clang rejects it under -Werror=return-type
+      // regardless of liveness. So those bodies are REWRITTEN to abort() below,
+      // exactly as the superseded-generic path already does: the C becomes
+      // valid, dead stubs stay harmless, and a LIVE stub aborts loudly instead
+      // of returning whatever was in the return register. Measured: 6 such
+      // functions in the tests/ batch corpus today.
+      // See issues/ftt-stub-in-live-closure-falls-off-non-void-function.md.
       if(stub_found_ftt && (c_function_name == "__yo_user_main"), {
         codegen_fatal(
           `Failed to transpile part of main's body — the emitted C for "${c_function_name}" contains an untranspiled expression, so the program would run without it`
         );
       });
-      if(stub_found_ftt && fid_fully_specialized(func_id.clone()), {
-        // RARE path (superseded generic original): rebuild the prefix from
-        // bytes once. Byte-exact equivalent of the former char-indexed
-        // `substring(0, stub_mark)` — stub_mark_b was taken at the same
-        // buffer position.
+      stub_is_superseded := fid_fully_specialized(func_id.clone());
+      stub_ret_unit := match(
+        function_type,
+        .Func({ result : stub_r }) => is_unit_type(resolve_some_type_to_concrete(stub_r.clone())),
+        _ => true
+      );
+      if(stub_found_ftt && (stub_is_superseded || !(stub_ret_unit)), {
+        // Rebuild the prefix from bytes once. Byte-exact equivalent of the
+        // former char-indexed `substring(0, stub_mark)` — stub_mark_b was taken
+        // at the same buffer position.
         pb := em.code.as_bytes();
         prefix_bytes := ArrayList(u8).new();
         (pi : usize) = usize(0);
@@ -665,7 +702,13 @@ generate_function :: (fn(function_value : EvalValue, c_function_name : String, c
         });
         em.code = String.from_bytes(prefix_bytes);
         em.emit_string_line(open.clone());
-        em.emit_string_line(String.from("  abort(); /* superseded generic original: all call sites dispatch a specialization */"));
+        em.emit_string_line(
+          if(
+            stub_is_superseded,
+            String.from("  abort(); /* superseded generic original: all call sites dispatch a specialization */"),
+            String.from("  abort(); /* untranspilable body in a value-returning fn: aborting beats falling off the end (UB) */")
+          )
+        );
         em.emit_string_line(String.from("}"));
       });
     },

--- a/src/main.yo
+++ b/src/main.yo
@@ -1809,10 +1809,24 @@ run_compile :: (
   //
   // WARNINGS ARE NOT PURELY A FUNCTION OF THE OPTIMIZATION LEVEL. Generated C is
   // full of harmless noise (unused temporaries, redundant parens, pointer-sign
-  // on string literals), so an optimized build passes `-w` to silence it. But a
-  // few diagnostics can ONLY mean the code GENERATOR emitted something
-  // inconsistent with its own prototypes, and those are re-enabled AFTER `-w`
-  // (clang and gcc honour the later flag, so exactly those come back).
+  // on string literals), so an optimized build silences it wholesale and then
+  // re-enables the few diagnostics that can ONLY mean the code GENERATOR
+  // emitted something inconsistent with its own prototypes.
+  //
+  // THE BLANKET FLAG MUST BE `-Wno-everything`, NOT `-w`. `-w` is ABSOLUTE: no
+  // later `-W…` or even `-Werror=…` can bring a diagnostic back, so the
+  // re-enable list below was decorative for as long as it sat after `-w`.
+  // MEASURED (clang 21.1.7, 2026-08-25) on a two-line file passing a `char *`
+  // to an `int *` parameter:
+  //   -Wincompatible-pointer-types                 -> warning
+  //   -w -Wincompatible-pointer-types              -> SILENT
+  //   -w -Werror=incompatible-pointer-types        -> SILENT
+  //   -Wno-everything -Wincompatible-pointer-types -> warning (comes back)
+  // The two int/implicit-decl entries appeared to work only because clang 16+
+  // made them errors BY DEFAULT, and `-w` cannot suppress an error — they
+  // would fire with or without this list. See
+  // issues/fixed/release-builds-suppress-all-c-warnings.md, whose fix this
+  // makes effective for the first time.
   //
   // This is not hypothetical: a specialized generic's `inout` parameter lost its
   // by-ref binding, so codegen passed a `T**` where its own prototype said `T*`.
@@ -1824,14 +1838,24 @@ run_compile :: (
   // between generated code and its own generated prototype is never noise:
   // both sides are written by this compiler.
   //
+  // `-Werror=return-type` is on the list for the same reason, and must be
+  // -Werror rather than a bare -W because a warning would still let the build
+  // succeed. A function whose body codegen could not transpile becomes
+  // `// Failed to transpile` COMMENTS with no return statement, and falling
+  // off the end of a value-returning function is undefined behaviour — that is
+  // how a missed rename inside an `io.async` closure made std/fs/walker's walk
+  // silently return an empty list with `check`, `build` and the whole suite
+  // green. See issues/ftt-stub-in-live-closure-falls-off-non-void-function.md.
+  //
   // The -O0 arm below needs no such re-enabling — `-Wall` and clang's
   // defaults already include all three.
   cond(
     ((optimize != "") && (optimize != "0")) => {
-      cmd.arg(String.from("-w"));
+      cmd.arg(String.from("-Wno-everything"));
       cmd.arg(String.from("-Wincompatible-pointer-types"));
       cmd.arg(String.from("-Wint-conversion"));
       cmd.arg(String.from("-Wimplicit-function-declaration"));
+      cmd.arg(String.from("-Werror=return-type"));
       cmd.arg(`-O${optimize}`);
     },
     true => {
@@ -1844,6 +1868,7 @@ run_compile :: (
       cmd.arg(String.from("-Wno-unused-label"));
       cmd.arg(String.from("-Wno-unused-value"));
       cmd.arg(String.from("-Wno-parentheses-equality"));
+      cmd.arg(String.from("-Werror=return-type"));
       cmd.arg(String.from("-O0"));
     }
   );


### PR DESCRIPTION
Three related fixes. Each was found by a battery failure caused by the previous one, and each is a real defect rather than a testing artifact.

## 1. `-w` is absolute — release builds have been discarding every generator-inconsistency diagnostic

`src/main.yo` silenced generated-C noise with `-w`, then "re-enabled" the few diagnostics that can only mean codegen contradicted its own prototypes. **That re-enable never worked.** Measured on clang 21.1.7, with a two-line file passing a `char *` to an `int *` parameter:

| flags | result |
| --- | --- |
| `-Wincompatible-pointer-types` | warning |
| `-w -Wincompatible-pointer-types` | **silent** |
| `-w -Werror=incompatible-pointer-types` | **silent** |
| `-Wno-everything -Wincompatible-pointer-types` | warning (comes back) |

So `issues/fixed/release-builds-suppress-all-c-warnings.md` (PR #260) was fixed by adding three flags **after** `-w`, and they were decorative. The very diagnostic that issue exists to preserve — the one that turned the specialized-`inout` miscompile into a silent wrong answer — was still suppressed in every release build. The other two only *appeared* to work because clang 16+ makes them errors by default, and `-w` cannot suppress an error; they fired with or without the list.

Fix: `-w` → `-Wno-everything`, which later flags override. That issue's fix becomes effective for the first time here. Plus `-Werror=return-type` on both arms — a bare `-W` would only warn and still build.

(The two `-w` arguments in `src/version_cache.yo` are curl's `--write-out`, untouched.)

## 2. Untranspilable value-returning bodies are now `abort()` stubs

`-Werror=return-type` immediately found **six pre-existing** instances in the tests corpus:

```c
static inline void* yo_id_9392() {
  // Failed to transpile (handler : (fn(msg : String) -> i32)) = ...
  // Failed to transpile return(handler);
}
```

These are the **dead** superseded-generic markers whose gating was tried and reverted before. But dead or not the C is invalid — falling off the end of a value-returning function is UB and clang rejects it regardless of liveness, so the flag alone would have broken the build on harmless code.

The fix makes the C *valid*: the existing abort-rewrite (previously only for `fid_fully_specialized` originals) now covers any non-unit result type. Dead stubs stay harmless; a live one aborts loudly instead of returning register garbage. The recorded reproducer went from printing `0` to `SIGABRT`.

## 3. The marker scan matched the compiler's own source text

Generalizing that rewrite broke the fixpoint outright — `STAGE3_RC=134`, SIGABRT.

The scan looks for raw bytes `// Failed to transpile` in emitted C, but that string is also **data** here: `codegen/exprs/generation.yo` builds the marker with `String.from("// Failed to transpile ")`, and five other files compare against it. On a self-compile the scan matched the compiler's own literals and mistook working emitter functions for stubs — **seven** substantial `(expr, indent, context)` functions replaced with `abort()`, ~950 KB of deleted bodies.

Measured on stage 2's emitted C after the fix:

| | count |
| --- | --- |
| needle occurrences | 13 |
| …string literals | **13** |
| …real markers | **0** |
| emitted stubs | **0** |

The compiler emits no FTT stub at all when compiling itself.

The discriminator is the byte **before** the match: a literal is always preceded by its opening quote, a real marker never is. I first tried line-anchoring, which was wrong in the other direction — it missed

```c
return // Failed to transpile x * i32(2);
```

a genuine mid-line marker, and the worst kind, since it leaves a `return` with no expression (batch 49 failed with `expected expression`). Both the rule and that counter-example are in the comment so the next person repeats neither attempt.

This also fixes the **pre-existing** gate, which had the same blind spot but was scoped too narrowly to hit it: a user program whose `main` merely *contains* that text trips `codegen_fatal` today for no reason.

## Scope

This is a **backstop, not a cure**. It makes the invalid C impossible to ship silently. The evaluator swallow that produces an untranspiled body is still the root and stays open in `issues/ftt-stub-in-live-closure-falls-off-non-void-function.md`.

## Also

A match-arm body that is a bare infix expression needs parens (`.Some(qv) => (qv != u8(34))`). `yo fmt` accepts the unparenthesised form and only the evaluator rejects it — a clean `fmt` is not evidence a file parses. Added to the syntax cheatsheet, which previously covered only the *left* side of an arm's `=>`.

## Verification

| gate | result |
| --- | --- |
| `yo check ./std` | 153/153 |
| `yo check ./src` | 262/262 |
| `yo build` | rc=0 |
| **reproducer** | compile 0, **run 134 (SIGABRT)** — was printing `0` |
| healthy program | rc=0 |
| full suite | **2905 / 2905** |
| CLI scorecard | PASS 51, zero golden drift |
| `gates_fast.sh` | `T1_DONE failures=0` |
| `fixpoint_only.sh` | `STAGE3_RC=0 FIXPOINT_HOLDS` |
| `hollow_sweep69.sh` | `SWEEP_GATE_OK` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
