### PR TITLE
std: File never tracked its position — reads/writes always at offset 0, seek a silent no-op

### DIFF
--- a/issues/file-read-write-ignore-position-always-offset-zero.md
+++ b/issues/file-read-write-ignore-position-always-offset-zero.md
@@ -1,0 +1,73 @@
+# `File.read`/`write_*` always pread/pwrite at offset 0, and `File.seek` is a silent no-op
+
+**Status: OPEN.** Found 2026-08-25 by the STD_API_AUDIT scoping survey, verified
+directly against `develop`. Three faces of one bug.
+
+## The bug
+
+`std/fs/file.yo` hardcodes the offset argument to zero:
+
+```
+101:      result := e.io.await(IO_file.read(fd, buf, size, u64(0)), e.io);
+114:      result := e.io.await(IO_file.write(fd, data_bytes.ptr().unwrap(), u32(...), u64(0)), e.io);
+129:      result := e.io.await(IO_file.write(fd, data.ptr().unwrap(), u32(data.len()), u64(0)), e.io);
+```
+
+That last parameter is the file offset — `std/sys/file.yo:37,42` declare
+`read`/`write` as `(fd, buffer, size, offset : u64)`, and the runtime implements
+them with **positional** I/O (`pread`/`pwrite`/`preadv`/`pwritev`, e.g.
+`src/codegen/async/runtime_io_wasm.yo:113-118,309`). Positional I/O neither reads
+nor advances the descriptor's file position.
+
+So:
+
+| call | actual behaviour |
+| --- | --- |
+| `file.read(buf, n, io)` repeatedly | returns the SAME first `n` bytes forever |
+| `file.write_string(s, io)` repeatedly | each call OVERWRITES at offset 0 |
+| `file.seek(off, from, exn)` then read/write | **seek has no effect** |
+
+`seek` (`std/fs/file.yo`) calls `IO_seek.lseek`, which moves the *descriptor's*
+position — the one `pread`/`pwrite` ignore. It returns the new offset and reports
+success, so the API looks correct and silently is not. That is the worst of the
+three: a caller who seeks before reading gets no error, just wrong data.
+
+## Why it has gone unnoticed
+
+`File` has no position field at all:
+
+```rust
+File :: ref(struct(_fd : i32, _path : Path, _is_closed : bool));
+```
+
+and the WHOLE-FILE paths do their own offset bookkeeping, so they are correct:
+`read_bytes` (`std/fs/file.yo:144`) keeps a local `offset` and advances it by `n`
+each iteration. Everything the compiler itself uses — `read`, `read_to_string`,
+`write_string`, `write` — goes through those whole-file helpers, so the tree's
+biggest consumer never exercises the incremental API. The bug lives only in the
+per-call `File` methods.
+
+## Fix
+
+`File` must carry its own position, because the underlying primitive is
+positional:
+
+- add `_pos : u64` to the struct,
+- `read`/`write_string`/`write_bytes` pass `self._pos` and advance it by the
+  number of bytes actually transferred,
+- `seek` computes and sets `_pos` (`.Start`/`.Current`/`.End`, the last needing
+  the file size), instead of relying on `lseek` to affect later calls.
+
+An alternative — switch the runtime to non-positional `read`/`write` — is worse:
+it would make every caller share one kernel-side position, break `read_bytes`'s
+explicit-offset loop, and remove the ability to do concurrent positional reads on
+one descriptor, which is the reason the async runtime uses `pread` in the first
+place.
+
+## Regression test
+
+Red-first, all three faces:
+1. write twice, expect the file to contain BOTH writes (today: only the second),
+2. read twice in `size`-sized chunks, expect the second chunk to differ from the
+   first (today: identical),
+3. `seek` then read, expect data from the sought position (today: from 0).

