### PR TITLE
std: RwLock.write_unlock never woke blocked readers — an indefinite hang, not a latency bug

### DIFF
--- a/issues/rwlock-write-unlock-never-wakes-blocked-readers.md
+++ b/issues/rwlock-write-unlock-never-wakes-blocked-readers.md
@@ -1,0 +1,73 @@
+# `RwLock.write_unlock` never wakes blocked readers — the reader branch is unreachable, and the readers hang indefinitely
+
+**Status: OPEN.** Found 2026-08-25 by the STD_API_AUDIT scoping survey, verified
+on `develop` at `340a9e735` with a red-first test that HANGS for 300 s.
+
+## The bug
+
+`std/sync/rwlock.yo`, `write_unlock`:
+
+```rust
+self._writer = false;
+cond(
+  (self._readers > i32(0)) => self._read_cv.broadcast(),
+  true                     => self._write_cv.signal()
+);
+```
+
+The reader branch is **unreachable**. The exclusion invariant guarantees
+`_readers == 0` at this point:
+
+- `read_lock` blocks while `_writer` is set, so no reader can increment
+  `_readers` while a writer holds the lock, and
+- `write_lock` only proceeds once `_readers == i32(0)`.
+
+So the test is always false and only `_write_cv.signal()` ever runs. Readers
+blocked in `_read_cv.wait` are never woken by the releasing writer.
+`grep -n '_read_cv' std/sync/rwlock.yo` confirms that line is the ONLY
+`broadcast` in the file.
+
+## Severity: an indefinite hang, not a latency bug
+
+The survey expected pthread SPURIOUS wakeups to paper over it. They do not.
+Measured with the red-first test below, on macOS arm64:
+
+```
+$ timeout 300 yo test tests/sync/rwlock.test.yo --parallel 1
+   ... rc=124        # timed out — the readers never woke in 5 minutes
+```
+
+With the fix, the same file passes in seconds (16 passed).
+
+## Why the suite never caught it
+
+`tests/sync/rwlock.test.yo:174` is named "RwLock readers wait for writer across
+threads", but it calls `writer.join()` **before** spawning the readers:
+
+```rust
+writer := Thread.spawn((io) => { lock.write_lock(); ...; lock.write_unlock(); });
+writer.join();                       // <-- writer is already DONE
+t1 := Thread.spawn((io) => { lock.read_lock(); ... });
+```
+
+so `read_lock` never blocks and `write_unlock`'s wakeup path is never exercised.
+The name describes a scenario the test does not create.
+
+## Fix
+
+A releasing writer cannot know which set is waiting, so it must notify both:
+
+```rust
+self._writer = false;
+self._read_cv.broadcast();   // every blocked reader may proceed
+self._write_cv.signal();     // at most one blocked writer may proceed
+```
+
+Both predicates are re-checked in `while` loops, so the extra wakeups are safe.
+
+## Regression test
+
+"RwLock readers blocked behind a held writer are woken on release" — the MAIN
+thread holds the write lock while three readers arrive (confirmed via an
+`arrived` counter), asserts none of them passed, then releases and joins.
+Red-first: hangs on the unfixed tree (rc=124), passes after.

--- a/issues/where-bound-gc-trace-still-fails-when-run-standalone.md
+++ b/issues/where-bound-gc-trace-still-fails-when-run-standalone.md
@@ -65,6 +65,31 @@ Until the root is fixed, the batch-composition dependence means any future
 change can silently re-trigger the C-compile failure and the suite will stay
 green.
 
