### PR TITLE
issues: close the two S2 bugs already fixed on develop

### DIFF
--- a/issues/fixed/file-read-write-ignore-position-always-offset-zero.md
+++ b/issues/fixed/file-read-write-ignore-position-always-offset-zero.md
@@ -1,7 +1,11 @@
 # `File.read`/`write_*` always pread/pwrite at offset 0, and `File.seek` is a silent no-op
 
-**Status: OPEN.** Found 2026-08-25 by the STD_API_AUDIT scoping survey, verified
-directly against `develop`. Three faces of one bug.
+**Status: FIXED 2026-08-25** in `8825bbb39` ("std: File never tracked its
+position", PR #277) — `File` gained a `_pos : u64` field that `read`/`write_*`
+advance and `seek` sets, with `tests/fs/file.test.yo` covering sequential reads,
+sequential writes, and all three `SeekFrom` origins. Found 2026-08-25 by the
+STD_API_AUDIT scoping survey, verified directly against `develop`. Three faces
+of one bug.
 
 ## The bug
 

--- a/issues/fixed/rwlock-write-unlock-never-wakes-blocked-readers.md
+++ b/issues/fixed/rwlock-write-unlock-never-wakes-blocked-readers.md
@@ -1,7 +1,11 @@
 # `RwLock.write_unlock` never wakes blocked readers — the reader branch is unreachable, and the readers hang indefinitely
 
-**Status: OPEN.** Found 2026-08-25 by the STD_API_AUDIT scoping survey, verified
-on `develop` at `340a9e735` with a red-first test that HANGS for 300 s.
+**Status: FIXED 2026-08-25** in `d6748e4cc` ("std: RwLock.write_unlock never
+woke blocked readers") — `write_unlock` now clears `_writer` and issues BOTH a
+reader `broadcast()` and a writer `signal()` unconditionally, so a reader
+blocked behind a writer is always woken. `tests/sync/rwlock.test.yo` carries the
+red-first case that used to hang for 300 s. Found 2026-08-25 by the
+STD_API_AUDIT scoping survey, verified on `develop` at `340a9e735`.
 
 ## The bug
 

--- a/issues/int-vs-i32-mismatch-reaches-codegen-and-emits-malformed-c.md
+++ b/issues/int-vs-i32-mismatch-reaches-codegen-and-emits-malformed-c.md
@@ -1,7 +1,7 @@
 # Passing a C `int` where `i32` is declared is accepted by the evaluator, and codegen splices a Yo type expression into a C identifier
 
 **Status: OPEN.** Found 2026-08-25 while fixing
-`issues/file-read-write-ignore-position-always-offset-zero.md`.
+`issues/fixed/file-read-write-ignore-position-always-offset-zero.md`.
 
 ## Symptom
 

--- a/issues/tempfile-dispose-and-file-pos-interaction.md
+++ b/issues/tempfile-dispose-and-file-pos-interaction.md
@@ -25,7 +25,7 @@ different batch, is NOT yet established — that is the open question here.
 
 ## 2. Making `read_bytes` honour `File._pos` crashes six of these tests
 
-While fixing `issues/file-read-write-ignore-position-always-offset-zero.md`,
+While fixing `issues/fixed/file-read-write-ignore-position-always-offset-zero.md`,
 `read_bytes` was changed to start from `self._pos` and leave it at EOF (rather
 than a local `offset := u64(0)`), so that mixing it with the incremental `read`
 stays coherent. That is the correct behaviour and mirrors Rust's `read_to_end`.


### PR DESCRIPTION
Two bugs found by the STD_API_AUDIT scoping survey were fixed on `develop` but their docs were still filed as **OPEN** in `issues/` root, so the open-issue list overstated what is broken.

- **`File.read`/`write_*` always pread/pwrite at offset 0; `File.seek` a silent no-op** — fixed in `8825bbb39` (#277): `File` gained `_pos : u64`, reads/writes advance it, `seek` sets it. Covered by `tests/fs/file.test.yo` (sequential reads, sequential writes, all three `SeekFrom` origins).
- **`RwLock.write_unlock` never woke blocked readers** — fixed in `d6748e4cc`: the old `cond` picked one waiting set and its reader arm was unreachable under the exclusion invariant, so readers escaped only on spurious pthread wakeups. `write_unlock` now broadcasts to readers *and* signals a writer unconditionally. Covered by the red-first case in `tests/sync/rwlock.test.yo` (unfixed tree times out at 300 s).

Each doc now records the fixing commit and the covering test; both move to `issues/fixed/`, and the two inbound references are repointed.

**Docs only** — no `.yo` file changed, so no battery was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)