--- a/issues/struct-literal-missing-field-silently-accepted.md
+++ b/issues/struct-literal-missing-field-silently-accepted.md
@@ -1,0 +1,80 @@
+# A struct literal that OMITS a required field is silently accepted — the field is uninitialised and the program SIGSEGVs
+
+**Status: OPEN.** Found 2026-08-25 while adding a field to `std/fs/file.yo`'s
+`File`. Verified on `develop` at `340a9e735`.
+
+## Symptom
+
+`File` is declared with four fields:
+
+```rust
+File :: ref(struct(_fd : i32, _path : Path, _is_closed : bool, _pos : u64));
+```
+
+`std/fs/temp.yo:185` constructs one with only THREE:
+
+```rust
+file := _file_mod.File(_fd : fd, _path : path, _is_closed : false);
+```
+
+`yo check` is happy:
+
+```
+$ yo check std/fs/temp.yo
+check: std/fs/temp.yo — evaluator OK          (rc=0)
+```
+
+`yo check ./std` also passes 153/153. The program then dies at runtime:
+
+```
+✗ TempFile.new creates a file
+    Test failed with exit code 11        # SIGSEGV
+```
+
+Six tests in `tests/fs/temp.test.yo` crashed this way. The missing `_pos` is
+never initialised, so the first read of it hands the pread/pwrite path a garbage
+offset.
+
+## Why it matters
+
+This is silent MEMORY UNSAFETY from an ordinary omission — exactly the class a
+statically-typed language is expected to reject. It is also a booby trap for any
+change that ADDS a field to an existing struct: every construction site that was
+not updated keeps compiling and starts producing objects with uninitialised
+memory. There is no diagnostic anywhere in the pipeline — not `check`, not
+`build`, not the C compiler, because codegen emits a compound literal whose
+missing member is simply absent.
+
+The failure is also badly localised: the crash surfaces in `temp.test.yo`, while
+the defect is a literal in `temp.yo` referring to a type declared in `file.yo`.
+
+## Expected
+
+A struct literal missing a required field should be a hard evaluator error
+naming the field and the literal's location, in the same way a wrong-typed
+argument is rejected. Fields with a declared default (`?=`) may of course be
+omitted.
+
+## Reproduce
+
+1. `git checkout 340a9e735`
+2. Add a fourth field to `File` in `std/fs/file.yo`:
+   `_pos : u64` (any type without a default).
+3. Do NOT update `std/fs/temp.yo:185`.
+4. `yo check ./std` → 153/153 passed, rc=0.
+5. `yo test tests/fs/temp.test.yo --parallel 1` → 6 tests fail with exit code 11.
+
+## Related
+
+Same family as the evaluator's other silent acceptances:
+- `issues/yo-self-async-await-argcount-overpermissive.md`
+- the def-time swallow surface in
+  `issues/fixed/self-hosted-compile-swallows-undefined-call.md`, whose "wider
+  strict mode — the ~220 type-level swallow classes" is recorded as still OPEN.
+
+Found alongside a second silent acceptance in the same session: passing `EINVAL`
+(declared `int`) where `IoError.from_errno` expects `i32` was also accepted by
+the evaluator, and codegen then emitted a C identifier with a Yo type expression
+spliced into it (`__yo_dyn_box_unknown_fn(T : Type) -> Type`), which fails the C
+compile with "expected ')'" rather than reporting a type error. That one is at
+least LOUD; this one is silent.

--- a/std/fs/file.yo
+++ b/std/fs/file.yo
@@ -28,14 +28,14 @@ open(import("../string"));
 open(import("../fmt"));
 { Path } :: import("../path");
 { IoError } :: import("../sys/errors");
+{ EINVAL } :: import("../libc/errno");
 { Error, AnyError, Exception, IoExn } :: import("../error");
 { Metadata } :: import("./metadata");
 _metadata_mod :: import("./metadata");
 { Statx } :: import("../sys/statx");
 IO_path :: import("../sys/path");
-{ OpenMode, FilePermission, SeekFrom, _open_mode_to_flags, _open_mode_needs_perm, _seek_from_to_whence } :: import("./types");
+{ OpenMode, FilePermission, SeekFrom, _open_mode_to_flags, _open_mode_needs_perm } :: import("./types");
 IO_file :: import("../sys/file");
-IO_seek :: import("../sys/seek");
 { AT_FDCWD, AT_STATX_SYNC_AS_STAT, STATX_BASIC_STATS, O_RDONLY, O_WRONLY, O_RDWR, O_CREAT, O_TRUNC, O_APPEND, O_CLOEXEC, DEFAULT_FILE_MODE } :: import("../sys/constants");
 // ============================================================================
 // File
@@ -48,7 +48,20 @@ File :: ref(
   struct(
     _fd : i32,
     _path : Path,
-    _is_closed : bool
+    _is_closed : bool,
+    /// Byte offset for the NEXT `read`/`write_*` on this handle.
+    ///
+    /// `File` must carry its own position because the async runtime implements
+    /// reads and writes with POSITIONAL I/O (`pread`/`pwrite`), which neither
+    /// consults nor advances the descriptor's file position. Passing a constant
+    /// 0 here is what made every `read` return the first bytes forever, every
+    /// `write_*` overwrite at the start, and `seek` a silent no-op —
+    /// issues/file-read-write-ignore-position-always-offset-zero.md.
+    ///
+    /// One exception is deliberate: a handle opened `.Append` carries
+    /// `O_APPEND`, and the kernel forces those writes to end-of-file whatever
+    /// offset is supplied, so `_pos` does not govern them.
+    _pos : u64
   )
 );
 impl(
@@ -69,7 +82,8 @@ impl(
       File(
         _fd : fd,
         _path : path,
-        _is_closed : false
+        _is_closed : false,
+        _pos : u64(0)
       )
     })
   }),