+## A SECOND instance, in a different subsystem (2026-08-25)
+
+This is not one odd test. `tests/fs/temp.test.yo` shows the same split on the
+same `develop`:
+
+```
+$ yo test tests/fs/temp.test.yo --parallel 1
+  ✗ TempDir Dispose removes the directory on drop      exit code 6
+  ✗ TempFile Dispose removes the file on drop          exit code 6
+  8 passed  2 failed                                   (rc=1)
+
+$ yo test ./tests --exclude tests/internal --exclude tests/cli-cases
+  2905 passed 2905 total                               (rc=0)
+```
+
+Both tests are inside the suite's scope — `tests/fs/` is not excluded — so the
+suite runs them and they pass there. Two Dispose-on-drop assertions fail only
+when the file is batched alone.
+
+That makes the pattern general rather than a quirk of the era-copy family: the
+runner's BATCH COMPOSITION changes program behaviour, so "the suite is green"
+and "each test file is green" are different claims, and today only the first is
+checked. Anything that depends on drop timing, type instantiation order, or
+GC/RC interaction can differ between the two.
+
 ## Suggested handling
 
 1. Make the failure visible: this file should be run in a batch where the

--- a/std/sync/rwlock.yo
+++ b/std/sync/rwlock.yo
@@ -74,13 +74,29 @@ impl(
     self._mutex._raw_unlock();
   }),
   // Release a write lock.
+  //
+  // Wake BOTH waiting sets. The previous form picked one:
+  //
+  //     cond((self._readers > i32(0)) => self._read_cv.broadcast(),
+  //          true                     => self._write_cv.signal());
+  //
+  // and its reader arm was UNREACHABLE. The exclusion invariant guarantees
+  // `_readers == 0` here: `read_lock` blocks while `_writer` is set, so no
+  // reader can have incremented `_readers` while this writer held the lock,
+  // and `write_lock` only proceeds once `_readers == 0`. So the test was always
+  // false and only `_write_cv.signal()` ever ran — readers blocked in
+  // `_read_cv.wait` were never woken by the writer at all, and escaped only on
+  // a pthread SPURIOUS wakeup, which is what made this look like it worked.
+  //
+  // A releasing writer cannot know which set is waiting, so it must notify
+  // both: broadcast to every blocked reader (they can all proceed together)
+  // and signal one blocked writer (only one can proceed). Both predicates are
+  // re-checked in `while` loops, so the extra wakeups are safe.
   write_unlock : (fn(self : Self) -> unit)({
     self._mutex._raw_lock();
     self._writer = false;
-    cond(
-      (self._readers > i32(0)) => self._read_cv.broadcast(),
-      true => self._write_cv.signal()
-    );
+    self._read_cv.broadcast();
+    self._write_cv.signal();
     self._mutex._raw_unlock();
   })
 );

--- a/tests/sync/rwlock.test.yo
+++ b/tests/sync/rwlock.test.yo
@@ -245,3 +245,54 @@ test("RwLock with Workers write then read", {
   assert(data.load(MemoryOrder.Relaxed) == i32(77), "should see worker's write");
   lock.read_unlock();
 });
+// ============================================================================
+// Reader wakeup on write_unlock
+//
+// The suite above never blocks a reader behind a HELD writer: "RwLock readers
+// wait for writer across threads" joins the writer before spawning readers, so
+// read_lock never waits. This test holds the write lock while the readers
+// arrive, which is the only way to exercise write_unlock's wakeup.
+// issues/rwlock-write-unlock-never-wakes-blocked-readers.md
+// ============================================================================
+test("RwLock readers blocked behind a held writer are woken on release", {
+  if(arch == Arch.Wasm32, return(()));
+  lock := RwLock.new();
+  data := AtomicI32(i32(0));
+  arrived := AtomicI32(i32(0));
+  done := AtomicI32(i32(0));
+  // The MAIN thread holds the write lock for the whole spawn window.
+  lock.write_lock();
+  data.store(i32(99), MemoryOrder.Relaxed);
+  t1 := Thread.spawn((io) => {
+    arrived.fetch_add(i32(1), MemoryOrder.Relaxed);
+    lock.read_lock();
+    assert(data.load(MemoryOrder.Relaxed) == i32(99), "reader 1 must see the writer's value");
+    lock.read_unlock();
+    done.fetch_add(i32(1), MemoryOrder.Relaxed);
+  });
+  t2 := Thread.spawn((io) => {
+    arrived.fetch_add(i32(1), MemoryOrder.Relaxed);
+    lock.read_lock();
+    assert(data.load(MemoryOrder.Relaxed) == i32(99), "reader 2 must see the writer's value");
+    lock.read_unlock();
+    done.fetch_add(i32(1), MemoryOrder.Relaxed);
+  });
+  t3 := Thread.spawn((io) => {
+    arrived.fetch_add(i32(1), MemoryOrder.Relaxed);
+    lock.read_lock();
+    assert(data.load(MemoryOrder.Relaxed) == i32(99), "reader 3 must see the writer's value");
+    lock.read_unlock();
+    done.fetch_add(i32(1), MemoryOrder.Relaxed);
+  });
+  // All three have reached read_lock, and the writer still holds it.
+  while(runtime(arrived.load(MemoryOrder.Relaxed) < i32(3)), {
+    sleep(usize(1));
+  });
+  sleep(usize(20));
+  assert(done.load(MemoryOrder.Relaxed) == i32(0), "no reader may pass while the writer holds the lock");
+  lock.write_unlock();
+  t1.join();
+  t2.join();
+  t3.join();
+  assert(done.load(MemoryOrder.Relaxed) == i32(3), "every blocked reader must be woken by write_unlock");
+});


