### PR TITLE
gates: the hollow detector was line-anchored, so mid-line untranspiled markers scored clean

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -200,6 +200,34 @@ Debugging one:
   `Eq` on the payload type specialized, which is a much heavier requirement than
   the assertion actually needs.
 
+#### Counting untranspiled bodies: never anchor to start-of-line
+
+Use `scripts/count-transpile-failures.sh <emitted.c>` — do not hand-roll a
+`grep`. Two things make a hand-rolled one wrong in opposite directions:
+
+- **Overcount.** Codegen spells its own marker strings (`String.from("// Failed
+  to transpile ")`), so the compiler compiling itself bakes them into stage-2 as
+  C string literals. That floor is 15 as of 2026-08-25 and moves whenever
+  codegen gains or loses a fallback branch — it is not the "fixed floor of 2"
+  older docs assert.
+- **Undercount.** `grep -cE '^\s*// Failed to transpile'` scores only the
+  standalone-comment form. Codegen also emits markers **mid-line**, as
+  `return // Failed to transpile <expr>;` and
+  `__yo_tN tmp = // Failed to transpile <expr>;`, and anchoring calls those
+  clean. That is the mistake that let a hollow `io.async` closure body ship
+  green (`issues/ftt-stub-in-live-closure-falls-off-non-void-function.md`).
+
+The rule that separates them: a **string-literal** occurrence is immediately
+preceded by a double quote; an **emitted marker** never is. Match anywhere on
+the line, then reject matches whose preceding byte is `"`. This is the same
+discriminator the codegen abort-stub detector uses
+(`src/codegen/functions/generation.yo`, PR #275).
+
+`fixpoint_only.sh` and `chunked_gate.sh` both call the script, and
+`fixpoint_only.sh` **gates** on it: a stage-2 carrying an untranspiled body is a
+broken compiler even when stage2 == stage3 byte-for-byte, because both stages
+emit the same hole.
+
 ### macOS 26 AMFI / ASAN dylib workaround
 
 On macOS 26+ (current release), locally-compiled C binaries linked against the

--- a/scripts/bootstrap/chunked_gate.sh
+++ b/scripts/bootstrap/chunked_gate.sh
@@ -50,7 +50,9 @@ echo "CHUNKED_EMIT_RC=$?"
 # A "Failed to transpile" marker in either emission would make a byte-identical
 # comparison vacuous — both could be equally hollow.
 for f in "/tmp/${P}_emit_single.c" "/tmp/${P}_emit_chunked.c"; do
-  echo "$(basename "$f") hollow=$(grep -cE '^\s*// (Failed to transpile|Unknown type:)' "$f")"
+  # Same detector as fixpoint_only.sh — anchoring to start-of-line misses the
+  # `return // Failed to transpile x;` and `__yo_tN tmp = // ...` forms.
+  echo "$(basename "$f") hollow=$(bash scripts/count-transpile-failures.sh "$f" | cut -d' ' -f1)"
 done
 
 if cmp -s "/tmp/${P}_emit_single.c" "/tmp/${P}_emit_chunked.c"; then

--- a/scripts/bootstrap/fixpoint_only.sh
+++ b/scripts/bootstrap/fixpoint_only.sh
@@ -6,7 +6,17 @@ cd "$(dirname "$0")/../.." || exit 2
 S1=${S1:?}; P=${P:?}
 YO_MAIN_STACK_MB=4096 "$S1" compile src/main.yo --release --emit-c --skip-c-compiler -o /tmp/${P}_stage2 &> /tmp/${P}_stage2_emit.log
 echo "STAGE2_RC=$?"
-echo "stage2 hollow=$(grep -cE '^\s*// (Failed to transpile|Unknown type:)' /tmp/${P}_stage2.c)"
+# GATE, not a readout: a stage-2 C carrying an untranspiled body is a broken
+# compiler even when stage2 == stage3 byte-for-byte (both stages would emit the
+# same hole). The count comes from scripts/count-transpile-failures.sh so the
+# string-literal floor and the mid-line marker forms are handled in one place —
+# the previous inline `grep -cE '^\s*// ...'` here anchored to start-of-line and
+# so scored `return // Failed to transpile x;` as clean.
+if bash scripts/count-transpile-failures.sh /tmp/${P}_stage2.c; then
+  echo "stage2 hollow=0"
+else
+  echo "stage2 hollow>0 STAGE2_HOLLOW_GATE_FAILED"
+fi
 clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 /tmp/${P}_stage2.c -o /tmp/${P}_s2 2> /tmp/${P}_clang.log
 echo "CLANG_RC=$?"
 YO_MAIN_STACK_MB=4096 /tmp/${P}_s2 compile src/main.yo --release --emit-c --skip-c-compiler -o /tmp/${P}_stage3 &> /tmp/${P}_stage3_emit.log

--- a/scripts/count-transpile-failures.sh
+++ b/scripts/count-transpile-failures.sh
@@ -1,27 +1,43 @@
 #!/usr/bin/env bash
-# Count REAL "Failed to transpile" markers in an emitted C file (P1 metric).
+# Count REAL untranspiled-body markers in an emitted C file.
 #
-# WHY THIS EXISTS: a naive `grep -c "Failed to transpile" stage2.c` OVERCOUNTS by
-# a fixed floor of 2. When the self-hosted compiler emits an unhandled expression
-# it writes a COMMENT LINE `// Failed to transpile <expr>` into its output. But the
-# codegen's own fallback branches DEFINE that message as a string literal —
-# `out := String.from("// Failed to transpile ")` at src/codegen/exprs/
-# generation.yo:409 (value-emit) and :577 (ref-emit). When yo-self compiles
-# yo-self, those two source strings become two C string literals
-# (`(const uint8_t*)"// Failed to transpile "`) baked into stage2.c — matched by a
-# naive grep even though they are not failures. Every historical P1 count
-# (527 → 30 → … → 2) was inflated by this floor of 2; "2" means ZERO real failures.
+# WHY THIS EXISTS: a naive `grep -c "Failed to transpile" stage2.c` OVERCOUNTS.
+# When codegen cannot emit an expression it writes `// Failed to transpile
+# <expr>` (or `// Unknown type: <t>`) into its output. But the codegen's own
+# fallback branches DEFINE those messages as string literals — e.g.
+# `out := String.from("// Failed to transpile ")` in
+# src/codegen/exprs/generation.yo. When the compiler compiles itself, each such
+# source string becomes a C string literal (`(const uint8_t*)"// Failed to
+# transpile "`) baked into stage2.c, which a naive grep counts as a failure.
+# That floor is NOT a fixed number — it tracks how many such literals the
+# codegen currently spells (15 on 2026-08-25, 2 when this script was written).
 #
-# A REAL marker is an emitted COMMENT line: leading whitespace then `// Failed`.
-# A FLOOR occurrence is inside a string literal: `…"// Failed` (non-`/` before it).
-# Distinguish by anchoring the comment form to the start of the line.
+# HOW TO TELL THEM APART: a string-literal occurrence is immediately preceded
+# by a double quote; an emitted marker never is. That is the same rule the
+# codegen's own abort-stub detector uses
+# (src/codegen/functions/generation.yo, PR #275).
+#
+# DO NOT go back to anchoring the comment form to the start of the line
+# (`^[[:space:]]*// Failed`). That was this script's original rule and it
+# UNDERCOUNTS: codegen also emits markers mid-line, as
+# `return // Failed to transpile <expr>;` and
+# `__yo_tN tmp = // Failed to transpile <expr>;`. Anchoring silently scores
+# those as clean — the same mistake that let a hollow `io.async` closure body
+# ship green (issues/ftt-stub-in-live-closure-falls-off-non-void-function.md).
 #
 # Usage: scripts/count-transpile-failures.sh <emitted.c>
-#   Prints "<real> real (<floor> string-literal floor)" and exits non-zero if
-#   real > 0 (so CI / drain loops can gate on real failures only).
-set -euo pipefail
+#   Prints "<real> real (<floor> string-literal floor) — <f>" and exits
+#   non-zero if real > 0, so gates and drain loops can key on real failures.
+set -uo pipefail
 f="${1:?usage: count-transpile-failures.sh <emitted.c>}"
-real=$(grep -cE '^[[:space:]]*// Failed to transpile' "$f" || true)
-floor=$(grep -cE '"// Failed to transpile' "$f" || true)
+# `.?` captures the byte before each marker (empty at start-of-line), so the
+# string-literal form sorts under a leading `"`.
+hits=$(grep -oE '.?// (Failed to transpile|Unknown type:)' "$f" || true)
+if [ -z "$hits" ]; then
+  real=0; floor=0
+else
+  real=$(printf '%s\n' "$hits" | grep -vc '^"' || true)
+  floor=$(printf '%s\n' "$hits" | grep -c '^"' || true)
+fi
 echo "$real real ($floor string-literal floor) — $f"
 [ "$real" -eq 0 ]


### PR DESCRIPTION
## The bug

`scripts/count-transpile-failures.sh`, and the two inline copies of its grep in `scripts/bootstrap/fixpoint_only.sh` and `scripts/bootstrap/chunked_gate.sh`, counted only markers anchored to the start of a line:

```
grep -cE '^\s*// (Failed to transpile|Unknown type:)'
```

Codegen also emits markers **mid-line**:

```c
  return // Failed to transpile <expr>;
  __yo_t7 tmp = // Failed to transpile <expr>;
```

The anchored rule scores those as clean. That is the same blind spot that let a hollow `io.async` closure body ship with `check`, `build` and the whole suite green — `issues/ftt-stub-in-live-closure-falls-off-non-void-function.md`.

## The fix

The discriminator that actually works, and the one codegen's own abort-stub detector already uses (#275): **a string-literal occurrence is immediately preceded by a double quote; an emitted marker never is.** So match anywhere on the line and reject matches whose preceding byte is `"`.

- `count-transpile-failures.sh` uses that rule, for both marker forms.
- The two gate scripts call it instead of re-spelling a grep.
- `fixpoint_only.sh` now **gates** on the count rather than echoing it. A stage-2 C carrying an untranspiled body is a broken compiler even when stage2 == stage3 byte-for-byte — both stages emit the same hole, so the byte comparison is vacuous there.
- The script's "fixed floor of 2" comment was stale: the floor is however many marker strings codegen currently spells, which is **15** today.

## Measurement

| input | old anchored rule | new rule |
| --- | --- | --- |
| the real stage-2 C from this tree (146 MB) | 0 | **0 real, 15 floor**, rc=0 |
| synthetic: 1 standalone marker, 2 mid-line, 1 `Unknown type:`, 2 string literals | 1 | **4 real**, rc=1 |

So turning the readout into a gate is free today, and the negative control shows the three previously-invisible forms are now caught.

Shell scripts and docs only — no `.yo` changed, so no battery. The next fixpoint run exercises the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)