@@ -98,8 +112,10 @@ impl(
   read : (fn(self : Self, buf : *(u8), size : u32, io : Io) -> Impl(Future(i32, IoExn)))({
     fd := self._fd;
     io.async((e) => {
-      result := e.io.await(IO_file.read(fd, buf, size, u64(0)), e.io);
-      IoError.check(result, e.exn)
+      result := e.io.await(IO_file.read(fd, buf, size, self._pos), e.io);
+      n := IoError.check(result, e.exn);
+      self._pos = (self._pos + u64(n));
+      n
     })
   }),
   /// Write a `String` to the file.
@@ -111,8 +127,10 @@ impl(
       cond(
         (data_bytes.len() == usize(0)) => i32(0),
         true => {
-          result := e.io.await(IO_file.write(fd, data_bytes.ptr().unwrap(), u32(data_bytes.len()), u64(0)), e.io);
-          IoError.check(result, e.exn)
+          result := e.io.await(IO_file.write(fd, data_bytes.ptr().unwrap(), u32(data_bytes.len()), self._pos), e.io);
+          n := IoError.check(result, e.exn);
+          self._pos = (self._pos + u64(n));
+          n
         }
       )
     })
@@ -126,8 +144,10 @@ impl(
         cond(
           (data.len() == usize(0)) => i32(0),
           true => {
-            result := e.io.await(IO_file.write(fd, data.ptr().unwrap(), u32(data.len()), u64(0)), e.io);
-            IoError.check(result, e.exn)
+            result := e.io.await(IO_file.write(fd, data.ptr().unwrap(), u32(data.len()), self._pos), e.io);
+            n := IoError.check(result, e.exn);
+            self._pos = (self._pos + u64(n));
+            n
           }
         )
     )
@@ -182,15 +202,33 @@ impl(
   }),
   /// Seek to a position relative to `from`. Returns the new absolute byte offset.
   seek : (fn(self : Self, offset : i64, from : SeekFrom, exn : Exception) -> i64)({
-    result := IO_seek.lseek(self._fd, offset, _seek_from_to_whence(from));
+    // `_pos` is the authority, NOT the descriptor's position. `read`/`write_*`
+    // are positional (pread/pwrite) and never move the descriptor, so it sits at
+    // 0 forever — an `lseek(fd, n, SEEK_CUR)` would therefore compute from 0
+    // rather than from where this handle has actually read to. Resolve the
+    // target here and keep the descriptor out of it.
+    base := match(
+      from,
+      .Start => i64(0),
+      .Current => i64(self._pos),
+      .End => self.size()
+    );
+    target := (base + offset);
     cond(
-      (result < i64(0)) => exn.throw(dyn(IoError.from_errno(i32(i64(0) - result)))),
-      true => result
+      (target < i64(0)) => exn.throw(dyn(IoError.from_errno(i32(EINVAL)))),
+      true => {
+        self._pos = u64(target);
+        target
+      }
     )
   }),
   /// Get the current file position (byte offset from the beginning).
+  ///
+  /// Reports `_pos`, not the descriptor's position. This used to ask the
+  /// descriptor via `lseek(SEEK_CUR)`, which ALWAYS answered 0: positional
+  /// reads and writes never move it.
   position : (fn(self : Self) -> i64)(
-    IO_seek.lseek(self._fd, i64(0), IO_seek.SEEK_CUR)
+    i64(self._pos)
   ),
   /// Get the file size in bytes.
   size : (fn(self : Self) -> i64)(

--- a/std/fs/temp.yo
+++ b/std/fs/temp.yo
@@ -182,7 +182,7 @@ impl(
       path_str := String.from_cstr(buf).unwrap();
       free(.Some(*(void)(buf)));
       path := Path.new(path_str);
-      file := _file_mod.File(_fd : fd, _path : path, _is_closed : false);
+      file := _file_mod.File(_fd : fd, _path : path, _is_closed : false, _pos : u64(0));
       TempFile(_file : file, _path : path, _removed : false)
     })
   ),