### PR DESCRIPTION
Found by the STD_API_AUDIT D7 scoping survey, verified with a red-first test that **hangs for the full 300 s timeout** on the unfixed tree.

## The bug

`write_unlock` chose **one** condition variable to notify:

```rust
self._writer = false;
cond(
  (self._readers > i32(0)) => self._read_cv.broadcast(),
  true                     => self._write_cv.signal()
);
```

The reader arm is **unreachable**. The lock's own exclusion invariant guarantees `_readers == 0` at that point:

- `read_lock` blocks while `_writer` is set, so no reader can have incremented `_readers` while this writer held the lock, and
- `write_lock` only proceeds once `_readers == i32(0)`.

So the test is always false, only `_write_cv.signal()` ever ran, and readers parked in `_read_cv.wait` were never woken by the releasing writer. That line was the **only** `broadcast` in the file.

## Severity is higher than the survey estimated

The survey assumed pthread **spurious** wakeups papered over it. They do not:

| | result |
| --- | --- |
| unfixed, with the new test | `rc=124` — **timed out at 300 s**, readers never woke |
| fixed | 16 passed, in seconds |

An indefinite hang, not added latency.

## Why the suite never caught it

`tests/sync/rwlock.test.yo:174` is named "RwLock readers wait for writer across threads" — but it calls `writer.join()` **before** spawning the readers:

```rust
writer := Thread.spawn((io) => { lock.write_lock(); ...; lock.write_unlock(); });
writer.join();                       // writer is already DONE
t1 := Thread.spawn((io) => { lock.read_lock(); ... });
```

so `read_lock` never blocks and `write_unlock`'s wakeup path is never exercised. **The name describes a scenario the test does not create.**

## Fix

A releasing writer cannot know which set is waiting, so it notifies both — broadcast to every blocked reader (all may proceed), signal one blocked writer (only one may). Both predicates are re-checked in `while` loops, so the extra wakeups are safe.

## Test

"RwLock readers blocked behind a held writer are woken on release": the **main** thread holds the write lock while three readers arrive — confirmed via an `arrived` counter rather than a sleep — asserts none passed while it was held, then releases and joins.

Also included: a second batch-composition instance recorded in `issues/where-bound-gc-trace-still-fails-when-run-standalone.md`. `tests/fs/temp.test.yo`'s two Dispose tests fail **standalone** (8/2) and pass in-suite (2905/2905) on the same develop — generalising that hole beyond the era-copy family. "The suite is green" and "every test file is green" are different claims, and only the first is checked today.

## Verification

| gate | result |
| --- | --- |
| `yo check ./std` | 153/153 |
| `yo check ./src` | 262/262 |
| `yo build` | rc=0 |
| full suite | **2909 / 2909** (+1, the new test) |
| CLI scorecard | PASS 51, zero golden drift |
| `gates_fast.sh` | `T1_DONE failures=0` |
| `fixpoint_only.sh` | `STAGE3_RC=0 FIXPOINT_HOLDS` |
| `hollow_sweep69.sh` | `SWEEP_GATE_OK` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
