### PR TITLE
std: S2 chunk 4 — Option(T) spelling and map entry accessors

### DIFF
--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -124,7 +124,7 @@ and `Error.source` actually used for chaining (`wrap`/`context` helper).
 | membership | `contains` (seq/set), `contains_key` (map) | BTreeMap's missing both |
 | value iterator | `into_iter()`; pointer iterator `iter()` | `iter_ptr`, OrderedMap's value-`iter` |
 | accessors | bare noun, no `get_` prefix | `ParsedArgs.get_flag`, reflection `get_info` |
-| byte codecs | `encode` / `decode` | `to_ascii`/`to_unicode` (punycode) |
+| byte codecs | `encode` / `decode` | ~~`to_ascii`/`to_unicode` (punycode)~~ — module deleted, §6 |
 | text formats | `parse` / `stringify` | `decode_html` (→ `html_decode` + new `html_encode`) |
 | conversion | `from_` / `to_` / `into_` (Rust discipline) | `to_cstr` vs `to_c_str` pair |
 | comptime twins | `Comptime` prefix on traits, `comptime_` on methods — and fix the one infix outlier (`to_comptime_string`) | — |
@@ -647,7 +647,7 @@ implementing the D5 traits.** Until it lands, std honestly refuses https.
 | encoding | STANDARDIZE | D2 verbs; one error style per D1; utf8 module; add `html_encode` (XSS!); percent-encoding module (P0 — nothing in std can build a safe query string); base32; CSV (P1); toml: floats/arrays/dates/serializer + `ToToml`/`FromToml` derives to mirror json (P1) |
 | json | EXTEND | enum representation for derives (open question O3); `JsonValue.Object` O(n) parallel arrays → keep repr, add index map if profiling demands |
 | regex | POLISH | `Regex.escape`, optional-flags `new`, callback replace, lazy `find_iter`, group byte-spans, typed error, private internals |
-| url | EXTEND | percent-encode/decode integration, `query_pairs`/`SearchParams`, `join` (RFC 3986 §5 — needed by http redirects), builder/setters, wire punycode into host handling (or delete punycode) |
+| url | EXTEND | percent-encode/decode integration, `query_pairs`/`SearchParams`, `join` (RFC 3986 §5 — needed by http redirects), builder/setters; ~~wire punycode into host handling (or delete punycode)~~ — DELETED, §6 round 1 |
 | io | REDESIGN | D5 |
 | fs | EXTEND + POLISH | wrappers: `copy`, `remove_dir_all` (compiler implements it TWICE as workaround — `src/fetch.yo:80`, `src/version_cache.yo:72`), `read_link`, `set_permissions`, `set_len`, `try_exists`, `watch` (sys/events exists); `OpenOptions` builder; `File.from_fd`; Metadata: real `btime`, `permissions()`, stop `metadata` re-stat by path; DirEntry `path()`; walker: lazy option + glob filter; complete the `_str`/`_cstr` variant matrix or (better) collapse it with a `Pattern`-style `AsPath` trait |
 | path | FIX + EXTEND | `join(str)`, `push`, `strip_prefix` (rename of `relative_from`, fallible), `Hash`/`Ord`/`Clone`, Windows separator in `to_string`, `ancestors`, PATH split/join; revisit eager `..` normalization (symlink semantics); delete dead `PathError` or make `new` fallible |
