### PR TITLE
std: D4 PRs 1-2 — the additive char_* vocabulary, and pinning every char-semantics site while the old basis still holds

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -119,6 +119,37 @@ is the same multiset of statements; the symbol-set diff says no function was
 added, removed or renamed. In-order differences that remain are pure
 declaration reordering.
 
+**And for a "no behaviour change" REWRITE, drop the emitted C entirely —
+compare the program's OUTPUT.** The recipe above still assumes the source is
+additive. A refactor that claims to preserve behaviour while changing function
+BODIES (a loop rewritten onto a different iterator, a method renamed and
+delegated) makes the emitted C differ on purpose, so no C-level comparison
+— normalized or not — can pass without weakening it into meaninglessness.
+Measured 2026-08-26 on the D4 PR 2 migration: 13567 → 14139 lines and a
+different symbol set, from a change whose whole contract was "no behaviour
+change". The gate that has teeth:
+
+```bash
+# 1. BEFORE editing: a standalone driver over the touched surface, with a
+#    corpus that includes the inputs the refactor is ABOUT (multibyte, empty,
+#    boundary). Print every result AND its length, so a silent truncation
+#    shows up.
+yo compile tmp/probe.yo --std-path "$PWD/std" --release -o tmp/probe.bin
+./tmp/probe.bin > before.txt; shasum -a 256 before.txt
+# 2. AFTER: same binary rebuilt, same corpus.
+./tmp/probe.bin > after.txt; diff before.txt after.txt     # must be EMPTY
+```
+
+Two companions make it airtight. **Body-identity** where the refactor claims a
+pure rename: extract the old body with `git show HEAD:<file>` and compare it
+character-for-character to the new one — that covers call sites no runtime test
+can reach (compiler-internal code, which does not take effect until the tree is
+rebuilt). And a **simulated future state**: if the refactor exists to survive a
+change that has not landed yet, apply that change in a throwaway edit and run
+the new tests against it, then run them again with the pre-refactor file. The
+new tests must fail in the second run. If they pass both ways they are not
+testing the refactor.
+
 So for a rename sweep the gate is the FULL suite plus READING the cli-case
 golden diff — never check/build. A golden that gets SMALLER or reports FEWER
 findings (`Scanned 1 .yo file(s)` -> `Scanned 0`) is a regression signal, not

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -88,6 +88,37 @@ symlink loop made `walk_with` return an EMPTY list, so `yo fetch`, `yo version`
 and both report lints kept building and traversed nothing. See
 `issues/ftt-stub-in-live-closure-falls-off-non-void-function.md`.
 
+### "Byte-identity of the emitted C" does NOT survive a `std/` source edit
+
+The standing acceptance test for an *additive codegen* change — record `sha256`
+of the emitted-C corpus before editing, require `same=N diff=0` — is only valid
+when the `.yo` SOURCE is unchanged. Generated C identifiers embed two families
+of number: anonymous type ids (`__yo_tN`) and a global declaration/expression
+counter (`yo_id_N`, `struct_decl_N`, `enum_decl_N`, `loop_yo_id_N`). **Adding
+declarations anywhere in `std/` shifts every counter ordered after the insertion
+point by a constant and permutes the `__yo_tN` numbering**, so the `.c` changes
+`sha256` even when the program is provably identical. Measured 2026-08-26 while
+adding six unused methods to `std/string/string.yo`: the shift was a uniform
++1004, and the numbers appear in `std/collections/array_list.yo` and
+`std/allocator.yo` identifiers too, not just the edited file's.
+
+Compare like this instead — it is strictly stronger than a `sha256` match:
+
+```bash
+norm() { sed -E 's/__yo_t[0-9]+/__yo_tT/g; s/__YO_T[0-9]+/__YO_TT/g;
+                 s/yo_id_[0-9]+/yo_id_N/g; s/(struct_decl|enum_decl|decl)_[0-9]+/\1_N/g;
+                 s/_temp_[0-9]+/_temp_N/g' "$1"; }
+diff <(norm before.c | sort) <(norm after.c | sort)          # must be EMPTY
+diff <(grep -oE '__yo_[A-Za-z0-9_]+\(' before.c | sort -u) \
+     <(grep -oE '__yo_[A-Za-z0-9_]+\(' after.c  | sort -u)  # must be EMPTY
+grep -c '<the new API you added>' after.c                    # must be 0 if unused
+```
+
+An empty sorted-normalized diff with equal line counts says the emitted program
+is the same multiset of statements; the symbol-set diff says no function was
+added, removed or renamed. In-order differences that remain are pure
+declaration reordering.
+
 So for a rename sweep the gate is the FULL suite plus READING the cli-case
 golden diff — never check/build. A golden that gets SMALLER or reports FEWER
 findings (`Scanned 1 .yo file(s)` -> `Scanned 0`) is a regression signal, not