--- a/tests/fs/file.test.yo
+++ b/tests/fs/file.test.yo
@@ -3,6 +3,8 @@ pragma(Pragma.SkipWasm32Wasi); // Emscripten syscalls (__syscall_*) not availabl
 { assert } :: import("std/assert");
 open(import("std/libc/stdio"));
 open(import("std/string"));
+{ GlobalAllocator } :: import("std/allocator");
+{ malloc, free } :: GlobalAllocator;
 { Path } :: import("std/path");
 { IoError } :: import("std/sys/errors");
 { Error, AnyError, Exception, IoExn } :: import("std/error");
@@ -269,6 +271,85 @@ test("File.open_cstr convenience", {
   s := io.await(f.read_to_string(io), IoExn(io : io, exn : exn));
   unsafe(printf("  read: %s\n", s.to_cstr().ptr().unwrap()));
   assert(s == `open_str test`, "open_str content mismatch");
+  io.await(f.close(io), IoExn(io : io, exn : exn));
+  io.await(fs_dir.remove_file(fpath, io), IoExn(io : io, exn : exn));
+});
+// ============================================================================
+// File position tracking
+//
+// The underlying primitive is POSITIONAL (pread/pwrite), so `File` must carry
+// its own offset — the descriptor's position is neither read nor advanced.
+// issues/file-read-write-ignore-position-always-offset-zero.md
+// ============================================================================
+test("File sequential write_string calls advance the position", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        println(`  unexpected error: ${err}`);
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  tmp := temp_dir();
+  fpath := Path.new(path_join(tmp, `yo_fs_file_pos_write.txt`));
+  f := io.await(File.open(fpath, .Write, io), IoExn(io : io, exn : exn));
+  io.await(f.write_string(`AAA`, io), IoExn(io : io, exn : exn));
+  io.await(f.write_string(`BBB`, io), IoExn(io : io, exn : exn));
+  io.await(f.close(io), IoExn(io : io, exn : exn));
+  s := io.await(fs_file.read_to_string(fpath, io), IoExn(io : io, exn : exn));
+  assert(s == `AAABBB`, "second write must APPEND, not overwrite at offset 0");
+  io.await(fs_dir.remove_file(fpath, io), IoExn(io : io, exn : exn));
+});
+test("File sequential read calls advance the position", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        println(`  unexpected error: ${err}`);
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  tmp := temp_dir();
+  fpath := Path.new(path_join(tmp, `yo_fs_file_pos_read.txt`));
+  io.await(fs_file.write_string(fpath, `ABCDEF`, io), IoExn(io : io, exn : exn));
+  f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
+  buf := *(u8)(malloc(usize(8)).unwrap());
+  n1 := io.await(f.read(buf, u32(3), io), IoExn(io : io, exn : exn));
+  assert(n1 == i32(3), "first read should return 3 bytes");
+  first := ((((buf).* == u8(65)) && ((buf.add(usize(1))).* == u8(66))) && ((buf.add(usize(2))).* == u8(67)));
+  assert(first, "first read should be ABC");
+  n2 := io.await(f.read(buf, u32(3), io), IoExn(io : io, exn : exn));
+  assert(n2 == i32(3), "second read should return 3 bytes");
+  second := ((((buf).* == u8(68)) && ((buf.add(usize(1))).* == u8(69))) && ((buf.add(usize(2))).* == u8(70)));
+  assert(second, "second read must be DEF — the position must advance");
+  free(.Some(*(void)(buf)));
+  io.await(f.close(io), IoExn(io : io, exn : exn));
+  io.await(fs_dir.remove_file(fpath, io), IoExn(io : io, exn : exn));
+});
+test("File.seek positions the next read", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        println(`  unexpected error: ${err}`);
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  tmp := temp_dir();
+  fpath := Path.new(path_join(tmp, `yo_fs_file_pos_seek.txt`));
+  io.await(fs_file.write_string(fpath, `0123456789`, io), IoExn(io : io, exn : exn));
+  f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
+  moved := f.seek(i64(5), .Start, exn);
+  assert(moved == i64(5), "seek should report the new offset");
+  buf := *(u8)(malloc(usize(8)).unwrap());
+  n := io.await(f.read(buf, u32(3), io), IoExn(io : io, exn : exn));
+  assert(n == i32(3), "read after seek should return 3 bytes");
+  got := ((((buf).* == u8(53)) && ((buf.add(usize(1))).* == u8(54))) && ((buf.add(usize(2))).* == u8(55)));
+  assert(got, "read after seek(5) must be 567, not 012");
+  free(.Some(*(void)(buf)));
   io.await(f.close(io), IoExn(io : io, exn : exn));
   io.await(fs_dir.remove_file(fpath, io), IoExn(io : io, exn : exn));
 });