@@ -727,7 +727,20 @@ small number of PRs with tree-wide fixups (compiler + std + tests + docs):
 - ~~`HashMap.iter_ptr`→`iter`~~ **DONE 2026-08-25** (no collision: HashMap had
   `into_iter` for values and `iter_ptr` for pointers, exactly D2's split);
   OrderedMap iterators get real `Iterator` impls
-- `?(T)` spelling in btree_map/deque → `Option(T)` (or bless `?(T)` everywhere — pick one)
+- ~~`?(T)` spelling in btree_map/deque → `Option(T)`~~ **DONE 2026-08-25 (S2
+  chunk 4)** — but NOT as "pick one everywhere". The counts decided it: of 140
+  `?(…)` uses in std, **130 are `?(*(…))`** — a nullable RAW POINTER, almost all
+  at the C boundary (`?(*(char))`, `?(*(FILE))`, `?(*(void))` in std/libc/*).
+  That is a real idiom, not an inconsistency, and it stays. Only the **10**
+  value-typed uses became `Option(T)`. Three of them were OUTSIDE this item's
+  stated scope — `std/sync/channel.yo` (2) and `std/fs/walker.yo` (1) — so the
+  "btree_map/deque" framing was incomplete
+- ~~maps `min()`/`max()` → `first_entry`/`last_entry`; sets keep `min`/`max`~~
+  **DONE 2026-08-25 (S2 chunk 4)** — only `BTreeMap` had the map form (it
+  returns `Option(MapEntry(K,V))`, i.e. a whole entry, which is exactly why the
+  name had to change); `imm/sorted_set` keeps `min`/`max` because it returns the
+  ELEMENT, and the `Iterator` combinators' `min()`/`max()` are a third, unrelated
+  thing. 2 declarations + 8 call sites
 - ~~`Bucket`/`BTreeEntry`/`OrderedMapEntry`/`Pair` → one `MapEntry(K,V)`~~
   **DONE 2026-08-25 (S2 chunk 3)** — all four were literally
   `struct(key : K, value : V)`, so this was one concept under four names. The
@@ -797,13 +810,25 @@ small number of PRs with tree-wide fixups (compiler + std + tests + docs):
   nothing in std/, src/ or tests/ uses a glob `open(import(...))` on either
   module (every import is destructuring); no file imports both `fs/file` and
   `sys/file`; neither name is in the prelude; and `std/fmt` (glob-imported by
-  `fs/file.yo`) exports only Alignment/Format/FormatSpec/ToString/Writer/
-  eprint/eprintln/print/println.
+  `fs/file.yo`) exports no `read`/`write`.
+
+  **Correction 2026-08-25:** that last check was stated with the wrong evidence.
+  It listed the union of exports across `std/fmt/*.yo`
+  (Alignment/Format/FormatSpec/ToString/Writer/eprint/eprintln/print/println),
+  but a glob `open(import("../fmt"))` resolves to the PACKAGE ENTRY POINT,
+  `std/fmt/index.yo`, which exports only **7** names — ToString, Format,
+  FormatSpec, println, print, eprintln, eprint. `Writer` and `Alignment` come
+  from the sibling `std/fmt/writer.yo:21,214`, which a glob does NOT pull in.
+  The conclusion is unchanged and in fact stronger (fewer names in scope), but
+  the reasoning matters for the NEXT check: when D5 introduces an I/O `Writer`
+  trait, the three files that glob-import `std/fmt` (`fs/file.yo`, `net/tcp.yo`,
+  `net/udp.yo`) will see no clash — because `fmt`'s `Writer` was never in their
+  scope to begin with.
 
   Method note: `write_bytes` and `write_string` are ALSO method names on four
   writer types (File, TcpStream, Writer, BufWriter). Only the free functions
   moved — the method vocabulary is deliberately shared and stays put.
-- `min()`/`max()` naming: maps `first_entry`/`last_entry`, sets keep `min`/`max`
+
 - `Http` inherent `to_string`→`ToString` impl; ~~`TcpStream.shutdown(i32)`→
   `shutdown(Shutdown)`~~ **DONE 2026-08-25 (S2 chunk 2)** — new `Shutdown` enum
   (`Read`/`Write`/`Both`, matching `std::net::Shutdown`) plus a private
@@ -817,7 +842,12 @@ small number of PRs with tree-wide fixups (compiler + std + tests + docs):
   byte-count call sites. This also SHARPENED `std/http/client.yo`, whose read
   loop tested `n <= i32(0)` — conflating "error" with EOF. Errors throw, so a
   count is never negative; the test is now `n == usize(0)`, i.e. EOF only
-- `punycode.to_ascii`/`to_unicode`→`domain_to_ascii`/`domain_to_unicode`
+- ~~`punycode.to_ascii`/`to_unicode`→`domain_to_ascii`/`domain_to_unicode`~~
+  **OBSOLETE 2026-08-25** — §6 round 1 DELETED `std/encoding/punycode.yo`
+  outright (zero importers, 343 untested spec-sensitive lines), so there is
+  nothing left to rename. Verified: zero `punycode` references in std/, src/
+  or tests/. If IDN support returns it comes back with tests and a `Url`
+  integration, and it gets these names then
 - two `sleep`s → `time.sleep(Duration, io)` async + `time.sleep_blocking(Duration)`
 - `str.join(items)` receiver-as-separator: keep (Python style is fine) but
   document; `index_of`/`last_index_of` keep (JS names are the local norm) —
@@ -871,7 +901,7 @@ test is ever re-expressed without it.
 | Target | Evidence |
 |---|---|
 | `std/alg/hash.yo` | zero importers; docstring false; FNV constants re-inlined in both String hashes — inline or wire in |
-| `std/encoding/punycode.yo` | zero importers incl. url; 343 untested spec-sensitive lines; ALSO duplicated at `vendor/markdown_yo` — delete OR wire into `Url` (D8) |
+| ~~`std/encoding/punycode.yo`~~ **DELETED** | zero importers incl. url; 343 untested spec-sensitive lines; ALSO duplicated at `vendor/markdown_yo` — deleted in §6 round 1 |
 | `std/collections/list_view.yo` | test-only, no Index/iter/consumers; superseded by `slice_copy` |
 | `std/collections/linked_list.yo` | test-only, 510 lines; `Deque` covers it (decide: delete vs keep-as-is; recommend delete) |
 | `mutex_t`, `cond_t` | zero in-tree users, duplicate `Mutex`/`Cond` unsafely |

--- a/std/collections/btree_map.yo
+++ b/std/collections/btree_map.yo
@@ -65,7 +65,7 @@ impl(
     _FindResult(lo, false)
   }),
   // Retrieve the value associated with key `k`.
-  get : (fn(self : Self, k : K, where(K <: Ord(K))) -> ?(V))({
+  get : (fn(self : Self, k : K, where(K <: Ord(K))) -> Option(V))({
     r := self._find(k);
     cond(
       r.found => .Some(self._entries(r.idx).value),
@@ -95,7 +95,7 @@ impl(
     );
   }),
   // Remove the entry with key `k`. Returns the old value, or .None.
-  remove : (fn(self : Self, k : K, where(K <: Ord(K))) -> ?(V))({
+  remove : (fn(self : Self, k : K, where(K <: Ord(K))) -> Option(V))({
     r := self._find(k);
     cond(
       r.found => {
@@ -106,15 +106,19 @@ impl(
       true => .None
     )
   }),
-  // Return the entry with the smallest key, or .None.
-  min : (fn(self : Self) -> ?(MapEntry(K, V)))(
+  /// Return the entry with the smallest key, or `.None`.
+  ///
+  /// Named `first_entry`/`last_entry` rather than `min`/`max` because this is a
+  /// MAP: it returns a whole `MapEntry`, not a key. Sets keep `min`/`max`,
+  /// which do return the element (plans/STD_API_AUDIT.md §5).
+  first_entry : (fn(self : Self) -> Option(MapEntry(K, V)))(
     cond(
       (self._entries.len() == usize(0)) => .None,
       true => .Some(self._entries(usize(0)))
     )
   ),
-  // Return the entry with the largest key, or .None.
-  max : (fn(self : Self) -> ?(MapEntry(K, V)))(
+  /// Return the entry with the largest key, or `.None`.
+  last_entry : (fn(self : Self) -> Option(MapEntry(K, V)))(
     cond(
       (self._entries.len() == usize(0)) => .None,
       true => .Some(self._entries(self._entries.len() - usize(1)))

--- a/std/collections/deque.yo
+++ b/std/collections/deque.yo
@@ -106,7 +106,7 @@ impl(
     self._len = (self._len + usize(1));
   }),
   // Remove and return the front element.
-  pop_front : (fn(self : Self) -> ?(T))(
+  pop_front : (fn(self : Self) -> Option(T))(
     cond(
       (self._len == usize(0)) => .None,
       true => {
@@ -121,7 +121,7 @@ impl(
     )
   ),
   // Remove and return the back element.
-  pop_back : (fn(self : Self) -> ?(T))(
+  pop_back : (fn(self : Self) -> Option(T))(
     cond(
       (self._len == usize(0)) => .None,
       true => {
@@ -139,7 +139,7 @@ impl(
     )
   ),
   // Get an element by logical index (0 = front).
-  get : (fn(self : Self, index : usize) -> ?(T))(
+  get : (fn(self : Self, index : usize) -> Option(T))(
     cond(
       (index >= self._len) => .None,
       true => {

--- a/std/fs/walker.yo
+++ b/std/fs/walker.yo
@@ -46,7 +46,7 @@ WalkEntry :: struct(
 export(WalkEntry);
 /// Options controlling directory walk behavior.
 WalkOptions :: struct(
-  max_depth : ?(u32),
+  max_depth : Option(u32),
   follow_symlinks : bool,
   include_dirs : bool
 );

--- a/std/sync/channel.yo
+++ b/std/sync/channel.yo
@@ -100,7 +100,7 @@ impl(
   /// Receive a value from the channel.
   /// Blocks if the channel is empty until a value is available.
   /// Returns .Some(value) on success, .None if the channel is closed and empty.
-  recv : (fn(self : Self) -> ?(T))({
+  recv : (fn(self : Self) -> Option(T))({
     self._mutex._raw_lock();
     // Wait while buffer is empty and channel is not closed
     while(runtime(
@@ -152,7 +152,7 @@ impl(
   }),
   /// Try to receive a value without blocking.
   /// Returns .Some(value) if available, .None if empty.
-  try_recv : (fn(self : Self) -> ?(T))({
+  try_recv : (fn(self : Self) -> Option(T))({
     self._mutex._raw_lock();
     cond(
       (self._len.load(MemoryOrder.Relaxed) == usize(0)) => {

--- a/tests/collections/btree_map.test.yo
+++ b/tests/collections/btree_map.test.yo
@@ -113,7 +113,7 @@ test("BTreeMap.min returns smallest key entry", {
   m.insert(i32(30), i32(3));
   m.insert(i32(10), i32(1));
   m.insert(i32(20), i32(2));
-  entry := m.min();
+  entry := m.first_entry();
   assert(entry.is_some(), "min should exist");
   assert(entry.unwrap().key == i32(10), "min key should be 10");
   assert(entry.unwrap().value == i32(1), "min value should be 1");
@@ -123,24 +123,24 @@ test("BTreeMap.max returns largest key entry", {
   m.insert(i32(30), i32(3));
   m.insert(i32(10), i32(1));
   m.insert(i32(20), i32(2));
-  entry := m.max();
+  entry := m.last_entry();
   assert(entry.is_some(), "max should exist");
   assert(entry.unwrap().key == i32(30), "max key should be 30");
   assert(entry.unwrap().value == i32(3), "max value should be 3");
 });
 test("BTreeMap.min returns None for empty map", {
   m := BTreeMap(i32, i32).new();
-  assert(m.min().is_none(), "min should be None for empty map");
+  assert(m.first_entry().is_none(), "first_entry should be None for empty map");
 });
 test("BTreeMap.max returns None for empty map", {
   m := BTreeMap(i32, i32).new();
-  assert(m.max().is_none(), "max should be None for empty map");
+  assert(m.last_entry().is_none(), "last_entry should be None for empty map");
 });
 test("BTreeMap.min and max same for single entry", {
   m := BTreeMap(i32, i32).new();
   m.insert(i32(42), i32(100));
-  assert(m.min().unwrap().key == i32(42), "min key should be 42");
-  assert(m.max().unwrap().key == i32(42), "max key should be 42");
+  assert(m.first_entry().unwrap().key == i32(42), "first_entry key should be 42");
+  assert(m.last_entry().unwrap().key == i32(42), "last_entry key should be 42");
 });
 // ===== Mixed Operations =====
 test("BTreeMap insert then remove then insert again", {
@@ -162,8 +162,8 @@ test("BTreeMap ordering after mixed inserts and removes", {
   m.remove(i32(3));
   m.remove(i32(7));
   assert(m.len() == usize(3), "len should be 3");
-  assert(m.min().unwrap().key == i32(1), "min should be 1");
-  assert(m.max().unwrap().key == i32(9), "max should be 9");
+  assert(m.first_entry().unwrap().key == i32(1), "first_entry should be 1");
+  assert(m.last_entry().unwrap().key == i32(9), "last_entry should be 9");
 });
 // ---- Iterator Tests ----
 test("BTreeMap into_iter - empty map", {


### PR DESCRIPTION
Two §5 items. Both turned out to rest on a wrong premise, which is the pattern this sweep keeps hitting.

## `?(T)` → `Option(T)` — but *not* "pick one everywhere"

§5 offered a choice between the two spellings. The counts decided it differently: of **140** `?(…)` uses in std, **130 are `?(*(…))`** — a nullable **raw pointer**, almost all at the C boundary:

| spelling | count |
| --- | --- |
| `?(*(char))` | 27 |
| `?(*(void))` | 9 |
| `?(*(FILE))`, `?(*(tm))`, `?(*(wchar_t))`, … | rest |

"A C pointer that may be null" reads differently from "an optional value". Flattening that would have *lost* information rather than gained consistency, so the pointer spelling stays.

Only the **10** value-typed uses moved. Three were outside this item's stated `btree_map`/`deque` scope: `std/sync/channel.yo` (`recv`, `try_recv`) and `std/fs/walker.yo` (`WalkOptions.max_depth`).

## `min`/`max` → `first_entry`/`last_entry`

The name was hiding **three unrelated things**:

| | returns | verdict |
| --- | --- | --- |
| `BTreeMap.min/max` | `Option(MapEntry(K,V))` — a whole entry | **renamed** (this is what §5 meant) |
| `imm/sorted_set.min/max` | `Option(T)` — the element | kept, exactly as §5 says |
| `Iterator.min()/max()` | combinator | untouched |

2 declarations + 8 call sites, all in `tests/collections/btree_map.test.yo`.

## Audit document corrections

**`punycode` renames were stale.** §5 still listed `to_ascii`/`to_unicode` → `domain_to_ascii`/`domain_to_unicode`, but §6 round 1 had **deleted the module**. Reconciled in four places (D2 table row, url row, §5 bullet, §6 table row); verified zero `punycode` references remain in `std/`, `src/` or `tests/`.

**Chunk 2's collision check was stated with the wrong evidence.** It listed `std/fmt` as exporting `Alignment/Format/FormatSpec/ToString/Writer/eprint/eprintln/print/println` — the union across `std/fmt/*.yo`. But a glob `open(import("../fmt"))` resolves to the package entry point `std/fmt/index.yo`, which exports only **7**: `ToString Format FormatSpec println print eprintln eprint`. `Writer` and `Alignment` come from the sibling `std/fmt/writer.yo:21,214`, which a glob never pulls in. The conclusion is unchanged and in fact *stronger*, but the reasoning matters for D5: when it introduces an I/O `Writer` trait, the three glob-importers of `std/fmt` will see no clash, because `fmt`'s `Writer` was never in their scope.

## Deferred, with reasons

`ArrayList.remove(start,count)` → `drain(range)` plus a single `remove(idx)` is **not** a rename:

- **D1 settles what §5 left loose.** `remove(idx) -> T` implies panic-on-out-of-bounds, which is precisely the "fourth style" D1 forbids — so it must be `Result(T, ArrayListError)`.
- **It is RC-sensitive.** The existing `remove` hand-writes dup/drop ordering: per-element `dst.* = src.*` for `Type.contains_rc_type(T)`, a tail-drop loop using `unsafe.drop`, and a memmove fast path otherwise. Making it *return* the removed element has to thread through that without double-dropping.

That deserves its own red-first test and battery, not a rename sweep's.

## Verification

| gate | result |
| --- | --- |
| `yo check ./std` | 153/153 |
| `yo check ./src` | 262/262 |
| `yo build` | rc=0 |
| full suite | **2905 / 2905** |
| CLI scorecard | PASS 51, zero golden drift |
| `gates_fast.sh` | `T1_DONE failures=0` |
| `fixpoint_only.sh` | `STAGE3_RC=0 FIXPOINT_HOLDS` |
| `hollow_sweep69.sh` | `SWEEP_GATE_OK` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