--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -1496,6 +1496,26 @@ while(i < s.len(), { b := s.byte_at(i); ... });
 match(s.index_of(w, from), .Some(idx) => s.byte_at(idx - usize(1)), ...);
 ```
 
+**Since 2026-08-26 there is a byte-safe vocabulary — prefer it over hand-rolled
+byte walks** (`std/string/string.yo`, same six on `std/imm/string.yo`, which also
+gained `chars()`):
+
+| call | basis | meaning |
+| --- | --- | --- |
+| `s.char_len()` | runes | the O(n) rune count. **Say this** when you mean runes; `len()` is scheduled to become the byte count (D4). |
+| `s.char_indices()` | — | iterator of `IterPair(byte_offset, rune)`; `p._0` is the BYTE offset, `p._1` the rune. Replaces `while(i < s.len()) { s.at(i) }`, which is O(n²). |
+| `s.is_char_boundary(i)` | byte | is byte `i` the start of a rune? `0` and `bytes_len()` are boundaries; past the end is not. |
+| `s.floor_char_boundary(i)` / `s.ceil_char_boundary(i)` | byte | snap an arbitrary byte offset back/forward onto a rune start (clamped to `bytes_len()`). |
+| `s.try_substring(a, b)` | **byte** | `Option(String)`; `.None` for `a > b`, `b > bytes_len()`, or an endpoint inside a rune. NOTE: byte offsets, unlike `substring`, which is still rune-indexed and clamps. |
+
+So the byte-exact slice above is now `s.try_substring(from, to).unwrap()`, and a
+fixed-width truncation that must not split a codepoint is
+`s.try_substring(usize(0), s.floor_char_boundary(n)).unwrap()`.
+
+`char_len` and `char_indices` sit on `std/encoding/utf8`, so they inherit its
+malformed-input behaviour: `char_len` counts non-continuation bytes, and
+`char_indices` (like `chars()`) stops at the first sequence that will not decode.
+
 ## Async: await only at the async-closure statement level
 
 An `e.io.await(...)` nested inside if-branches of an `io.async` closure has

--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -182,6 +182,7 @@ impl(Counter,
   reflection reports source-module namespaces as `TypeInfo.Struct(...)`.
 - Wrap `fn` types in parentheses when they appear after `:`
 - **Forward references between methods in the same `impl` block are supported.** A method defined later in the block can be called by a method defined earlier. Both `self.method()` and `Self.method(...)` dispatch work. Only the canonical `name : (fn(...) -> R)(body)` method shape participates; bare lambdas do not get forward-ref shells.
+- **…but NOT between two `impl` blocks on the same type.** A method in an EARLIER `impl(T, …)` block cannot call one defined in a LATER `impl(T, …)` block — the failure is `Error: No matching call found with arguments: (self.X)()` at `yo check` time, which reads like a missing method rather than an ordering problem. Adding a method to a type in a fresh trailing `impl` block is therefore only safe for NEW call sites; if an existing method below needs it, move the definition up into a block that precedes every caller. (Measured twice while migrating `std/string/string.yo` for D4.)
 - **Module-level `::` function definitions are processed in order.** A function body that calls another function declared later in the same file will fail with "Variable not found". Always define leaf helpers first (bottom-up order): `eval_identifier` → `eval_atom` → `evaluate`.
 
 ### Named arguments and default values
@@ -1507,10 +1508,19 @@ gained `chars()`):
 | `s.is_char_boundary(i)` | byte | is byte `i` the start of a rune? `0` and `bytes_len()` are boundaries; past the end is not. |
 | `s.floor_char_boundary(i)` / `s.ceil_char_boundary(i)` | byte | snap an arbitrary byte offset back/forward onto a rune start (clamped to `bytes_len()`). |
 | `s.try_substring(a, b)` | **byte** | `Option(String)`; `.None` for `a > b`, `b > bytes_len()`, or an endpoint inside a rune. NOTE: byte offsets, unlike `substring`, which is still rune-indexed and clamps. |
+| `s.char_substring(a, b)` | runes | (added 2026-08-26) exactly what `substring` does today, under a name that says so. `substring` is now a one-line delegation to it, so **`substring` will change basis and `char_substring` will not.** Say `char_substring` at any site that means runes. |
+| `s.truncate_chars(n)` | runes | (added 2026-08-26) keep at most `n` runes. Never splits a rune, never lengthens. This is the right tool for "cut arbitrary human text to a display length". |
 
 So the byte-exact slice above is now `s.try_substring(from, to).unwrap()`, and a
 fixed-width truncation that must not split a codepoint is
-`s.try_substring(usize(0), s.floor_char_boundary(n)).unwrap()`.
+`s.truncate_chars(n)` (or, if you are working in byte offsets,
+`s.try_substring(usize(0), s.floor_char_boundary(n)).unwrap()`).
+
+**The migration rule, in one line:** if a site means runes, spell it
+`char_len`/`char_indices`/`char_substring`/`truncate_chars` *now*; if it means
+bytes, leave it on `len`/`substring` and it becomes correct when D4 flips them.
+`while(i < s.len()) { s.at(i).unwrap() }` is the shape to hunt — after the flip
+`at()` at a continuation byte is `.None`, so that `.unwrap()` **panics**.
 
 `char_len` and `char_indices` sit on `std/encoding/utf8`, so they inherit its
 malformed-input behaviour: `char_len` counts non-continuation bytes, and

--- a/issues/mkdir-all-uses-a-byte-index-as-a-rune-index.md
+++ b/issues/mkdir-all-uses-a-byte-index-as-a-rune-index.md
@@ -1,0 +1,69 @@
+# `mkdir_all` feeds a BYTE index to the rune-indexed `substring`
+
+**Status:** OPEN. Found 2026-08-26 while migrating call sites for
+`plans/STD_API_AUDIT_D4_PLAN.md` PR 2. **Deliberately not fixed there** — PR 2's
+contract is that it changes no behaviour. **D4 PR 3 fixes it for free** by
+making `substring` byte-indexed, which is the basis `i` already has.
+
+## Where
+
+`std/fs/dir.yo`, `mkdir_all`'s ENOENT recovery path (lines ~93-121):
+
+```rust
+bytes := path_s.as_bytes();      // BYTE array
+i := usize(1);
+...
+while(runtime(i < bytes.len()), {
+  b := bytes(i);
+  cond(
+    ((b == u8(47)) || (b == u8(92))) => {
+      // '/' found - try to create this prefix
+      prefix := path_s.substring(usize(0), i);   // <-- `substring` is RUNE-indexed
+      ...
+```
+
+`i` is a byte offset into `path_s.as_bytes()`. `String.substring(start, end)` is
+**character**-indexed today (`std/string/string.yo`), so `substring(0, i)` cuts
+after `i` RUNES, not after `i` bytes.
+
+## Consequence
+
+For an all-ASCII path the two coincide and the code is correct — which is why
+this has never been noticed. For a path with any non-ASCII component ahead of a
+separator, `i` overshoots the rune count and the prefix handed to `mkdir` is
+**longer than intended**, or (when the rune count runs out) the clamped whole
+string. `mkdir_all("/tmp/日本語/a/b")` therefore creates the wrong parent
+directories, and the subsequent `mkdir` of the real leaf either fails with
+`ENOENT` again or leaves a tree the caller did not ask for. rc can be 0 with the
+wrong filesystem state.
+
+## Reproducer sketch
+
+```rust
+{ mkdir_all } :: import("std/fs/dir");
+// under an effect handler providing io/exn:
+mkdir_all(Path.from(`/tmp/yo-d4/日本語/deep/leaf`));
+// expected: /tmp/yo-d4/日本語/deep/leaf exists
+// actual:   the intermediate prefixes are cut at the wrong offsets
+```
+
+## Family
+
+This is the same shape as the six already recorded in
+`plans/STD_API_AUDIT_D4_PLAN.md` §5.1 — `src/main.yo:789-802` `_win_dirname`,
+`src/main.yo:852-866` `_path_has_extension`, `src/install_command.yo:60,66`,
+`src/pkg_config.yo:34-66` `_split_whitespace` — a `len()`/`as_bytes()` byte walk
+whose index is then handed to a rune-indexed slice. It is the **eighth**
+confirmed instance and the **first in `std/`** rather than `src/`.
+
+## Fix
+
+Do nothing here; land D4 PR 3. When `String.substring` becomes byte-indexed,
+`substring(0, i)` means exactly what the loop already intends and the bug
+disappears without an edit. If D4 PR 3 is ever abandoned, the standalone fix is
+`path_s.try_substring(usize(0), i).unwrap_or(path_s.clone())` — `i` always sits
+on a separator byte, which is a rune boundary, so `try_substring` cannot refuse.
+
+**A test must come with PR 3** (`tests/fs/` has no non-ASCII path coverage):
+create a directory tree with a multibyte component and assert every level
+exists.

--- a/issues/unsafe-report-relative-path-uses-a-byte-prefix-length.md
+++ b/issues/unsafe-report-relative-path-uses-a-byte-prefix-length.md
@@ -1,0 +1,64 @@
+# `yo unsafe-report` / `yo public-safe-report` cut the relative path with a BYTE length
+
+**Status:** OPEN. Found 2026-08-26 while reviewing
+`plans/STD_API_AUDIT_D4_PLAN.md` PR 2. **Deliberately not fixed there** — PR 2's
+contract is that it changes no behaviour. **D4 PR 3 fixes it for free** by
+making `substring` byte-indexed, which is the basis `root_prefix_len` already
+has.
+
+This is an **8th** instance of the §5.1 "mixed-basis" family; the plan's §5.1
+table lists 7 and does not name these two files.
+
+## Where
+
+Two files carrying the same copied walker:
+
+- `src/unsafe_report.yo:511` + `:521` (`_walk_yo_files`)
+- `src/public_safe_report.yo:517` + `:525` (same function, duplicated)
+
+```rust
+root_prefix_len := walk_root.as_bytes().len();   // BYTES
+...
+rel := p.substring(root_prefix_len + usize(1), p.len());   // substring is RUNE-indexed today
+segs := rel.split(`/`);
+```
+
+`root_prefix_len` is the **byte** length of the scan root. `String.substring`
+is **character**-indexed today (`std/string/string.yo`), so for any root path
+containing a non-ASCII byte the cut starts `bytes(root) - runes(root)`
+positions too far into `p`.
+
+## Consequence
+
+`rel` is truncated at the front. Its `/`-split then loses leading segments, so
+
+- the directory-skip filter (`node_modules`, `.git`, `dist`, `yo-out`,
+  `build`, dot-directories) is applied to the **wrong** segments, and
+- when the scan root is `.` (`is_dot`), the mangled `rel` is what gets printed
+  as the file label in the report.
+
+Both subcommands are user-facing: `src/main.yo:3245` `run_unsafe_report_cmd`
+(`yo unsafe-report [path] [--json]`) and its public-safe twin.
+
+## Measured
+
+Standalone reproducer of the exact two lines (compiled `--release`, run
+2026-08-26):
+
+```
+ascii  root -> "a.yo"      (want "a.yo")
+cjk    root -> "yo"        (want "a.yo")       root = /tmp/名
+accent root -> "rc/a.yo"   (want "src/a.yo")   root = /tmp/café
+```
+
+## Fix direction
+
+Do **not** patch it in PR 2 — that would be a behaviour change inside a
+provably-inert commit. D4 PR 3 rebases `substring` onto bytes, at which point
+`root_prefix_len` and the slice agree and both lines become correct with no
+edit. Add the CJK-root case above to whatever multibyte battery PR 3 ships so
+the fix is witnessed rather than assumed.
+
+If D4 is ever abandoned, the standalone fix is
+`p.substring(walk_root.len() + usize(1), p.len())` (rune length on both sides)
+— but the two files must be changed together, since the walker is duplicated.

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -555,6 +555,20 @@ audit, and `RegexMatch.index()`'s public basis change). It also finds that D4
 all find/slice APIs byte-indexed with a documented char-boundary contract.
 This is THE breaking change to do before stability — it cannot be done after.
 
+~~**Step 1 of that plan (PR 1, additive vocabulary)**~~ **LANDED 2026-08-26.**
+`String` and `imm.String` both gained `char_len()`, `char_indices()`,
+`is_char_boundary()`, `floor_char_boundary()`, `ceil_char_boundary()` and
+`try_substring()`, and `imm.String` gained `chars()`. All of it is built on
+`std/encoding/utf8.yo` (D8, #286) — no second decoder, no second width table.
+Nothing existing changed: the only line REMOVED anywhere in that PR was
+`export(String);` in `std/imm/string.yo`, replaced by a longer export list.
+`char_len() == len()` on both types today, which is exactly what makes the
+D4 PR 2 migration a provable no-op. Coverage is
+`tests/string/string_char_api.test.yo` (17 tests) plus a 6-test section in
+`tests/imm_string.test.yo`, every assertion multibyte with hand-computed byte
+offsets. The remaining D4 steps (PRs 2-9) are unchanged and still in
+`plans/STD_API_AUDIT_D4_PLAN.md` §4.
+
 **SCOPE EXTENDED (user, 2026-08-25): `std/imm/string` is IN, and so is the
 `imm.String` → `ImmString` rename** (moved here from the §4 imm row, which had it
 as an open "or drop if COW String lands" question — it is now part of this one
@@ -935,7 +949,7 @@ implementing the D5 traits.** Until it lands, std honestly refuses https.
 | spec/ | FREEZE AS DOC | identity stubs; mark experimental, exclude from stability promise |
 | collections/* | RENAME + EXTEND | §5 renames; entry API, `retain/extend/drain`, `binary_search`, real `sort` (not O(n²) insertion), `sort_by`; HashSet = HashMap(T, unit) to kill ~500 duplicated SwissTable lines; hide pub `ctrl/data/…` fields; `BTreeMap` → rename `FlatMap` OR implement a real B-tree with `range()` (recommend: real B-tree, keep name); add `BTreeSet`; `PriorityQueue`: keep name, add comparator ctor, DOCUMENT min-heap |
 | imm/* | KEEP (O4) + FIX | stays in std (decided 2026-08-23); require `Acyclic` element bounds per O7, add iteration + `Index` where doc'd, rename `imm.String` → `ImmString` (**folded into D4** 2026-08-25 — decided, no longer conditional on COW `String`), dedupe set pair; mark unstable until exercised |
-| string | FIX + EXTEND | D4 indexing; Unicode-correct `to_lowercase` (+ `to_ascii_*` variants); `Pattern` impl for `rune` + `Regex`; `replace*` Pattern-generic; `parse_f64`/radix; `split_once`, `strip_prefix/suffix`, `char_indices`; move `panic_dyn`/`assert_dyn` to assert; delete dead `StringError`, one of `to_cstr`/`to_c_str` |
+| string | FIX + EXTEND | D4 indexing; Unicode-correct `to_lowercase` (+ `to_ascii_*` variants); `Pattern` impl for `rune` + `Regex`; `replace*` Pattern-generic; `parse_f64`/radix; `split_once`, `strip_prefix/suffix`, ~~`char_indices`~~ (landed 2026-08-26 with the rest of the D4 PR-1 vocabulary); move `panic_dyn`/`assert_dyn` to assert; delete dead `StringError`, one of `to_cstr`/`to_c_str` |
 | encoding | STANDARDIZE | D2 verbs; one error style per D1; utf8 module; add `html_encode` (XSS!); percent-encoding module (P0 — nothing in std can build a safe query string); base32; CSV (P1); toml: floats/arrays/dates/serializer + `ToToml`/`FromToml` derives to mirror json (P1) |
 | json | EXTEND | enum representation for derives (open question O3); `JsonValue.Object` O(n) parallel arrays → keep repr, add index map if profiling demands |
 | regex | POLISH | `Regex.escape`, optional-flags `new`, callback replace, lazy `find_iter`, group byte-spans, ~~typed error, private internals~~ (**both DONE 2026-08-25**, D8) |
@@ -1425,7 +1439,10 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
 
 - **O1 (D4)**: **DECIDED — byte-indexed, matching Rust.** `len()` = bytes O(1),
   `chars()`/`char_indices()` for rune walks, `char_len()` for the O(n) count,
-  find/slice APIs byte-indexed with a char-boundary contract.
+  find/slice APIs byte-indexed with a char-boundary contract. The additive half
+  (`char_len`/`char_indices`/`is_char_boundary`/`floor_char_boundary`/
+  `ceil_char_boundary`/`try_substring`, on both string types) **landed
+  2026-08-26**; the basis flip itself is still ahead (D4 plan PRs 2-9).
 - **O2 (D6)**: **DECIDED — platform TLS libraries via `pkg_config`**
   (SecureTransport/Schannel/OpenSSL), behind one `TlsStream` implementing the
   D5 traits. Until it lands, https throws `UnsupportedScheme` (C1).

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -577,17 +577,31 @@ the new `truncate_chars`; `String.split("")` is pinned; and in `src/`,
 `_peel_spec`, the doc-summary cut, the caret column and all ten
 comptime-string-builtin sites are pinned. Two additive helpers came with it:
 `char_substring` (which holds `substring`'s CURRENT body verbatim, `substring`
-becoming a one-line delegation to it) and `truncate_chars`. **PR 3's review
-question is now "does this site want bytes?", and the answer is yes everywhere
-left.** The gate was output-identity of a multibyte behavioural probe (862
-lines, same `sha256` before and after) plus a simulated flip in which the new
-multibyte tests fail without the migration and pass with it — NOT emitted-C
-identity, which PR 2 measured to be the wrong instrument for a body rewrite.
-Coverage went from 8 → 12 tests in `tests/encoding/html.test.yo`, 7 → 12 in
-`tests/format_specs.test.yo`, 17 → 21 in `tests/string/string_char_api.test.yo`.
+becoming a one-line delegation to it) and `truncate_chars`. The gate was
+output-identity of a multibyte behavioural probe (same `sha256` before and
+after) plus a simulated flip in which the new multibyte tests fail without the
+migration and pass with it — NOT emitted-C identity, which PR 2 measured to be
+the wrong instrument for a body rewrite. Coverage went from 8 → 12 tests in
+`tests/encoding/html.test.yo`, 7 → 13 in `tests/format_specs.test.yo`,
+17 → 21 in `tests/string/string_char_api.test.yo`.
 PR 2 also found an **8th live mixed-basis bug** (`std/fs/dir.yo:121`
 `mkdir_all`, the first in `std/` rather than `src/`) that D4 PR 3 fixes for
 free, and settled the 14 `substring` sites the plan had left UNMEASURED.
+
+**A skeptical review pass on the same branch (2026-08-26) closed the claim PR 2
+could not yet make.** PR 2 as first committed had migrated only the ONE instance
+of the "rune column + `tok.value.len()`" pattern that the plan's §5.2 named
+(`src/error.yo`, S7); the pattern actually occurs at **11 more sites in 6
+files** — `src/formatter.yo`, `src/lsp/{hover,symbols,definition,references,
+rename,completion}.yo` and `src/doc/builder.yo`. All 11 are now on `char_len()`
+(plan §5.2 **S11**); the worst of them would have made `textDocument/rename`
+replace past the end of a multibyte identifier. The review also replaced a
+**vacuous** `pad_numeric` test (it asserted only through `String.format`, which
+never reaches `pad_numeric`) and recorded a **9th** live mixed-basis bug,
+duplicated across `src/unsafe_report.yo` and `src/public_safe_report.yo`
+(`issues/unsafe-report-relative-path-uses-a-byte-prefix-length.md`).
+**Only now is PR 3's review question "does this site want bytes?" — and the
+answer is yes everywhere left except S8 and S9, which are open by design.**
 
 The remaining D4 steps (PRs 3-9) are unchanged and still in
 `plans/STD_API_AUDIT_D4_PLAN.md` §4.

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -566,7 +566,30 @@ Nothing existing changed: the only line REMOVED anywhere in that PR was
 D4 PR 2 migration a provable no-op. Coverage is
 `tests/string/string_char_api.test.yo` (17 tests) plus a 6-test section in
 `tests/imm_string.test.yo`, every assertion multibyte with hand-computed byte
-offsets. The remaining D4 steps (PRs 2-9) are unchanged and still in
+offsets.
+
+~~**Step 2 of that plan (PR 2, pin char semantics)**~~ **LANDED 2026-08-26.**
+Every site that genuinely needs CHARACTER semantics now says so in its own
+source — `std/encoding/html.yo` (the highest-risk file in the tree) scans a
+`char_indices()` rune table instead of `s.at(i).unwrap()` in a `len()`-bounded
+loop; `std/fmt/spec.yo`'s width, precision and numeric total use `char_len()` +
+the new `truncate_chars`; `String.split("")` is pinned; and in `src/`,
+`_peel_spec`, the doc-summary cut, the caret column and all ten
+comptime-string-builtin sites are pinned. Two additive helpers came with it:
+`char_substring` (which holds `substring`'s CURRENT body verbatim, `substring`
+becoming a one-line delegation to it) and `truncate_chars`. **PR 3's review
+question is now "does this site want bytes?", and the answer is yes everywhere
+left.** The gate was output-identity of a multibyte behavioural probe (862
+lines, same `sha256` before and after) plus a simulated flip in which the new
+multibyte tests fail without the migration and pass with it — NOT emitted-C
+identity, which PR 2 measured to be the wrong instrument for a body rewrite.
+Coverage went from 8 → 12 tests in `tests/encoding/html.test.yo`, 7 → 12 in
+`tests/format_specs.test.yo`, 17 → 21 in `tests/string/string_char_api.test.yo`.
+PR 2 also found an **8th live mixed-basis bug** (`std/fs/dir.yo:121`
+`mkdir_all`, the first in `std/` rather than `src/`) that D4 PR 3 fixes for
+free, and settled the 14 `substring` sites the plan had left UNMEASURED.
+
+The remaining D4 steps (PRs 3-9) are unchanged and still in
 `plans/STD_API_AUDIT_D4_PLAN.md` §4.
 
 **SCOPE EXTENDED (user, 2026-08-25): `std/imm/string` is IN, and so is the
@@ -1442,7 +1465,9 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
   find/slice APIs byte-indexed with a char-boundary contract. The additive half
   (`char_len`/`char_indices`/`is_char_boundary`/`floor_char_boundary`/
   `ceil_char_boundary`/`try_substring`, on both string types) **landed
-  2026-08-26**; the basis flip itself is still ahead (D4 plan PRs 2-9).
+  2026-08-26**, and so did the char-semantics pin (PR 2, plus
+  `char_substring`/`truncate_chars`); the basis flip itself is still ahead
+  (D4 plan PRs 3-9).
 - **O2 (D6)**: **DECIDED — platform TLS libraries via `pkg_config`**
   (SecureTransport/Schannel/OpenSSL), behind one `TlsStream` implementing the
   D5 traits. Until it lands, https throws `UnsupportedScheme` (C1).

--- a/plans/STD_API_AUDIT_D4_PLAN.md
+++ b/plans/STD_API_AUDIT_D4_PLAN.md
@@ -1,6 +1,7 @@
 # D4 — String indexing model: the executable migration plan
 
-> **Status:** PLAN (survey complete 2026-08-25, nothing implemented).
+> **Status:** **PR 1 LANDED 2026-08-26**; PRs 2-9 still PLAN.
+> (Survey complete 2026-08-25.)
 > **Parent decision:** `plans/STD_API_AUDIT.md` §3 **D4** + §8 **O1** —
 > `String` goes byte-indexed like Rust/Go. Scope extended (user, 2026-08-25)
 > to `std/imm/string` and the `imm.String` → `ImmString` rename.
@@ -61,13 +62,23 @@ contract.
 | `replace` / `replace_all` | 1056 / 1162 | — | — | ✅ unchanged |
 | `trim` / `trim_start` / `trim_end` | 1318 / 1360 / 1405 | — (byte-internal, ASCII whitespace) | — | ✅ unchanged |
 | `to_uppercase` / `to_lowercase` / `concat` / `repeat` / `join` | | — | — | ✅ unchanged |
-| `char_len()` | — | **DOES NOT EXIST** | new, **C**, O(n) | ➕ additive |
-| `char_indices()` | — | **DOES NOT EXIST** | new, yields `(byte_offset, rune)` | ➕ additive |
-| `is_char_boundary(i)` | — | **DOES NOT EXIST** | new | ➕ additive |
+| ~~`char_len()`~~ | 1840 | — | **C**, O(n) | ✅ **LANDED PR 1** |
+| ~~`char_indices()`~~ | 1872 | — | yields `IterPair(byte_offset, rune)` | ✅ **LANDED PR 1** |
+| ~~`is_char_boundary(i)`~~ | 1879 | — | **B** | ✅ **LANDED PR 1** |
+| ~~`floor_char_boundary(i)`~~ | 1903 | — | **B** | ✅ **LANDED PR 1** |
+| ~~`ceil_char_boundary(i)`~~ | 1930 | — | **B** | ✅ **LANDED PR 1** |
+| ~~`try_substring(a, b)`~~ | 1961 | — | **B**, `Option(String)` | ✅ **LANDED PR 1** |
 
-**Verified absent today:** `grep -rn "char_indices\|char_len" std/` returns
-only unrelated locals in `std/regex/index.yo` and `std/string/string.yo:978`.
-Neither `char_len()` nor `char_indices()` exists anywhere.
+**Was verified absent before PR 1:** `grep -rn "char_indices\|char_len" std/`
+returned only unrelated locals in `std/regex/index.yo` and
+`std/string/string.yo:978`. PR 1 added all six names on `String` and on
+`imm.String` (plus `imm.String.chars()`); the `std/regex/index.yo` hits are
+still unrelated locals.
+
+**PR 1's yield type is `IterPair(usize, rune)`** (the prelude's positional pair,
+`std/prelude.yo:8368`), not a bare tuple — Yo has no tuple literal, and
+`IterPair` is what `enumerate`/`zip` already yield. Destructure it as
+`p._0` / `p._1`.
 
 ### 1.2 `std/imm/string.yo` — `imm.String`
 
@@ -81,7 +92,8 @@ Neither `char_len()` nor `char_indices()` exists anywhere.
 | `at(index) -> Option(rune)` | 577 | **C** | **B** (mirror `String.at`) | 🔴 **SILENT** |
 | `starts_with` / `ends_with` / `contains` | 217/235/286 | no position arg | — | ✅ |
 | `split` / `trim*` / `replace*` / `repeat` | | — | — | ✅ |
-| `chars()` / `char_indices()` / `char_len()` | — | **absent** | new | ➕ additive |
+| ~~`chars()` / `char_indices()` / `char_len()`~~ | 672/676/683 | — | new | ✅ **LANDED PR 1** |
+| ~~`is_char_boundary` / `floor_char_boundary` / `ceil_char_boundary` / `try_substring`~~ | 707/723/747/773 | — | **B** | ✅ **LANDED PR 1** |
 
 The audit's claim that "applying D4 to `imm.String` is SMALL" is **confirmed**:
 one silent flip (`len()`), one alias fold, one `at()` alignment, three additions.
@@ -388,9 +400,9 @@ no-op and PR 3 only has to change definitions.
 
 | PR | content | gate |
 | --- | --- | --- |
-| **0** | `std/encoding/utf8.yo` (in flight, other agent). Primitives: `seq_len(lead: u8) -> usize`, `decode(bytes, i) -> Option((rune, usize))`, `encode(r, out)`, `is_char_boundary(bytes, i)`, `validate`. **Dependency:** PR 1 and PR 6 both consume it; PR 2 does not. | `yo check ./std`; new `tests/encoding/utf8.test.yo` |
-| **1** | **Additive only.** `String.char_len()`, `String.char_indices()`, `String.is_char_boundary()`, `floor_char_boundary`, `ceil_char_boundary`, `try_substring`. Same six on `imm.String`, plus `imm.String.chars()`. No existing behaviour changes. Ships its own multibyte tests. | full language suite green; **byte-identity** of the compiler's emitted C (nothing in `src/` calls the new API yet) |
-| **2** | **Pin char semantics, no basis change.** Rewrite the §3.1-RISK and §5.2 sites to the new char APIs: `std/encoding/html.yo` `at()` loops → `chars()`; `std/fmt/spec.yo` width/precision → `char_len()` + `truncate_chars`; `src/error.yo:43` → `char_len()`; `src/doc/render_html.yo:406` → `truncate_chars`; `src/parser.yo:_peel_spec` → `char_indices()`; comptime string builtins pinned to explicit char helpers (O1c). **Because `char_len() == len()` today, this PR must not change one byte of behaviour.** | full language suite; **BYTE-IDENTITY of the whole emitted-C corpus** (record sha256 before editing — the repo's standing acceptance test for an "additive" codegen change) |
+| ~~**0**~~ **LANDED** (#286) | `std/encoding/utf8.yo`. Primitives: `seq_len(lead: u8) -> usize`, `decode(bytes, i) -> Option((rune, usize))`, `encode(r, out)`, `is_char_boundary(bytes, i)`, `validate`. **Dependency:** PR 1 and PR 6 both consume it; PR 2 does not. | `yo check ./std`; new `tests/encoding/utf8.test.yo` |
+| ~~**1**~~ **LANDED 2026-08-26** | **Additive only.** `String.char_len()`, `String.char_indices()`, `String.is_char_boundary()`, `floor_char_boundary`, `ceil_char_boundary`, `try_substring`. Same six on `imm.String`, plus `imm.String.chars()`. Built on `std/encoding/utf8` (PR 0), no second decoder. New `tests/string/string_char_api.test.yo` (17 tests) + 6 tests appended to `tests/imm_string.test.yo`, all multibyte. | achieved: `yo check ./std` 153/153; `tests/string/string_char_api` 17/17, `tests/imm_string` 34/34, `tests/string/string` 253/253, `imm_map`/`imm_vec`/`imm_threading` green; 0 `Failed to transpile` in both kept batches; emitted-C **equivalence** measured as below (literal byte-identity is unattainable — see the correction under §6.1) |
+| **2** | **Pin char semantics, no basis change.** Rewrite the §3.1-RISK and §5.2 sites to the new char APIs: `std/encoding/html.yo` `at()` loops → `chars()`; `std/fmt/spec.yo` width/precision → `char_len()` + `truncate_chars`; `src/error.yo:43` → `char_len()`; `src/doc/render_html.yo:406` → `truncate_chars`; `src/parser.yo:_peel_spec` → `char_indices()`; comptime string builtins pinned to explicit char helpers (O1c). **Because `char_len() == len()` today, this PR must not change one byte of behaviour.** | full language suite; **emitted-C equivalence of the corpus** — NOT literal byte-identity, which PR 1 measured to be unattainable for any `std` edit; use the normalized comparison in the §6.1 correction |
 | **3** | **The flip.** `String.len()` → bytes O(1); `at`/`substring`/`slice_copy*`/`index_of`/`last_index_of`/`contains(from)`/`starts_with(pos)`/`ends_with(pos)`/`Pattern`'s five methods → bytes. `bytes_len()` becomes a deprecated alias. Fix §1.3(a) by construction. `src/` migrates **in the same PR** — the repo build compiles `src/` against the *repo's* `std` (`--std-path > YO_STD > exe-walk-up > ./std`), so it cannot lag. Add `Token.byte_offset` and retire `_byte_offset_of_char_index` (`src/formatter.yo:1496`). | `yo check ./std && yo check ./src`; full language suite; `tests/internal`; `gates_fast.sh` + fixpoint; new §6 multibyte battery |
 | **4** | `imm.String`: `len()` → bytes, `at()` aligned, `bytes_len()` aliased, `chars()`/`char_indices()`/`char_len()` wired. | `tests/imm_string.test.yo` (rewritten per §6.2), `imm_vec`, `imm_threading` |
 | **5** | `imm.String` → `ImmString` rename. ~15 lines: the `String ::` binding + `export`, 3 test imports, 4 doc lines × 2 languages. | suite + docs both languages |
@@ -401,7 +413,18 @@ no-op and PR 3 only has to change definitions.
 
 **Ordering constraints, explicitly:**
 
-- PR 1 **must** precede PR 2 (`char_indices()` is what PR 2 migrates onto).
+- PR 1 **must** precede PR 2 (`char_indices()` is what PR 2 migrates onto). ✅ done.
+- **PR 1 did NOT ship `truncate_chars`.** §4 PR 2 names it for S2/S6 but §4 PR 1
+  does not list it, so it was deliberately left out. PR 2 either adds it (as a
+  `char_len` + `floor_char_boundary` + `try_substring` composition — the shape is
+  covered by `tests/string/string_char_api.test.yo`'s last test) or migrates
+  those two sites without it.
+- **`try_substring` is BYTE-based from day one**, while `substring` is still
+  character-based until PR 3. That is intentional: a NEW name can carry the final
+  contract, and a new name that flipped basis under its callers in PR 3 would be
+  exactly the silent hazard this plan exists to avoid. PR 2 must not reach for
+  `try_substring` as a drop-in for `substring`; its migration targets are
+  `char_len()` and `char_indices()`.
 - PR 2 **must** precede PR 3. This is the whole safety argument: after PR 2,
   every site that *needs* char semantics says so in its own source, so PR 3's
   review question collapses to "does this site want bytes?" — and the answer
@@ -578,6 +601,39 @@ claims to change no behaviour; record `sha256` of every `.c` before editing and
 require `same=N diff=0`. That is the repo's standing acceptance test for an
 "additive" codegen change and it makes the PR-2 review free.
 
+**CORRECTION (measured in PR 1, 2026-08-26): literal byte-identity of emitted C
+is unattainable for ANY `std` edit, additive or not.** The C backend embeds two
+families of generated number into its identifiers — anonymous type ids
+(`__yo_tN`) and a global declaration/expression counter (`yo_id_N`,
+`struct_decl_N`, `enum_decl_N`, `loop_yo_id_N`). Adding declarations to
+`std/string/string.yo` shifted every counter ordered after the insertion point
+by a constant (+1004 here) and permuted the `__yo_tN` numbering, so a
+String-heavy probe's `.c` changed `sha256` while the *program* did not change at
+all. Do not write "byte-identity" as a gate for PR 2; it will fail vacuously and
+hide whether anything real moved.
+
+**What to measure instead** (this is what PR 1 ran, and it is decisive):
+
+```bash
+# 1. before editing: emit the probe's C
+yo compile tmp/probe.yo --skip-c-compiler --release -o tmp/probe.bin   # writes tmp/probe.bin.c
+# 2. after editing: emit again, then compare modulo the generated-id families
+norm() { sed -E 's/__yo_t[0-9]+/__yo_tT/g; s/__YO_T[0-9]+/__YO_TT/g;
+                 s/yo_id_[0-9]+/yo_id_N/g; s/(struct_decl|enum_decl|decl)_[0-9]+/\1_N/g;
+                 s/_temp_[0-9]+/_temp_N/g' "$1"; }
+diff <(norm before.c | sort) <(norm after.c | sort)      # must be EMPTY
+# 3. and the emitted function-symbol sets must be identical
+grep -oE '__yo_[A-Za-z0-9_]+\(' before.c | sort -u > b.syms   # same for after.c
+```
+
+PR 1's result on a probe exercising `String.len/substring/index_of/chars/split`
+and `imm.String.len/slice/at`: **5016 lines both sides, sorted normalized diff
+= 0 lines, 196 emitted symbols both sides with an empty diff, and zero
+occurrences of the new API in the C.** The only in-order differences were the
+renumbering above plus a reordering of a handful of type declarations. That is
+the strongest inertness statement available, and it is stronger than a `sha256`
+would have been even if one had matched.
+
 ### 6.2 Which existing tests cannot catch this class
 
 Per-test measurement (a test counts only if the **same test body** contains
@@ -593,6 +649,8 @@ both a non-ASCII literal and an index-basis call):
 | `tests/imm_string.test.yo` | 28 | 1 | **1** |
 | `tests/index.test.yo` | 49 | 2 | **1** |
 | `tests/string_multibyte_literal.test.yo` | 2 | 2 | **1** |
+| `tests/string/string_char_api.test.yo` **(new, PR 1)** | 17 | 17 | **17** |
+| `tests/imm_string.test.yo` **(PR 1 section)** | +6 | +6 | **+6** |
 | `tests/string/rune.test.yo` | 36 | 0 | **0** |
 | `tests/string/string_builder.test.yo` | 21 | 0 | **0** |
 | `tests/string/string_parse.test.yo` | 28 | 0 | **0** |
@@ -600,7 +658,9 @@ both a non-ASCII literal and an index-basis call):
 | `tests/format_specs.test.yo` | 7 | 1 | **0** |
 | `tests/template_string_specs.test.yo` | 6 | 0 | **0** |
 
-**≈ 33 tests repo-wide are the entire net.** Consequences:
+**≈ 33 tests repo-wide were the entire net** before PR 1; PR 1 added 23 more
+that are multibyte-plus-index by construction, all of them on the NEW names, so
+they guard the vocabulary and not yet the flipping methods. Consequences:
 
 - The `std/fmt/spec.yo` width regression (S2) has **zero** coverage —
   `tests/format_specs.test.yo` never pads a multibyte body. **Add it in PR 2.**

--- a/plans/STD_API_AUDIT_D4_PLAN.md
+++ b/plans/STD_API_AUDIT_D4_PLAN.md
@@ -1,6 +1,7 @@
 # D4 — String indexing model: the executable migration plan
 
-> **Status:** **PRs 1-2 LANDED 2026-08-26**; PRs 3-9 still PLAN.
+> **Status:** **PRs 1-2 LANDED 2026-08-26** (+ a skeptical review pass on the
+> same branch that added §5.2 **S11**); PRs 3-9 still PLAN.
 > (Survey complete 2026-08-25.)
 > **Parent decision:** `plans/STD_API_AUDIT.md` §3 **D4** + §8 **O1** —
 > `String` goes byte-indexed like Rust/Go. Scope extended (user, 2026-08-25)
@@ -404,7 +405,7 @@ no-op and PR 3 only has to change definitions.
 | --- | --- | --- |
 | ~~**0**~~ **LANDED** (#286) | `std/encoding/utf8.yo`. Primitives: `seq_len(lead: u8) -> usize`, `decode(bytes, i) -> Option((rune, usize))`, `encode(r, out)`, `is_char_boundary(bytes, i)`, `validate`. **Dependency:** PR 1 and PR 6 both consume it; PR 2 does not. | `yo check ./std`; new `tests/encoding/utf8.test.yo` |
 | ~~**1**~~ **LANDED 2026-08-26** | **Additive only.** `String.char_len()`, `String.char_indices()`, `String.is_char_boundary()`, `floor_char_boundary`, `ceil_char_boundary`, `try_substring`. Same six on `imm.String`, plus `imm.String.chars()`. Built on `std/encoding/utf8` (PR 0), no second decoder. New `tests/string/string_char_api.test.yo` (17 tests) + 6 tests appended to `tests/imm_string.test.yo`, all multibyte. | achieved: `yo check ./std` 153/153; `tests/string/string_char_api` 17/17, `tests/imm_string` 34/34, `tests/string/string` 253/253, `imm_map`/`imm_vec`/`imm_threading` green; 0 `Failed to transpile` in both kept batches; emitted-C **equivalence** measured as below (literal byte-identity is unattainable — see the correction under §6.1) |
-| ~~**2**~~ **LANDED 2026-08-26** | **Pin char semantics, no basis change.** Done: `std/encoding/html.yo` onto a `char_indices()` rune table (S1); `std/fmt/spec.yo` width/precision/numeric-total onto `char_len()` + the new `truncate_chars` (S2); `std/string/string.yo` `_split_impl`'s empty-separator arm onto `char_len`/`char_substring` (S5); `src/parser.yo:_peel_spec` onto `char_indices()` + `try_substring` (S4); `src/doc/render_html.yo` onto `char_len`/`truncate_chars` (S6); `src/error.yo:43` onto `char_len()` (S7); all 10 comptime-string-builtin sites onto `char_len`/`char_substring` (S10, O1c). Two additive helpers were needed and added: `char_substring` (the rune-indexed slice, holding `substring`'s CURRENT body verbatim — `substring` is now a one-line delegation to it) and `truncate_chars`. **NOT done here, and why:** S8 (`src/doc/builder.yo`) needs `Token.byte_offset`, S9 (`src/lsp/completion.yo`) needs the UTF-16 work — both are PR 3 by §5.4; S3 (regex) is PR 6. | achieved: `yo check ./std --std-path <tree>/std` 153/153; every touched `src/` file `check`s clean; `tests/encoding/html` 12/12 (was 8), `tests/format_specs` 12/12 (was 7), `tests/string/string_char_api` 21/21 (was 17), `tests/string/string` 253/253, `tests/template_string_specs` 6/6, `tests/imm_string` 34/34, `string_builder` 21/21, `rune` 36/36. Behavioural gate: a 862-line multibyte probe over `decode_html` / `FormatSpec.pad` / `pad_numeric` / `split("")` / the rune vocabulary hashes **`828549f0f0a9bdf747692bc872f018499a53435f518741fe055742d8561105e3` before AND after** the migration. Emitted C is NOT identical and cannot be — see the §6.1 correction extension below. |
+| ~~**2**~~ **LANDED 2026-08-26** | **Pin char semantics, no basis change.** Done: `std/encoding/html.yo` onto a `char_indices()` rune table (S1); `std/fmt/spec.yo` width/precision/numeric-total onto `char_len()` + the new `truncate_chars` (S2); `std/string/string.yo` `_split_impl`'s empty-separator arm onto `char_len`/`char_substring` (S5); `src/parser.yo:_peel_spec` onto `char_indices()` + `try_substring` (S4); `src/doc/render_html.yo` onto `char_len`/`truncate_chars` (S6); `src/error.yo:43` onto `char_len()` (S7); all 10 comptime-string-builtin sites onto `char_len`/`char_substring` (S10, O1c). Two additive helpers were needed and added: `char_substring` (the rune-indexed slice, holding `substring`'s CURRENT body verbatim — `substring` is now a one-line delegation to it) and `truncate_chars`. **NOT done here, and why:** S8 (`src/doc/builder.yo`) needs `Token.byte_offset`, S9 (`src/lsp/completion.yo`) needs the UTF-16 work — both are PR 3 by §5.4; S3 (regex) is PR 6. | achieved: `yo check ./std --std-path <tree>/std` 153/153; every touched `src/` file `check`s clean; `tests/encoding/html` 12/12 (was 8), `tests/format_specs` 13/13 (was 7; 12 as PR 2 committed it), `tests/string/string_char_api` 21/21 (was 17), `tests/string/string` 253/253, `tests/template_string_specs` 6/6, `tests/imm_string` 34/34, `string_builder` 21/21, `rune` 36/36. Behavioural gate: a 862-line multibyte probe over `decode_html` / `FormatSpec.pad` / `pad_numeric` / `split("")` / the rune vocabulary hashes **`828549f0f0a9bdf747692bc872f018499a53435f518741fe055742d8561105e3` before AND after** the migration. Emitted C is NOT identical and cannot be — see the §6.1 correction extension below. **Review pass 2026-08-26 (same branch) added §5.2 S11** — 11 more rune-column sites in `formatter`/`lsp`/`doc` that PR 2 as first committed had missed — plus a real `pad_numeric` multibyte test (the one it shipped was vacuous), and recorded a 9th live mixed-basis bug in `unsafe_report.yo`/`public_safe_report.yo`. Independently re-verified there: a 1481-line multibyte behavioural probe hashes `b7a76ec66909fbab41940268b645d950fc56f5788a45ed17e9fe8be87b2233c1` on the base `std` and on the migrated `std`; `char_len ≡ len` and `char_substring ≡ substring` over 39,488 exhaustive comparisons, 0 mismatches; `_peel_spec` old-vs-new 35 inputs (20 multibyte), 0 mismatches; `substring`'s new one-line delegation costs 0 measurable time at `-O2`. |
 | **3** | **The flip.** `String.len()` → bytes O(1); `at`/`substring`/`slice_copy*`/`index_of`/`last_index_of`/`contains(from)`/`starts_with(pos)`/`ends_with(pos)`/`Pattern`'s five methods → bytes. `bytes_len()` becomes a deprecated alias. Fix §1.3(a) by construction. `src/` migrates **in the same PR** — the repo build compiles `src/` against the *repo's* `std` (`--std-path > YO_STD > exe-walk-up > ./std`), so it cannot lag. Add `Token.byte_offset` and retire `_byte_offset_of_char_index` (`src/formatter.yo:1496`). | `yo check ./std && yo check ./src`; full language suite; `tests/internal`; `gates_fast.sh` + fixpoint; new §6 multibyte battery |
 | **4** | `imm.String`: `len()` → bytes, `at()` aligned, `bytes_len()` aliased, `chars()`/`char_indices()`/`char_len()` wired. | `tests/imm_string.test.yo` (rewritten per §6.2), `imm_vec`, `imm_threading` |
 | **5** | `imm.String` → `ImmString` rename. ~15 lines: the `String ::` binding + `export`, 3 test imports, 4 doc lines × 2 languages. | suite + docs both languages |
@@ -436,6 +437,20 @@ no-op and PR 3 only has to change definitions.
   every site that *needs* char semantics says so in its own source, so PR 3's
   review question collapses to "does this site want bytes?" — and the answer
   is yes everywhere left.
+  **That claim was only true after the review pass of 2026-08-26 added §5.2
+  S11.** PR 2 as committed migrated the ONE instance of the rune-column pattern
+  that §5.2 happened to name (`src/error.yo`, S7) and left **11 more in 6 files**
+  the plan never listed. The lesson for PR 3: `grep` the *pattern*, not the
+  plan's site list. The two detectors that found them are
+
+  ```bash
+  grep -rnE '\.column\s*\+|\.character\s*\+' src/     # rune column + a width
+  grep -rn  '\.value\.len()' src/                        # token width in an unstated basis
+  ```
+
+  Both must come back with `char_len()` (or a `Token.byte_offset`) at every hit
+  before PR 3 lands. **Still open by design after S11: S8 and S9**, which need
+  `Token.byte_offset` and the UTF-16 correction respectively.
 - PR 3 is the only PR that cannot be split across `std` and `src`.
 - **`impl` blocks do not see FORWARD across each other** — measured twice in
   PR 2, both times as `No matching call found with arguments: (self.X)()` from
@@ -462,7 +477,7 @@ no-op and PR 3 only has to change definitions.
 
 ## 5. The trap list
 
-### 5.1 (a) `len()` bound mixed with a byte loop — **8 confirmed live bugs D4 FIXES**
+### 5.1 (a) `len()` bound mixed with a byte loop — **9 confirmed live bugs D4 FIXES**
 
 Detector (25-line window, receiver-matched):
 
@@ -476,7 +491,8 @@ grep -rn -A40 'while(.* < [A-Za-z_][A-Za-z_0-9.]*\.len()' std src tests vendor
 ```
 
 Repo-wide the detector reports **41 co-occurrence windows**. Confirmed by
-reading (7 at survey time; an 8th, `std/fs/dir.yo`, was found in PR 2):
+reading (7 at survey time; an 8th, `std/fs/dir.yo`, was found in PR 2; a 9th,
+the duplicated report walker, was found in the PR-1/PR-2 review pass):
 
 | site | shape | verdict |
 | --- | --- | --- |
@@ -488,6 +504,7 @@ reading (7 at survey time; an 8th, `std/fs/dir.yo`, was found in PR 2):
 | `src/lsp/diagnostics.yo:72-89` `_ident_len_at` | rune `col` indexed into `line.as_bytes()` | **LIVE BUG**, **NOT fixed by D4** — `col` stays a rune column. Needs the `Token.byte_offset` work (PR 3). |
 | `std/fmt/writer.yo:42` | `while(i < s.len())` + `s.bytes(i)` | **false positive** — `s : str`, whose `len()` is already bytes. Clean. |
 | `std/fs/dir.yo:93-121` `mkdir_all` | `bytes := path_s.as_bytes()`, `i` walks `bytes`, then `path_s.substring(usize(0), i)` | **LIVE BUG, FOUND IN PR 2 (2026-08-26) — an 8th, and the first in `std/` rather than `src/`; written up in `issues/mkdir-all-uses-a-byte-index-as-a-rune-index.md`.** `i` is a byte index into `as_bytes()`; `substring` reads it as a rune index, so `mkdir_all` on a path with a non-ASCII component creates the WRONG parent directory (a short prefix) and then fails or silently makes the wrong tree. Exactly the `_win_dirname` / `_split_whitespace` shape. **D4 PR 3 fixes it for free** — deliberately NOT touched in PR 2, whose contract is no behaviour change. |
+| `src/unsafe_report.yo:511,521` + `src/public_safe_report.yo:517,525` `_walk_yo_files` | `root_prefix_len := walk_root.as_bytes().len()` (**bytes**), then `p.substring(root_prefix_len + 1, p.len())` (**runes**) | **LIVE BUG, FOUND IN THE PR-1/PR-2 REVIEW (2026-08-26) — a 9th, and it is DUPLICATED across two files**; written up in `issues/unsafe-report-relative-path-uses-a-byte-prefix-length.md`. The relative path is cut `bytes(root) - runes(root)` positions too far in, so the directory-skip filter runs on the wrong segments and the printed label is mangled. Measured on a standalone reproducer: root `/tmp/名` gives `"yo"` where `"a.yo"` is wanted; root `/tmp/café` gives `"rc/a.yo"` where `"src/a.yo"` is wanted. Reachable from `yo unsafe-report` and `yo public-safe-report` (`src/main.yo:3245`). **D4 PR 3 fixes it for free** — deliberately NOT touched, same reason as `mkdir_all`. |
 
 **Precedent, already paid for once:**
 `issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md` — a
@@ -519,6 +536,7 @@ corruption in the stage-2 binary") and
 | **S8** | `src/doc/builder.yo:233-235` | `Token.character` (rune) into `substring` | `Token.byte_offset` — **deliberately NOT in PR 2**: it needs a new lexer field, which is a behaviour-affecting change to `Token`. PR 3. |
 | **S9** | `src/lsp/completion.yo:762-780, 875, 1010` | LSP `character` into `substring` | see (c) below — **deliberately NOT in PR 2**: §5.4 says the UTF-16 correction lands WITH PR 3, and these sites are already two-based today, so any change here changes behaviour. PR 3. |
 | ~~**S10**~~ **DONE (PR 2)** | comptime string builtins — **10 sites, not 4**: `comptime_string_fns.yo` (1 `len` + 4 `len` defaults + 1 `substring`), `comptime_index_fns.yo` (2 `len` + 2 `substring`), `index_trait.yo` (2 `len` + 2 `substring`) | semantics ride on `substring` | pinned to `char_len`/`char_substring`, each with a `COMPTIME BASIS PIN` comment naming O1c. PR 7 now changes the comptime basis only by editing these names. |
+| ~~**S11**~~ **DONE (review pass, 2026-08-26)** | `src/formatter.yo:1246`; `src/lsp/hover.yo:50,292`; `src/lsp/symbols.yo:98`; `src/lsp/definition.yo:104`; `src/lsp/references.yo:34,98`; `src/lsp/rename.yo:35`; `src/lsp/completion.yo:926,930`; `src/doc/builder.yo:379` — **11 sites in 6 files this plan never named** | Exactly S7's shape: a RUNE column (`Token.column` / `Token.character`, both produced by the lexer's `ArrayList(rune)` walk at `src/lexer.yo:97-99`) added to `tok.value.len()`. After PR 3 the width becomes BYTES, so every one of them overruns on a multibyte token: hover matches the wrong token, `definition`/`references`/`symbols`/`rename` emit ranges longer than the identifier (**rename would replace past the end of the name**), completion's `ends_at_dot`/`before_dot` stop finding the receiver, `fmt`'s tight-call adjacency test changes formatting, and doc-comment adjacency inserts a stray space. | `char_len()` at all 11. Inert by the same construction as S7 (`char_len`'s body IS `len`'s body). **PR 2's original claim that "every site that needs char semantics now says so" was FALSE until this row landed** — §5.2 had listed only the `src/error.yo` instance of the pattern. |
 
 ### 5.3 (b) regex `_byte_to_char_index` — see S3
 
@@ -730,10 +748,19 @@ they guard the vocabulary and not yet the flipping methods. Consequences:
 
 - ~~The `std/fmt/spec.yo` width regression (S2) has **zero** coverage —
   `tests/format_specs.test.yo` never pads a multibyte body. **Add it in PR 2.**~~
-  **DONE 2026-08-26:** `tests/format_specs.test.yo` 7 → 12 tests, all five new
+  **DONE 2026-08-26:** `tests/format_specs.test.yo` 7 → 13 tests, all six new
   ones multibyte (width, multibyte FILL runes, precision, width+precision
-  composed, numeric padding). Under a simulated byte flip the five fail without
-  the S2 migration and pass with it.
+  composed, numeric padding, and `pad_numeric` called directly). Under a
+  simulated byte flip they fail without the S2 migration and pass with it.
+  **One of the six was vacuous as first written and was replaced in the review
+  pass:** the "numeric padding measures … in characters" test asserted only
+  through `Format::format`, and `String.format` routes a String body to
+  `FormatSpec.pad`, **never** to `pad_numeric` — while the radix formatters only
+  ever hand `pad_numeric` ASCII. So `pad_numeric`'s three `char_len()` calls
+  (S2's un-listed lines 219-220) had **no** coverage at all. The replacement
+  calls `FormatSpec.parse(...).pad_numeric(sign, prefix, digits)` directly with
+  multibyte parts; every expected value differs under a byte basis, and the
+  differing byte-basis value is written in a comment beside each assertion.
 - **Also with zero coverage, and not on this list: `std/encoding/html.yo`.**
   `tests/encoding/html.test.yo`'s 8 tests put multibyte content only in the
   decoder's OUTPUT — every INPUT was ASCII, so the scanner's rune arithmetic
@@ -742,6 +769,17 @@ they guard the vocabulary and not yet the flipping methods. Consequences:
   tests, the four new ones running multibyte text through the scanner on both
   sides of every entity form and through the legacy-backtracking and
   invalid-code-point arms.
+- **`src/parser.yo`'s `_peel_spec` (S4) had NO from-source coverage at all** —
+  `tests/template_string_specs.test.yo` runs through the *installed* compiler,
+  and `tests/internal/parser.test.yo` had no template-string test whatsoever.
+  **DONE 2026-08-26 (review pass):** 49 → 52 tests there, the three new ones
+  parsing `${名前:>8}`-shaped template strings from source and asserting the
+  peeled rendering (`(名前.format)(">8")`). Measured discrimination: a
+  differential driver holding the migrated peel, the pre-PR-2 peel, and the
+  pre-PR-2 peel **under a byte-based slice** reports 35 cases, **0** mismatches
+  between the first two (PR 2 is inert) and **12** cases where the third
+  differs — i.e. the migration is load-bearing on 12 of 35 inputs once PR 3
+  lands, and these tests are what will notice.
 - The regex `index()` flip (S3) has 2 tests. **Add byte-offset assertions.**
 - `imm.String.len()` → bytes is guarded by **one** test
   (`tests/imm_string.test.yo:129`, "Unicode rune count"). **Add a byte battery
@@ -763,6 +801,18 @@ they guard the vocabulary and not yet the flipping methods. Consequences:
   `array_list_convenience` (6), `os/env` (5), `encoding/base64` (5) — **will
   stay green through a completely wrong migration.** Do not read their
   greenness as evidence.
+
+**Which test files can and cannot witness a `src/` migration.** `yo test` loads
+`std/` from source but runs `src/` **through the installed compiler binary**. So
+`tests/encoding/html`, `tests/format_specs`, `tests/string/*` and
+`tests/imm_string` DO exercise PR 2's `std/` half, while `tests/comptime`,
+`tests/index` and `tests/template_string_specs` exercise the **installed**
+comptime builtins and parser — not the migrated ones. Their greenness is a
+no-regression signal for the `std/` half and **nothing at all** for S4/S7/S10.
+The only gates that witness the `src/` half are a rebuild (`yo build` /
+`gates_fast.sh` / fixpoint) and, short of that, source-level body identity
+(§6.1 item 2) plus a differential driver holding both implementations (what S4
+got).
 
 ### 6.3 Gate battery per PR
 

--- a/plans/STD_API_AUDIT_D4_PLAN.md
+++ b/plans/STD_API_AUDIT_D4_PLAN.md
@@ -1,6 +1,6 @@
 # D4 — String indexing model: the executable migration plan
 
-> **Status:** **PR 1 LANDED 2026-08-26**; PRs 2-9 still PLAN.
+> **Status:** **PRs 1-2 LANDED 2026-08-26**; PRs 3-9 still PLAN.
 > (Survey complete 2026-08-25.)
 > **Parent decision:** `plans/STD_API_AUDIT.md` §3 **D4** + §8 **O1** —
 > `String` goes byte-indexed like Rust/Go. Scope extended (user, 2026-08-25)
@@ -68,6 +68,8 @@ contract.
 | ~~`floor_char_boundary(i)`~~ | 1903 | — | **B** | ✅ **LANDED PR 1** |
 | ~~`ceil_char_boundary(i)`~~ | 1930 | — | **B** | ✅ **LANDED PR 1** |
 | ~~`try_substring(a, b)`~~ | 1961 | — | **B**, `Option(String)` | ✅ **LANDED PR 1** |
+| ~~`char_substring(start, end)`~~ | 497 | — | **C** — holds `substring`'s CURRENT body verbatim; `substring` is now a one-line delegation to it, which is PR 3's insertion point | ✅ **LANDED PR 2** |
+| ~~`truncate_chars(max_runes)`~~ | 2013 | — | **C**, `char_substring(0, n)` | ✅ **LANDED PR 2** |
 
 **Was verified absent before PR 1:** `grep -rn "char_indices\|char_len" std/`
 returned only unrelated locals in `std/regex/index.yo` and
@@ -369,7 +371,7 @@ The dominant idiom is `x.substring(K, x.len())` with `K` the length of an
 | `src/error.yo:43` | `caret_col := token.column + (token.value.len() / usize(2))` | mixes a **rune** column with a token-value length; after the flip the length is bytes → caret drifts |
 | `src/evaluator/builtins/comptime_index_fns.yo:781,862` | comptime `s[i]` / `s(a..b)` | comptime language semantics ride on `substring` (O1c) |
 | `src/evaluator/calls/index_trait.yo:804,865` | same, other path | ditto |
-| `src/doc_command.yo:223,231,235,242,253` | `content.substring(j, j + usize(1))` char-at-a-time scan of `build.yo` text | a 1-**byte** slice compared against `` ` ` `` etc. — works only because the delimiters are ASCII, but the *cursor* `j` advances by 1 per byte, so multibyte values inside a build.yo string are mis-scanned. **REVIEW** — likely fine, prove it |
+| ~~`src/doc_command.yo:223,231,235,242,253`~~ **RESOLVED INVARIANT (PR 2)** | `content.substring(j, j + usize(1))` char-at-a-time scan of `build.yo` text | **Reviewed 2026-08-26: single-basis and self-consistent, so it is INVARIANT, not RISK.** Every index in `_scan_quoted_value_after` comes from `content.index_of(...)` or `marker.len()`, both in the SAME basis as the `substring` that consumes them, and `content.len()` bounds the same walk. The only comparisons are 1-unit slices against ASCII delimiters (space, tab, CR, LF, `:`/`=`, `"`), which simply fail to match on any interior byte of a multibyte rune — and the loops those comparisons drive only SKIP whitespace, so advancing by a byte instead of a rune reaches the same place. Not migrated. |
 | `src/pkg_config.yo:57,65` | `s.substring(start, k)` with `k` walking `bytes.len()` | **LIVE BUG TODAY** (§5.1) |
 | `src/install_command.yo:60,66` | `substring(…, s.bytes_len())` | **LIVE BUG TODAY** (§5.1) |
 | `src/main.yo:802` | `p.substring(usize(0), usize(last_sep))` | `last_sep` is a **byte** index from the `byte_at` loop at `:792` — **LIVE BUG TODAY** |
@@ -402,7 +404,7 @@ no-op and PR 3 only has to change definitions.
 | --- | --- | --- |
 | ~~**0**~~ **LANDED** (#286) | `std/encoding/utf8.yo`. Primitives: `seq_len(lead: u8) -> usize`, `decode(bytes, i) -> Option((rune, usize))`, `encode(r, out)`, `is_char_boundary(bytes, i)`, `validate`. **Dependency:** PR 1 and PR 6 both consume it; PR 2 does not. | `yo check ./std`; new `tests/encoding/utf8.test.yo` |
 | ~~**1**~~ **LANDED 2026-08-26** | **Additive only.** `String.char_len()`, `String.char_indices()`, `String.is_char_boundary()`, `floor_char_boundary`, `ceil_char_boundary`, `try_substring`. Same six on `imm.String`, plus `imm.String.chars()`. Built on `std/encoding/utf8` (PR 0), no second decoder. New `tests/string/string_char_api.test.yo` (17 tests) + 6 tests appended to `tests/imm_string.test.yo`, all multibyte. | achieved: `yo check ./std` 153/153; `tests/string/string_char_api` 17/17, `tests/imm_string` 34/34, `tests/string/string` 253/253, `imm_map`/`imm_vec`/`imm_threading` green; 0 `Failed to transpile` in both kept batches; emitted-C **equivalence** measured as below (literal byte-identity is unattainable — see the correction under §6.1) |
-| **2** | **Pin char semantics, no basis change.** Rewrite the §3.1-RISK and §5.2 sites to the new char APIs: `std/encoding/html.yo` `at()` loops → `chars()`; `std/fmt/spec.yo` width/precision → `char_len()` + `truncate_chars`; `src/error.yo:43` → `char_len()`; `src/doc/render_html.yo:406` → `truncate_chars`; `src/parser.yo:_peel_spec` → `char_indices()`; comptime string builtins pinned to explicit char helpers (O1c). **Because `char_len() == len()` today, this PR must not change one byte of behaviour.** | full language suite; **emitted-C equivalence of the corpus** — NOT literal byte-identity, which PR 1 measured to be unattainable for any `std` edit; use the normalized comparison in the §6.1 correction |
+| ~~**2**~~ **LANDED 2026-08-26** | **Pin char semantics, no basis change.** Done: `std/encoding/html.yo` onto a `char_indices()` rune table (S1); `std/fmt/spec.yo` width/precision/numeric-total onto `char_len()` + the new `truncate_chars` (S2); `std/string/string.yo` `_split_impl`'s empty-separator arm onto `char_len`/`char_substring` (S5); `src/parser.yo:_peel_spec` onto `char_indices()` + `try_substring` (S4); `src/doc/render_html.yo` onto `char_len`/`truncate_chars` (S6); `src/error.yo:43` onto `char_len()` (S7); all 10 comptime-string-builtin sites onto `char_len`/`char_substring` (S10, O1c). Two additive helpers were needed and added: `char_substring` (the rune-indexed slice, holding `substring`'s CURRENT body verbatim — `substring` is now a one-line delegation to it) and `truncate_chars`. **NOT done here, and why:** S8 (`src/doc/builder.yo`) needs `Token.byte_offset`, S9 (`src/lsp/completion.yo`) needs the UTF-16 work — both are PR 3 by §5.4; S3 (regex) is PR 6. | achieved: `yo check ./std --std-path <tree>/std` 153/153; every touched `src/` file `check`s clean; `tests/encoding/html` 12/12 (was 8), `tests/format_specs` 12/12 (was 7), `tests/string/string_char_api` 21/21 (was 17), `tests/string/string` 253/253, `tests/template_string_specs` 6/6, `tests/imm_string` 34/34, `string_builder` 21/21, `rune` 36/36. Behavioural gate: a 862-line multibyte probe over `decode_html` / `FormatSpec.pad` / `pad_numeric` / `split("")` / the rune vocabulary hashes **`828549f0f0a9bdf747692bc872f018499a53435f518741fe055742d8561105e3` before AND after** the migration. Emitted C is NOT identical and cannot be — see the §6.1 correction extension below. |
 | **3** | **The flip.** `String.len()` → bytes O(1); `at`/`substring`/`slice_copy*`/`index_of`/`last_index_of`/`contains(from)`/`starts_with(pos)`/`ends_with(pos)`/`Pattern`'s five methods → bytes. `bytes_len()` becomes a deprecated alias. Fix §1.3(a) by construction. `src/` migrates **in the same PR** — the repo build compiles `src/` against the *repo's* `std` (`--std-path > YO_STD > exe-walk-up > ./std`), so it cannot lag. Add `Token.byte_offset` and retire `_byte_offset_of_char_index` (`src/formatter.yo:1496`). | `yo check ./std && yo check ./src`; full language suite; `tests/internal`; `gates_fast.sh` + fixpoint; new §6 multibyte battery |
 | **4** | `imm.String`: `len()` → bytes, `at()` aligned, `bytes_len()` aliased, `chars()`/`char_indices()`/`char_len()` wired. | `tests/imm_string.test.yo` (rewritten per §6.2), `imm_vec`, `imm_threading` |
 | **5** | `imm.String` → `ImmString` rename. ~15 lines: the `String ::` binding + `export`, 3 test imports, 4 doc lines × 2 languages. | suite + docs both languages |
@@ -414,22 +416,42 @@ no-op and PR 3 only has to change definitions.
 **Ordering constraints, explicitly:**
 
 - PR 1 **must** precede PR 2 (`char_indices()` is what PR 2 migrates onto). ✅ done.
-- **PR 1 did NOT ship `truncate_chars`.** §4 PR 2 names it for S2/S6 but §4 PR 1
-  does not list it, so it was deliberately left out. PR 2 either adds it (as a
-  `char_len` + `floor_char_boundary` + `try_substring` composition — the shape is
-  covered by `tests/string/string_char_api.test.yo`'s last test) or migrates
-  those two sites without it.
+- ~~**PR 1 did NOT ship `truncate_chars`.**~~ **PR 2 added it**, together with
+  `char_substring`. Not as the `floor_char_boundary` composition PR 1 guessed at:
+  `truncate_chars(n)` is `char_substring(0, n)`, and `char_substring` holds
+  `substring`'s CURRENT body byte-for-byte (mechanically verified against
+  `git show HEAD:std/string/string.yo`), with `substring` reduced to
+  `self.char_substring(start, end)`. That is what makes every
+  `substring → char_substring` rewrite in PR 2 provably inert, and it is also
+  **PR 3's insertion point**: PR 3 gives `substring` a byte-slice body and leaves
+  `char_substring` alone.
 - **`try_substring` is BYTE-based from day one**, while `substring` is still
   character-based until PR 3. That is intentional: a NEW name can carry the final
   contract, and a new name that flipped basis under its callers in PR 3 would be
   exactly the silent hazard this plan exists to avoid. PR 2 must not reach for
   `try_substring` as a drop-in for `substring`; its migration targets are
   `char_len()` and `char_indices()`.
-- PR 2 **must** precede PR 3. This is the whole safety argument: after PR 2,
+- PR 2 **must** precede PR 3. ✅ done. This is the whole safety argument: after
+  PR 2,
   every site that *needs* char semantics says so in its own source, so PR 3's
   review question collapses to "does this site want bytes?" — and the answer
   is yes everywhere left.
 - PR 3 is the only PR that cannot be split across `std` and `src`.
+- **`impl` blocks do not see FORWARD across each other** — measured twice in
+  PR 2, both times as `No matching call found with arguments: (self.X)()` from
+  `yo check ./std`. A method defined in a LATER `impl(String, …)` block is not
+  callable from an earlier one (within a single block, forward references are
+  fine — `slice_copy_inclusive` already calls `substring` defined below it).
+  PR 1 put the whole rune vocabulary in a new trailing block; PR 2 had to move
+  `char_len` up beside `len()` so `_split_impl` (line ~660) could call it.
+  **PR 3 will hit this again:** the byte-basis `at()` wants
+  `is_char_boundary`, which still lives in the trailing block, so
+  `is_char_boundary` has to move up beside `at()` (or `at()` has to inline
+  `utf8.is_boundary`, which is what PR 2's throwaway flip experiment did).
+- **PR 3's insertion point is now one function.** `substring` is
+  `self.char_substring(start, end)`; give it a byte-slice body and leave
+  `char_substring` alone, and `slice_copy` / `slice_copy_inclusive` follow for
+  free since they already delegate to `substring`.
 - PR 6 can land before or after PR 3 **only if** it lands after — regex's
   `index()` is consumed by its own `replace*` which re-walks; splitting them
   leaves a half-converted state. Keep 6 after 3.
@@ -440,7 +462,7 @@ no-op and PR 3 only has to change definitions.
 
 ## 5. The trap list
 
-### 5.1 (a) `len()` bound mixed with a byte loop — **7 confirmed live bugs D4 FIXES**
+### 5.1 (a) `len()` bound mixed with a byte loop — **8 confirmed live bugs D4 FIXES**
 
 Detector (25-line window, receiver-matched):
 
@@ -454,7 +476,7 @@ grep -rn -A40 'while(.* < [A-Za-z_][A-Za-z_0-9.]*\.len()' std src tests vendor
 ```
 
 Repo-wide the detector reports **41 co-occurrence windows**. Confirmed by
-reading:
+reading (7 at survey time; an 8th, `std/fs/dir.yo`, was found in PR 2):
 
 | site | shape | verdict |
 | --- | --- | --- |
@@ -465,6 +487,7 @@ reading:
 | `src/pkg_config.yo:34-66` `_split_whitespace` | `n := bytes.len()`, walks `k` over bytes, then `s.substring(start, k)` | **LIVE BUG**. D4 fixes it. |
 | `src/lsp/diagnostics.yo:72-89` `_ident_len_at` | rune `col` indexed into `line.as_bytes()` | **LIVE BUG**, **NOT fixed by D4** — `col` stays a rune column. Needs the `Token.byte_offset` work (PR 3). |
 | `std/fmt/writer.yo:42` | `while(i < s.len())` + `s.bytes(i)` | **false positive** — `s : str`, whose `len()` is already bytes. Clean. |
+| `std/fs/dir.yo:93-121` `mkdir_all` | `bytes := path_s.as_bytes()`, `i` walks `bytes`, then `path_s.substring(usize(0), i)` | **LIVE BUG, FOUND IN PR 2 (2026-08-26) — an 8th, and the first in `std/` rather than `src/`; written up in `issues/mkdir-all-uses-a-byte-index-as-a-rune-index.md`.** `i` is a byte index into `as_bytes()`; `substring` reads it as a rune index, so `mkdir_all` on a path with a non-ASCII component creates the WRONG parent directory (a short prefix) and then fails or silently makes the wrong tree. Exactly the `_win_dirname` / `_split_whitespace` shape. **D4 PR 3 fixes it for free** — deliberately NOT touched in PR 2, whose contract is no behaviour change. |
 
 **Precedent, already paid for once:**
 `issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md` — a
@@ -486,16 +509,16 @@ corruption in the stage-2 binary") and
 
 | id | site | why | fix |
 | --- | --- | --- | --- |
-| **S1** | `std/encoding/html.yo:34, 52, 80, 92, 99, 106, 117, 140, 151, 175, 185` | `while(i < s.len())` + `s.at(i).unwrap()` over **arbitrary HTML text**. After the flip `at()` at a continuation byte is `.None` → `.unwrap()` **panics**. Highest-risk file in the tree. | rewrite the three loops onto `char_indices()`; also removes today's O(n²) |
-| **S2** | `std/fmt/spec.yo:36, 69, 206-207` | `width` is documented "Minimum width in **CHARACTERS**"; `_apply_width` uses `text.len()`, `pad` truncates with `substring(0, p)`. After the flip padding counts bytes and precision can split a codepoint. Rust counts chars here. | `char_len()` + boundary-safe `truncate_chars` |
+| ~~**S1**~~ **DONE (PR 2)** | `std/encoding/html.yo:34, 52, 80, 92, 99, 106, 117, 140, 151, 175, 185` | `while(i < s.len())` + `s.at(i).unwrap()` over **arbitrary HTML text**. After the flip `at()` at a continuation byte is `.None` → `.unwrap()` **panics**. Highest-risk file in the tree. | done, but NOT as "three loops onto `chars()`" — `decode_html` is a **backtracking** scanner (`try_end` walks back one rune at a time, `substring(start, i)` re-slices between two scanner positions), which a forward-only iterator cannot express. It now materializes one `char_indices()` table of `(byte_offset, rune)` and indexes that by rune; `_parse_hex`/`_parse_dec` — which really are plain forward loops — did go onto `chars()`. The O(n²) is gone either way. |
+| ~~**S2**~~ **DONE (PR 2)** | `std/fmt/spec.yo:36, 69, 206-207` **plus 219-220, which this plan missed** | `width` is documented "Minimum width in **CHARACTERS**"; `_apply_width` uses `text.len()`, `pad` truncates with `substring(0, p)`. After the flip padding counts bytes and precision can split a codepoint. Rust counts chars here. **`pad_numeric`'s `sign.len() + prefix.len() + digits.len()` was not on the list but is compared against the same `self.width`**, so it had to move to the same basis or the two paths would disagree. | `char_len()` + the new `truncate_chars`; `pad_numeric`'s three lengths too |
 | **S3** | `std/regex/index.yo:70, 144` + `:535-545, 582-592, 634-644` | `RegexMatch.index()` is a **char** index produced by an O(n) `_byte_to_char_index` per match, then converted **back** to bytes by three more O(n) walks in `replace`/`replace_all`. `replace_all` is O(n·m) purely from basis conversion. | delete all four walks; `index()` becomes a byte index (public API change — release note) |
-| **S4** | `src/parser.yo:517-546` `_peel_spec` | rune indices from an `ArrayList(rune)` fed to `text.substring` | `char_indices()` |
-| **S5** | `std/string/string.yo:662-676` `_split_impl`, empty-separator arm | `self.substring(i, i+1)` per char, bounded by `self.len()` — "split into characters". Must stay **char**-based or `split("")` returns invalid-UTF-8 fragments. | pin to `char_indices()` |
-| **S6** | `src/doc/render_html.yo:404-406` | fixed 120-unit cut of arbitrary doc text | `truncate_chars(120)` |
-| **S7** | `src/error.yo:43` | rune column + token-value length | `char_len()` |
-| **S8** | `src/doc/builder.yo:233-235` | `Token.character` (rune) into `substring` | `Token.byte_offset` |
-| **S9** | `src/lsp/completion.yo:762-780, 875, 1010` | LSP `character` into `substring` | see (c) below |
-| **S10** | comptime string builtins (4 sites, §1.4 O1c) | semantics ride on `substring` | pin, then decide in PR 7 |
+| ~~**S4**~~ **DONE (PR 2)** | `src/parser.yo:517-546` `_peel_spec` | rune indices from an `ArrayList(rune)` fed to `text.substring` | `char_indices()` fills a parallel `ArrayList(usize)` of byte offsets; the two cuts go through `try_substring`. Verified by a differential driver holding BOTH implementations (`tmp/d4pr2_peel.yo` shape): 29 inputs, 15 multibyte, **0 mismatches**. |
+| ~~**S5**~~ **DONE (PR 2)** | `std/string/string.yo:662-676` `_split_impl`, empty-separator arm | `self.substring(i, i+1)` per char, bounded by `self.len()` — "split into characters". Must stay **char**-based or `split("")` returns invalid-UTF-8 fragments. | pinned to `char_len()` + `char_substring()` rather than rewritten onto `char_indices()`: a `char_indices` walk needs lookahead for each rune's end offset, so it would add code and a new failure mode for no behaviour change, in a PR whose contract is exactly "no behaviour change". The O(n²) here is pre-existing and left; unlike html.yo the inputs are short. |
+| ~~**S6**~~ **DONE (PR 2)** | `src/doc/render_html.yo:404-406` | fixed 120-unit cut of arbitrary doc text | `char_len() > 120` + `truncate_chars(120)`. The `> 120` guard is KEPT: `.trim()` is chained onto the cut and only runs when the cut happens, so dropping the guard would change the result for short summaries. |
+| ~~**S7**~~ **DONE (PR 2)** | `src/error.yo:43` | rune column + token-value length | `char_len()` |
+| **S8** | `src/doc/builder.yo:233-235` | `Token.character` (rune) into `substring` | `Token.byte_offset` — **deliberately NOT in PR 2**: it needs a new lexer field, which is a behaviour-affecting change to `Token`. PR 3. |
+| **S9** | `src/lsp/completion.yo:762-780, 875, 1010` | LSP `character` into `substring` | see (c) below — **deliberately NOT in PR 2**: §5.4 says the UTF-16 correction lands WITH PR 3, and these sites are already two-based today, so any change here changes behaviour. PR 3. |
+| ~~**S10**~~ **DONE (PR 2)** | comptime string builtins — **10 sites, not 4**: `comptime_string_fns.yo` (1 `len` + 4 `len` defaults + 1 `substring`), `comptime_index_fns.yo` (2 `len` + 2 `substring`), `index_trait.yo` (2 `len` + 2 `substring`) | semantics ride on `substring` | pinned to `char_len`/`char_substring`, each with a `COMPTIME BASIS PIN` comment naming O1c. PR 7 now changes the comptime basis only by editing these names. |
 
 ### 5.3 (b) regex `_byte_to_char_index` — see S3
 
@@ -596,10 +619,10 @@ things catch it:
    "did the rune count change?" (must be no) from "did `len()` change?" (must
    be yes).
 
-Plus, for PR 2 specifically: **byte-identity of the emitted-C corpus**. PR 2
-claims to change no behaviour; record `sha256` of every `.c` before editing and
-require `same=N diff=0`. That is the repo's standing acceptance test for an
-"additive" codegen change and it makes the PR-2 review free.
+Plus, for PR 2 specifically: ~~**byte-identity of the emitted-C corpus**~~ —
+see the SECOND CORRECTION below. PR 2 claims to change no behaviour, but it
+does so by rewriting bodies, so the artefact to hash is the **program's
+output**, not its C.
 
 **CORRECTION (measured in PR 1, 2026-08-26): literal byte-identity of emitted C
 is unattainable for ANY `std` edit, additive or not.** The C backend embeds two
@@ -634,6 +657,49 @@ renumbering above plus a reordering of a handful of type declarations. That is
 the strongest inertness statement available, and it is stronger than a `sha256`
 would have been even if one had matched.
 
+**SECOND CORRECTION (measured in PR 2, 2026-08-26): emitted-C comparison is the
+wrong gate for PR 2 ALTOGETHER — not merely "not byte-identity".** PR 1 was
+purely additive, so its emitted C could differ only by renumbering. PR 2 is a
+*rewrite*: `decode_html`'s scanner, `_parse_hex`/`_parse_dec`, `_apply_width`,
+`pad`, `pad_numeric`, `_split_impl` and `_peel_spec` all get different bodies on
+purpose. Measured on the same probe: **13567 → 14139 lines, `sha256`
+`a53f0a58…` → `76cb77fb…`, and the emitted-symbol set genuinely gains a
+`ArrayList(IterPair(usize, rune))` family.** Requiring the C to match would
+either fail vacuously or force the migration not to happen. Do not write
+"byte-identity" or "emitted-C equivalence" as PR 2's gate.
+
+**What IS decisive for PR 2 — three things, all run:**
+
+1. **Output-identity of a behavioural probe.** A standalone driver over a
+   deliberately multibyte corpus (40 `decode_html` inputs, 11 text bodies × 21
+   specs through `pad`/`pad_numeric`, `split("")`, and the whole rune
+   vocabulary) printing every result with its rune and byte length: 862 lines,
+   `sha256` **`828549f0f0a9bdf747692bc872f018499a53435f518741fe055742d8561105e3`
+   before AND after**. That is what "no behaviour change" actually means, and
+   unlike a C hash it cannot be satisfied vacuously.
+2. **Body-identity where a rename is claimed.** `char_substring`'s body is
+   byte-for-byte `substring`'s body at the parent commit (checked mechanically
+   against `git show HEAD:std/string/string.yo`), and `char_len`'s algorithm is
+   `len`'s. So every `substring → char_substring` and `len → char_len` rewrite
+   — including all ten comptime-builtin sites, which no runtime test can reach
+   until the compiler is rebuilt — is inert by construction, not by testing.
+3. **A simulated flip, run both ways.** `len`/`at`/`substring` were temporarily
+   made byte-based in a throwaway edit and the two migrated files were run
+   against it:
+
+   | | ASCII-only tests (pre-existing) | multibyte tests (added in PR 2) |
+   | --- | --- | --- |
+   | migrated `html.yo` + flipped std | 8/8 pass | **4/4 pass** |
+   | HEAD `html.yo` + flipped std | 8/8 pass | **0/4 pass** |
+   | migrated `spec.yo` + flipped std | 7/7 pass | **5/5 pass** |
+   | HEAD `spec.yo` + flipped std | 7/7 pass | **0/5 pass** |
+
+   This is the whole D4 safety argument reduced to one table. The pre-existing
+   ASCII tests are *invariant to the bug*, exactly as §6.2 warns; the new tests
+   fail without the migration and pass with it; and both pass under today's
+   char basis, which is why PR 2 is a no-op. The flip was reverted and the
+   probe re-hashed to `828549f0…` to prove the tree came back clean.
+
 ### 6.2 Which existing tests cannot catch this class
 
 Per-test measurement (a test counts only if the **same test body** contains
@@ -662,8 +728,20 @@ both a non-ASCII literal and an index-basis call):
 that are multibyte-plus-index by construction, all of them on the NEW names, so
 they guard the vocabulary and not yet the flipping methods. Consequences:
 
-- The `std/fmt/spec.yo` width regression (S2) has **zero** coverage —
-  `tests/format_specs.test.yo` never pads a multibyte body. **Add it in PR 2.**
+- ~~The `std/fmt/spec.yo` width regression (S2) has **zero** coverage —
+  `tests/format_specs.test.yo` never pads a multibyte body. **Add it in PR 2.**~~
+  **DONE 2026-08-26:** `tests/format_specs.test.yo` 7 → 12 tests, all five new
+  ones multibyte (width, multibyte FILL runes, precision, width+precision
+  composed, numeric padding). Under a simulated byte flip the five fail without
+  the S2 migration and pass with it.
+- **Also with zero coverage, and not on this list: `std/encoding/html.yo`.**
+  `tests/encoding/html.test.yo`'s 8 tests put multibyte content only in the
+  decoder's OUTPUT — every INPUT was ASCII, so the scanner's rune arithmetic
+  was never exercised at all. For the file §5.2 calls the highest-risk in the
+  tree, that is worse than the `spec.yo` gap. **DONE 2026-08-26:** 8 → 12
+  tests, the four new ones running multibyte text through the scanner on both
+  sides of every entity form and through the legacy-backtracking and
+  invalid-code-point arms.
 - The regex `index()` flip (S3) has 2 tests. **Add byte-offset assertions.**
 - `imm.String.len()` → bytes is guarded by **one** test
   (`tests/imm_string.test.yo:129`, "Unicode rune count"). **Add a byte battery
@@ -739,9 +817,17 @@ Stated so nothing here reads as more certain than it is.
 - **Exact `String.len()` call-site count.** Bounded to 500-1050 in `src/`
   (§2.2); not exact. A `yo check`-driven type-directed count would settle it
   and is worth building once as a throwaway.
-- **`std/http/http.yo`, `std/http/client.yo`, `std/encoding/toml.yo`,
+- ~~**`std/http/http.yo`, `std/http/client.yo`, `std/encoding/toml.yo`,
   `std/fs/dir.yo`, `std/path.yo`** — 14 `substring` sites not individually
-  classified. Assume RISK.
+  classified. Assume RISK.~~ **CLASSIFIED in PR 2 (2026-08-26).** 13 of the 14
+  are INVARIANT: `http.yo:156,165,166,190,191` and `client.yo:157,161` pair an
+  `index_of` result with a `substring` in the same basis, or slice to
+  `X.len()`; `toml.yo:120,165` strip ASCII `"`/`[`/`]` delimiters with
+  `substring(1, len-1)`, where both endpoints are one ASCII byte in from an end
+  and so name the same cut in either basis; `toml.yo:178,179` and
+  `path.yo:251,278` are `index_of`/`last_index_of` results fed straight back.
+  **The 14th, `std/fs/dir.yo:121`, is not INVARIANT — it is a LIVE BUG**, now
+  listed in §5.1.
 - **`src/doc_command.yo:223-253`** — the char-at-a-time `build.yo` scanner;
   classified REVIEW, not proven.
 - **`vendor/markdown_yo`** — 2 `substring`, 19 heuristic `String.len()`, 4

--- a/src/doc/builder.yo
+++ b/src/doc/builder.yo
@@ -377,7 +377,7 @@ _render_token_span :: (
     if(k > start, {
       prev := match(toks.get(k - usize(1)), .Some(pt) => pt, .None => t);
       // `Token.character` is a RUNE offset, so the token width added to one
-      // has to be a rune count (§5.2 S7).
+      // has to be a rune count (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S11).
       adjacent := ((prev.character + prev.value.char_len()) == t.character);
       suppress := ((prev.kind == TokenKind.LParen) || (t.kind == TokenKind.RParen) || (t.kind == TokenKind.Comma) || (t.kind == TokenKind.Semicolon));
       if(!(adjacent) && !(suppress), {

--- a/src/doc/builder.yo
+++ b/src/doc/builder.yo
@@ -376,7 +376,9 @@ _render_token_span :: (
     );
     if(k > start, {
       prev := match(toks.get(k - usize(1)), .Some(pt) => pt, .None => t);
-      adjacent := ((prev.character + prev.value.len()) == t.character);
+      // `Token.character` is a RUNE offset, so the token width added to one
+      // has to be a rune count (§5.2 S7).
+      adjacent := ((prev.character + prev.value.char_len()) == t.character);
       suppress := ((prev.kind == TokenKind.LParen) || (t.kind == TokenKind.RParen) || (t.kind == TokenKind.Comma) || (t.kind == TokenKind.Semicolon));
       if(!(adjacent) && !(suppress), {
         out = `${out} `;

--- a/src/doc/render_html.yo
+++ b/src/doc/render_html.yo
@@ -401,9 +401,12 @@ _first_sentence :: (fn(text : String) -> String)({
     });
     i = (i + usize(1));
   });
-  // Cap at 120 CHARS (TS slice(0,120) is UTF-16 units; doc text is ASCII-ish)
-  if(result.len() > usize(120), {
-    result = result.substring(usize(0), usize(120)).trim();
+  // Cap at 120 CHARS (TS slice(0,120) is UTF-16 units; doc text is ASCII-ish).
+  // Doc text is arbitrary human prose, so the cut must land on a rune
+  // boundary — a fixed byte cut would emit invalid UTF-8 into the search
+  // index (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S6).
+  if(result.char_len() > usize(120), {
+    result = result.truncate_chars(usize(120)).trim();
   });
   result
 });

--- a/src/error.yo
+++ b/src/error.yo
@@ -40,7 +40,11 @@ get_line_at_token :: (fn(token : Token) -> String)({
     .Some(line) => line,
     .None => String.new()
   );
-  caret_col := (token.column + (token.value.len() / usize(2)));
+  // `token.column` is a RUNE column (src/lexer.yo indexes an ArrayList(rune)),
+  // so the half-width offset added to it has to be a rune count too — say so,
+  // rather than inheriting whatever basis `len()` happens to have
+  // (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S7).
+  caret_col := (token.column + (token.value.char_len() / usize(2)));
   spaces := String.from(" ").repeat(caret_col);
   row_plus1 := (token.row + usize(1));
   col_plus1 := (token.column + usize(1));

--- a/src/evaluator/builtins/comptime_index_fns.yo
+++ b/src/evaluator/builtins/comptime_index_fns.yo
@@ -765,7 +765,7 @@ ci_eval_string_index :: (
       );
     });
     idx_usize := usize(idx_i64);
-    str_len := unquoted.len();
+    str_len := unquoted.char_len();
     if(idx_usize >= str_len, {
       exn.throw(
         dyn(
@@ -778,7 +778,10 @@ ci_eval_string_index :: (
         )
       );
     });
-    char_str := unquoted.substring(idx_usize, idx_usize + usize(1));
+    // COMPTIME BASIS PIN (STD_API_AUDIT_D4_PLAN §1.4 O1c): comptime `s[i]`
+    // yields the i-th CHARACTER as a 1-char StrLit, not the i-th byte. Runtime
+    // `s[i]` already differs (it is a u8); PR 7 decides whether to unify them.
+    char_str := unquoted.char_substring(idx_usize, idx_usize + usize(1));
     out_info := new_expr_info(cur_env, result_ty);
     out_info.value = Option(EvalValue).Some(EvalValue.StrLit(ci_str_quote(char_str)));
     expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_info);
@@ -822,7 +825,7 @@ ci_eval_string_index :: (
   );
   start_idx := ci_range.start_idx;
   end_idx := ci_range.end_idx;
-  str_len := unquoted.len();
+  str_len := unquoted.char_len();
   if(start_idx > str_len, {
     exn.throw(
       dyn(
@@ -859,7 +862,9 @@ ci_eval_string_index :: (
       )
     );
   });
-  sliced := unquoted.substring(start_idx, end_idx);
+  // COMPTIME BASIS PIN (STD_API_AUDIT_D4_PLAN §1.4 O1c): comptime `s(a..b)`
+  // slices CHARACTERS.
+  sliced := unquoted.char_substring(start_idx, end_idx);
   out_info := new_expr_info(cur_env, result_ty);
   out_info.value = Option(EvalValue).Some(EvalValue.StrLit(ci_str_quote(sliced)));
   expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_info);

--- a/src/evaluator/builtins/comptime_string_fns.yo
+++ b/src/evaluator/builtins/comptime_string_fns.yo
@@ -186,7 +186,10 @@ evaluate_yo_comptime_string_functions :: (
             av,
             .StrLit(raw) => {
               unquoted := str_lit_unquote(raw);
-              EvalValue.IntLit(unquoted.len().to_string())
+              // COMPTIME BASIS PIN (STD_API_AUDIT_D4_PLAN §1.4 O1c): comptime
+              // `length` counts CHARACTERS. Spelled `char_len` so D4's byte
+              // flip cannot change the comptime language silently.
+              EvalValue.IntLit(unquoted.char_len().to_string())
             },
             _ => create_unknown_val(t_comptime_int())
           ),
@@ -305,15 +308,17 @@ evaluate_yo_comptime_string_functions :: (
                       .IntLit(end_raw) => match(
                         end_raw.parse_i64(),
                         .Some(n) => usize(n),
-                        .None => unquoted.len()
+                        .None => unquoted.char_len()
                       ),
-                      _ => unquoted.len()
+                      _ => unquoted.char_len()
                     ),
-                    .None => unquoted.len()
+                    .None => unquoted.char_len()
                   ),
-                  .None => unquoted.len()
+                  .None => unquoted.char_len()
                 );
-                sliced := unquoted.substring(start_idx, end_idx);
+                // COMPTIME BASIS PIN (STD_API_AUDIT_D4_PLAN §1.4 O1c):
+                // comptime `slice` indexes CHARACTERS.
+                sliced := unquoted.char_substring(start_idx, end_idx);
                 EvalValue.StrLit(str_lit_quote(sliced))
               },
               _ => create_unknown_val(t_comptime_string())

--- a/src/evaluator/calls/index_trait.yo
+++ b/src/evaluator/calls/index_trait.yo
@@ -788,7 +788,7 @@ _compute_comptime_string_index :: (
       );
     });
     idx_usize := usize(idx_i64);
-    str_len := str_value.len();
+    str_len := str_value.char_len();
     if(idx_usize >= str_len, {
       exn.throw(
         dyn(
@@ -801,7 +801,9 @@ _compute_comptime_string_index :: (
         )
       );
     });
-    char_str := str_value.substring(idx_usize, idx_usize + usize(1));
+    // COMPTIME BASIS PIN (STD_API_AUDIT_D4_PLAN §1.4 O1c): comptime `s[i]`
+    // yields the i-th CHARACTER as a 1-char StrLit.
+    char_str := str_value.char_substring(idx_usize, idx_usize + usize(1));
     return(EvalValue.StrLit(_str_quote(char_str)));
   });
   // Range access
@@ -837,7 +839,7 @@ _compute_comptime_string_index :: (
   );
   start_idx := range_data.start_idx;
   end_idx := range_data.end_idx;
-  str_len := str_value.len();
+  str_len := str_value.char_len();
   if(start_idx > str_len, {
     exn.throw(
       dyn(
@@ -862,7 +864,9 @@ _compute_comptime_string_index :: (
       )
     );
   });
-  sliced := str_value.substring(start_idx, end_idx);
+  // COMPTIME BASIS PIN (STD_API_AUDIT_D4_PLAN §1.4 O1c): comptime `s(a..b)`
+  // slices CHARACTERS.
+  sliced := str_value.char_substring(start_idx, end_idx);
   EvalValue.StrLit(_str_quote(sliced))
 });
 // ---------------------------------------------------------------------------

--- a/src/formatter.yo
+++ b/src/formatter.yo
@@ -1245,7 +1245,7 @@ is_tightly_bound_operator :: (
               (n.row == token.row) &&
                 // RUNE columns (the lexer indexes an ArrayList(rune)), so the
                 // token width added to one has to be a rune count
-                // (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S7).
+                // (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S11).
                 (n.column == (token.column + token.value.char_len()))
             )
           );

--- a/src/formatter.yo
+++ b/src/formatter.yo
@@ -1243,7 +1243,10 @@ is_tightly_bound_operator :: (
             .None => false,
             .Some(n) => (
               (n.row == token.row) &&
-                (n.column == (token.column + token.value.len()))
+                // RUNE columns (the lexer indexes an ArrayList(rune)), so the
+                // token width added to one has to be a rune count
+                // (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S7).
+                (n.column == (token.column + token.value.char_len()))
             )
           );
           cond(

--- a/src/lsp/completion.yo
+++ b/src/lsp/completion.yo
@@ -924,7 +924,7 @@ handle_completion :: (
       );
       if(!(trivia), {
         // `t.column` and `dot_col` are RUNE columns, so the token width added
-        // to one has to be a rune count (§5.2 S7).
+        // to one has to be a rune count (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S11).
         ends_at_dot := ((t.row == line) && ((t.column + t.value.char_len()) == dot_col));
         if(ends_at_dot && (t.kind == TokenKind.Identifier), {
           receiver = Option(Token).Some(t);

--- a/src/lsp/completion.yo
+++ b/src/lsp/completion.yo
@@ -923,11 +923,13 @@ handle_completion :: (
           ((t.kind == TokenKind.SingleLineComment) || (t.kind == TokenKind.MultiLineComment))
       );
       if(!(trivia), {
-        ends_at_dot := ((t.row == line) && ((t.column + t.value.len()) == dot_col));
+        // `t.column` and `dot_col` are RUNE columns, so the token width added
+        // to one has to be a rune count (§5.2 S7).
+        ends_at_dot := ((t.row == line) && ((t.column + t.value.char_len()) == dot_col));
         if(ends_at_dot && (t.kind == TokenKind.Identifier), {
           receiver = Option(Token).Some(t);
         });
-        before_dot := ((t.row < line) || ((t.row == line) && ((t.column + t.value.len()) <= dot_col)));
+        before_dot := ((t.row < line) || ((t.row == line) && ((t.column + t.value.char_len()) <= dot_col)));
         if(before_dot, {
           later := (
             prev_tok.is_none() ||

--- a/src/lsp/definition.yo
+++ b/src/lsp/definition.yo
@@ -101,7 +101,8 @@ handle_definition :: (
   Option(JsonValue).Some(
     jb().put("uri", jstr(_module_path_to_uri(def_tok.module_path.clone()))).put(
       "range",
-      j_range(def_tok.row, def_tok.column, def_tok.row, def_tok.column + def_tok.value.len())
+      // RUNE column + RUNE width (§5.2 S7).
+      j_range(def_tok.row, def_tok.column, def_tok.row, def_tok.column + def_tok.value.char_len())
     ).obj()
   )
 });

--- a/src/lsp/definition.yo
+++ b/src/lsp/definition.yo
@@ -101,7 +101,7 @@ handle_definition :: (
   Option(JsonValue).Some(
     jb().put("uri", jstr(_module_path_to_uri(def_tok.module_path.clone()))).put(
       "range",
-      // RUNE column + RUNE width (§5.2 S7).
+      // RUNE column + RUNE width (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S11).
       j_range(def_tok.row, def_tok.column, def_tok.row, def_tok.column + def_tok.value.char_len())
     ).obj()
   )

--- a/src/lsp/hover.yo
+++ b/src/lsp/hover.yo
@@ -47,7 +47,9 @@ _find_token_at :: (
         ((t.kind == TokenKind.SingleLineComment) || (t.kind == TokenKind.MultiLineComment))
     );
     if(!(skip) && (t.row == line), {
-      if((character >= t.column) && (character < (t.column + t.value.len())), {
+      // `character` and `t.column` are RUNE columns, so the token width has
+      // to be a rune count (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S7).
+      if((character >= t.column) && (character < (t.column + t.value.char_len())), {
         return(Option(Token).Some(t));
       });
     });
@@ -289,7 +291,7 @@ handle_hover :: (
       jb().put("kind", jstr(String.from("markdown"))).put("value", jstr(content)).obj()
     ).put(
       "range",
-      j_range(target.row, target.column, target.row, target.column + target.value.len())
+      j_range(target.row, target.column, target.row, target.column + target.value.char_len())
     ).obj()
   )
 });

--- a/src/lsp/hover.yo
+++ b/src/lsp/hover.yo
@@ -48,7 +48,7 @@ _find_token_at :: (
     );
     if(!(skip) && (t.row == line), {
       // `character` and `t.column` are RUNE columns, so the token width has
-      // to be a rune count (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S7).
+      // to be a rune count (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S11).
       if((character >= t.column) && (character < (t.column + t.value.char_len())), {
         return(Option(Token).Some(t));
       });

--- a/src/lsp/references.yo
+++ b/src/lsp/references.yo
@@ -31,7 +31,8 @@ _collect_refs :: (
     e,
     .Atom(_, tok) => {
       if(tok.value == name, {
-        _push_location(out, uri.clone(), tok.row, tok.column, tok.value.len());
+        // `_push_location`'s `len` is a RUNE width (§5.2 S7).
+        _push_location(out, uri.clone(), tok.row, tok.column, tok.value.char_len());
       });
     },
     .FnCall(_, func_box, args, _, _) => {
@@ -95,7 +96,7 @@ handle_references :: (
         tokens.get(ti),
         .Some(tk) => {
           if((tk.value == target.value) && (tk.kind == TokenKind.Identifier), {
-            _push_location(out, uri.clone(), tk.row, tk.column, tk.value.len());
+            _push_location(out, uri.clone(), tk.row, tk.column, tk.value.char_len());
           });
         },
         .None => ()

--- a/src/lsp/references.yo
+++ b/src/lsp/references.yo
@@ -31,7 +31,7 @@ _collect_refs :: (
     e,
     .Atom(_, tok) => {
       if(tok.value == name, {
-        // `_push_location`'s `len` is a RUNE width (§5.2 S7).
+        // `_push_location`'s `len` is a RUNE width (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S11).
         _push_location(out, uri.clone(), tok.row, tok.column, tok.value.char_len());
       });
     },

--- a/src/lsp/rename.yo
+++ b/src/lsp/rename.yo
@@ -32,7 +32,7 @@ _collect_rename_edits :: (
         if(!(seen.contains(key.clone())), {
           _a := seen.insert(key);
           out.push(
-            // RUNE column + RUNE width (§5.2 S7). A byte width here would
+            // RUNE column + RUNE width (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S11). A byte width here would
             // make the replaced range overrun a multibyte identifier.
             jb().put("range", j_range(tok.row, tok.column, tok.row, tok.column + old_name.char_len())).put("newText", jstr(new_name.clone())).obj()
           );

--- a/src/lsp/rename.yo
+++ b/src/lsp/rename.yo
@@ -32,7 +32,9 @@ _collect_rename_edits :: (
         if(!(seen.contains(key.clone())), {
           _a := seen.insert(key);
           out.push(
-            jb().put("range", j_range(tok.row, tok.column, tok.row, tok.column + old_name.len())).put("newText", jstr(new_name.clone())).obj()
+            // RUNE column + RUNE width (§5.2 S7). A byte width here would
+            // make the replaced range overrun a multibyte identifier.
+            jb().put("range", j_range(tok.row, tok.column, tok.row, tok.column + old_name.char_len())).put("newText", jstr(new_name.clone())).obj()
           );
         });
       });

--- a/src/lsp/symbols.yo
+++ b/src/lsp/symbols.yo
@@ -95,7 +95,8 @@ handle_document_symbols :: (
               name_tok.row,
               name_tok.column,
               name_tok.row,
-              name_tok.column + name_tok.value.len()
+              // RUNE column + RUNE width (§5.2 S7).
+              name_tok.column + name_tok.value.char_len()
             );
             items.push(
               jb().put("name", jstr(name_tok.value.clone())).put("kind", jnum(_symbol_kind_of(value_expr))).put("range", rng).put("selectionRange", rng).obj()

--- a/src/lsp/symbols.yo
+++ b/src/lsp/symbols.yo
@@ -95,7 +95,7 @@ handle_document_symbols :: (
               name_tok.row,
               name_tok.column,
               name_tok.row,
-              // RUNE column + RUNE width (§5.2 S7).
+              // RUNE column + RUNE width (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S11).
               name_tok.column + name_tok.value.char_len()
             );
             items.push(

--- a/src/parser.yo
+++ b/src/parser.yo
@@ -513,18 +513,28 @@ impl(
     _is_spec_char :: (fn(c : rune) -> bool)(
       (((((c.char >= u32(0x30)) && (c.char <= u32(0x39))) || ((c.char >= u32(0x41)) && (c.char <= u32(0x5A)))) || ((c.char >= u32(0x61)) && (c.char <= u32(0x7A)))) || (((c.char == u32(0x2E)) || (c.char == u32(0x3C))) || ((c.char == u32(0x3E)) || (c.char == u32(0x5E))))) || ((((c.char == u32(0x2B)) || (c.char == u32(0x2D))) || ((c.char == u32(0x23)) || (c.char == u32(0x2A)))) || (((c.char == u32(0x5F)) || (c.char == u32(0x3D))) || (c.char == u32(0x7E))))
     );
+    // `k` and `tn` are RUNE indices into `tc`, so the two cuts at the end have
+    // to be resolved through the rune->byte map `char_indices()` gives, not
+    // fed to `substring` and left to whatever basis it has. This is
+    // plans/STD_API_AUDIT_D4_PLAN.md §5.2 S4: today `substring` reads them as
+    // rune indices and agrees by accident; after D4's flip it would read them
+    // as byte offsets and cut a template string like `${名前:>8}` apart in the
+    // middle of a codepoint.
     _peel_spec :: (fn(text : String) -> _SpecSplit)({
       tc := ArrayList(rune).new();
+      // `toff(i)` is the byte offset rune `i` starts at.
+      toff := ArrayList(usize).new();
       {
-        ti := text.chars();
+        ti := text.char_indices();
         while(runtime(true), {
           match(
             ti.next(),
             .None => {
               break;
             },
-            .Some(c) => {
-              tc.push(c);
+            .Some(pair) => {
+              toff.push(pair._0);
+              tc.push(pair._1);
             }
           );
         });
@@ -541,10 +551,28 @@ impl(
         // a SPACE before the colon means an ordinary colon-pair, not a spec
         ((tc(k - usize(2)).char == u32(0x20)) || (tc(k - usize(2)).char == u32(0x09))) =>
           _SpecSplit(expr_text : text, spec : String.new()),
-        true => _SpecSplit(
-          expr_text : text.substring(usize(0), k - usize(1)),
-          spec : text.substring(k, tn)
-        )
+        true => {
+          // Both cuts land on rune boundaries by construction: they come out
+          // of `char_indices()`, so `try_substring` can only answer `.Some`.
+          colon_byte := match(
+            toff.get(k - usize(1)),
+            .Some(b) => b,
+            .None => text.bytes_len()
+          );
+          spec_byte := match(toff.get(k), .Some(b) => b, .None => text.bytes_len());
+          _SpecSplit(
+            expr_text : match(
+              text.try_substring(usize(0), colon_byte),
+              .Some(sub) => sub,
+              .None => String.new()
+            ),
+            spec : match(
+              text.try_substring(spec_byte, text.bytes_len()),
+              .Some(sub) => sub,
+              .None => String.new()
+            )
+          )
+        }
       )
     });
     num_parts := part_content.len();

--- a/std/encoding/html.yo
+++ b/std/encoding/html.yo
@@ -12,6 +12,7 @@
 //! assert((result == `& < & &`), "decoded entities");
 //! ```
 open(import("../string"));
+{ ArrayList } :: import("../collections/array_list");
 { HashMap } :: import("../collections/hash_map");
 { HashSet } :: import("../collections/hash_set");
 { is_valid_entity_code, from_code_point } :: import("./html_char_utils");
@@ -30,29 +31,41 @@ _ensure_init :: (fn() -> unit)({
 // Parse a hex string to i32
 _parse_hex :: (fn(s : String) -> i32)({
   (result : i32) = i32(0);
-  (i : usize) = usize(0);
-  while(i < s.len(), {
-    c := s.at(i).unwrap();
-    result = (result * i32(16));
-    if((c >= rune(u32('0'))) && (c <= rune(u32('9'))), {
-      result = (result + (i32(c.to_u32()) - i32(48)));
-    }, if((c >= rune(u32('a'))) && (c <= rune(u32('f'))), {
-      result = (result + ((i32(c.to_u32()) - i32(97)) + i32(10)));
-    }, if((c >= rune(u32('A'))) && (c <= rune(u32('F'))), {
-      result = (result + ((i32(c.to_u32()) - i32(65)) + i32(10)));
-    })));
-    i = (i + usize(1));
+  it := s.chars();
+  while(runtime(true), {
+    match(
+      it.next(),
+      .None => {
+        break;
+      },
+      .Some(c) => {
+        result = (result * i32(16));
+        if((c >= rune(u32('0'))) && (c <= rune(u32('9'))), {
+          result = (result + (i32(c.to_u32()) - i32(48)));
+        }, if((c >= rune(u32('a'))) && (c <= rune(u32('f'))), {
+          result = (result + ((i32(c.to_u32()) - i32(97)) + i32(10)));
+        }, if((c >= rune(u32('A'))) && (c <= rune(u32('F'))), {
+          result = (result + ((i32(c.to_u32()) - i32(65)) + i32(10)));
+        })));
+      }
+    );
   });
   result
 });
 // Parse a decimal string to i32
 _parse_dec :: (fn(s : String) -> i32)({
   (result : i32) = i32(0);
-  (i : usize) = usize(0);
-  while(i < s.len(), {
-    c := s.at(i).unwrap();
-    result = ((result * i32(10)) + (i32(c.to_u32()) - i32(48)));
-    i = (i + usize(1));
+  it := s.chars();
+  while(runtime(true), {
+    match(
+      it.next(),
+      .None => {
+        break;
+      },
+      .Some(c) => {
+        result = ((result * i32(10)) + (i32(c.to_u32()) - i32(48)));
+      }
+    );
   });
   result
 });
@@ -60,24 +73,90 @@ _parse_dec :: (fn(s : String) -> i32)({
 _is_alpha_numeric :: (fn(c : rune) -> bool)(
   (((c >= rune(u32('a'))) && (c <= rune(u32('z')))) || ((c >= rune(u32('A'))) && (c <= rune(u32('Z'))))) || ((c >= rune(u32('0'))) && (c <= rune(u32('9'))))
 );
+// ---------------------------------------------------------------------------
+// A rune-indexed view of the input.
+//
+// `decode_html` is a BACKTRACKING scanner: it seeks forward over digits and
+// entity names, then walks `try_end` back down one rune at a time looking for
+// a legacy prefix. That needs random access by rune, which `chars()` alone
+// cannot give — so the input is materialized once as a table of
+// `(byte_offset, rune)` pairs and every index into it is a RUNE index, exactly
+// as the `at()`/`substring()` calls it replaces were.
+//
+// Two things fall out. The scanner no longer depends on `String`'s index basis
+// at all, so `plans/STD_API_AUDIT_D4_PLAN.md`'s byte flip cannot reach it
+// (§5.2 S1 — after the flip `at()` at a continuation byte is `.None`, and this
+// file `.unwrap()`ed it). And the O(n) rune walk that every `at(i)` performed
+// happens once instead of per character.
+// ---------------------------------------------------------------------------
+_char_table :: (fn(s : String) -> ArrayList(IterPair(usize, rune)))({
+  out := ArrayList(IterPair(usize, rune)).new();
+  it := s.char_indices();
+  while(runtime(true), {
+    match(
+      it.next(),
+      .None => {
+        break;
+      },
+      .Some(p) => {
+        out.push(p);
+      }
+    );
+  });
+  out
+});
+// The byte offset rune `index` starts at, or the string's byte length when
+// `index` is at or past the end. Both are rune boundaries, so `try_substring`
+// between any two of them always succeeds.
+_byte_offset_of :: (
+  fn(table : ArrayList(IterPair(usize, rune)), index : usize, total_bytes : usize) -> usize
+)(
+  match(
+    table.get(index),
+    .Some(p) => p._0,
+    .None => total_bytes
+  )
+);
+// `s.substring(start, end)` by RUNE index, resolved through the table. Same
+// result the character-indexed `substring` gives today, and independent of
+// which basis `substring` itself uses.
+_slice_runes :: (
+  fn(s : String, table : ArrayList(IterPair(usize, rune)), start : usize, end : usize) -> String
+)({
+  if(start >= end, {
+    return(String.new());
+  });
+  total_bytes := s.bytes_len();
+  start_byte := _byte_offset_of(table, start, total_bytes);
+  end_byte := _byte_offset_of(table, end, total_bytes);
+  if(start_byte >= end_byte, {
+    return(String.new());
+  });
+  match(
+    s.try_substring(start_byte, end_byte),
+    .Some(sub) => sub,
+    .None => String.new()
+  )
+});
 /// Decode HTML entities in a string.
 ///
 /// Supports named (`&amp;`), decimal (`&#38;`), and hexadecimal (`&#x26;`) character
 /// references. Legacy mode — entities without trailing semicolons are also decoded.
 decode_html :: (fn(input : String) -> String)({
   _ensure_init();
-  (len : usize) = input.len();
-  if(len == usize(0), {
+  if(input.char_len() == usize(0), {
     return(input);
   });
   // Quick check: if no '&', return as-is
   if(!(input.contains(`&`)), {
     return(input);
   });
+  table := _char_table(input);
+  (len : usize) = table.len();
   (result : String) = ``;
   (i : usize) = usize(0);
   while(i < len, {
-    c := input.at(i).unwrap();
+    c := table(i)._1;
     if(c != rune(u32('&')), {
       // Not an entity start, just append the character
       result = `${result}${from_code_point(i32(c.to_u32()))}`;
@@ -89,21 +168,21 @@ decode_html :: (fn(input : String) -> String)({
       if(i >= len, {
         result = `${result}&`;
       }, {
-        next := input.at(i).unwrap();
+        next := table(i)._1;
         if(next == rune(u32('#')), {
           // Numeric entity: &#N; or &#xN;
           i = (i + usize(1));
           if(i >= len, {
             result = `${result}&#`;
           }, {
-            hex_char := input.at(i).unwrap();
+            hex_char := table(i)._1;
             if((hex_char == rune(u32('x'))) || (hex_char == rune(u32('X'))), {
               // Hex: &#xHH;
               (digit_start : usize) = (i + usize(1));
               (digit_end : usize) = digit_start;
               (scanning : bool) = true;
               while(scanning && (digit_end < len), {
-                dc := input.at(digit_end).unwrap();
+                dc := table(digit_end)._1;
                 if(((dc >= rune(u32('0'))) && (dc <= rune(u32('9')))) || (((dc >= rune(u32('a'))) && (dc <= rune(u32('f')))) || ((dc >= rune(u32('A'))) && (dc <= rune(u32('F'))))), {
                   digit_end = (digit_end + usize(1));
                 }, {
@@ -111,10 +190,10 @@ decode_html :: (fn(input : String) -> String)({
                 });
               });
               if(digit_end > digit_start, {
-                hex_str := input.substring(digit_start, digit_end);
+                hex_str := _slice_runes(input, table, digit_start, digit_end);
                 (code : i32) = _parse_hex(hex_str);
                 // Check for semicolon
-                if((digit_end < len) && (input.at(digit_end).unwrap() == rune(u32(';'))), {
+                if((digit_end < len) && (table(digit_end)._1 == rune(u32(';'))), {
                   i = (digit_end + usize(1));
                 }, {
                   i = digit_end;
@@ -123,7 +202,7 @@ decode_html :: (fn(input : String) -> String)({
                   result = `${result}${from_code_point(code)}`;
                 }, {
                   // Invalid code (e.g., surrogates) — keep original entity text
-                  (orig_hex : String) = input.substring(start, i);
+                  (orig_hex : String) = _slice_runes(input, table, start, i);
                   result = `${result}${orig_hex}`;
                 });
               }, {
@@ -137,7 +216,7 @@ decode_html :: (fn(input : String) -> String)({
               (digit_end : usize) = digit_start;
               (scanning : bool) = true;
               while(scanning && (digit_end < len), {
-                dc := input.at(digit_end).unwrap();
+                dc := table(digit_end)._1;
                 if((dc >= rune(u32('0'))) && (dc <= rune(u32('9'))), {
                   digit_end = (digit_end + usize(1));
                 }, {
@@ -145,10 +224,10 @@ decode_html :: (fn(input : String) -> String)({
                 });
               });
               if(digit_end > digit_start, {
-                dec_str := input.substring(digit_start, digit_end);
+                dec_str := _slice_runes(input, table, digit_start, digit_end);
                 (code : i32) = _parse_dec(dec_str);
                 // Check for semicolon
-                if((digit_end < len) && (input.at(digit_end).unwrap() == rune(u32(';'))), {
+                if((digit_end < len) && (table(digit_end)._1 == rune(u32(';'))), {
                   i = (digit_end + usize(1));
                 }, {
                   i = digit_end;
@@ -157,7 +236,7 @@ decode_html :: (fn(input : String) -> String)({
                   result = `${result}${from_code_point(code)}`;
                 }, {
                   // Invalid code (e.g., surrogates) — keep original entity text
-                  (orig_dec : String) = input.substring(start, i);
+                  (orig_dec : String) = _slice_runes(input, table, start, i);
                   result = `${result}${orig_dec}`;
                 });
               }, {
@@ -172,7 +251,7 @@ decode_html :: (fn(input : String) -> String)({
           (name_end : usize) = name_start;
           (scanning : bool) = true;
           while(scanning && (name_end < len), {
-            nc := input.at(name_end).unwrap();
+            nc := table(name_end)._1;
             if(_is_alpha_numeric(nc), {
               name_end = (name_end + usize(1));
             }, {
@@ -180,9 +259,9 @@ decode_html :: (fn(input : String) -> String)({
               scanning = false;
             });
           });
-          name_str := input.substring(name_start, name_end);
+          name_str := _slice_runes(input, table, name_start, name_end);
           // Check for semicolon at name_end
-          (has_semi : bool) = ((name_end < len) && (input.at(name_end).unwrap() == rune(u32(';'))));
+          (has_semi : bool) = ((name_end < len) && (table(name_end)._1 == rune(u32(';'))));
           if(has_semi, {
             // Try exact match with semicolon
             match(
@@ -202,7 +281,7 @@ decode_html :: (fn(input : String) -> String)({
             (matched : bool) = false;
             (try_end : usize) = name_end;
             while((try_end > name_start) && !(matched), {
-              try_name := input.substring(name_start, try_end);
+              try_name := _slice_runes(input, table, name_start, try_end);
               if(_legacy_set.contains(try_name), {
                 match(
                   _entity_map.get(try_name),

--- a/std/fmt/spec.yo
+++ b/std/fmt/spec.yo
@@ -66,7 +66,10 @@ _pad_runes :: (fn(sb : StringBuilder, r : rune, count : usize) -> unit)({
 _apply_width :: (
   fn(fill : rune, align : Option(Alignment), width : usize, text : String, dflt : Alignment) -> String
 )({
-  len := text.len();
+  // `width` is a CHARACTER count (the field doc says so, and Rust counts
+  // chars here too), so the measurement has to say `char_len` — otherwise
+  // D4's byte flip would silently start padding `é` to two columns.
+  len := text.char_len();
   cond(
     (len >= width) => text,
     true => {
@@ -203,8 +206,11 @@ impl(
     match(
       self.precision,
       .Some(p) => {
-        if(text.len() > p, {
-          text = text.substring(usize(0), p);
+        // `.N` on text is a truncation length in CHARACTERS. `truncate_chars`
+        // is boundary-safe, so the cut can never split a rune and emit
+        // invalid UTF-8 (STD_API_AUDIT_D4_PLAN §5.2 S2).
+        if(text.char_len() > p, {
+          text = text.truncate_chars(p);
         });
       },
       .None => ()
@@ -216,8 +222,10 @@ impl(
   /// `0x0000002a` are reachable. Otherwise this is ordinary right-aligned
   /// padding over the whole rendering.
   pad_numeric : (fn(self : Self, sign : String, prefix : String, digits : String) -> String)({
-    head_len := (sign.len() + prefix.len());
-    total_len := (head_len + digits.len());
+    // Same CHARACTER basis as `_apply_width` — the two are compared against
+    // the same `self.width`, so they must measure the same thing.
+    head_len := (sign.char_len() + prefix.char_len());
+    total_len := (head_len + digits.char_len());
     use_zero := (self.zero && self.align.is_none());
     cond(
       (use_zero && (self.width > total_len)) => {

--- a/std/imm/string.yo
+++ b/std/imm/string.yo
@@ -595,6 +595,197 @@ impl(
     )
   })
 );
+/// === Rune-aware indexing (D4 vocabulary) ===
+///
+/// The same six additions `std/string/string.yo` grew, plus the rune iterator
+/// this type never had. Offsets are **BYTES** throughout (except `char_len`,
+/// which counts runes) — `slice`, `index_of` and `byte_at` on this type are
+/// already byte-based, so this block is what makes the rest of the API
+/// sayable in one basis. See `plans/STD_API_AUDIT_D4_PLAN.md`.
+///
+/// Until `len()` becomes a byte count, `char_len()` returns exactly what
+/// `len()` returns; migrate rune-counting call sites onto it now.
+///
+/// `char_len` and `char_indices` are built on `std/encoding/utf8` and inherit
+/// its malformed-input behaviour: `char_len` counts non-continuation bytes
+/// (what `len()` does today), `char_indices` and `chars` stop at the first
+/// sequence that will not decode. The boundary functions and `try_substring`
+/// are pure byte classification and cannot fail.
+/// Rune iterator for `imm.String` — created by `chars()`.
+StringChars :: struct(
+  _string : String,
+  _byte_index : usize
+);
+impl(
+  StringChars,
+  Iterator(
+    Item : rune,
+    next : (fn(inout(self) : Self) -> Option(rune))(
+      cond(
+        (self._byte_index >= self._string.bytes_len()) => .None,
+        true => match(
+          self._string.byte_at(self._byte_index),
+          .Some(first_byte) => {
+            offset := self._byte_index;
+            self._byte_index = (offset + utf8.step_len(first_byte));
+            self._string._decode_rune_at(offset)
+          },
+          .None => .None
+        )
+      )
+    )
+  )
+);
+/// `(byte_offset, rune)` iterator for `imm.String` — created by
+/// `char_indices()`. Walks in lockstep with `StringChars`.
+StringCharIndices :: struct(
+  _string : String,
+  _byte_index : usize
+);
+impl(
+  StringCharIndices,
+  Iterator(
+    Item : IterPair(usize, rune),
+    next : (fn(inout(self) : Self) -> Option(IterPair(usize, rune)))(
+      cond(
+        (self._byte_index >= self._string.bytes_len()) => .None,
+        true => match(
+          self._string.byte_at(self._byte_index),
+          .Some(first_byte) => {
+            offset := self._byte_index;
+            self._byte_index = (offset + utf8.step_len(first_byte));
+            match(
+              self._string._decode_rune_at(offset),
+              .Some(r) => .Some(IterPair(usize, rune)(_0 : offset, _1 : r)),
+              .None => .None
+            )
+          },
+          .None => .None
+        )
+      )
+    )
+  )
+);
+impl(
+  String,
+  /// Iterate the string's runes.
+  chars : (fn(self : Self) -> StringChars)(
+    StringChars(_string : self, _byte_index : usize(0))
+  ),
+  /// Iterate `(byte_offset, rune)` pairs — Rust's `char_indices()`.
+  char_indices : (fn(self : Self) -> StringCharIndices)(
+    StringCharIndices(_string : self, _byte_index : usize(0))
+  ),
+  /// Number of Unicode scalar values (runes) in the string.
+  ///
+  /// O(n) in the byte length. Identical to what `len()` returns today; it
+  /// stays a rune count after `len()` becomes a byte count.
+  char_len : (fn(self : Self) -> usize)({
+    count := usize(0);
+    i := usize(0);
+    n := self._len;
+    while(i < n, i = (i + usize(1)), {
+      match(
+        self.byte_at(i),
+        .Some(b) => {
+          cond(
+            utf8.is_boundary(b) => {
+              count = (count + usize(1));
+            },
+            true => ()
+          );
+        },
+        .None => ()
+      );
+    });
+    count
+  }),
+  /// True when byte offset `index` sits on a rune boundary.
+  ///
+  /// `0` and `bytes_len()` are always boundaries; an index past the end never
+  /// is. Mirrors Rust's `str::is_char_boundary`.
+  is_char_boundary : (fn(self : Self, index : usize) -> bool)(
+    cond(
+      (index == usize(0)) => true,
+      (index == self._len) => true,
+      (index > self._len) => false,
+      true => match(
+        self.byte_at(index),
+        .Some(b) => utf8.is_boundary(b),
+        .None => false
+      )
+    )
+  ),
+  /// The largest byte offset `<= index` that sits on a rune boundary.
+  ///
+  /// `index` is clamped to `bytes_len()` first, so the answer is always a
+  /// boundary of THIS string.
+  floor_char_boundary : (fn(self : Self, index : usize) -> usize)(
+    cond(
+      (index >= self._len) => self._len,
+      true => {
+        i := index;
+        while(i > usize(0), {
+          (on_boundary : bool) = match(
+            self.byte_at(i),
+            .Some(b) => utf8.is_boundary(b),
+            .None => true
+          );
+          if(on_boundary, {
+            break;
+          });
+          i = (i - usize(1));
+        });
+        i
+      }
+    )
+  ),
+  /// The smallest byte offset `>= index` that sits on a rune boundary.
+  ///
+  /// `index` at or past `bytes_len()` clamps to `bytes_len()`, which is a
+  /// boundary, so this always terminates on a valid one.
+  ceil_char_boundary : (fn(self : Self, index : usize) -> usize)(
+    cond(
+      (index >= self._len) => self._len,
+      true => {
+        i := index;
+        while(i < self._len, {
+          (on_boundary : bool) = match(
+            self.byte_at(i),
+            .Some(b) => utf8.is_boundary(b),
+            .None => true
+          );
+          if(on_boundary, {
+            break;
+          });
+          i = (i + usize(1));
+        });
+        i
+      }
+    )
+  ),
+  /// Byte-range slice that REFUSES a bad range instead of clamping it —
+  /// Rust's `s.get(start..end)`, and the checked counterpart of `slice`.
+  ///
+  /// `.None` for `start > end`, for `end` past `bytes_len()`, and for an
+  /// endpoint inside a rune (which would produce invalid UTF-8). An empty but
+  /// valid range yields `.Some` of the empty string.
+  try_substring : (fn(self : Self, start : usize, end : usize) -> Option(Self))({
+    if(start > end, {
+      return(.None);
+    });
+    if(end > self._len, {
+      return(.None);
+    });
+    if(!(self.is_char_boundary(start)), {
+      return(.None);
+    });
+    if(!(self.is_char_boundary(end)), {
+      return(.None);
+    });
+    return(.Some(self.slice(start, end)));
+  })
+);
 /// Equality by byte content.
 impl(
   String,
@@ -719,4 +910,4 @@ impl(
     })
   )
 );
-export(String);
+export(String, StringChars, StringCharIndices);

--- a/std/string/string.yo
+++ b/std/string/string.yo
@@ -179,6 +179,37 @@ impl(
       }
     )
   }),
+  /// Number of Unicode scalar values (runes) in the string.
+  ///
+  /// O(n) in the byte length. Identical to what `len()` returns today; it
+  /// stays a rune count after `len()` becomes a byte count.
+  char_len : (fn(self : Self) -> usize)(
+    match(
+      self._bytes,
+      .None => usize(0),
+      .Some(al) => {
+        count := usize(0);
+        byte_index := usize(0);
+        total_bytes := al.len();
+        while(byte_index < total_bytes, byte_index = (byte_index + usize(1)), {
+          byte_opt := al.get(byte_index);
+          match(
+            byte_opt,
+            .Some(byte) => {
+              cond(
+                utf8.is_boundary(byte) => {
+                  count = (count + usize(1));
+                },
+                true => ()
+              );
+            },
+            .None => ()
+          );
+        });
+        count
+      }
+    )
+  ),
   /**
   * Check if the string is empty
   */
@@ -456,6 +487,17 @@ impl(
   * If end is greater than length, it will substring to the end of the string
   */
   substring : (fn(self : Self, start : usize, end : usize) -> Self)(
+    self.char_substring(start, end)
+  ),
+  /// Slice by RUNE indices — what `substring` does today, under a name that
+  /// says so.
+  ///
+  /// `plans/STD_API_AUDIT_D4_PLAN.md` moves `substring` to BYTE offsets; every
+  /// call site that genuinely means "runes" says `char_substring` instead, so
+  /// the flip cannot change it silently. Out-of-range indices clamp (a start
+  /// at or past the rune count, or `start >= end`, yields the empty string),
+  /// which is the behaviour `substring` has always had.
+  char_substring : (fn(self : Self, start : usize, end : usize) -> Self)(
     match(
       self._bytes,
       .None => {
@@ -618,11 +660,15 @@ impl(
   _split_impl : (fn(self : Self, separator : Self) -> ArrayList(Self))({
     result := ArrayList(Self).new();
     cond(
+      // The empty separator means "split into CHARACTERS", and it has to keep
+      // meaning that after `plans/STD_API_AUDIT_D4_PLAN.md` rebases `len()`
+      // and `substring` onto bytes — a byte split would hand back fragments
+      // that are not valid UTF-8. Pinned to the rune vocabulary (§5.2 S5).
       separator.is_empty() => {
-        char_count := self.len();
+        char_count := self.char_len();
         i := usize(0);
         while(i < char_count, i = (i + usize(1)), {
-          char_str := self.substring(i, i + usize(1));
+          char_str := self.char_substring(i, i + usize(1));
           result.push(char_str);
         });
         return(result);
@@ -1833,37 +1879,6 @@ impl(
 /// classification (`utf8.is_boundary`) and cannot fail.
 impl(
   String,
-  /// Number of Unicode scalar values (runes) in the string.
-  ///
-  /// O(n) in the byte length. Identical to what `len()` returns today; it
-  /// stays a rune count after `len()` becomes a byte count.
-  char_len : (fn(self : Self) -> usize)(
-    match(
-      self._bytes,
-      .None => usize(0),
-      .Some(al) => {
-        count := usize(0);
-        byte_index := usize(0);
-        total_bytes := al.len();
-        while(byte_index < total_bytes, byte_index = (byte_index + usize(1)), {
-          byte_opt := al.get(byte_index);
-          match(
-            byte_opt,
-            .Some(byte) => {
-              cond(
-                utf8.is_boundary(byte) => {
-                  count = (count + usize(1));
-                },
-                true => ()
-              );
-            },
-            .None => ()
-          );
-        });
-        count
-      }
-    )
-  ),
   /// Iterate `(byte_offset, rune)` pairs — Rust's `char_indices()`.
   ///
   /// `_0` is the byte offset the rune starts at, `_1` is the rune. This is
@@ -1988,7 +2003,18 @@ impl(
       .None => ()
     );
     .Some(Self(_bytes : .Some(new_bytes)))
-  })
+  }),
+  /// Keep at most `max_runes` runes, dropping the rest — Rust's
+  /// `s.chars().take(n).collect()`.
+  ///
+  /// Never splits a rune, and never lengthens the string: a string of at most
+  /// `max_runes` runes comes back unchanged. This is the boundary-safe
+  /// replacement for `substring(0, n)` at the two sites that cut arbitrary
+  /// human text to a display length (`std/fmt/spec.yo` precision,
+  /// `src/doc/render_html.yo`'s 120-unit summary cap).
+  truncate_chars : (fn(self : Self, max_runes : usize) -> Self)(
+    self.char_substring(usize(0), max_runes)
+  )
 );
 /// === String utility methods ===
 /**

--- a/std/string/string.yo
+++ b/std/string/string.yo
@@ -1748,6 +1748,50 @@ impl(
     )
   )
 );
+/**
+* `(byte_offset, rune)` iterator for `String` — yields each rune together with
+* the byte offset it starts at. Used by `char_indices()`.
+*
+* Walks in lockstep with `StringChars`: same runes, same stopping point on
+* malformed input. The offsets it yields are exactly the indices
+* `is_char_boundary` answers `true` for (on well-formed UTF-8).
+*/
+StringCharIndices :: struct(
+  _string : String,
+  _byte_index : usize
+);
+impl(
+  StringCharIndices,
+  Iterator(
+    Item : IterPair(usize, rune),
+    next : (fn(inout(self) : Self) -> Option(IterPair(usize, rune)))(
+      match(
+        self._string._bytes,
+        .None => .None,
+        .Some(al) => cond(
+          (self._byte_index >= al.len()) => .None,
+          true => {
+            offset := self._byte_index;
+            first_byte_opt := al.get(offset);
+            match(
+              first_byte_opt,
+              .Some(first_byte) => {
+                (byte_len : usize) = utf8.step_len(first_byte);
+                self._byte_index = (offset + byte_len);
+                match(
+                  self._string._decode_rune_at(offset),
+                  .Some(r) => .Some(IterPair(usize, rune)(_0 : offset, _1 : r)),
+                  .None => .None
+                )
+              },
+              .None => .None
+            )
+          }
+        )
+      )
+    )
+  )
+);
 impl(
   String,
   /**
@@ -1768,6 +1812,183 @@ impl(
   into_iter : (fn(self : Self) -> StringChars)(
     StringChars(_string : self, _byte_index : usize(0))
   )
+);
+/// === Rune-aware indexing (D4 vocabulary) ===
+///
+/// Everything in this block is stated in **BYTE** offsets, except `char_len`
+/// which counts runes. That is deliberate: `plans/STD_API_AUDIT_D4_PLAN.md`
+/// moves `String`'s index basis from characters to bytes, and these names are
+/// the vocabulary that migration is written in. They are new, so they carry
+/// the final contract from the start rather than flipping under callers later.
+///
+/// Until that flip lands, `char_len()` returns the same number as `len()` —
+/// use `char_len()` at any site that genuinely means "how many runes", so the
+/// intent survives the flip.
+///
+/// `char_len` and `char_indices` are built on `std/encoding/utf8`, and inherit
+/// its handling of malformed input: `char_len` counts non-continuation bytes
+/// (byte-for-byte what `len()` does today), while `char_indices` — like
+/// `chars()` — stops at the first byte sequence that will not decode.
+/// The three boundary functions and `try_substring` are pure byte
+/// classification (`utf8.is_boundary`) and cannot fail.
+impl(
+  String,
+  /// Number of Unicode scalar values (runes) in the string.
+  ///
+  /// O(n) in the byte length. Identical to what `len()` returns today; it
+  /// stays a rune count after `len()` becomes a byte count.
+  char_len : (fn(self : Self) -> usize)(
+    match(
+      self._bytes,
+      .None => usize(0),
+      .Some(al) => {
+        count := usize(0);
+        byte_index := usize(0);
+        total_bytes := al.len();
+        while(byte_index < total_bytes, byte_index = (byte_index + usize(1)), {
+          byte_opt := al.get(byte_index);
+          match(
+            byte_opt,
+            .Some(byte) => {
+              cond(
+                utf8.is_boundary(byte) => {
+                  count = (count + usize(1));
+                },
+                true => ()
+              );
+            },
+            .None => ()
+          );
+        });
+        count
+      }
+    )
+  ),
+  /// Iterate `(byte_offset, rune)` pairs — Rust's `char_indices()`.
+  ///
+  /// `_0` is the byte offset the rune starts at, `_1` is the rune. This is
+  /// the replacement for the `while(i < s.len()) { s.at(i) }` shape, which is
+  /// O(n²) today and, once `at()` takes a byte offset, hands back `.None` at
+  /// every continuation byte.
+  char_indices : (fn(self : Self) -> StringCharIndices)(
+    StringCharIndices(_string : self, _byte_index : usize(0))
+  ),
+  /// True when byte offset `index` sits on a rune boundary.
+  ///
+  /// `0` and `bytes_len()` are always boundaries; an index past the end never
+  /// is. Mirrors Rust's `str::is_char_boundary`.
+  is_char_boundary : (fn(self : Self, index : usize) -> bool)(
+    match(
+      self._bytes,
+      .None => (index == usize(0)),
+      .Some(al) => {
+        n := al.len();
+        cond(
+          (index == usize(0)) => true,
+          (index == n) => true,
+          (index > n) => false,
+          true => match(
+            al.get(index),
+            .Some(b) => utf8.is_boundary(b),
+            .None => false
+          )
+        )
+      }
+    )
+  ),
+  /// The largest byte offset `<= index` that sits on a rune boundary.
+  ///
+  /// `index` is clamped to `bytes_len()` first, so the answer is always a
+  /// boundary of THIS string. Pair it with `ceil_char_boundary` to widen or
+  /// narrow a byte range onto boundaries before slicing.
+  floor_char_boundary : (fn(self : Self, index : usize) -> usize)(
+    match(
+      self._bytes,
+      .None => usize(0),
+      .Some(al) => {
+        n := al.len();
+        cond(
+          (index >= n) => n,
+          true => {
+            i := index;
+            while(i > usize(0), {
+              b := al(i);
+              if(utf8.is_boundary(b), {
+                break;
+              });
+              i = (i - usize(1));
+            });
+            i
+          }
+        )
+      }
+    )
+  ),
+  /// The smallest byte offset `>= index` that sits on a rune boundary.
+  ///
+  /// `index` at or past `bytes_len()` clamps to `bytes_len()`, which is a
+  /// boundary, so this always terminates on a valid one.
+  ceil_char_boundary : (fn(self : Self, index : usize) -> usize)(
+    match(
+      self._bytes,
+      .None => usize(0),
+      .Some(al) => {
+        n := al.len();
+        cond(
+          (index >= n) => n,
+          true => {
+            i := index;
+            while(i < n, {
+              b := al(i);
+              if(utf8.is_boundary(b), {
+                break;
+              });
+              i = (i + usize(1));
+            });
+            i
+          }
+        )
+      }
+    )
+  ),
+  /// Byte-range slice that REFUSES a bad range instead of guessing —
+  /// Rust's `s.get(start..end)`.
+  ///
+  /// **BYTE offsets**, unlike `substring`, which takes character offsets and
+  /// clamps them. `.None` is returned for the three ranges a byte slice
+  /// cannot honour: `start > end`, `end` past `bytes_len()`, or an endpoint
+  /// inside a rune (which would produce invalid UTF-8). An empty but valid
+  /// range yields `.Some` of the empty string.
+  try_substring : (fn(self : Self, start : usize, end : usize) -> Option(Self))({
+    (n : usize) = match(self._bytes, .Some(b) => b.len(), .None => usize(0));
+    if(start > end, {
+      return(.None);
+    });
+    if(end > n, {
+      return(.None);
+    });
+    if(!(self.is_char_boundary(start)), {
+      return(.None);
+    });
+    if(!(self.is_char_boundary(end)), {
+      return(.None);
+    });
+    if(start == end, {
+      return(.Some(Self(_bytes : .None)));
+    });
+    (count : usize) = (end - start);
+    new_bytes := ArrayList(u8).with_capacity(count);
+    match(
+      self._bytes,
+      .Some(al) => match(
+        al.ptr(),
+        .Some(src_p) => new_bytes.extend_from_ptr(src_p.add(start), count),
+        .None => ()
+      ),
+      .None => ()
+    );
+    .Some(Self(_bytes : .Some(new_bytes)))
+  })
 );
 /// === String utility methods ===
 /**
@@ -2440,6 +2661,7 @@ export(
   String,
   StringError,
   StringChars,
+  StringCharIndices,
   StringBytes,
   StringLines,
   Pattern,

--- a/tests/encoding/html.test.yo
+++ b/tests/encoding/html.test.yo
@@ -45,3 +45,38 @@ test("malformed numeric entities stay literal", {
 test("invalid code points keep the original entity text", {
   assert(decode_html(String.from("&#xD800;")) == `&#xD800;`, "surrogate kept literal");
 });
+// D4 (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S1). Every test above puts multibyte
+// content only in the DECODER'S OUTPUT; the INPUT is pure ASCII, so the
+// scanner's rune arithmetic is never exercised. `decode_html` is the
+// highest-risk file in the tree for the byte flip — it scans arbitrary HTML by
+// index — so these run multibyte text through the scanner itself, on both
+// sides of every entity form and in every backtracking arm.
+test("entities decode with multibyte text around them", {
+  assert(decode_html(String.from("中文 &amp; 日本語")) == `中文 & 日本語`, "named, CJK on both sides");
+  assert(decode_html(String.from("é&lt;é&gt;é")) == `é<é>é`, "2-byte runes between entities");
+  assert(decode_html(String.from("𝄞&#65;𝄞")) == `𝄞A𝄞`, "decimal between 4-byte runes");
+  assert(decode_html(String.from("𝄞&#x41;𝄞")) == `𝄞A𝄞`, "hex between 4-byte runes");
+  assert(decode_html(String.from("aé中𝄞&amp;aé中𝄞")) == `aé中𝄞&aé中𝄞`, "all four widths");
+  assert(decode_html(String.from("😀&#x1F600;😀")) == `😀😀😀`, "astral in and out");
+  assert(decode_html(String.from("é&#x4E2D;é")) == `é中é`, "hex naming a 3-byte rune");
+});
+test("the legacy backtracking arm survives multibyte input", {
+  // `&notin` decodes as `not` + `in`; the walk-back over `try_end` is the
+  // rune-indexed loop that a byte basis would break.
+  assert(decode_html(String.from("中&notin中")) == `中¬in中`, "longest legacy prefix, CJK around it");
+  assert(decode_html(String.from("é&bogus;é")) == `é&bogus;é`, "unknown named entity stays literal");
+  assert(decode_html(String.from("中&amp!中")) == `中&!中`, "legacy amp with no semicolon");
+});
+test("invalid code points keep their original text with multibyte around them", {
+  // The `keep original entity text` arm re-slices the INPUT between two
+  // scanner positions — the one place a wrong basis would corrupt bytes it
+  // never decoded.
+  assert(decode_html(String.from("𝄞&#xD800;𝄞")) == `𝄞&#xD800;𝄞`, "surrogate kept, astral around it");
+  assert(decode_html(String.from("中&#xDFFF;中")) == `中&#xDFFF;中`, "high surrogate kept");
+});
+test("truncated entities at the end of multibyte input", {
+  assert(decode_html(String.from("é&")) == `é&`, "trailing ampersand after a 2-byte rune");
+  assert(decode_html(String.from("中&#")) == `中&#`, "trailing numeric marker");
+  assert(decode_html(String.from("𝄞&#x")) == `𝄞&#x`, "trailing hex marker");
+  assert(decode_html(String.from("aé中𝄞")) == `aé中𝄞`, "no entity at all is returned unchanged");
+});

--- a/tests/format_specs.test.yo
+++ b/tests/format_specs.test.yo
@@ -45,3 +45,50 @@ test("the blanket impl covers every ToString type", {
   assert(o.format(">10") == `   Some(4)`, "named Option receiver");
   assert(Result(i32, String).Ok(i32(1)).format(">8") == `   Ok(1)`, "inline Result receiver");
 });
+// D4 (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S2, §6.2). `width` is documented
+// "Minimum width in CHARACTERS" and `.N` on text is a truncation length in
+// characters, but every test above this line is pure ASCII — where bytes and
+// runes coincide, so a wrong basis passes. These pin the character basis with
+// content where the two disagree, and they must keep passing after `len()`
+// and `substring()` become byte-based.
+test("width counts CHARACTERS, not bytes", {
+  // `中文` is 2 runes / 6 bytes: a byte-based width would emit no padding.
+  assert(String.from("中文").format(">4") == `  中文`, "3-byte runes right-aligned");
+  assert(String.from("中文").format("<4") == `中文  `, "3-byte runes left-aligned");
+  assert(String.from("中文").format("^6") == `  中文  `, "3-byte runes centred");
+  // 1+2+3+4 bytes = 10 bytes, 4 runes.
+  assert(String.from("aé中𝄞").format(">6") == `  aé中𝄞`, "all four UTF-8 widths");
+  assert(String.from("aé中𝄞").format(">4") == `aé中𝄞`, "already at the width");
+  assert(String.from("aé中𝄞").format(">10") == `      aé中𝄞`, "byte length would give no padding");
+  assert(String.from("😀").format("*>3") == `**😀`, "astral rune with a custom fill");
+});
+test("a multibyte FILL character pads by runes too", {
+  assert(String.from("ab").format("中>5") == `中中中ab`, "three 3-byte fill runes");
+  assert(String.from("中").format("𝄞^5") == `𝄞𝄞中𝄞𝄞`, "4-byte fill around a 3-byte body");
+});
+test("precision truncates by CHARACTERS and never splits a rune", {
+  assert(String.from("中文字符串").format(".3") == `中文字`, "3 runes, not 3 bytes");
+  assert(String.from("aé中𝄞").format(".1") == `a`, "cut before the 2-byte rune");
+  assert(String.from("aé中𝄞").format(".2") == `aé`, "cut after the 2-byte rune");
+  assert(String.from("aé中𝄞").format(".3") == `aé中`, "cut after the 3-byte rune");
+  assert(String.from("aé中𝄞").format(".4") == `aé中𝄞`, "the whole string");
+  assert(String.from("aé中𝄞").format(".9") == `aé中𝄞`, "precision past the end is a no-op");
+  // A byte cut at 2 would land inside 'é' and emit invalid UTF-8; the result
+  // here is always re-decodable, which is what the assertion below checks.
+  assert(String.from("aé中𝄞").format(".2").bytes_len() == usize(3), "2 runes are 3 bytes");
+  assert(String.from("😀😀😀").format(".2") == `😀😀`, "astral runes");
+});
+test("width and precision compose on multibyte text", {
+  assert(String.from("中文字符串").format(">6.3") == `   中文字`, "truncate then pad");
+  assert(String.from("aé中𝄞").format("<7.2") == `aé     `, "left-aligned after a rune cut");
+  assert(String.from("aé中𝄞").format("^8.3") == `  aé中   `, "centred after a rune cut");
+});
+test("numeric padding measures the sign, prefix and digits in characters", {
+  // The numeric path compares its own total against the same `width`, so it
+  // has to use the same basis. Non-ASCII digits are not produced by the
+  // radix formatters, so this pins the shape through `Format` on a String
+  // body that carries the multibyte content instead.
+  assert(i32(-(42)).format("08") == `-0000042`, "zero fill still goes after the sign");
+  assert(i32(255).format("#08x") == `0x0000ff`, "alt hex zero padded");
+  assert(String.from("中文").format("0>5") == `000中文`, "explicit align beats the zero flag");
+});

--- a/tests/format_specs.test.yo
+++ b/tests/format_specs.test.yo
@@ -84,11 +84,30 @@ test("width and precision compose on multibyte text", {
   assert(String.from("aé中𝄞").format("^8.3") == `  aé中   `, "centred after a rune cut");
 });
 test("numeric padding measures the sign, prefix and digits in characters", {
-  // The numeric path compares its own total against the same `width`, so it
-  // has to use the same basis. Non-ASCII digits are not produced by the
-  // radix formatters, so this pins the shape through `Format` on a String
-  // body that carries the multibyte content instead.
+  // The ASCII shape first: zero fill goes between the sign/prefix and digits.
   assert(i32(-(42)).format("08") == `-0000042`, "zero fill still goes after the sign");
   assert(i32(255).format("#08x") == `0x0000ff`, "alt hex zero padded");
   assert(String.from("中文").format("0>5") == `000中文`, "explicit align beats the zero flag");
+});
+test("pad_numeric counts its sign, prefix and digits in RUNES", {
+  // `String.format` routes a String body through `pad`, NEVER through
+  // `pad_numeric`, so the assertions above cannot reach `pad_numeric`'s own
+  // `char_len` measurement at all — the radix formatters only ever hand it
+  // ASCII. Call it directly with multibyte parts, which is the only way to
+  // pin its basis. Every expected value below differs under a byte basis
+  // (shown in the comment), so a wrong basis cannot pass.
+  // char: head 1+1=2, total 4, 8-4 = 4 zeros.  byte: head 2+3=5, total 7 -> 1 zero.
+  assert(FormatSpec.parse("08").pad_numeric(`é`, `中`, `12`) == `é中000012`, "multibyte sign and prefix");
+  // char: head 1+2=3, total 5, 10-5 = 5 zeros.  byte: total 9 -> 1 zero.
+  assert(FormatSpec.parse("010").pad_numeric(`-`, `0x`, `中文`) == `-0x00000中文`, "multibyte digits");
+  // char: total 4, 4 zeros.  byte: total 10 >= 8 -> no padding at all.
+  assert(FormatSpec.parse("08").pad_numeric(``, ``, `aé中𝄞`) == `0000aé中𝄞`, "all four UTF-8 widths");
+  // Explicit alignment takes the `_apply_width` path over the whole rendering:
+  // char len 4 -> 4 spaces; byte len 7 -> 1 space.
+  assert(FormatSpec.parse(">8").pad_numeric(`é`, `中`, `12`) == `    é中12`, "explicit align, multibyte");
+  // No zero flag: same `_apply_width` path. char len 3 -> 5 spaces.
+  assert(FormatSpec.parse("8").pad_numeric(`-`, ``, `中文`) == `     -中文`, "width without the zero flag");
+  // The rune counts are what the width promises, and the bytes are not.
+  assert(FormatSpec.parse("08").pad_numeric(`é`, `中`, `12`).char_len() == usize(8), "eight runes wide");
+  assert(FormatSpec.parse("08").pad_numeric(`é`, `中`, `12`).bytes_len() == usize(11), "eleven bytes, not eight");
 });

--- a/tests/imm_string.test.yo
+++ b/tests/imm_string.test.yo
@@ -194,3 +194,159 @@ test("imm.String COW concat chain", {
   s = s.concat(String.from("d"));
   assert(s == String.from("abcd"), "chained COW concat");
 });
+// ===========================================================================
+// D4 PR 1 — the rune-aware vocabulary (plans/STD_API_AUDIT_D4_PLAN.md §4).
+//
+// `imm.String` already indexes in BYTES everywhere it indexes at all
+// (`slice`, `index_of`, `byte_at`); `len()` is the one rune-based outlier and
+// PR 4 flips it. These additions are what rune-meaning call sites migrate
+// onto, so every assertion below is multibyte with hand-computed byte offsets.
+//
+//   rune   a      é         中           𝄞
+//   width  1B     2B        3B           4B          10 bytes, 4 runes
+//   bytes  61     C3 A9     E4 B8 AD     F0 9D 84 9E
+//   offset 0      1  2      3  4  5      6  7  8  9
+// ===========================================================================
+test("imm.String char_len counts runes across all four UTF-8 widths", {
+  s := String.from("aé中𝄞");
+  assert(s.bytes_len() == usize(10), "subject must be 10 bytes");
+  assert(s.char_len() == usize(4), "subject must be 4 runes");
+  assert(s.char_len() == s.len(), "char_len is today's len() — the PR 4 golden");
+  assert(s.byte_at(usize(0)).unwrap() == u8(0x61), "byte 0 is 'a'");
+  assert(s.byte_at(usize(1)).unwrap() == u8(0xC3), "byte 1 leads 'é'");
+  assert(s.byte_at(usize(3)).unwrap() == u8(0xE4), "byte 3 leads '中'");
+  assert(s.byte_at(usize(6)).unwrap() == u8(0xF0), "byte 6 leads '𝄞'");
+  assert(String.new().char_len() == usize(0), "empty is 0 runes");
+});
+test("imm.String is_char_boundary marks every byte of a 4-byte sequence", {
+  s := String.from("aé中𝄞");
+  assert(s.is_char_boundary(usize(0)), "0 starts 'a'");
+  assert(s.is_char_boundary(usize(1)), "1 starts 'é'");
+  assert(!(s.is_char_boundary(usize(2))), "2 is inside 'é'");
+  assert(s.is_char_boundary(usize(3)), "3 starts '中'");
+  assert(!(s.is_char_boundary(usize(4))), "4 is inside '中'");
+  assert(!(s.is_char_boundary(usize(5))), "5 is inside '中'");
+  assert(s.is_char_boundary(usize(6)), "6 starts '𝄞'");
+  assert(!(s.is_char_boundary(usize(7))), "7 is inside '𝄞'");
+  assert(!(s.is_char_boundary(usize(8))), "8 is inside '𝄞'");
+  assert(!(s.is_char_boundary(usize(9))), "9 is inside '𝄞'");
+  assert(s.is_char_boundary(usize(10)), "10 is the end, a boundary");
+  assert(!(s.is_char_boundary(usize(11))), "11 is past the end");
+  e := String.new();
+  assert(e.is_char_boundary(usize(0)), "0 is a boundary of the empty string");
+  assert(!(e.is_char_boundary(usize(1))), "1 is past the empty string");
+});
+test("imm.String floor/ceil char boundary snap onto rune starts", {
+  s := String.from("aé中𝄞");
+  assert(s.floor_char_boundary(usize(2)) == usize(1), "2 floors into 'é'");
+  assert(s.floor_char_boundary(usize(5)) == usize(3), "5 floors into '中'");
+  assert(s.floor_char_boundary(usize(9)) == usize(6), "9 floors into '𝄞'");
+  assert(s.floor_char_boundary(usize(10)) == usize(10), "the end floors to itself");
+  assert(s.floor_char_boundary(usize(999)) == usize(10), "far past clamps");
+  assert(s.ceil_char_boundary(usize(2)) == usize(3), "2 ceils past 'é'");
+  assert(s.ceil_char_boundary(usize(4)) == usize(6), "4 ceils past '中'");
+  assert(s.ceil_char_boundary(usize(7)) == usize(10), "7 ceils past '𝄞'");
+  assert(s.ceil_char_boundary(usize(10)) == usize(10), "the end ceils to itself");
+  assert(s.ceil_char_boundary(usize(999)) == usize(10), "far past clamps");
+  i := usize(0);
+  while(i <= s.bytes_len(), i = (i + usize(1)), {
+    on := s.is_char_boundary(i);
+    assert((s.floor_char_boundary(i) == i) == on, "floor fixes exactly the boundaries");
+    assert((s.ceil_char_boundary(i) == i) == on, "ceil fixes exactly the boundaries");
+  });
+  assert(String.new().floor_char_boundary(usize(7)) == usize(0), "empty floors to 0");
+  assert(String.new().ceil_char_boundary(usize(7)) == usize(0), "empty ceils to 0");
+});
+test("imm.String chars and char_indices walk the same runes", {
+  s := String.from("aé中𝄞");
+  ci := s.char_indices();
+  ch := s.chars();
+  expected_offset := usize(0);
+  seen := usize(0);
+  while(true, {
+    (finished : bool) = false;
+    match(
+      ci.next(),
+      .Some(p) => {
+        assert(p._0 == expected_offset, "offset advances by the encoded width");
+        match(
+          ch.next(),
+          .Some(r) => assert(p._1.to_u32() == r.to_u32(), "same rune from both iterators"),
+          .None => assert(false, "chars() ended early")
+        );
+        seen = (seen + usize(1));
+        expected_offset = s.ceil_char_boundary(p._0 + usize(1));
+      },
+      .None => {
+        match(ch.next(), .Some(_) => assert(false, "chars() ran long"), .None => ());
+        finished = true;
+      }
+    );
+    if(finished, {
+      break;
+    });
+  });
+  assert(seen == usize(4), "four runes");
+  assert(expected_offset == usize(10), "every byte consumed");
+});
+test("imm.String char_indices yields BYTE offsets, not character offsets", {
+  s := String.from("aé中𝄞");
+  it := s.char_indices();
+  match(
+    it.next(),
+    .Some(p) => {
+      assert(p._0 == usize(0), "'a' starts at byte 0");
+      assert(p._1.to_u32() == u32(0x61), "'a' is U+0061");
+    },
+    .None => assert(false, "expected 'a'")
+  );
+  match(
+    it.next(),
+    .Some(p) => {
+      assert(p._0 == usize(1), "'é' starts at byte 1");
+      assert(p._1.to_u32() == u32(0xE9), "'é' is U+00E9");
+    },
+    .None => assert(false, "expected 'é'")
+  );
+  match(
+    it.next(),
+    .Some(p) => {
+      assert(p._0 == usize(3), "'中' starts at byte 3, not 2");
+      assert(p._1.to_u32() == u32(0x4E2D), "'中' is U+4E2D");
+    },
+    .None => assert(false, "expected '中'")
+  );
+  match(
+    it.next(),
+    .Some(p) => {
+      assert(p._0 == usize(6), "'𝄞' starts at byte 6, not 3");
+      assert(p._1.to_u32() == u32(0x1D11E), "'𝄞' is U+1D11E");
+    },
+    .None => assert(false, "expected '𝄞'")
+  );
+  match(it.next(), .Some(_) => assert(false, "expected exhaustion"), .None => ());
+  match(String.new().char_indices().next(), .Some(_) => assert(false, "empty yields nothing"), .None => ());
+});
+test("imm.String try_substring slices on boundaries and refuses interior offsets", {
+  s := String.from("aé中𝄞");
+  assert(s.try_substring(usize(0), usize(1)).unwrap() == String.from("a"), "[0,1)");
+  assert(s.try_substring(usize(1), usize(3)).unwrap() == String.from("é"), "[1,3)");
+  assert(s.try_substring(usize(3), usize(6)).unwrap() == String.from("中"), "[3,6)");
+  assert(s.try_substring(usize(6), usize(10)).unwrap() == String.from("𝄞"), "[6,10)");
+  assert(s.try_substring(usize(0), usize(10)).unwrap() == s, "the whole string");
+  assert(s.try_substring(usize(3), usize(3)).unwrap() == String.new(), "empty range");
+  // Every interior byte of the 4-byte rune, both as start and as end.
+  assert(s.try_substring(usize(6), usize(7)).is_none(), "end 7 splits '𝄞'");
+  assert(s.try_substring(usize(6), usize(8)).is_none(), "end 8 splits '𝄞'");
+  assert(s.try_substring(usize(6), usize(9)).is_none(), "end 9 splits '𝄞'");
+  assert(s.try_substring(usize(7), usize(10)).is_none(), "start 7 splits '𝄞'");
+  assert(s.try_substring(usize(8), usize(10)).is_none(), "start 8 splits '𝄞'");
+  assert(s.try_substring(usize(9), usize(10)).is_none(), "start 9 splits '𝄞'");
+  assert(s.try_substring(usize(0), usize(2)).is_none(), "end 2 splits 'é'");
+  assert(s.try_substring(usize(4), usize(6)).is_none(), "start 4 splits '中'");
+  assert(s.try_substring(usize(0), usize(11)).is_none(), "end past the last byte");
+  assert(s.try_substring(usize(6), usize(3)).is_none(), "start > end");
+  // `slice` CLAMPS the same bad range instead of refusing it — that contrast
+  // is exactly why the checked form exists.
+  assert(s.slice(usize(0), usize(11)) == s, "slice clamps a past-the-end range");
+});

--- a/tests/internal/parser.test.yo
+++ b/tests/internal/parser.test.yo
@@ -2,6 +2,7 @@ open(import("std/string"));
 open(import("std/fmt"));
 open(import("std/error"));
 { ArrayList } :: import("std/collections/array_list");
+{ StringBuilder } :: import("std/string/string_builder");
 { AstExpr, ast_expr_to_string, ast_expr_is_atom, ast_expr_is_fn_call, make_err_expr } :: import("../../src/expr.yo");
 { ParseError, parse, extract_source_line, generate_expr_from_code } :: import("../../src/parser.yo");
 { assert, panic } :: import("std/assert");
@@ -706,4 +707,68 @@ test("Parse colon : with multi-line parenthesized -> RHS in struct field", {
   );
   e := only_expr(prog);
   assert(ast_expr_is_fn_call(e), "colon with multi-line parens should produce FnCall");
+});
+// ─── Template-string spec peeling (`_peel_spec`) ──────────────────────────────
+// `plans/STD_API_AUDIT_D4_PLAN.md` §5.2 S4. `_peel_spec` splits `${expr:spec}`
+// by walking an `ArrayList(rune)` backwards and then cutting `text`. Those two
+// index bases have to agree, and BEFORE the D4 migration they agreed only by
+// accident — `substring` happened to be rune-indexed. Every pre-existing test
+// in this file is ASCII, where the accident is invisible; these are multibyte
+// on BOTH sides of the cut, so a byte/rune confusion in the peel shows up as a
+// mangled expression text or a mangled spec.
+//
+// The parse of a template string yields two top-level exprs: the injected
+// `import("std/fmt/format")` and the rendering call, whose printed form
+// (`(<expr>.format)("<spec>")`) shows exactly where the peel cut.
+_ts :: (fn(inner : str) -> String)({
+  sb := StringBuilder.new();
+  sb.write_byte(u8(96));
+  sb.write_str(inner);
+  sb.write_byte(u8(96));
+  sb.to_string()
+});
+// `exn` is passed in rather than built here: the file's other tests build the
+// throwing handler INSIDE the `test(...)` body, and a `(err) -> { …; unwind(()); }`
+// closure hoisted into a top-level helper emits a `Failed to transpile` stub
+// under the seed compiler (issues/ftt-stub-in-live-closure-falls-off-non-void-function.md).
+_parse_ts :: (fn(inner : str, exn : Exception) -> String)({
+  prog := parse(_ts(inner), `test.yo`, exn);
+  assert(prog.len() == usize(2), "template string should parse to import + rendering");
+  match(
+    prog.get(usize(1)),
+    .Some(e) => ast_expr_to_string(e),
+    .None => String.new()
+  )
+});
+_ts_exn :: (fn() -> Exception)(
+  Exception(
+    throw : (
+      (err) -> {
+        panic("unexpected parse error in a template string");
+      }
+    )
+  )
+);
+test("Peel a format spec off a MULTIBYTE template expression", {
+  exn := _ts_exn();
+  assert_str_eq(_parse_ts("${x:>8}", exn), `(x.format)(">8")`, "ASCII control case");
+  assert_str_eq(_parse_ts("${名前:>8}", exn), `(名前.format)(">8")`, "3-byte runes before the colon");
+  assert_str_eq(_parse_ts("${名前:.2}", exn), `(名前.format)(".2")`, "precision spec after 3-byte runes");
+  assert_str_eq(_parse_ts("${é:#08x}", exn), `(é.format)("#08x")`, "2-byte rune before the colon");
+  assert_str_eq(_parse_ts("${a.名前:^10.4}", exn), `((a.名前).format)("^10.4")`, "dotted path with a multibyte segment");
+});
+test("A spaced colon-pair stays a colon-pair with multibyte content", {
+  exn := _ts_exn();
+  // The `space before the colon` guard reads `tc(k - 2)`, a RUNE index; the
+  // whole point of S4 is that the cut that follows agrees with it.
+  assert_str_eq(_parse_ts("${名前 : y}", exn), `((名前 : y).to_string)()`, "spaced colon is not a spec");
+  assert_str_eq(_parse_ts("${名前}", exn), `(名前.to_string)()`, "no spec at all");
+});
+test("Peeling survives multibyte literal text around the interpolation", {
+  exn := _ts_exn();
+  assert_str_eq(
+    _parse_ts("中${名前:>8}文", exn),
+    `((("中".to_string)().(+))((名前.format)(">8")).(+))(("文".to_string)())`,
+    "multibyte literal segments on both sides"
+  );
 });

--- a/tests/string/string_char_api.test.yo
+++ b/tests/string/string_char_api.test.yo
@@ -1,0 +1,308 @@
+//! The rune-aware `String` vocabulary added by D4 PR 1
+//! (`plans/STD_API_AUDIT_D4_PLAN.md` §4): `char_len`, `char_indices`,
+//! `is_char_boundary`, `floor_char_boundary`, `ceil_char_boundary` and
+//! `try_substring`.
+//!
+//! EVERY assertion here is against multibyte content with hand-computed byte
+//! offsets. That is the point: a byte-vs-rune basis error is invisible to
+//! ASCII input by construction, so an ASCII test of this API proves nothing
+//! (`plans/STD_API_AUDIT_D4_PLAN.md` §6.1-§6.2).
+//!
+//! The canonical subject covers all four UTF-8 widths in one string:
+//!
+//! ```text
+//!   rune   a      é         中           𝄞
+//!   width  1B     2B        3B           4B          10 bytes, 4 runes
+//!   bytes  61     C3 A9     E4 B8 AD     F0 9D 84 9E
+//!   offset 0      1  2      3  4  5      6  7  8  9
+//! ```
+{ assert } :: import("std/assert");
+open(import("std/fmt"));
+open(import("std/string"));
+open(import("std/collections/array_list"));
+/// The four-width subject string, rebuilt per test so nothing is shared.
+_subject :: (fn() -> String)(
+  `aé中𝄞`
+);
+// ===========================================================================
+// char_len
+// ===========================================================================
+test("String char_len counts runes across all four UTF-8 widths", {
+  s := _subject();
+  assert(s.bytes_len() == usize(10), "subject must be 10 bytes");
+  assert(s.char_len() == usize(4), "subject must be 4 runes");
+  // Pin the corpus: if these bytes ever change, every offset below is wrong.
+  assert(s.byte_at(usize(0)) == u8(0x61), "byte 0 is 'a'");
+  assert(s.byte_at(usize(1)) == u8(0xC3), "byte 1 leads 'é'");
+  assert(s.byte_at(usize(2)) == u8(0xA9), "byte 2 continues 'é'");
+  assert(s.byte_at(usize(3)) == u8(0xE4), "byte 3 leads '中'");
+  assert(s.byte_at(usize(4)) == u8(0xB8), "byte 4 continues '中'");
+  assert(s.byte_at(usize(5)) == u8(0xAD), "byte 5 continues '中'");
+  assert(s.byte_at(usize(6)) == u8(0xF0), "byte 6 leads '𝄞'");
+  assert(s.byte_at(usize(7)) == u8(0x9D), "byte 7 continues '𝄞'");
+  assert(s.byte_at(usize(8)) == u8(0x84), "byte 8 continues '𝄞'");
+  assert(s.byte_at(usize(9)) == u8(0x9E), "byte 9 continues '𝄞'");
+});
+test("String char_len equals len() today — the D4 cross-PR golden", {
+  // PR 3 flips `len()` to bytes. `char_len()` must return the SAME number
+  // before and after that flip, so this is the regression gate that isolates
+  // "did the rune count change?" from "did len() change?".
+  // (plans/STD_API_AUDIT_D4_PLAN.md §6.1 item 3.)
+  assert(_subject().char_len() == _subject().len(), "four-width subject");
+  assert(`你好世界`.char_len() == `你好世界`.len(), "CJK");
+  assert(`héllo`.char_len() == `héllo`.len(), "latin-1 supplement");
+  assert(`😀🎉`.char_len() == `😀🎉`.len(), "astral emoji");
+  assert(`abc`.char_len() == `abc`.len(), "ASCII");
+  assert(String.new().char_len() == String.new().len(), "empty");
+  // And the absolute values, so the golden is readable without running len().
+  assert(`你好世界`.char_len() == usize(4), "4 CJK runes");
+  assert(`😀🎉`.char_len() == usize(2), "2 emoji runes");
+  assert(`😀🎉`.bytes_len() == usize(8), "8 emoji bytes");
+});
+test("String char_len on the empty string", {
+  assert(String.new().char_len() == usize(0), "empty is 0 runes");
+  assert(String.from("").char_len() == usize(0), "from empty str is 0 runes");
+});
+// ===========================================================================
+// is_char_boundary — every byte of every width, including all four bytes of
+// the 4-byte sequence.
+// ===========================================================================
+test("String is_char_boundary marks every byte of the four-width subject", {
+  s := _subject();
+  assert(s.is_char_boundary(usize(0)), "0 starts 'a'");
+  assert(s.is_char_boundary(usize(1)), "1 starts 'é'");
+  assert(!(s.is_char_boundary(usize(2))), "2 is inside 'é'");
+  assert(s.is_char_boundary(usize(3)), "3 starts '中'");
+  assert(!(s.is_char_boundary(usize(4))), "4 is inside '中'");
+  assert(!(s.is_char_boundary(usize(5))), "5 is inside '中'");
+  assert(s.is_char_boundary(usize(6)), "6 starts '𝄞'");
+  assert(!(s.is_char_boundary(usize(7))), "7 is inside '𝄞'");
+  assert(!(s.is_char_boundary(usize(8))), "8 is inside '𝄞'");
+  assert(!(s.is_char_boundary(usize(9))), "9 is inside '𝄞'");
+  assert(s.is_char_boundary(usize(10)), "10 is the end, a boundary");
+  assert(!(s.is_char_boundary(usize(11))), "11 is past the end");
+  assert(!(s.is_char_boundary(usize(100))), "100 is far past the end");
+});
+test("String is_char_boundary over a standalone 4-byte sequence", {
+  // The 4-byte width alone, so the offsets are not shifted by anything else.
+  s := `𝄞`;
+  assert(s.bytes_len() == usize(4), "U+1D11E is 4 bytes");
+  assert(s.char_len() == usize(1), "U+1D11E is 1 rune");
+  assert(s.is_char_boundary(usize(0)), "byte 0 is the lead");
+  assert(!(s.is_char_boundary(usize(1))), "byte 1 is a continuation");
+  assert(!(s.is_char_boundary(usize(2))), "byte 2 is a continuation");
+  assert(!(s.is_char_boundary(usize(3))), "byte 3 is a continuation");
+  assert(s.is_char_boundary(usize(4)), "byte 4 is the end");
+  assert(!(s.is_char_boundary(usize(5))), "byte 5 is past the end");
+});
+test("String is_char_boundary on the empty string", {
+  e := String.new();
+  assert(e.is_char_boundary(usize(0)), "0 is a boundary of the empty string");
+  assert(!(e.is_char_boundary(usize(1))), "1 is past the empty string");
+});
+// ===========================================================================
+// floor_char_boundary / ceil_char_boundary
+// ===========================================================================
+test("String floor_char_boundary walks back to the rune start", {
+  s := _subject();
+  assert(s.floor_char_boundary(usize(0)) == usize(0), "0 -> 0");
+  assert(s.floor_char_boundary(usize(1)) == usize(1), "1 -> 1");
+  assert(s.floor_char_boundary(usize(2)) == usize(1), "2 -> 1 (inside 'é')");
+  assert(s.floor_char_boundary(usize(3)) == usize(3), "3 -> 3");
+  assert(s.floor_char_boundary(usize(4)) == usize(3), "4 -> 3 (inside '中')");
+  assert(s.floor_char_boundary(usize(5)) == usize(3), "5 -> 3 (inside '中')");
+  assert(s.floor_char_boundary(usize(6)) == usize(6), "6 -> 6");
+  assert(s.floor_char_boundary(usize(7)) == usize(6), "7 -> 6 (inside '𝄞')");
+  assert(s.floor_char_boundary(usize(8)) == usize(6), "8 -> 6 (inside '𝄞')");
+  assert(s.floor_char_boundary(usize(9)) == usize(6), "9 -> 6 (inside '𝄞')");
+  assert(s.floor_char_boundary(usize(10)) == usize(10), "10 -> 10 (the end)");
+  assert(s.floor_char_boundary(usize(11)) == usize(10), "11 clamps to the end");
+  assert(s.floor_char_boundary(usize(999)) == usize(10), "far past clamps");
+  assert(String.new().floor_char_boundary(usize(7)) == usize(0), "empty -> 0");
+});
+test("String ceil_char_boundary walks forward to the next rune start", {
+  s := _subject();
+  assert(s.ceil_char_boundary(usize(0)) == usize(0), "0 -> 0");
+  assert(s.ceil_char_boundary(usize(1)) == usize(1), "1 -> 1");
+  assert(s.ceil_char_boundary(usize(2)) == usize(3), "2 -> 3 (inside 'é')");
+  assert(s.ceil_char_boundary(usize(3)) == usize(3), "3 -> 3");
+  assert(s.ceil_char_boundary(usize(4)) == usize(6), "4 -> 6 (inside '中')");
+  assert(s.ceil_char_boundary(usize(5)) == usize(6), "5 -> 6 (inside '中')");
+  assert(s.ceil_char_boundary(usize(6)) == usize(6), "6 -> 6");
+  assert(s.ceil_char_boundary(usize(7)) == usize(10), "7 -> 10 (inside '𝄞')");
+  assert(s.ceil_char_boundary(usize(8)) == usize(10), "8 -> 10 (inside '𝄞')");
+  assert(s.ceil_char_boundary(usize(9)) == usize(10), "9 -> 10 (inside '𝄞')");
+  assert(s.ceil_char_boundary(usize(10)) == usize(10), "10 -> 10 (the end)");
+  assert(s.ceil_char_boundary(usize(11)) == usize(10), "11 clamps to the end");
+  assert(String.new().ceil_char_boundary(usize(7)) == usize(0), "empty -> 0");
+});
+test("String floor/ceil agree exactly on the boundaries themselves", {
+  // The invariant that makes them safe to use as a slicing pair:
+  // is_char_boundary(i)  <=>  floor(i) == i  <=>  ceil(i) == i.
+  s := _subject();
+  i := usize(0);
+  while(i <= s.bytes_len(), i = (i + usize(1)), {
+    on := s.is_char_boundary(i);
+    assert((s.floor_char_boundary(i) == i) == on, "floor fixes exactly the boundaries");
+    assert((s.ceil_char_boundary(i) == i) == on, "ceil fixes exactly the boundaries");
+    assert(s.is_char_boundary(s.floor_char_boundary(i)), "floor lands on a boundary");
+    assert(s.is_char_boundary(s.ceil_char_boundary(i)), "ceil lands on a boundary");
+  });
+});
+// ===========================================================================
+// char_indices
+// ===========================================================================
+test("String char_indices yields BYTE offsets, not character offsets", {
+  s := _subject();
+  it := s.char_indices();
+  match(
+    it.next(),
+    .Some(p) => {
+      assert(p._0 == usize(0), "'a' starts at byte 0");
+      assert(p._1.to_u32() == u32(0x61), "'a' is U+0061");
+    },
+    .None => assert(false, "expected 'a'")
+  );
+  match(
+    it.next(),
+    .Some(p) => {
+      assert(p._0 == usize(1), "'é' starts at byte 1");
+      assert(p._1.to_u32() == u32(0xE9), "'é' is U+00E9");
+    },
+    .None => assert(false, "expected 'é'")
+  );
+  match(
+    it.next(),
+    .Some(p) => {
+      assert(p._0 == usize(3), "'中' starts at byte 3, not 2");
+      assert(p._1.to_u32() == u32(0x4E2D), "'中' is U+4E2D");
+    },
+    .None => assert(false, "expected '中'")
+  );
+  match(
+    it.next(),
+    .Some(p) => {
+      assert(p._0 == usize(6), "'𝄞' starts at byte 6, not 3");
+      assert(p._1.to_u32() == u32(0x1D11E), "'𝄞' is U+1D11E");
+    },
+    .None => assert(false, "expected '𝄞'")
+  );
+  match(it.next(), .Some(_) => assert(false, "expected exhaustion"), .None => ());
+});
+test("String char_indices offsets are exactly the char boundaries", {
+  // The §6.1 property: i is a char_indices key <=> is_char_boundary(i),
+  // for every i in [0, bytes_len). (bytes_len itself is a boundary but is
+  // not a key, since no rune starts there.)
+  s := _subject();
+  offsets := ArrayList(usize).new();
+  it := s.char_indices();
+  while(true, {
+    match(
+      it.next(),
+      .Some(p) => {
+        offsets.push(p._0);
+      },
+      .None => {
+        break;
+      }
+    );
+  });
+  assert(offsets.len() == s.char_len(), "one key per rune");
+  i := usize(0);
+  while(i < s.bytes_len(), i = (i + usize(1)), {
+    assert(offsets.contains(i) == s.is_char_boundary(i), "key set matches the boundary set");
+  });
+  assert(!(offsets.contains(s.bytes_len())), "no rune starts at the end offset");
+});
+test("String char_indices walks in lockstep with chars()", {
+  s := `héllo, 世界! 😀`;
+  ci := s.char_indices();
+  ch := s.chars();
+  expected_offset := usize(0);
+  seen := usize(0);
+  while(true, {
+    (finished : bool) = false;
+    match(
+      ci.next(),
+      .Some(p) => {
+        assert(p._0 == expected_offset, "offset advances by the encoded width");
+        match(
+          ch.next(),
+          .Some(r) => assert(p._1.to_u32() == r.to_u32(), "same rune from both iterators"),
+          .None => assert(false, "chars() ended early")
+        );
+        seen = (seen + usize(1));
+        // The next rune starts at the next boundary strictly after `p._0`.
+        expected_offset = s.ceil_char_boundary(p._0 + usize(1));
+      },
+      .None => {
+        match(ch.next(), .Some(_) => assert(false, "chars() ran long"), .None => ());
+        finished = true;
+      }
+    );
+    if(finished, {
+      break;
+    });
+  });
+  assert(seen == s.char_len(), "both iterators yielded every rune");
+  assert(expected_offset == s.bytes_len(), "both iterators consumed every byte");
+});
+test("String char_indices on the empty string yields nothing", {
+  it := String.new().char_indices();
+  match(it.next(), .Some(_) => assert(false, "empty yields nothing"), .None => ());
+});
+// ===========================================================================
+// try_substring — BYTE offsets, refuses interior offsets
+// ===========================================================================
+test("String try_substring slices on rune boundaries", {
+  s := _subject();
+  assert(s.try_substring(usize(0), usize(1)).unwrap() == `a`, "[0,1) is 'a'");
+  assert(s.try_substring(usize(1), usize(3)).unwrap() == `é`, "[1,3) is 'é'");
+  assert(s.try_substring(usize(3), usize(6)).unwrap() == `中`, "[3,6) is '中'");
+  assert(s.try_substring(usize(6), usize(10)).unwrap() == `𝄞`, "[6,10) is '𝄞'");
+  assert(s.try_substring(usize(0), usize(10)).unwrap() == s, "[0,10) is the whole string");
+  assert(s.try_substring(usize(1), usize(6)).unwrap() == `é中`, "[1,6) spans two runes");
+  assert(s.try_substring(usize(0), usize(0)).unwrap() == String.new(), "[0,0) is empty");
+  assert(s.try_substring(usize(6), usize(6)).unwrap() == String.new(), "[6,6) is empty");
+  assert(s.try_substring(usize(10), usize(10)).unwrap() == String.new(), "[10,10) is empty");
+});
+test("String try_substring REFUSES an offset inside a rune", {
+  s := _subject();
+  // Inside the 2-byte 'é'.
+  assert(s.try_substring(usize(0), usize(2)).is_none(), "end 2 splits 'é'");
+  assert(s.try_substring(usize(2), usize(3)).is_none(), "start 2 splits 'é'");
+  // Inside the 3-byte '中'.
+  assert(s.try_substring(usize(3), usize(4)).is_none(), "end 4 splits '中'");
+  assert(s.try_substring(usize(3), usize(5)).is_none(), "end 5 splits '中'");
+  assert(s.try_substring(usize(4), usize(6)).is_none(), "start 4 splits '中'");
+  assert(s.try_substring(usize(5), usize(6)).is_none(), "start 5 splits '中'");
+  // Every interior byte of the 4-byte '𝄞'.
+  assert(s.try_substring(usize(6), usize(7)).is_none(), "end 7 splits '𝄞'");
+  assert(s.try_substring(usize(6), usize(8)).is_none(), "end 8 splits '𝄞'");
+  assert(s.try_substring(usize(6), usize(9)).is_none(), "end 9 splits '𝄞'");
+  assert(s.try_substring(usize(7), usize(10)).is_none(), "start 7 splits '𝄞'");
+  assert(s.try_substring(usize(8), usize(10)).is_none(), "start 8 splits '𝄞'");
+  assert(s.try_substring(usize(9), usize(10)).is_none(), "start 9 splits '𝄞'");
+});
+test("String try_substring refuses out-of-range and inverted ranges", {
+  s := _subject();
+  assert(s.try_substring(usize(0), usize(11)).is_none(), "end past the last byte");
+  assert(s.try_substring(usize(11), usize(12)).is_none(), "start past the last byte");
+  assert(s.try_substring(usize(6), usize(3)).is_none(), "start > end");
+  assert(s.try_substring(usize(10), usize(0)).is_none(), "start > end at the end");
+  assert(String.new().try_substring(usize(0), usize(0)).unwrap() == String.new(), "empty [0,0)");
+  assert(String.new().try_substring(usize(0), usize(1)).is_none(), "empty [0,1)");
+});
+test("String try_substring composes with floor/ceil to make any range safe", {
+  // The intended idiom: snap an arbitrary byte cut onto boundaries, then
+  // slice. This is what a byte-basis `truncate` has to do.
+  s := _subject();
+  cut := usize(8);
+  assert(s.try_substring(usize(0), cut).is_none(), "byte 8 splits a rune");
+  head := s.try_substring(usize(0), s.floor_char_boundary(cut)).unwrap();
+  assert(head == `aé中`, "floored cut keeps whole runes");
+  tail := s.try_substring(s.ceil_char_boundary(cut), s.bytes_len()).unwrap();
+  assert(tail == String.new(), "ceiled cut lands at the end here");
+  mid := s.try_substring(s.floor_char_boundary(cut), s.bytes_len()).unwrap();
+  assert(mid == `𝄞`, "floored start keeps the whole rune");
+});

--- a/tests/string/string_char_api.test.yo
+++ b/tests/string/string_char_api.test.yo
@@ -306,3 +306,68 @@ test("String try_substring composes with floor/ceil to make any range safe", {
   mid := s.try_substring(s.floor_char_boundary(cut), s.bytes_len()).unwrap();
   assert(mid == `𝄞`, "floored start keeps the whole rune");
 });
+// ===========================================================================
+// char_substring / truncate_chars — the RUNE-indexed slice PR 2 pins onto
+// ===========================================================================
+test("String char_substring slices by RUNE index, not byte offset", {
+  s := _subject();
+  assert(s.char_substring(usize(0), usize(1)) == `a`, "rune 0");
+  assert(s.char_substring(usize(1), usize(2)) == `é`, "rune 1 is 2 bytes wide");
+  assert(s.char_substring(usize(2), usize(3)) == `中`, "rune 2 starts at byte 3");
+  assert(s.char_substring(usize(3), usize(4)) == `𝄞`, "rune 3 starts at byte 6");
+  assert(s.char_substring(usize(0), usize(4)) == s, "the whole string");
+  assert(s.char_substring(usize(1), usize(3)) == `é中`, "an interior run");
+  // A BYTE slice of the same numbers is something else entirely — that gap is
+  // exactly what D4's flip opens, and what `char_substring` closes.
+  assert(s.try_substring(usize(1), usize(3)).unwrap() == `é`, "BYTES 1..3 is just 'é'");
+  assert(s.char_substring(usize(1), usize(3)) == `é中`, "RUNES 1..3 is 'é中'");
+});
+test("String char_substring clamps exactly the way substring always has", {
+  s := _subject();
+  assert(s.char_substring(usize(0), usize(99)) == s, "end past the rune count clamps");
+  assert(s.char_substring(usize(2), usize(99)) == `中𝄞`, "clamped tail");
+  assert(s.char_substring(usize(4), usize(9)) == String.new(), "start at the rune count");
+  assert(s.char_substring(usize(9), usize(99)) == String.new(), "start past the rune count");
+  assert(s.char_substring(usize(2), usize(2)) == String.new(), "empty range");
+  assert(s.char_substring(usize(3), usize(1)) == String.new(), "inverted range");
+  assert(String.new().char_substring(usize(0), usize(3)) == String.new(), "empty receiver");
+});
+test("String truncate_chars keeps whole runes and never lengthens", {
+  s := _subject();
+  assert(s.truncate_chars(usize(0)) == String.new(), "zero runes");
+  assert(s.truncate_chars(usize(1)) == `a`, "one rune");
+  assert(s.truncate_chars(usize(2)) == `aé`, "two runes — 3 BYTES, not 2");
+  assert(s.truncate_chars(usize(2)).bytes_len() == usize(3), "byte length of the cut");
+  assert(s.truncate_chars(usize(3)) == `aé中`, "three runes");
+  assert(s.truncate_chars(usize(4)) == s, "exactly the rune count");
+  assert(s.truncate_chars(usize(5)) == s, "more than the rune count is a no-op");
+  assert(s.truncate_chars(usize(999)) == s, "far more is still a no-op");
+  // The property that makes it safe for arbitrary text: every result is a
+  // prefix that ends on a rune boundary.
+  i := usize(0);
+  while(i <= usize(6), i = (i + usize(1)), {
+    cut := s.truncate_chars(i);
+    assert(s.is_char_boundary(cut.bytes_len()), "the cut lands on a boundary");
+    assert(cut.char_len() == if(i < usize(4), i, usize(4)), "rune count of the cut");
+  });
+});
+test("String split on the EMPTY separator stays character-based", {
+  // STD_API_AUDIT_D4_PLAN §5.2 S5: `split("")` means "split into characters".
+  // A byte split would hand back fragments that are not valid UTF-8.
+  s := _subject();
+  parts := s.split(String.new());
+  assert(parts.len() == usize(4), "four runes, four parts — not ten bytes");
+  assert(parts(usize(0)) == `a`, "part 0");
+  assert(parts(usize(1)) == `é`, "part 1");
+  assert(parts(usize(2)) == `中`, "part 2");
+  assert(parts(usize(3)) == `𝄞`, "part 3");
+  assert(parts(usize(1)).bytes_len() == usize(2), "'é' is two bytes");
+  assert(parts(usize(3)).bytes_len() == usize(4), "'𝄞' is four bytes");
+  rejoined := String.new();
+  i := usize(0);
+  while(i < parts.len(), i = (i + usize(1)), {
+    rejoined.push_string(parts(i));
+  });
+  assert(rejoined == s, "the parts concatenate back to the original");
+  assert(String.new().split(String.new()).len() == usize(0), "empty string, no parts");
+});


### PR DESCRIPTION
The first two steps of `plans/STD_API_AUDIT_D4_PLAN.md`. **No basis changes here** — this is the work that makes the byte-indexing flip reviewable instead of a 194-site leap of faith.

## PR 1 — additive only

`char_len()`, `char_indices()`, `is_char_boundary()`, `floor_char_boundary()`, `ceil_char_boundary()`, `try_substring()` on both `String` and `imm.String`, plus `imm.String.chars()`, which it never had. All built on `std/encoding/utf8.yo` from #286 — no second decoder, no second width table.

`try_substring` is **byte**-based from day one while `substring` stays char-based until PR 3. A new name can carry the final contract; a new name that flipped basis under its callers would be exactly the silent hazard D4 exists to remove.

## PR 2 — pin char semantics, provably inert

Every site that genuinely needs characters now *says so in its own source*: `std/encoding/html.yo`'s backtracking scanner, `std/fmt/spec.yo` width/precision, `src/parser.yo:_peel_spec`, `std/string/string.yo:_split_impl`, `src/doc/render_html.yo`, `src/error.yo`, and **10** comptime string sites (the plan said 4).

The mechanism that makes PR 3 tractable: **`char_substring` holds `substring`'s body verbatim, and `substring` delegates to it.** Every rewrite is inert by construction, and the flip becomes a single insertion point.

## What PR 2 caught — eleven bugs, while they are still inert

**PR 2's central claim was false, and the review found it.** `Token.column`/`Token.character` are **rune** offsets (`src/lexer.yo` walks an `ArrayList(rune)`), so `tok.column + tok.value.len()` mixes a rune column with a length PR 3 turns into bytes. The plan named **one** such site; there are **eleven more across six files it never named**:

| site | what would have broken after PR 3 |
| --- | --- |
| `src/lsp/rename.yo:35` | **rename replaces past the end of a multibyte identifier** |
| `src/lsp/hover.yo:50` | hit test matches the wrong token |
| `src/lsp/{hover,symbols,definition,references}.yo` (5 sites) | LSP ranges longer than the identifier |
| `src/lsp/completion.yo:926,930` | `ends_at_dot`/`before_dot` stop finding the receiver |
| `src/formatter.yo:1246` | tight-call adjacency → **`yo fmt` output changes** |
| `src/doc/builder.yo:379` | doc-comment adjacency → stray space |

All eleven are migrated. The **detector patterns** — not the site list — are written into the plan, so PR 3 greps for the shape.

Two further live mixed-basis bugs were filed rather than folded in silently: `issues/mkdir-all-uses-a-byte-index-as-a-rune-index.md` and `issues/unsafe-report-relative-path-uses-a-byte-prefix-length.md`.

## A vacuous test, replaced

`tests/format_specs.test.yo`'s "numeric padding measures in characters" asserted only through `String.format` — which routes a String body to `FormatSpec.pad`, **never** to `pad_numeric`, and the radix formatters only ever hand `pad_numeric` ASCII. Its three `char_len()` calls had **zero** coverage. Replaced with direct `pad_numeric` calls on multibyte parts.

## A plan gate that was unattainable — corrected, not worked around

§4 specified "**byte-identity** of the compiler's emitted C" for both PRs. That is impossible for any `std/` source addition: generated identifiers embed a global declaration counter, so adding declarations shifted every id after the insertion point by a uniform **+1004** — including inside `array_list.yo` and `allocator.yo`, files never touched. The sha256 changes while the program provably does not, so the gate would have **failed vacuously and hidden whether anything real moved**.

Both rows corrected, the working recipe written into §6.1 and `.github/instructions/testing.instructions.md`. Byte-identity remains the right gate for `src/codegen/` edits, where the `.yo` source is unchanged.

Inertness was instead established by A/B against the base `std` via `--std-path`: a 1481-line behavioural probe (identical sha256, empty diff), **39,488** `(a,b)` comparisons of `char_len ≡ len` and `char_substring ≡ substring` with 0 mismatches, and a differential driver for `_peel_spec` (35 inputs, 20 multibyte, 0 mismatches) — which also showed the migration is **load-bearing**: the pre-PR-2 peel under a byte-based slice differs on 12 of 35.

## Battery

| gate | result |
| --- | --- |
| `yo check ./std` / `./src` | 154/154, 262/262 |
| `yo build` | rc=0 |
| full suite | **3089 passed / 3089** (+37) |
| cli-diff scorecard | PASS 52, GOLDEN-DIFF 0, NO-GOLDEN 0, **zero drift** |
| `gates_fast.sh` | `T1_DONE failures=0` |
| `fixpoint_only.sh` | `stage2 hollow=0`, `STAGE3_RC=0`, **`FIXPOINT_HOLDS`** |
| `hollow_sweep69.sh` | `SWEEP_GATE_OK`, allowlisted known-failing 0 |

Zero golden drift is the load-bearing number here: `src/formatter.yo:1246` feeds `yo fmt`'s adjacency and the LSP sites feed the `lsp-*` cases, so any of those eleven migrations changing behaviour would have moved a golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)