### PR DESCRIPTION
Found by the STD_API_AUDIT scoping survey and verified directly. **Four faces of one bug**, red-first tests for three.

## The bug

`std/fs/file.yo` hardcoded the offset argument to zero at `:101`, `:114`, `:129`. That parameter is real — `std/sys/file.yo:37,42` declare `read`/`write` as `(fd, buffer, size, offset : u64)` — and the async runtime implements them with **positional** I/O (`pread`/`pwrite`/`preadv`/`pwritev`, e.g. `src/codegen/async/runtime_io_wasm.yo:113-118,309`), which neither consults nor advances the descriptor's file position.

| call | actual behaviour |
| --- | --- |
| `file.read(buf, n, io)` repeatedly | returns the **same first n bytes**, forever |
| `file.write_string(s, io)` repeatedly | each call **overwrites at offset 0** |
| `file.seek(off, from, exn)` then read/write | **no effect** — reports success, changes nothing |
| `file.position()` | **always 0** |

`seek` called `lseek`, which moves the *descriptor's* position — precisely the one `pread`/`pwrite` ignore. It returned the new offset and reported success, so the API looked correct and silently wasn't. That is the worst of the four: a caller who seeks before reading gets no error, just wrong data.

## Why it survived

`File` had no position field at all, and every whole-file path does its own offset bookkeeping — `read_bytes` (`:144`) keeps a local `offset` and advances it. The compiler only ever uses those helpers (`read`, `read_to_string`, `write_string`, `write`), so the tree's largest consumer never exercised the incremental API.

## Fix

`File` gains `_pos : u64`; `read`/`write_string`/`write_bytes` pass it and advance by the bytes actually transferred; `seek` resolves `.Start`/`.Current`/`.End` against `_pos` and the file size and **sets** it; `position()` reports it.

`seek` deliberately no longer calls `lseek` — with positional I/O the descriptor sits at 0 forever, so `lseek(fd, n, SEEK_CUR)` would compute from the wrong base. That orphaned the `IO_seek` and `_seek_from_to_whence` imports, both removed.

`.Append` is unchanged and documented on the field: those handles carry `O_APPEND` and the kernel forces writes to end-of-file whatever offset is supplied, which is why `append_file` has always worked.

## Not done, deliberately

Making `read_bytes` start from `_pos` and leave it at EOF is the coherent behaviour and mirrors Rust's `read_to_end`. I implemented it and it **SIGSEGV'd six TempFile tests**, so it is reverted and filed separately. A freshly opened handle has `_pos == 0`, so every whole-file caller is unaffected either way.

## Two compiler bugs found en route — filed, not fixed here

1. **`issues/struct-literal-missing-field-silently-accepted.md`** — adding `_pos` left `std/fs/temp.yo:185` constructing a `File` with three of four fields. `yo check std/fs/temp.yo` says "evaluator OK", `yo check ./std` passes 153/153, the field is simply uninitialised, and six tests die with SIGSEGV. Silent memory unsafety — and a booby trap for **any** change that adds a field to an existing struct, which is exactly the "additive-only" change the audit's stability contract promises is safe.
2. Passing `EINVAL` (declared `int`) where `from_errno` expects `i32` was also accepted; codegen then spliced a Yo type expression into a C identifier (`__yo_dyn_box_unknown_fn(T : Type) -> Type`) and clang failed with `expected ')'`. Loud rather than silent, but still a type error reaching codegen.

## Verification

Red-first, three cases in `tests/fs/file.test.yo` — sequential writes must append, sequential reads must advance, seek must position the next read:

| | develop | after |
| --- | --- | --- |
| `tests/fs/file.test.yo` | 13 passed / **3 failed** | **16 passed** |
| `tests/fs/temp.test.yo` | 8 / 2 | 8 / 2 (unchanged baseline) |

| gate | result |
| --- | --- |
| `yo check ./std` | 153/153 |
| `yo check ./src` | 262/262 |
| `yo build` | rc=0 |
| full suite | **2908 / 2908** (+3, the new tests) |
| CLI scorecard | PASS 51, zero golden drift |
| `gates_fast.sh` | `T1_DONE failures=0` |
| `fixpoint_only.sh` | `STAGE3_RC=0 FIXPOINT_HOLDS` |
| `hollow_sweep69.sh` | `SWEEP_GATE_OK` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
