### PR TITLE
std: D4 PR 3 — the flip. String is byte-indexed

### DIFF
--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -1478,53 +1478,68 @@ total := sums.fold(i32(0), (fn(acc : i32, x : i32) -> i32)((acc + x)));
 
 **Test API format**: Use `evaluate_module_body(exprs, &(env))` (reference syntax, returns `Option`). Match with function-style `match(result, .None => ..., .Some(m) => ...)`. Do NOT use block-style `match(result) { ... }` — it causes a parse error ("Paren-less function and operator calls are not supported").
 
-**String indexing: `len()`/`substring`/`index_of` are RUNE-based; `byte_at`/`as_bytes` are BYTE-based — never mix.** `String.from("a→b").len()` is `3` (runes) while `.as_bytes().len()` is `5`. A loop `while(i < s.len(), { b := s.byte_at(i); ... })` UNDER-WALKS multibyte content by `bytes − runes` (this truncated emitted C in yo-self codegen: an `assert(_, "… → …")` message chopped the compound literal's closing `}`). `index_of` returns a RUNE index — never feed it to `byte_at`, and never feed a byte index to `substring`. Rules:
+**String indexing is BYTE-based, everywhere.** Since 2026-08-26
+(`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3) `String.len()`, `at`, `substring`,
+the `s(a..b)` / `s(a..=b)` sugar, `index_of`, `last_index_of`,
+`contains(from_index)`, `starts_with(position)`, `ends_with(end_position)` and
+the whole `Pattern` trait all speak BYTE offsets — the same unit as
+`byte_at` / `as_bytes` / `Index(usize)` / `str.len()` / `StringBuilder.len()`.
+`String.from("a→b").len()` is `5`, not `3`. **This is the reverse of what it
+used to be**: before that flip they were rune-based, and mixing the two bases
+was the standing hazard. Now the only rune-based names are the `char_*` family
+below.
 
 ```
-// ✅ byte loop: byte bound
-n := s.as_bytes().len();
-while(i < n, { b := s.byte_at(i); ... });
-
-// ✅ byte-exact slicing: rebuild from bytes (substring is rune-indexed)
-bytes := s.as_bytes();
-inner := ArrayList(u8).new();
-// push bytes[from..to), then:
-String.from_bytes(inner)
-
-// ❌ WRONG — rune bound, byte reads
+// ✅ byte loop, byte bound — the bases now agree
 while(i < s.len(), { b := s.byte_at(i); ... });
-// ❌ WRONG — rune index from index_of fed to byte_at
-match(s.index_of(w, from), .Some(idx) => s.byte_at(idx - usize(1)), ...);
+
+// ✅ index_of's answer feeds straight back into substring
+match(s.index_of(w), .Some(idx) => s.substring(idx, idx + w.len()), .None => ...);
+
+// ✅ rune iteration with the byte offset of each rune
+it := s.char_indices();
+// p._0 is the BYTE offset, p._1 the rune
+
+// ❌ WRONG — a rune count is not a byte offset
+while(i < s.char_len(), { b := s.byte_at(i); ... });
+// ❌ PANICS — an endpoint inside a rune
+s.substring(usize(0), usize(1)) // on "→…", byte 1 is a continuation byte
 ```
 
-**Since 2026-08-26 there is a byte-safe vocabulary — prefer it over hand-rolled
-byte walks** (`std/string/string.yo`, same six on `std/imm/string.yo`, which also
-gained `chars()`):
+**Boundary policy for `substring` (and the `s(a..b)` sugar):** out-of-range
+CLAMPS, but a **non-boundary index PANICS** — an offset inside a rune is a
+programmer error, not a range condition. The escape hatches:
+`try_substring(a, b)` returns `.None` instead, and
+`floor_char_boundary` / `ceil_char_boundary` snap an arbitrary offset onto a
+boundary first. `index_of` / `starts_with` / `ends_with` never panic: a
+valid-UTF-8 needle simply cannot match at a continuation byte, so a mid-rune
+argument answers `false` / `.None`.
+
+**The rune vocabulary** (`std/string/string.yo`; the same names exist on
+`std/imm/string.yo`, whose own `len()` is still rune-based until D4 PR 4):
 
 | call | basis | meaning |
 | --- | --- | --- |
-| `s.char_len()` | runes | the O(n) rune count. **Say this** when you mean runes; `len()` is scheduled to become the byte count (D4). |
-| `s.char_indices()` | — | iterator of `IterPair(byte_offset, rune)`; `p._0` is the BYTE offset, `p._1` the rune. Replaces `while(i < s.len()) { s.at(i) }`, which is O(n²). |
-| `s.is_char_boundary(i)` | byte | is byte `i` the start of a rune? `0` and `bytes_len()` are boundaries; past the end is not. |
-| `s.floor_char_boundary(i)` / `s.ceil_char_boundary(i)` | byte | snap an arbitrary byte offset back/forward onto a rune start (clamped to `bytes_len()`). |
-| `s.try_substring(a, b)` | **byte** | `Option(String)`; `.None` for `a > b`, `b > bytes_len()`, or an endpoint inside a rune. NOTE: byte offsets, unlike `substring`, which is still rune-indexed and clamps. |
-| `s.char_substring(a, b)` | runes | (added 2026-08-26) exactly what `substring` does today, under a name that says so. `substring` is now a one-line delegation to it, so **`substring` will change basis and `char_substring` will not.** Say `char_substring` at any site that means runes. |
-| `s.truncate_chars(n)` | runes | (added 2026-08-26) keep at most `n` runes. Never splits a rune, never lengthens. This is the right tool for "cut arbitrary human text to a display length". |
-
-So the byte-exact slice above is now `s.try_substring(from, to).unwrap()`, and a
-fixed-width truncation that must not split a codepoint is
-`s.truncate_chars(n)` (or, if you are working in byte offsets,
-`s.try_substring(usize(0), s.floor_char_boundary(n)).unwrap()`).
-
-**The migration rule, in one line:** if a site means runes, spell it
-`char_len`/`char_indices`/`char_substring`/`truncate_chars` *now*; if it means
-bytes, leave it on `len`/`substring` and it becomes correct when D4 flips them.
-`while(i < s.len()) { s.at(i).unwrap() }` is the shape to hunt — after the flip
-`at()` at a continuation byte is `.None`, so that `.unwrap()` **panics**.
+| `s.char_len()` | runes | the O(n) rune count. **Say this** whenever you mean "how many characters" — `len()` is bytes. |
+| `s.char_indices()` | — | iterator of `IterPair(byte_offset, rune)`; `p._0` is the BYTE offset, `p._1` the rune. This is the replacement for `while(i < s.len()) { s.at(i) }`, which now visits continuation bytes and yields `.None` at each of them. |
+| `s.char_substring(a, b)` | runes | the rune-indexed slice — what `substring` meant before the flip. Clamps, never panics. |
+| `s.truncate_chars(n)` | runes | keep at most `n` runes. Never splits a rune, never lengthens. The right tool for "cut arbitrary human text to a display length". |
+| `s.is_char_boundary(i)` | byte | is byte `i` the start of a rune? `0` and `len()` are boundaries; past the end is not. |
+| `s.floor_char_boundary(i)` / `s.ceil_char_boundary(i)` | byte | snap an arbitrary byte offset back/forward onto a rune start (clamped to `len()`). |
+| `s.try_substring(a, b)` | byte | `Option(String)`; `.None` for `a > b`, `b > len()`, or an endpoint inside a rune. The non-panicking `substring`. |
+| `s.bytes_len()` | byte | DEPRECATED alias of `len()`. It existed to say "bytes, not runes"; that distinction is gone. Write `len()`. |
 
 `char_len` and `char_indices` sit on `std/encoding/utf8`, so they inherit its
 malformed-input behaviour: `char_len` counts non-continuation bytes, and
 `char_indices` (like `chars()`) stops at the first sequence that will not decode.
+
+**Lexer/AST note:** `Token.character` is a RUNE offset into `Token.input`
+(the lexer walks `input.chars()`); `Token.byte_offset` is the byte offset of
+the same position. **Never index `input` with `character`** — that was
+`issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md`, where `yo
+fmt` silently destroyed non-ASCII source at rc=0. `Token.column` is likewise a
+rune column, so a width added to it must be `value.char_len()`, not
+`value.len()`.
 
 ## Async: await only at the async-closure statement level
 

--- a/issues/async-effect-setter-emits-a-raw-non-ascii-identifier-as-a-c-member-name.md
+++ b/issues/async-effect-setter-emits-a-raw-non-ascii-identifier-as-a-c-member-name.md
@@ -1,0 +1,95 @@
+# The async effect setter emits a raw non-ASCII identifier as a C member name
+
+**Status: OPEN.** Found 2026-08-26 while reviewing D4 PR 3 (the `String`
+byte-index flip). **Pre-existing and unrelated to D4** — it reproduces on the
+seed compiler `yo 0.2.17`, whose `std` is still rune-indexed.
+
+**Severity:** the emitted C does not compile. Loud, not silent — `yo compile`
+fails with a `clang` error naming the member, so nothing wrong ships.
+
+## Symptom
+
+A struct-typed effect bundle with a non-ASCII **function-typed field** makes
+`generate_future_effect_setter` (`src/codegen/exprs/async.yo`) write the field
+name into the generated `set_effect` body verbatim, while the struct itself was
+declared with the sanitized C name.
+
+`tmp/repro.yo`:
+
+```rust
+open(import("std/string"));
+open(import("std/fmt"));
+Handler :: (fn(msg : String) -> i32);
+MyEff :: struct(io : Io, é : Handler);
+inner :: (fn(io : Io) -> Impl(Future(i32, MyEff)))(
+  io.async((e) => {
+    v := e.é(`hi`);
+    return(v);
+  })
+);
+work :: (fn(io : Io) -> Impl(Future(i32, MyEff)))(
+  io.async((e) => {
+    r := e.io.await(inner(io), e);
+    return(r);
+  })
+);
+main :: (fn(io : Io) -> unit)({
+  (h : Handler) = (
+    (m) -> {
+      return(i32(7));
+    }
+  );
+  eff := MyEff(io : io, é : h);
+  r := io.await(work(io), eff);
+  println(`r=${r}`);
+});
+export(main);
+```
+
+```console
+$ yo compile tmp/repro.yo --release -o tmp/repro.bin
+tmp/repro.bin.c:653:22: error: no member named 'é' in 'struct __yo_t0_struct'
+  653 |     sm->__yo_param_0.é = value;
+      |     ~~~~~~~~~~~~~~~~ ^
+yo: error: compile: C compiler failed (exit 1) on tmp/repro.bin.c
+```
+
+The nested `io.await(inner(...), e)` is load-bearing: it is what makes the
+injectable-effect-mapping loop run at all. Without it only the `__bundle`
+branch is emitted and the file compiles.
+
+## Why it is worth fixing
+
+Non-ASCII identifiers are otherwise fully supported. This compiles and runs:
+
+```rust
+Pt :: struct(é : i32, 名前 : String);
+名 :: (fn(x : i32) -> i32)((x + i32(1)));
+```
+
+So the effect setter is the outlier: everywhere else the codegen sanitizes an
+identifier before it becomes a C name, and here it does not.
+
+## Root cause
+
+`generate_future_effect_setter` builds the assignment from
+`EffectFieldMapping.access_path`, which `_visit_effect_struct_fields`
+(`src/codegen/exprs/async.yo`) assembles as `` `${base_path}.${flabel}` `` from
+the SOURCE field label. Every other consumer of a field label goes through the
+codegen's C-name sanitizer first. The `strcmp(field, "é")` half is fine — that
+is a string literal, not an identifier.
+
+## Fix direction (not applied)
+
+Run `flabel` through the same sanitizer the struct declaration used when
+building `access_path`, leaving the `effect_label` (the `strcmp` key) as the
+source spelling. The two are already distinct fields on `EffectFieldMapping`,
+so the change is local.
+
+## Regression coverage that already exists
+
+`tests/codegen-bootstrap/effect_label_non_ascii.yo` covers the neighbouring
+FUNCTION-typed-effect shape, where the label is a non-ASCII effect **type**
+name and the access path is an ASCII capture field. That one compiles and runs
+today (`r=7`), and it is the D4 ratchet for `_capitalize_last_segment`. This
+issue is the struct-FIELD variant, which that file deliberately does not use.

--- a/issues/fixed/mkdir-all-uses-a-byte-index-as-a-rune-index.md
+++ b/issues/fixed/mkdir-all-uses-a-byte-index-as-a-rune-index.md
@@ -1,9 +1,18 @@
 # `mkdir_all` feeds a BYTE index to the rune-indexed `substring`
 
-**Status:** OPEN. Found 2026-08-26 while migrating call sites for
-`plans/STD_API_AUDIT_D4_PLAN.md` PR 2. **Deliberately not fixed there** — PR 2's
-contract is that it changes no behaviour. **D4 PR 3 fixes it for free** by
-making `substring` byte-indexed, which is the basis `i` already has.
+**Status: FIXED 2026-08-26 by `plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3** —
+with no edit to `std/fs/dir.yo` at all. `String.substring` is byte-indexed now,
+which is the basis `i` always had, so the two agree.
+
+Found 2026-08-26 while migrating call sites for D4 PR 2, and deliberately not
+fixed there because PR 2's contract was that it changed no behaviour.
+
+**Witnessed, not assumed.** `tests/fs/dir.test.yo` gained
+"create_dir_all creates nested directories with a multibyte component", which
+builds `<tmp>/yo_fs_dir_all_日本語/sub1/sub2` through the ENOENT recovery path
+and asserts all three levels exist. Measured 2026-08-26: it **fails** against a
+`std` tree whose only difference is the pre-flip `std/string/string.yo`, and
+passes against the flipped one (13/14 vs 14/14 in the same file).
 
 ## Where
 

--- a/issues/fixed/unsafe-report-relative-path-uses-a-byte-prefix-length.md
+++ b/issues/fixed/unsafe-report-relative-path-uses-a-byte-prefix-length.md
@@ -1,10 +1,26 @@
 # `yo unsafe-report` / `yo public-safe-report` cut the relative path with a BYTE length
 
-**Status:** OPEN. Found 2026-08-26 while reviewing
-`plans/STD_API_AUDIT_D4_PLAN.md` PR 2. **Deliberately not fixed there** — PR 2's
-contract is that it changes no behaviour. **D4 PR 3 fixes it for free** by
-making `substring` byte-indexed, which is the basis `root_prefix_len` already
-has.
+**Status: FIXED 2026-08-26 by `plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3** —
+with no edit to either file. `String.substring` is byte-indexed now, which is
+the basis `root_prefix_len` always had.
+
+Found 2026-08-26 while reviewing D4 PR 2, and deliberately not fixed there
+because PR 2's contract was that it changed no behaviour.
+
+**Re-measured on the same standalone reproducer after the flip** (the exact two
+lines, compiled `--release`, 2026-08-26):
+
+```
+ascii  root -> "a.yo"        (want "a.yo")     ✓
+cjk    root -> "a.yo"        (want "a.yo")     ✓   was "yo"
+accent root -> "src/a.yo"    (want "src/a.yo") ✓   was "rc/a.yo"
+```
+
+**Not covered by a repo test**, honestly stated: `_walk_yo_files` is private to
+each of the two files and neither subcommand has a test harness, so the
+reproducer above is the whole evidence. A regression here would be caught only
+by the `substring` contract tests in
+`tests/string/string_byte_index.test.yo`.
 
 This is an **8th** instance of the §5.1 "mixed-basis" family; the plan's §5.1
 table lists 7 and does not name these two files.

--- a/issues/retired/yo-test-std-path-not-forwarded-to-the-batch-compile.md
+++ b/issues/retired/yo-test-std-path-not-forwarded-to-the-batch-compile.md
@@ -1,5 +1,28 @@
 # `yo test --std-path <dir>` is silently ignored — the batch compile is a CHILD process that never receives the flag
 
+> **RETIRED 2026-08-26 — this is a DUPLICATE of an already-fixed issue, and its
+> "Fix sketch (not applied)" is wrong.**
+>
+> The forwarding fix landed in **#286** and is in the tree today:
+> `src/main.yo`'s per-batch child-compile block forwards
+> `get_std_path_override()` as `--std-path` right after `--c-compiler` /
+> `--target`, and `tests/cli-cases/test-std-path-forwarded` is its regression
+> gate. The write-up is `issues/fixed/yo-test-does-not-forward-std-path-to-batch-compile.md`.
+> **This file was created afterwards, in #287, by someone who hit the symptom
+> and did not find the fixed issue.**
+>
+> **What is actually true, and why the symptom is still real:** the `yo` on
+> `PATH` is a released SEED (v0.2.17) built before #286, so it still drops the
+> flag. Every measurement made with the seed must therefore use
+> `YO_STD=$PWD/std`, exactly as the sections below say — but the compiler this
+> tree BUILDS honours `--std-path`, and nothing needs implementing.
+> Re-measured 2026-08-26 during the D4 PR-3 review: with the seed,
+> `yo test ./tests/string/string_byte_index.test.yo --std-path $PWD/std`
+> fails in the CHILD compile (`char_len` is absent from the installed std)
+> while `YO_STD=$PWD/std yo test …` scores 19/19.
+>
+> The historical report follows unchanged.
+
 **Status: OPEN.** Found 2026-08-26 while reviewing the STD_API_AUDIT §D7
 `RwLock`/`OnceCell` change, where it caused a whole test run to score the
 INSTALLED std instead of the working tree's.

--- a/issues/yo-test-std-path-not-forwarded-to-the-batch-compile.md
+++ b/issues/yo-test-std-path-not-forwarded-to-the-batch-compile.md
@@ -4,6 +4,16 @@
 `RwLock`/`OnceCell` change, where it caused a whole test run to score the
 INSTALLED std instead of the working tree's.
 
+**Hit again, in its DANGEROUS form, during D4 PR 3 (2026-08-26.)** With
+`String`'s index basis flipped in the working tree,
+`yo test ./tests/string/string.test.yo --std-path ./std` reported a clean
+**253 passed / 253 total**. The same command with `YO_STD=$PWD/std` reported
+**36 failures**. Nothing in the first run's output hints that the flag was
+dropped — there is no "using std from ..." line and no warning. That is the
+silent case this issue warns about, and it cost a full re-run to notice.
+**Until this is fixed, use `YO_STD=$PWD/std yo test ...` for anything that
+depends on the working tree's `std`, never `--std-path`.**
+
 ## Symptom
 
 From a worktree whose `std/` differs from the installed bundle's:

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -1182,7 +1182,7 @@ implementing the D5 traits.** Until it lands, std honestly refuses https.
 | spec/ | FREEZE AS DOC | identity stubs; mark experimental, exclude from stability promise |
 | collections/* | RENAME + EXTEND | §5 renames; entry API, `retain/extend/drain`, `binary_search`, real `sort` (not O(n²) insertion), `sort_by`; HashSet = HashMap(T, unit) to kill ~500 duplicated SwissTable lines; hide pub `ctrl/data/…` fields; `BTreeMap` → rename `FlatMap` OR implement a real B-tree with `range()` (recommend: real B-tree, keep name); add `BTreeSet`; `PriorityQueue`: keep name, add comparator ctor, DOCUMENT min-heap |
 | imm/* | KEEP (O4) + FIX | stays in std (decided 2026-08-23); require `Acyclic` element bounds per O7, add iteration + `Index` where doc'd, rename `imm.String` → `ImmString` (**folded into D4** 2026-08-25 — decided, no longer conditional on COW `String`), dedupe set pair; mark unstable until exercised |
-| string | FIX + EXTEND | D4 indexing; Unicode-correct `to_lowercase` (+ `to_ascii_*` variants); `Pattern` impl for `rune` + `Regex`; `replace*` Pattern-generic; `parse_f64`/radix; `split_once`, `strip_prefix/suffix`, ~~`char_indices`~~ (landed 2026-08-26 with the rest of the D4 PR-1 vocabulary); move `panic_dyn`/`assert_dyn` to assert; delete dead `StringError`, one of `to_cstr`/`to_c_str` |
+| string | FIX + EXTEND | ~~D4 indexing~~ (**byte-indexed 2026-08-26**, D4 PR 3; `imm.String` is D4 PR 4); Unicode-correct `to_lowercase` (+ `to_ascii_*` variants); `Pattern` impl for `rune` + `Regex`; `replace*` Pattern-generic; `parse_f64`/radix; `split_once`, `strip_prefix/suffix`, ~~`char_indices`~~ (landed 2026-08-26 with the rest of the D4 PR-1 vocabulary); move `panic_dyn`/`assert_dyn` to assert; delete dead `StringError`, one of `to_cstr`/`to_c_str` |
 | encoding | STANDARDIZE | D2 verbs; one error style per D1; utf8 module; add `html_encode` (XSS!); percent-encoding module (P0 — nothing in std can build a safe query string); base32; CSV (P1); toml: floats/arrays/dates/serializer + `ToToml`/`FromToml` derives to mirror json (P1) |
 | json | EXTEND | enum representation for derives (open question O3); `JsonValue.Object` O(n) parallel arrays → keep repr, add index map if profiling demands |
 | regex | POLISH | `Regex.escape`, optional-flags `new`, callback replace, lazy `find_iter`, group byte-spans, ~~typed error, private internals~~ (**both DONE 2026-08-25**, D8) |
@@ -1677,9 +1677,12 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
   find/slice APIs byte-indexed with a char-boundary contract. The additive half
   (`char_len`/`char_indices`/`is_char_boundary`/`floor_char_boundary`/
   `ceil_char_boundary`/`try_substring`, on both string types) **landed
-  2026-08-26**, and so did the char-semantics pin (PR 2, plus
-  `char_substring`/`truncate_chars`); the basis flip itself is still ahead
-  (D4 plan PRs 3-9).
+  2026-08-26**, so did the char-semantics pin (PR 2, plus
+  `char_substring`/`truncate_chars`), **and so did the basis flip itself (PR 3,
+  2026-08-26)** — `String` is byte-indexed, with clamping for out-of-range and
+  a panic for a non-boundary index. What remains is `imm.String` (PR 4), the
+  `ImmString` rename (PR 5), regex's `index()` (PR 6), the comptime basis
+  (PR 7), the docs sweep (PR 8) and the decoder dedup (PR 9).
 - **O2 (D6)**: **DECIDED — platform TLS libraries via `pkg_config`**
   (SecureTransport/Schannel/OpenSSL), behind one `TlsStream` implementing the
   D5 traits. Until it lands, https throws `UnsupportedScheme` (C1).

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -769,9 +769,15 @@ implementing the D5 traits.** Until it lands, std honestly refuses https.
   D sketch, which gave BOTH `with_read` and `with_write` a `ref(v) : T` body
   parameter; splitting them into by-value / `inout` is what makes the read/write
   distinction mean anything. Found while reviewing: `yo test --std-path <dir>` is
-  silently ignored (the per-batch compile is a child process and the flag is not
-  forwarded), so a `--std-path` test run scores the INSTALLED std —
-  issues/yo-test-std-path-not-forwarded-to-the-batch-compile.md.
+  silently ignored, so a `--std-path` test run scores the INSTALLED std.
+  **Correction (D4 PR-3 review, 2026-08-26): that is the SEED's behaviour, not
+  the tree's.** The forwarding fix landed in #286
+  (issues/fixed/yo-test-does-not-forward-std-path-to-batch-compile.md, gated by
+  `tests/cli-cases/test-std-path-forwarded`); the write-up filed here was a
+  duplicate and is now
+  issues/retired/yo-test-std-path-not-forwarded-to-the-batch-compile.md. The
+  practical rule stands while the seed on `PATH` predates #286: use
+  `YO_STD=$PWD/std`.
 - **BLOCKER found while doing the row above:** a callback generic over its
   result — the `with_lock` / `with_read` / `with_write` signature itself —
   emits `void* tmp = <void call>;` when the closure returns unit, so

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -603,11 +603,37 @@ replace past the end of a multibyte identifier. The review also replaced a
 **vacuous** `pad_numeric` test (it asserted only through `String.format`, which
 never reaches `pad_numeric`) and recorded a **9th** live mixed-basis bug,
 duplicated across `src/unsafe_report.yo` and `src/public_safe_report.yo`
-(`issues/unsafe-report-relative-path-uses-a-byte-prefix-length.md`).
+(`issues/fixed/unsafe-report-relative-path-uses-a-byte-prefix-length.md`).
 **Only now is PR 3's review question "does this site want bytes?" — and the
 answer is yes everywhere left except S8 and S9, which are open by design.**
 
-The remaining D4 steps (PRs 3-9) are unchanged and still in
+~~**Step 3 of that plan (PR 3, THE FLIP)**~~ **LANDED 2026-08-26.**
+`String.len()` is now the BYTE count at O(1), and `at`, `substring`,
+`slice_copy`/`slice_copy_inclusive` (the `s(a..b)` sugar), `index_of`,
+`last_index_of`, `contains(from_index)`, `starts_with(position)`,
+`ends_with(end_position)` and the `Pattern` trait's five index-carrying methods
+all take and return BYTE offsets. `bytes_len()` is a deprecated alias of
+`len()`. **Boundary policy, stated on every flipped method:** out-of-range
+CLAMPS, a non-boundary index PANICS in the infallible `substring`,
+`try_substring` returns `.None` instead, and `floor_char_boundary` /
+`ceil_char_boundary` are there for callers doing arithmetic; the search
+methods never panic, because a valid-UTF-8 needle cannot match at a
+continuation byte. §1.3(a)'s broken `starts_with(position)` rune walk is fixed
+BY CONSTRUCTION — byte indexing deletes the walk rather than repairing it.
+`src/` migrated in the same commit, `Token.byte_offset` was added and
+`src/formatter.yo`'s `_byte_offset_of_char_index` retired, and the LSP grew a
+`rune_col_to_byte_offset` / `byte_offset_to_rune_col` pair so the three
+handlers that SLICE a line convert instead of mixing bases.
+PR 3 found a **10th** live mixed-basis bug the survey had missed —
+`std/http/client.yo:325` sent a RUNE count as `Content-Length` — and confirmed
+that `std/regex/` is basis-INDEPENDENT (it works entirely on `ArrayList(u8)`),
+so PR 6 is a cleanup, not a repair. Gates: `yo build`, `fixpoint_only.sh`
+FIXPOINT_HOLDS with stage-2 hollow=0, `gates_fast.sh` all seven gates,
+codegen corpus 155/155 with its goldens UNCHANGED, and a new
+`tests/string/string_byte_index.test.yo` (19 tests) of which **15 fail against
+the pre-flip `std` and pass against the flipped one**.
+
+The remaining D4 steps (PRs 4-9) are unchanged and still in
 `plans/STD_API_AUDIT_D4_PLAN.md` §4.
 
 **SCOPE EXTENDED (user, 2026-08-25): `std/imm/string` is IN, and so is the

--- a/plans/STD_API_AUDIT_D4_PLAN.md
+++ b/plans/STD_API_AUDIT_D4_PLAN.md
@@ -1,7 +1,11 @@
 # D4 — String indexing model: the executable migration plan
 
 > **Status:** **PRs 1-3 LANDED 2026-08-26** (PR 2 got a skeptical review pass on
-> the same branch that added §5.2 **S11**); PRs 4-9 still PLAN.
+> the same branch that added §5.2 **S11**; **PR 3 got one too — it found one
+> live regression the flip introduced, `_capitalize_last_segment`, §5.1's last
+> row, and one contract hole, the empty needle, §1.4. Both are fixed on the
+> same branch; the review's full method and measurements are §6.1.2**);
+> PRs 4-9 still PLAN.
 > **PR 3 was the flip.** `String` is byte-indexed from here on; the numbers in
 > §0/§2/§3 below are the pre-flip survey and are kept as the historical record
 > of what the migration measured, not as a description of the tree today.
@@ -153,7 +157,17 @@ most. That is a stronger argument for the change than the one in the audit.
 > and deliberately so:** UTF-8 is self-synchronizing, so a valid-UTF-8 needle
 > can never match starting at a continuation byte, which means a mid-rune
 > `from_index` / `position` / `end_position` cannot invent a hit and simply
-> answers `false` / `.None`. O1c is unchanged: comptime stays pinned to
+> answers `false` / `.None`. **That argument has exactly one hole, found in the
+> skeptical review (2026-08-26) and now documented on the two methods it
+> affects: the EMPTY needle matches everywhere.** `index_of(``, i)` answers
+> `.Some(i)` verbatim, so it is the one search result that can be a
+> continuation byte or past `len()` — feed THAT to `substring` and it panics.
+> `last_index_of(``, i)` answers `len()` regardless of `i`, exceeding the cap
+> the caller asked for. Both are pre-D4 behaviours carried over unchanged (only
+> the unit moved, rune→byte); what was new in PR 3 was the doc comments'
+> universally-quantified claim that "every index this returns is a rune
+> boundary", which was false. Docs corrected, behaviour untouched, and
+> `tests/string/string_byte_index.test.yo` pins it. O1c is unchanged: comptime stays pinned to
 > `char_len`/`char_substring` (S10) and is PR 7's to align.
 
 - **O1a — what does `at()` mean after the flip?** Options: (i) `at(byte_index)`
@@ -427,7 +441,7 @@ no-op and PR 3 only has to change definitions.
 | ~~**0**~~ **LANDED** (#286) | `std/encoding/utf8.yo`. Primitives: `seq_len(lead: u8) -> usize`, `decode(bytes, i) -> Option((rune, usize))`, `encode(r, out)`, `is_char_boundary(bytes, i)`, `validate`. **Dependency:** PR 1 and PR 6 both consume it; PR 2 does not. | `yo check ./std`; new `tests/encoding/utf8.test.yo` |
 | ~~**1**~~ **LANDED 2026-08-26** | **Additive only.** `String.char_len()`, `String.char_indices()`, `String.is_char_boundary()`, `floor_char_boundary`, `ceil_char_boundary`, `try_substring`. Same six on `imm.String`, plus `imm.String.chars()`. Built on `std/encoding/utf8` (PR 0), no second decoder. New `tests/string/string_char_api.test.yo` (17 tests) + 6 tests appended to `tests/imm_string.test.yo`, all multibyte. | achieved: `yo check ./std` 153/153; `tests/string/string_char_api` 17/17, `tests/imm_string` 34/34, `tests/string/string` 253/253, `imm_map`/`imm_vec`/`imm_threading` green; 0 `Failed to transpile` in both kept batches; emitted-C **equivalence** measured as below (literal byte-identity is unattainable — see the correction under §6.1) |
 | ~~**2**~~ **LANDED 2026-08-26** | **Pin char semantics, no basis change.** Done: `std/encoding/html.yo` onto a `char_indices()` rune table (S1); `std/fmt/spec.yo` width/precision/numeric-total onto `char_len()` + the new `truncate_chars` (S2); `std/string/string.yo` `_split_impl`'s empty-separator arm onto `char_len`/`char_substring` (S5); `src/parser.yo:_peel_spec` onto `char_indices()` + `try_substring` (S4); `src/doc/render_html.yo` onto `char_len`/`truncate_chars` (S6); `src/error.yo:43` onto `char_len()` (S7); all 10 comptime-string-builtin sites onto `char_len`/`char_substring` (S10, O1c). Two additive helpers were needed and added: `char_substring` (the rune-indexed slice, holding `substring`'s CURRENT body verbatim — `substring` is now a one-line delegation to it) and `truncate_chars`. **NOT done here, and why:** S8 (`src/doc/builder.yo`) needs `Token.byte_offset`, S9 (`src/lsp/completion.yo`) needs the UTF-16 work — both are PR 3 by §5.4; S3 (regex) is PR 6. | achieved: `yo check ./std --std-path <tree>/std` 153/153; every touched `src/` file `check`s clean; `tests/encoding/html` 12/12 (was 8), `tests/format_specs` 13/13 (was 7; 12 as PR 2 committed it), `tests/string/string_char_api` 21/21 (was 17), `tests/string/string` 253/253, `tests/template_string_specs` 6/6, `tests/imm_string` 34/34, `string_builder` 21/21, `rune` 36/36. Behavioural gate: a 862-line multibyte probe over `decode_html` / `FormatSpec.pad` / `pad_numeric` / `split("")` / the rune vocabulary hashes **`828549f0f0a9bdf747692bc872f018499a53435f518741fe055742d8561105e3` before AND after** the migration. Emitted C is NOT identical and cannot be — see the §6.1 correction extension below. **Review pass 2026-08-26 (same branch) added §5.2 S11** — 11 more rune-column sites in `formatter`/`lsp`/`doc` that PR 2 as first committed had missed — plus a real `pad_numeric` multibyte test (the one it shipped was vacuous), and recorded a 9th live mixed-basis bug in `unsafe_report.yo`/`public_safe_report.yo`. Independently re-verified there: a 1481-line multibyte behavioural probe hashes `b7a76ec66909fbab41940268b645d950fc56f5788a45ed17e9fe8be87b2233c1` on the base `std` and on the migrated `std`; `char_len ≡ len` and `char_substring ≡ substring` over 39,488 exhaustive comparisons, 0 mismatches; `_peel_spec` old-vs-new 35 inputs (20 multibyte), 0 mismatches; `substring`'s new one-line delegation costs 0 measurable time at `-O2`. |
-| ~~**3**~~ **LANDED 2026-08-26** | **The flip.** `String.len()` → bytes O(1); `at`/`substring`/`slice_copy*`/`index_of`/`last_index_of`/`contains(from)`/`starts_with(pos)`/`ends_with(pos)`/`Pattern`'s five methods → bytes. `bytes_len()` is now `self.len()`. §1.3(a) fixed by construction. `src/` migrated in the same commit. `Token.byte_offset` added (a `?= usize(0)` defaulted field, so only the ~20 synthetic construction sites that COPY a source token's position needed touching) and `_byte_offset_of_char_index` retired. S8 (`src/doc/builder.yo`) done via `byte_offset`; S9 (`src/lsp/completion.yo`) and `src/lsp/diagnostics.yo:_ident_len_at` done via a new `rune_col_to_byte_offset` / `byte_offset_to_rune_col` pair in `src/lsp/protocol.yo` — **the UTF-16 half of §5.4 was NOT done, see the note under §5.4.** One site needed a rewrite the plan had classified INVARIANT: `src/doc_command.yo:_scan_quoted_value_after` peeked one unit at a time with `substring(j, j+1)`, which under the new panic policy would abort on a lead byte; it now reads bytes. | achieved: `yo build` green; `fixpoint_only.sh` **FIXPOINT_HOLDS**, stage-2 hollow=0; `gates_fast.sh` all 7 gates (battery 23/23 files hollow=0, corpus **155/155 with goldens unchanged**, `check ./std` 154/154, `check ./src` 262/262, cli-diff 52 PASS / 0 GOLDEN-DIFF, fmt idempotent); new `tests/string/string_byte_index.test.yo` 19/19 of which **15 FAIL against the pre-flip `std`**; `tests/string/string.test.yo` 253/253 after rewriting the **36** (not 20) multibyte+index tests; `string_char_api` 21/21, `encoding/utf8` 35/35, `encoding/html` 12/12, `format_specs` 13/13, `imm_string` 34/34, `regex` 156/156, `index` 49/49, `json` 53/53, `utf16` 13/13, `template_string_specs` 6/6, `string_multibyte_literal` 2/2, and `tests/internal/{lexer 45,parser 52,formatter 8,doc_extractor 39,doc_sections 23,doc_render_markdown 25,pkg_config 11,lock_file 15,build_runner 10,install_command 43,version 21,fetch 10,cache 6,init 13,target 22,error 16,env 11,type_key 5,…}` all green |
+| ~~**3**~~ **LANDED 2026-08-26** | **The flip.** `String.len()` → bytes O(1); `at`/`substring`/`slice_copy*`/`index_of`/`last_index_of`/`contains(from)`/`starts_with(pos)`/`ends_with(pos)`/`Pattern`'s five methods → bytes. `bytes_len()` is now `self.len()`. §1.3(a) fixed by construction. `src/` migrated in the same commit. `Token.byte_offset` added (a `?= usize(0)` defaulted field, so only the ~20 synthetic construction sites that COPY a source token's position needed touching) and `_byte_offset_of_char_index` retired. S8 (`src/doc/builder.yo`) done via `byte_offset`; S9 (`src/lsp/completion.yo`) and `src/lsp/diagnostics.yo:_ident_len_at` done via a new `rune_col_to_byte_offset` / `byte_offset_to_rune_col` pair in `src/lsp/protocol.yo` — **the UTF-16 half of §5.4 was NOT done, see the note under §5.4.** One site needed a rewrite the plan had classified INVARIANT: `src/doc_command.yo:_scan_quoted_value_after` peeked one unit at a time with `substring(j, j+1)`, which under the new panic policy would abort on a lead byte; it now reads bytes. | achieved: `yo build` green; `fixpoint_only.sh` **FIXPOINT_HOLDS**, stage-2 hollow=0; `gates_fast.sh` all 7 gates (battery 23/23 files hollow=0, corpus **155/155 with goldens unchanged** (**156** after the review pass added `effect_label_non_ascii.yo`), `check ./std` 154/154, `check ./src` 262/262, cli-diff 52 PASS / 0 GOLDEN-DIFF, fmt idempotent); new `tests/string/string_byte_index.test.yo` 19/19 of which **15 FAIL against the pre-flip `std`** (**21/21 and 17 failing** after the review pass added the empty-needle and floor/ceil rows; both figures re-measured independently, §6.1.2); `tests/string/string.test.yo` 253/253 after rewriting the **36** (not 20) multibyte+index tests; `string_char_api` 21/21, `encoding/utf8` 35/35, `encoding/html` 12/12, `format_specs` 13/13, `imm_string` 34/34, `regex` 156/156, `index` 49/49, `json` 53/53, `utf16` 13/13, `template_string_specs` 6/6, `string_multibyte_literal` 2/2, and `tests/internal/{lexer 45,parser 52,formatter 8,doc_extractor 39,doc_sections 23,doc_render_markdown 25,pkg_config 11,lock_file 15,build_runner 10,install_command 43,version 21,fetch 10,cache 6,init 13,target 22,error 16,env 11,type_key 5,…}` all green |
 | **4** | `imm.String`: `len()` → bytes, `at()` aligned, `bytes_len()` aliased, `chars()`/`char_indices()`/`char_len()` wired. | `tests/imm_string.test.yo` (rewritten per §6.2), `imm_vec`, `imm_threading` |
 | **5** | `imm.String` → `ImmString` rename. ~15 lines: the `String ::` binding + `export`, 3 test imports, 4 doc lines × 2 languages. | suite + docs both languages |
 | **6** | **Regex.** Delete `_byte_to_char_index` (`std/regex/index.yo:70`) and the three char→byte re-walks at `:535-545`, `:582-592`, `:634-644`. `RegexMatch.index()` becomes a **byte** index — a silent public API change that needs its own release note. Adopt `std/encoding/utf8.yo`. | `tests/regex/regex.test.yo` + new multibyte index assertions |
@@ -556,6 +570,8 @@ the duplicated report walker, was found in the PR-1/PR-2 review pass):
 | `src/unsafe_report.yo:511,521` + `src/public_safe_report.yo:517,525` `_walk_yo_files` | `root_prefix_len := walk_root.as_bytes().len()` (**bytes**), then `p.substring(root_prefix_len + 1, p.len())` (**runes**) | **LIVE BUG, FOUND IN THE PR-1/PR-2 REVIEW (2026-08-26) — a 9th, and it is DUPLICATED across two files**; written up in `issues/fixed/unsafe-report-relative-path-uses-a-byte-prefix-length.md`. The relative path is cut `bytes(root) - runes(root)` positions too far in, so the directory-skip filter runs on the wrong segments and the printed label is mangled. Measured on a standalone reproducer: root `/tmp/名` gives `"yo"` where `"a.yo"` is wanted; root `/tmp/café` gives `"rc/a.yo"` where `"src/a.yo"` is wanted. Reachable from `yo unsafe-report` and `yo public-safe-report` (`src/main.yo:3245`). **FIXED by D4 PR 3 (2026-08-26) with no edit to either file**; the same standalone reproducer now answers `a.yo` / `src/a.yo`. Not covered by a repo test — `_walk_yo_files` is private and neither subcommand has a harness. |
 
 | `std/http/client.yo:325` `fetch` | `req.set_header(\`Content-Length\`, \`${opts.body.len()}\`)` with `opts.body : String` | **LIVE BUG, FOUND IN PR 3 (2026-08-26) — a 10th, and the first that is wrong ON THE WIRE rather than internally.** `Content-Length` is defined in bytes; a rune count under-reports any non-ASCII request body, so the server reads a truncated body (or blocks waiting for one). The survey missed it because the detector looked for `len()` mixed with a byte LOOP, and this one mixes it with a protocol. **D4 PR 3 fixes it for free** — the site is unchanged and now correct. |
+
+| `src/codegen/exprs/async.yo:366` `_capitalize_last_segment` | `last.substring(usize(0), usize(1)).to_uppercase()` on a user-written effect LABEL | **A site the flip BREAKS, not one it fixes — the ONLY one found in the skeptical review (2026-08-26), and it broke a program that WORKED.** `generate_future_effect_setter` calls this on every injectable effect label so the emitted `strcmp(field, …)` chain also accepts the capitalized alias. Yo identifiers may start with a non-ASCII rune (`src/token.yo` `is_identifier_start`: `c.char >= 0xA0`), so the label can be multibyte — and `substring(0, 1)` then lands INSIDE the first rune, which post-flip **aborts the compiler** (`String.substring: end is not on a UTF-8 character boundary`, rc=134, no source location, nothing emitted). Pre-flip the same expression was a rune slice and simply worked. **FIXED in the review pass** by cutting with `char_substring` — the rune vocabulary, which is what the function always meant; ASCII output is byte-identical (`io.async` → `Async`, `errors.raise` → `Raise`, `x` → `X`). Ratchet: `tests/codegen-bootstrap/effect_label_non_ascii.yo` (+ golden), a program that compiles and runs `r=7` on the seed and would abort the flipped compiler without the fix. |
 
 **All nine of the pre-existing rows above are fixed by PR 3**, seven of them
 without touching the site (`_win_dirname`, `_path_has_extension`,
@@ -837,12 +853,124 @@ asserts in their place is `try_substring` answering `.None` at exactly those
 indices.
 
 **METHOD TRAP, cost one full re-run:** `yo test --std-path ./std` **silently
-ignores the flag** (`issues/yo-test-std-path-not-forwarded-to-the-batch-compile.md`)
-— the batch compile is a child process. `tests/string/string.test.yo` scored a
-clean 253/253 that way against the flipped tree, because it had actually
-scored the INSTALLED std. `YO_STD=$PWD/std yo test ...` is the working lever,
-and it reported the 36 real failures. Any future std-facing measurement in this
-campaign must use `YO_STD`.
+ignores the flag** — the batch compile is a child process.
+`tests/string/string.test.yo` scored a clean 253/253 that way against the
+flipped tree, because it had actually scored the INSTALLED std.
+`YO_STD=$PWD/std yo test ...` is the working lever, and it reported the 36 real
+failures (re-measured in the review pass: **exactly 36**, and `tests/fs/dir`
+exactly 13/1). Any std-facing measurement in this campaign must use `YO_STD`.
+
+**CORRECTION to that trap (review pass, 2026-08-26): the flag is NOT broken in
+this tree — it is broken in the SEED.** `src/main.yo`'s per-batch child-compile
+block already forwards `get_std_path_override()` as `--std-path`, landed in
+#286 with `tests/cli-cases/test-std-path-forwarded` as its gate
+(`issues/fixed/yo-test-does-not-forward-std-path-to-batch-compile.md`). The
+issue PR 3 cited was a duplicate filed AFTER that fix and has been retired
+(`issues/retired/yo-test-std-path-not-forwarded-to-the-batch-compile.md`). The
+`yo` on `PATH` is v0.2.17, built before #286, which is why the symptom is real
+today — but nothing needs implementing, and a future agent must not re-derive
+the "fix sketch" that file carried.
+
+### 6.1.2 What the SKEPTICAL REVIEW re-ran, and what it found (2026-08-26)
+
+A second pass over the landed flip, attacking the five things that could still
+be wrong. Everything below was run with `YO_STD=$PWD/std` against the seed
+`yo 0.2.17`, one command at a time.
+
+**1. Re-ran the detectors on the POST-flip tree, and added new ones.**
+`.at(` repo-wide outside `string.yo` (the `.unwrap()`-panic shape S1 was
+about): 2 sites, both in `src/install_command.yo`, both correct in either
+basis. `Token.column`/`character` + `.len()` (the S11 shape): **zero** — all
+11 sites carry `char_len()`. Every `Token(` construction that copies a real
+`character` also sets `byte_offset` (11 constructions set `character :
+usize(0)`, matching `byte_offset`'s default of 0; **no** construction sets a
+non-zero `character` without a `byte_offset`) — checked mechanically with a
+balanced-paren scan of all 46 sites, which is the invariant `_slice_token_text`
+and `read_raw_template_string` depend on. New detector: every
+`substring`/`try_substring`/`slice_copy` site in `src` (135) and `std` (17),
+classified by whether both endpoints are provably rune boundaries. Exactly TWO
+have a literal end offset (`src/fetch.yo:401` `commit.substring(0, 12)` on a
+git SHA; `src/codegen/exprs/async.yo:366`); every other endpoint is `0`,
+`X.len()`, an `index_of` result, a byte-walk cursor, or a literal guarded by an
+ASCII `starts_with`/`ends_with`. Only `async.yo:366` was live and wrong — §5.1's
+new row. Two now-FALSE comments were corrected in passing
+(`src/version_cache.yo:476` "String indices are rune-based",
+`src/codegen/utils/index.yo:1402` "the rune-indexed substring"), and
+`src/main.yo`'s `extract_bare_import_path` / `extract_import_path` /
+`collect_import_paths_recursive` / `collect_module_deps` were found to be
+**dead code with no caller in the tree** — which is the only reason their
+unguarded `raw.substring(1, n - 1)` on an arbitrary Atom token is not a
+reachable abort. Left in place; flagged, not deleted.
+
+**2. Boundary policy, measured on every method rather than argued.** A new
+exhaustive driver sweeps `0 ..= len+2` (and every `(a, b)` pair) over seven
+strings — `aé中𝄞`, `你好世界你好`, `abc`, empty, `a`, `𝄞`, `aa中bb` — and asserts:
+`is_char_boundary` equals the raw byte classification; `floor`/`ceil` land on
+boundaries and bracket the input; `at` is `.Some` exactly at an in-range
+boundary; `try_substring` is `.Some` exactly on a legal range and agrees with
+`substring` there; every non-empty search result is an in-range boundary; a
+mid-rune `position`/`end_position` never yields `true`; and `char_substring`
+stays rune-exact. **Result: clean on all seven, with exactly one exception —
+the empty needle (§1.4).** The panic arms were re-verified out-of-band and
+EXTENDED beyond what PR 3 checked: `substring(1,2)`, `substring(2,3)`,
+`substring(0,9)`, **`s(1 .. 2)`** and **`s(1 ..= 1)`** all exit 134 with a named
+message, and `char_substring(1,2)` does not.
+
+**3. `_has_prefix` / `_index_of_impl`: the "fixed by construction" claim
+holds.** The pre-flip `_index_of_impl` was read at the parent commit and has
+exactly the shape §1.3(a) describes (a `char_index` incremented on seeing a
+lead byte inside a loop that also steps one byte, and a `char_index` returned).
+The behavioural proof is the discrimination table below.
+
+**4. The discrimination table was re-derived independently, not taken on
+trust.** A pre-flip `std` was rebuilt by restoring ONLY
+`std/string/string.yo` from the parent commit (confirmed: it is the one and only
+`std/` file the flip touched) and every claim re-scored against it:
+
+| | pre-flip `std` | flipped `std` |
+| --- | ---: | ---: |
+| `tests/string/string_byte_index.test.yo` | 4 / 15 | 19 / 0 |
+| the same file, +2 tests added in this review | 4 / 17 | **21 / 0** |
+| `tests/string/string.test.yo` | 217 / **36** | 253 / 0 |
+| `tests/fs/dir.test.yo` | 13 / 1 | 14 / 0 |
+
+So "36, not 20" and "13/1 → 14/0" are both exactly right. The `src/` half was
+checked the same way: reverting `raw_token_value` to `t.character` scores
+`tests/internal/formatter.test.yo` at **7 / 1**, and `t.byte_offset` at 8 / 0 —
+the new formatter test is genuinely red-first, and it is the only in-tree gate
+on the whole `Token.byte_offset` mechanism.
+
+**5. LSP: the flip made it BETTER, and nothing worse.** Checked by hand, since
+the cli-cases cannot see it. Every handler that only COMPARES columns
+(`hover`, `definition`, `references`, `rename`, `symbols`, `doc/builder`,
+`formatter`'s adjacency test) moved `len()` → `char_len()`, whose body IS
+`len()`'s pre-flip body — inert. The three handlers that SLICE went through
+`rune_col_to_byte_offset`, which returns a `char_indices` key or `line.len()`
+and therefore **always a boundary**, so `line_text.substring(0, cur)` cannot
+panic. `completion.yo`'s `ws` walk backs up over `_is_word_byte`, which is
+ASCII-only, so it cannot land mid-rune either. And the pre-flip shape was
+already mixed-basis — `cur` was a rune column clamped by a BYTE length and then
+used as a byte index into `bytes` — so `ws`/`dot_before`/`prefix` were wrong on
+any multibyte line before this PR and are right after it. `_ident_len_at` is
+§5.1's 6th live bug and is likewise fixed. The UTF-16 gap of §5.4 is untouched
+in either direction.
+
+**6. Vacuous-green audit.** Every rewritten assertion in
+`tests/string/string.test.yo` was read against the byte layout in its own
+comment: the multibyte content sits BEFORE the asserted offsets in every case
+(`at(2)`→`at(4)`, `at(1)`→`at(3)`, `substring(2,4)`→`substring(6,12)`, …), the
+rune assertion is kept alongside under `char_len`/`char_substring`, and the
+whole file scores 36 failures against the pre-flip `std` — which is the
+mechanical proof that none of it is basis-invariant. Same for the new
+`string_byte_index` file: 4 of its 21 tests pass on both bases, and those 4 are
+exactly the ones that MUST (clamping, `try_substring`, `byte_at`/`Index`,
+`split("")`).
+
+**What this review changed:** the `async.yo` rune-cut fix + its corpus ratchet
+(now **156** files, was 155); the two empty-needle doc corrections in
+`std/string/string.yo` and two tests pinning them; two stale comments; one new
+issue (`issues/async-effect-setter-emits-a-raw-non-ascii-identifier-as-a-c-member-name.md`,
+pre-existing and unrelated to D4); one duplicate issue retired.
 
 ### 6.2 Which existing tests cannot catch this class
 

--- a/plans/STD_API_AUDIT_D4_PLAN.md
+++ b/plans/STD_API_AUDIT_D4_PLAN.md
@@ -1,7 +1,10 @@
 # D4 — String indexing model: the executable migration plan
 
-> **Status:** **PRs 1-2 LANDED 2026-08-26** (+ a skeptical review pass on the
-> same branch that added §5.2 **S11**); PRs 3-9 still PLAN.
+> **Status:** **PRs 1-3 LANDED 2026-08-26** (PR 2 got a skeptical review pass on
+> the same branch that added §5.2 **S11**); PRs 4-9 still PLAN.
+> **PR 3 was the flip.** `String` is byte-indexed from here on; the numbers in
+> §0/§2/§3 below are the pre-flip survey and are kept as the historical record
+> of what the migration measured, not as a description of the tree today.
 > (Survey complete 2026-08-25.)
 > **Parent decision:** `plans/STD_API_AUDIT.md` §3 **D4** + §8 **O1** —
 > `String` goes byte-indexed like Rust/Go. Scope extended (user, 2026-08-25)
@@ -41,18 +44,18 @@ contract.
 
 | Method | line | basis TODAY | basis after D4 | change class |
 | --- | --- | --- | --- | --- |
-| `len()` | 126 | **C**, O(n) | **B**, O(1) | 🔴 **SILENT** |
-| `at(index) -> Option(rune)` | 311 | **C** | **B** (decode at byte offset) — see §1.4 O1a | 🔴 **SILENT** |
-| `substring(start, end)` | 497 | **C** | **B** | 🔴 **SILENT** |
-| `slice_copy(Range)` — the `s(a..b)` sugar | 485 | **C** (delegates to `substring`) | **B** | 🔴 **SILENT** |
-| `slice_copy_inclusive(RangeInclusive)` | 489 | **C** | **B** | 🔴 **SILENT** |
-| `index_of(p, from_index?) -> Option(usize)` | 1690 → `_index_of_impl` 555 | **C** in *and* out | **B** in and out | 🔴 **SILENT** |
-| `last_index_of(p, from_index?)` | 1693 → 769 | **C** | **B** | 🔴 **SILENT** |
-| `contains(p, from_index?)` | 1687 → 651 | **C** (`from_index` only) | **B** | 🔴 **SILENT** (only when the 2nd arg is passed) |
-| `starts_with(p, position?)` | 1681 → `_has_prefix` 883 | **C** — *and buggy*, see §1.3 | **B** | 🔴 **SILENT** |
-| `ends_with(p, end_position?)` | 1684 → `_ends_with_impl` 966 | **C** (`self.len()` char length) | **B** | 🔴 **SILENT** |
-| `Pattern.is_prefix_of / is_suffix_of / is_contained_in / index_in / last_index_in` | 1621-1625 | **C** | **B** | 🔴 **SILENT** — public trait, 5 signatures |
-| `bytes_len()` | 464 | **B** | **B** (becomes an alias of `len()`) | 🟡 redundant; keep as deprecated alias |
+| ~~`len()`~~ | 126 | **C**, O(n) | **B**, O(1) | ✅ **LANDED PR 3** |
+| ~~`at(index) -> Option(rune)`~~ | 311 | **C** | **B** — O1a option (i), `.None` at a continuation byte | ✅ **LANDED PR 3** |
+| ~~`substring(start, end)`~~ | 497 | **C** | **B** | ✅ **LANDED PR 3** |
+| ~~`slice_copy(Range)`~~ — the `s(a..b)` sugar | 485 | **C** (delegates to `substring`) | **B** | ✅ **LANDED PR 3** |
+| ~~`slice_copy_inclusive(RangeInclusive)`~~ | 489 | **C** | **B** | ✅ **LANDED PR 3** |
+| ~~`index_of(p, from_index?) -> Option(usize)`~~ | 1690 → `_index_of_impl` 555 | **C** in *and* out | **B** in and out | ✅ **LANDED PR 3** |
+| ~~`last_index_of(p, from_index?)`~~ | 1693 → 769 | **C** | **B** | ✅ **LANDED PR 3** |
+| ~~`contains(p, from_index?)`~~ | 1687 → 651 | **C** (`from_index` only) | **B** | ✅ **LANDED PR 3** |
+| ~~`starts_with(p, position?)`~~ | 1681 → `_has_prefix` 883 | **C** — *and buggy*, see §1.3 | **B** | ✅ **LANDED PR 3** — §1.3(a) fixed by construction |
+| ~~`ends_with(p, end_position?)`~~ | 1684 → `_ends_with_impl` 966 | **C** (`self.len()` char length) | **B** | ✅ **LANDED PR 3** |
+| ~~`Pattern.is_prefix_of / is_suffix_of / is_contained_in / index_in / last_index_in`~~ | 1621-1625 | **C** | **B** | ✅ **LANDED PR 3** — all 5 documented as bytes |
+| ~~`bytes_len()`~~ | 464 | **B** | **B** — now `self.len()` | ✅ **LANDED PR 3** as a deprecated alias |
 | `byte_at(index) -> u8` | 470 | **B** | **B** | ✅ unchanged |
 | `Index(usize) -> u8` | 2402 | **B** | **B** | ✅ unchanged |
 | `chars() -> StringChars` | 1812 | — | — | ✅ unchanged |
@@ -103,7 +106,11 @@ one silent flip (`len()`), one alias fold, one `at()` alignment, three additions
 
 ### 1.3 Two contract defects found while tabling (report these, don't inherit them)
 
-**(a) `starts_with(prefix, position)` is broken for multibyte haystacks today.**
+**(a) `starts_with(prefix, position)` was broken for multibyte haystacks.**
+**FIXED BY CONSTRUCTION in PR 3** — byte indexing deletes the walk below rather
+than repairing it, and `tests/string/string_byte_index.test.yo`'s
+"starts_with position is a byte offset — the 1.3(a) fix" pins it. The
+description that follows is the pre-flip state.
 `_has_prefix` (`std/string/string.yo:883`) advances with
 
 ```rust
@@ -134,6 +141,20 @@ convention — it makes `String` agree with the two types it interoperates with
 most. That is a stronger argument for the change than the one in the audit.
 
 ### 1.4 Sub-decisions this plan needs and the audit does not settle
+
+> **SETTLED IN PR 3 (2026-08-26):** O1a took option (i) — `at(byte_index)`
+> decodes the rune STARTING at that byte and answers `.None` at a continuation
+> byte, past the end, or on bytes that do not decode (its body is now just
+> `self._decode_rune_at(index)`). O1b took the recommendation as written:
+> out-of-range CLAMPS, a NON-BOUNDARY index panics in `substring`,
+> `try_substring` is the non-panicking form, and `floor_char_boundary` /
+> `ceil_char_boundary` are the arithmetic helpers — all four stated in
+> `substring`'s own doc comment. **The search methods are NOT boundary-checked
+> and deliberately so:** UTF-8 is self-synchronizing, so a valid-UTF-8 needle
+> can never match starting at a continuation byte, which means a mid-rune
+> `from_index` / `position` / `end_position` cannot invent a hit and simply
+> answers `false` / `.None`. O1c is unchanged: comptime stays pinned to
+> `char_len`/`char_substring` (S10) and is PR 7's to align.
 
 - **O1a — what does `at()` mean after the flip?** Options: (i) `at(byte_index)`
   decodes the rune starting at that byte (Rust's `s[i..].chars().next()`),
@@ -406,7 +427,7 @@ no-op and PR 3 only has to change definitions.
 | ~~**0**~~ **LANDED** (#286) | `std/encoding/utf8.yo`. Primitives: `seq_len(lead: u8) -> usize`, `decode(bytes, i) -> Option((rune, usize))`, `encode(r, out)`, `is_char_boundary(bytes, i)`, `validate`. **Dependency:** PR 1 and PR 6 both consume it; PR 2 does not. | `yo check ./std`; new `tests/encoding/utf8.test.yo` |
 | ~~**1**~~ **LANDED 2026-08-26** | **Additive only.** `String.char_len()`, `String.char_indices()`, `String.is_char_boundary()`, `floor_char_boundary`, `ceil_char_boundary`, `try_substring`. Same six on `imm.String`, plus `imm.String.chars()`. Built on `std/encoding/utf8` (PR 0), no second decoder. New `tests/string/string_char_api.test.yo` (17 tests) + 6 tests appended to `tests/imm_string.test.yo`, all multibyte. | achieved: `yo check ./std` 153/153; `tests/string/string_char_api` 17/17, `tests/imm_string` 34/34, `tests/string/string` 253/253, `imm_map`/`imm_vec`/`imm_threading` green; 0 `Failed to transpile` in both kept batches; emitted-C **equivalence** measured as below (literal byte-identity is unattainable — see the correction under §6.1) |
 | ~~**2**~~ **LANDED 2026-08-26** | **Pin char semantics, no basis change.** Done: `std/encoding/html.yo` onto a `char_indices()` rune table (S1); `std/fmt/spec.yo` width/precision/numeric-total onto `char_len()` + the new `truncate_chars` (S2); `std/string/string.yo` `_split_impl`'s empty-separator arm onto `char_len`/`char_substring` (S5); `src/parser.yo:_peel_spec` onto `char_indices()` + `try_substring` (S4); `src/doc/render_html.yo` onto `char_len`/`truncate_chars` (S6); `src/error.yo:43` onto `char_len()` (S7); all 10 comptime-string-builtin sites onto `char_len`/`char_substring` (S10, O1c). Two additive helpers were needed and added: `char_substring` (the rune-indexed slice, holding `substring`'s CURRENT body verbatim — `substring` is now a one-line delegation to it) and `truncate_chars`. **NOT done here, and why:** S8 (`src/doc/builder.yo`) needs `Token.byte_offset`, S9 (`src/lsp/completion.yo`) needs the UTF-16 work — both are PR 3 by §5.4; S3 (regex) is PR 6. | achieved: `yo check ./std --std-path <tree>/std` 153/153; every touched `src/` file `check`s clean; `tests/encoding/html` 12/12 (was 8), `tests/format_specs` 13/13 (was 7; 12 as PR 2 committed it), `tests/string/string_char_api` 21/21 (was 17), `tests/string/string` 253/253, `tests/template_string_specs` 6/6, `tests/imm_string` 34/34, `string_builder` 21/21, `rune` 36/36. Behavioural gate: a 862-line multibyte probe over `decode_html` / `FormatSpec.pad` / `pad_numeric` / `split("")` / the rune vocabulary hashes **`828549f0f0a9bdf747692bc872f018499a53435f518741fe055742d8561105e3` before AND after** the migration. Emitted C is NOT identical and cannot be — see the §6.1 correction extension below. **Review pass 2026-08-26 (same branch) added §5.2 S11** — 11 more rune-column sites in `formatter`/`lsp`/`doc` that PR 2 as first committed had missed — plus a real `pad_numeric` multibyte test (the one it shipped was vacuous), and recorded a 9th live mixed-basis bug in `unsafe_report.yo`/`public_safe_report.yo`. Independently re-verified there: a 1481-line multibyte behavioural probe hashes `b7a76ec66909fbab41940268b645d950fc56f5788a45ed17e9fe8be87b2233c1` on the base `std` and on the migrated `std`; `char_len ≡ len` and `char_substring ≡ substring` over 39,488 exhaustive comparisons, 0 mismatches; `_peel_spec` old-vs-new 35 inputs (20 multibyte), 0 mismatches; `substring`'s new one-line delegation costs 0 measurable time at `-O2`. |
-| **3** | **The flip.** `String.len()` → bytes O(1); `at`/`substring`/`slice_copy*`/`index_of`/`last_index_of`/`contains(from)`/`starts_with(pos)`/`ends_with(pos)`/`Pattern`'s five methods → bytes. `bytes_len()` becomes a deprecated alias. Fix §1.3(a) by construction. `src/` migrates **in the same PR** — the repo build compiles `src/` against the *repo's* `std` (`--std-path > YO_STD > exe-walk-up > ./std`), so it cannot lag. Add `Token.byte_offset` and retire `_byte_offset_of_char_index` (`src/formatter.yo:1496`). | `yo check ./std && yo check ./src`; full language suite; `tests/internal`; `gates_fast.sh` + fixpoint; new §6 multibyte battery |
+| ~~**3**~~ **LANDED 2026-08-26** | **The flip.** `String.len()` → bytes O(1); `at`/`substring`/`slice_copy*`/`index_of`/`last_index_of`/`contains(from)`/`starts_with(pos)`/`ends_with(pos)`/`Pattern`'s five methods → bytes. `bytes_len()` is now `self.len()`. §1.3(a) fixed by construction. `src/` migrated in the same commit. `Token.byte_offset` added (a `?= usize(0)` defaulted field, so only the ~20 synthetic construction sites that COPY a source token's position needed touching) and `_byte_offset_of_char_index` retired. S8 (`src/doc/builder.yo`) done via `byte_offset`; S9 (`src/lsp/completion.yo`) and `src/lsp/diagnostics.yo:_ident_len_at` done via a new `rune_col_to_byte_offset` / `byte_offset_to_rune_col` pair in `src/lsp/protocol.yo` — **the UTF-16 half of §5.4 was NOT done, see the note under §5.4.** One site needed a rewrite the plan had classified INVARIANT: `src/doc_command.yo:_scan_quoted_value_after` peeked one unit at a time with `substring(j, j+1)`, which under the new panic policy would abort on a lead byte; it now reads bytes. | achieved: `yo build` green; `fixpoint_only.sh` **FIXPOINT_HOLDS**, stage-2 hollow=0; `gates_fast.sh` all 7 gates (battery 23/23 files hollow=0, corpus **155/155 with goldens unchanged**, `check ./std` 154/154, `check ./src` 262/262, cli-diff 52 PASS / 0 GOLDEN-DIFF, fmt idempotent); new `tests/string/string_byte_index.test.yo` 19/19 of which **15 FAIL against the pre-flip `std`**; `tests/string/string.test.yo` 253/253 after rewriting the **36** (not 20) multibyte+index tests; `string_char_api` 21/21, `encoding/utf8` 35/35, `encoding/html` 12/12, `format_specs` 13/13, `imm_string` 34/34, `regex` 156/156, `index` 49/49, `json` 53/53, `utf16` 13/13, `template_string_specs` 6/6, `string_multibyte_literal` 2/2, and `tests/internal/{lexer 45,parser 52,formatter 8,doc_extractor 39,doc_sections 23,doc_render_markdown 25,pkg_config 11,lock_file 15,build_runner 10,install_command 43,version 21,fetch 10,cache 6,init 13,target 22,error 16,env 11,type_key 5,…}` all green |
 | **4** | `imm.String`: `len()` → bytes, `at()` aligned, `bytes_len()` aliased, `chars()`/`char_indices()`/`char_len()` wired. | `tests/imm_string.test.yo` (rewritten per §6.2), `imm_vec`, `imm_threading` |
 | **5** | `imm.String` → `ImmString` rename. ~15 lines: the `String ::` binding + `export`, 3 test imports, 4 doc lines × 2 languages. | suite + docs both languages |
 | **6** | **Regex.** Delete `_byte_to_char_index` (`std/regex/index.yo:70`) and the three char→byte re-walks at `:535-545`, `:582-592`, `:634-644`. `RegexMatch.index()` becomes a **byte** index — a silent public API change that needs its own release note. Adopt `std/encoding/utf8.yo`. | `tests/regex/regex.test.yo` + new multibyte index assertions |
@@ -449,8 +470,20 @@ no-op and PR 3 only has to change definitions.
   ```
 
   Both must come back with `char_len()` (or a `Token.byte_offset`) at every hit
-  before PR 3 lands. **Still open by design after S11: S8 and S9**, which need
-  `Token.byte_offset` and the UTF-16 correction respectively.
+  before PR 3 lands. ~~**Still open by design after S11: S8 and S9**~~ — **both
+  closed in PR 3** (S8 with `Token.byte_offset`, S9 with a rune⟷byte conversion
+  pair; the UTF-16 half of §5.4 was deliberately left, see the note there).
+  **PR 3 re-ran both detectors and they came back clean**: after PR 3,
+  `grep -rnE '\.column\s*\+|\.character\s*\+' src/` hits only `char_len()`
+  sites, `to_string()` formatting and `Token.byte_offset`, and
+  `grep -rn '\.value\.len()' src/` hits only three genuinely byte-wanting
+  sites (`src/main.yo:276` strips ASCII `"` delimiters, `ptr_fns.yo:183` is an
+  emptiness test, `_expr.yo:508` is an ASCII-keyword-length perf gate) plus
+  `src/doc/builder.yo:234`, which is now correctly paired with `byte_offset`.
+  **The verdict on PR 2's central claim: it held, with one exception nobody had
+  reason to anticipate** — `src/doc_command.yo`, which does not want RUNES, but
+  whose one-unit slices become an ABORT rather than a wrong answer once
+  `substring` panics on a non-boundary. See the panic-policy bullet below.
 - PR 3 is the only PR that cannot be split across `std` and `src`.
 - **`impl` blocks do not see FORWARD across each other** — measured twice in
   PR 2, both times as `No matching call found with arguments: (self.X)()` from
@@ -463,10 +496,26 @@ no-op and PR 3 only has to change definitions.
   `is_char_boundary`, which still lives in the trailing block, so
   `is_char_boundary` has to move up beside `at()` (or `at()` has to inline
   `utf8.is_boundary`, which is what PR 2's throwaway flip experiment did).
-- **PR 3's insertion point is now one function.** `substring` is
-  `self.char_substring(start, end)`; give it a byte-slice body and leave
-  `char_substring` alone, and `slice_copy` / `slice_copy_inclusive` follow for
-  free since they already delegate to `substring`.
+- ~~**PR 3's insertion point is now one function.**~~ **CONFIRMED, and it held.**
+  `substring` got a byte-slice body, `char_substring` was untouched, and
+  `slice_copy` / `slice_copy_inclusive` followed for free. **The forward-reference
+  prediction above also held exactly:** the byte-basis `substring` needs
+  `is_char_boundary` for its panic check, and `is_char_boundary` lived in the
+  trailing block, so it was MOVED up beside `at`. Moving it backwards is safe —
+  a LATER block can call an earlier one, which is how `try_substring` still
+  reaches it.
+- **One thing the plan did not predict, and it is the panic policy's cost.**
+  Making a non-boundary index panic turns every one-unit `substring(j, j+1)`
+  peek into an abort on a lead byte. `src/doc_command.yo`'s
+  `_scan_quoted_value_after` does exactly that, and §3.1 had reclassified it
+  INVARIANT in PR 2 on the reasoning that a one-unit slice "simply fails to
+  match on any interior byte" — true under clamping, fatal under panicking. It
+  was rewritten onto `byte_at` / `starts_with(connector, j)`. A repo-wide grep
+  for `substring(x, x + usize(1))` found no other site (the two comptime
+  builtins and `_split_impl` use `char_substring`). **The general rule for
+  anyone extending this: a panic policy makes the `substring` call sites that
+  were merely WRONG before into sites that ABORT, so re-audit any site that
+  slices at an index it did not get from `index_of` or a boundary function.**
 - PR 6 can land before or after PR 3 **only if** it lands after — regex's
   `index()` is consumed by its own `replace*` which re-walks; splitting them
   leaves a half-converted state. Keep 6 after 3.
@@ -501,10 +550,20 @@ the duplicated report walker, was found in the PR-1/PR-2 review pass):
 | `src/install_command.yo:60` | `s.substring(usize(0), s.bytes_len() - usize(4))` | **LIVE BUG**: char slice, byte end. D4 fixes it. |
 | `src/install_command.yo:66` | `s2.substring(idx + usize(1), s2.bytes_len())` — `idx` from char `last_index_of` | **LIVE BUG** (two bases in one call). D4 fixes it. |
 | `src/pkg_config.yo:34-66` `_split_whitespace` | `n := bytes.len()`, walks `k` over bytes, then `s.substring(start, k)` | **LIVE BUG**. D4 fixes it. |
-| `src/lsp/diagnostics.yo:72-89` `_ident_len_at` | rune `col` indexed into `line.as_bytes()` | **LIVE BUG**, **NOT fixed by D4** — `col` stays a rune column. Needs the `Token.byte_offset` work (PR 3). |
+| `src/lsp/diagnostics.yo:72-89` `_ident_len_at` | rune `col` indexed into `line.as_bytes()` | **LIVE BUG**, **not fixed by the flip itself** — `col` stays a rune column. **FIXED IN PR 3** by converting it with the new `rune_col_to_byte_offset`. The returned length needs no conversion back: `_is_ident_byte` matches only ASCII, so every byte counted is one rune. |
 | `std/fmt/writer.yo:42` | `while(i < s.len())` + `s.bytes(i)` | **false positive** — `s : str`, whose `len()` is already bytes. Clean. |
-| `std/fs/dir.yo:93-121` `mkdir_all` | `bytes := path_s.as_bytes()`, `i` walks `bytes`, then `path_s.substring(usize(0), i)` | **LIVE BUG, FOUND IN PR 2 (2026-08-26) — an 8th, and the first in `std/` rather than `src/`; written up in `issues/mkdir-all-uses-a-byte-index-as-a-rune-index.md`.** `i` is a byte index into `as_bytes()`; `substring` reads it as a rune index, so `mkdir_all` on a path with a non-ASCII component creates the WRONG parent directory (a short prefix) and then fails or silently makes the wrong tree. Exactly the `_win_dirname` / `_split_whitespace` shape. **D4 PR 3 fixes it for free** — deliberately NOT touched in PR 2, whose contract is no behaviour change. |
-| `src/unsafe_report.yo:511,521` + `src/public_safe_report.yo:517,525` `_walk_yo_files` | `root_prefix_len := walk_root.as_bytes().len()` (**bytes**), then `p.substring(root_prefix_len + 1, p.len())` (**runes**) | **LIVE BUG, FOUND IN THE PR-1/PR-2 REVIEW (2026-08-26) — a 9th, and it is DUPLICATED across two files**; written up in `issues/unsafe-report-relative-path-uses-a-byte-prefix-length.md`. The relative path is cut `bytes(root) - runes(root)` positions too far in, so the directory-skip filter runs on the wrong segments and the printed label is mangled. Measured on a standalone reproducer: root `/tmp/名` gives `"yo"` where `"a.yo"` is wanted; root `/tmp/café` gives `"rc/a.yo"` where `"src/a.yo"` is wanted. Reachable from `yo unsafe-report` and `yo public-safe-report` (`src/main.yo:3245`). **D4 PR 3 fixes it for free** — deliberately NOT touched, same reason as `mkdir_all`. |
+| `std/fs/dir.yo:93-121` `mkdir_all` | `bytes := path_s.as_bytes()`, `i` walks `bytes`, then `path_s.substring(usize(0), i)` | **LIVE BUG, FOUND IN PR 2 (2026-08-26) — an 8th, and the first in `std/` rather than `src/`; written up in `issues/fixed/mkdir-all-uses-a-byte-index-as-a-rune-index.md`.** `i` is a byte index into `as_bytes()`; `substring` reads it as a rune index, so `mkdir_all` on a path with a non-ASCII component creates the WRONG parent directory (a short prefix) and then fails or silently makes the wrong tree. Exactly the `_win_dirname` / `_split_whitespace` shape. **FIXED by D4 PR 3 (2026-08-26) with no edit to the file**, and witnessed by a new multibyte `create_dir_all` test in `tests/fs/dir.test.yo` that fails against a pre-flip `std`. |
+| `src/unsafe_report.yo:511,521` + `src/public_safe_report.yo:517,525` `_walk_yo_files` | `root_prefix_len := walk_root.as_bytes().len()` (**bytes**), then `p.substring(root_prefix_len + 1, p.len())` (**runes**) | **LIVE BUG, FOUND IN THE PR-1/PR-2 REVIEW (2026-08-26) — a 9th, and it is DUPLICATED across two files**; written up in `issues/fixed/unsafe-report-relative-path-uses-a-byte-prefix-length.md`. The relative path is cut `bytes(root) - runes(root)` positions too far in, so the directory-skip filter runs on the wrong segments and the printed label is mangled. Measured on a standalone reproducer: root `/tmp/名` gives `"yo"` where `"a.yo"` is wanted; root `/tmp/café` gives `"rc/a.yo"` where `"src/a.yo"` is wanted. Reachable from `yo unsafe-report` and `yo public-safe-report` (`src/main.yo:3245`). **FIXED by D4 PR 3 (2026-08-26) with no edit to either file**; the same standalone reproducer now answers `a.yo` / `src/a.yo`. Not covered by a repo test — `_walk_yo_files` is private and neither subcommand has a harness. |
+
+| `std/http/client.yo:325` `fetch` | `req.set_header(\`Content-Length\`, \`${opts.body.len()}\`)` with `opts.body : String` | **LIVE BUG, FOUND IN PR 3 (2026-08-26) — a 10th, and the first that is wrong ON THE WIRE rather than internally.** `Content-Length` is defined in bytes; a rune count under-reports any non-ASCII request body, so the server reads a truncated body (or blocks waiting for one). The survey missed it because the detector looked for `len()` mixed with a byte LOOP, and this one mixes it with a protocol. **D4 PR 3 fixes it for free** — the site is unchanged and now correct. |
+
+**All nine of the pre-existing rows above are fixed by PR 3**, seven of them
+without touching the site (`_win_dirname`, `_path_has_extension`,
+`install_command`'s two, `_split_whitespace`, `mkdir_all`, the duplicated
+report walker) plus `src/main.yo:1294-1295` — an ELEVENTH found in PR 3's own
+sweep, where `-Dname=value` splits on an `eq_at` produced by a `byte_at` walk
+and fed to a then-rune-indexed `substring`. `_ident_len_at` needed the explicit
+conversion described in its row.
 
 **Precedent, already paid for once:**
 `issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md` — a
@@ -528,13 +587,13 @@ corruption in the stage-2 binary") and
 | --- | --- | --- | --- |
 | ~~**S1**~~ **DONE (PR 2)** | `std/encoding/html.yo:34, 52, 80, 92, 99, 106, 117, 140, 151, 175, 185` | `while(i < s.len())` + `s.at(i).unwrap()` over **arbitrary HTML text**. After the flip `at()` at a continuation byte is `.None` → `.unwrap()` **panics**. Highest-risk file in the tree. | done, but NOT as "three loops onto `chars()`" — `decode_html` is a **backtracking** scanner (`try_end` walks back one rune at a time, `substring(start, i)` re-slices between two scanner positions), which a forward-only iterator cannot express. It now materializes one `char_indices()` table of `(byte_offset, rune)` and indexes that by rune; `_parse_hex`/`_parse_dec` — which really are plain forward loops — did go onto `chars()`. The O(n²) is gone either way. |
 | ~~**S2**~~ **DONE (PR 2)** | `std/fmt/spec.yo:36, 69, 206-207` **plus 219-220, which this plan missed** | `width` is documented "Minimum width in **CHARACTERS**"; `_apply_width` uses `text.len()`, `pad` truncates with `substring(0, p)`. After the flip padding counts bytes and precision can split a codepoint. Rust counts chars here. **`pad_numeric`'s `sign.len() + prefix.len() + digits.len()` was not on the list but is compared against the same `self.width`**, so it had to move to the same basis or the two paths would disagree. | `char_len()` + the new `truncate_chars`; `pad_numeric`'s three lengths too |
-| **S3** | `std/regex/index.yo:70, 144` + `:535-545, 582-592, 634-644` | `RegexMatch.index()` is a **char** index produced by an O(n) `_byte_to_char_index` per match, then converted **back** to bytes by three more O(n) walks in `replace`/`replace_all`. `replace_all` is O(n·m) purely from basis conversion. | delete all four walks; `index()` becomes a byte index (public API change — release note) |
+| **S3** | `std/regex/index.yo:70, 144` + `:535-545, 582-592, 634-644` | `RegexMatch.index()` is a **char** index produced by an O(n) `_byte_to_char_index` per match, then converted **back** to bytes by three more O(n) walks in `replace`/`replace_all`. `replace_all` is O(n·m) purely from basis conversion. | delete all four walks; `index()` becomes a byte index (public API change — release note). **MEASURED IN PR 3: `std/regex/` is basis-INDEPENDENT and came through the flip untouched and green (156/156).** Every regex internal works on `ArrayList(u8)` from `as_bytes()`; the only `String.len()` in the package is on `literal_prefix`, which is itself an `ArrayList(u8)`. So PR 6 is a performance/API cleanup, not a repair, and nothing forced it into PR 3. |
 | ~~**S4**~~ **DONE (PR 2)** | `src/parser.yo:517-546` `_peel_spec` | rune indices from an `ArrayList(rune)` fed to `text.substring` | `char_indices()` fills a parallel `ArrayList(usize)` of byte offsets; the two cuts go through `try_substring`. Verified by a differential driver holding BOTH implementations (`tmp/d4pr2_peel.yo` shape): 29 inputs, 15 multibyte, **0 mismatches**. |
 | ~~**S5**~~ **DONE (PR 2)** | `std/string/string.yo:662-676` `_split_impl`, empty-separator arm | `self.substring(i, i+1)` per char, bounded by `self.len()` — "split into characters". Must stay **char**-based or `split("")` returns invalid-UTF-8 fragments. | pinned to `char_len()` + `char_substring()` rather than rewritten onto `char_indices()`: a `char_indices` walk needs lookahead for each rune's end offset, so it would add code and a new failure mode for no behaviour change, in a PR whose contract is exactly "no behaviour change". The O(n²) here is pre-existing and left; unlike html.yo the inputs are short. |
 | ~~**S6**~~ **DONE (PR 2)** | `src/doc/render_html.yo:404-406` | fixed 120-unit cut of arbitrary doc text | `char_len() > 120` + `truncate_chars(120)`. The `> 120` guard is KEPT: `.trim()` is chained onto the cut and only runs when the cut happens, so dropping the guard would change the result for short summaries. |
 | ~~**S7**~~ **DONE (PR 2)** | `src/error.yo:43` | rune column + token-value length | `char_len()` |
-| **S8** | `src/doc/builder.yo:233-235` | `Token.character` (rune) into `substring` | `Token.byte_offset` — **deliberately NOT in PR 2**: it needs a new lexer field, which is a behaviour-affecting change to `Token`. PR 3. |
-| **S9** | `src/lsp/completion.yo:762-780, 875, 1010` | LSP `character` into `substring` | see (c) below — **deliberately NOT in PR 2**: §5.4 says the UTF-16 correction lands WITH PR 3, and these sites are already two-based today, so any change here changes behaviour. PR 3. |
+| ~~**S8**~~ **DONE (PR 3)** | `src/doc/builder.yo:233-235` | `Token.character` (rune) into `substring` | `Token.byte_offset`, a new `(byte_offset : usize) ?= usize(0)` field on `Token`. The lexer fills it from a `char_indices()` pass that builds `chars` and a parallel `char_byte_offsets` in one walk; the operator-run splitter adds the same `k` to `column`/`character`/`byte_offset`, which is sound only because every operator char is one ASCII byte. The default is what kept this to ~20 edited construction sites (the ones that COPY a source token's position) instead of all 98. |
+| ~~**S9**~~ **DONE (PR 3), minus the UTF-16 half** | `src/lsp/completion.yo:875, 1010` (the `762-780` sites are downstream of them and needed no change — they pair an `index_of` with a `substring` in one basis) | LSP `character` into `substring` | `rune_col_to_byte_offset` / `byte_offset_to_rune_col` in `src/lsp/protocol.yo`. `handle_completion` converts the incoming rune column to a byte offset ONCE and works in bytes from there; `dot_col` converts back before it is compared against `Token.column`. The same pair fixed `src/lsp/diagnostics.yo:_ident_len_at`, §5.1's 6th live bug, which the plan said D4 would NOT fix. **The UTF-16 correction of §5.4 was deliberately NOT done** — see the note there. |
 | ~~**S10**~~ **DONE (PR 2)** | comptime string builtins — **10 sites, not 4**: `comptime_string_fns.yo` (1 `len` + 4 `len` defaults + 1 `substring`), `comptime_index_fns.yo` (2 `len` + 2 `substring`), `index_trait.yo` (2 `len` + 2 `substring`) | semantics ride on `substring` | pinned to `char_len`/`char_substring`, each with a `COMPTIME BASIS PIN` comment naming O1c. PR 7 now changes the comptime basis only by editing these names. |
 | ~~**S11**~~ **DONE (review pass, 2026-08-26)** | `src/formatter.yo:1246`; `src/lsp/hover.yo:50,292`; `src/lsp/symbols.yo:98`; `src/lsp/definition.yo:104`; `src/lsp/references.yo:34,98`; `src/lsp/rename.yo:35`; `src/lsp/completion.yo:926,930`; `src/doc/builder.yo:379` — **11 sites in 6 files this plan never named** | Exactly S7's shape: a RUNE column (`Token.column` / `Token.character`, both produced by the lexer's `ArrayList(rune)` walk at `src/lexer.yo:97-99`) added to `tok.value.len()`. After PR 3 the width becomes BYTES, so every one of them overruns on a multibyte token: hover matches the wrong token, `definition`/`references`/`symbols`/`rename` emit ranges longer than the identifier (**rename would replace past the end of the name**), completion's `ends_at_dot`/`before_dot` stop finding the receiver, `fmt`'s tight-call adjacency test changes formatting, and doc-comment adjacency inserts a stray space. | `char_len()` at all 11. Inert by the same construction as S7 (`char_len`'s body IS `len`'s body). **PR 2's original claim that "every site that needs char semantics now says so" was FALSE until this row landed** — §5.2 had listed only the `src/error.yo` instance of the pattern. |
 
@@ -573,6 +632,21 @@ Interaction with D4:
   `utf16_offset ⟷ byte_offset` pair in `src/lsp/protocol.yo`, and declare
   `positionEncoding` in the server capabilities. Doing it later means two
   passes over the same 9 handler sites.
+- **WHAT PR 3 ACTUALLY DID, and why it is less than that recommendation.**
+  `Token.byte_offset` landed, and `src/lsp/protocol.yo` gained
+  `rune_col_to_byte_offset` / `byte_offset_to_rune_col` — a **rune**⟷byte pair,
+  not a **UTF-16**⟷byte pair. That is exactly enough to keep the flip from
+  regressing anything: the three handler sites that SLICE a line
+  (`completion.yo`'s `up_to` and `prefix`, `diagnostics.yo`'s `_ident_len_at`)
+  now convert instead of mixing bases, and every other handler only ever
+  COMPARES columns, which is basis-independent as long as both sides are runes.
+  The UTF-16 correction was left out on purpose: it is a **protocol-visible**
+  change (it moves the positions this server emits and accepts, and wants a
+  `positionEncoding` capability declaration), it is a pre-existing defect
+  unrelated to `String`'s index basis, and folding it in would have made the
+  flip's diff unreviewable. It remains open, and the conversion pair added here
+  is the seam it should be built on — `rune_col_to_byte_offset` /
+  `byte_offset_to_rune_col` gain a UTF-16 sibling rather than being rewritten.
 
 ### 5.5 (d) An index from one String type fed into the other's slice
 
@@ -718,6 +792,58 @@ either fail vacuously or force the migration not to happen. Do not write
    char basis, which is why PR 2 is a no-op. The flip was reverted and the
    probe re-hashed to `828549f0…` to prove the tree came back clean.
 
+### 6.1.1 What PR 3 actually ran, and what it proved (2026-08-26)
+
+**The battery §6.1 asks for exists as `tests/string/string_byte_index.test.yo`**
+— 19 tests over the four-width subject `aé中𝄞` (a@0, é@1, 中@3, 𝄞@6; 10 bytes,
+4 runes), with the pre-flip answer written in a comment beside every assertion
+that has one. It covers `len`, `bytes_len`, `at`, `substring` (both the
+byte-range cases and the clamping policy), `try_substring`, the `s(a..b)` /
+`s(a..=b)` sugar, `index_of` (result AND `from_index`), `last_index_of` (result
+AND `from_index`), `contains(from_index)`, `starts_with(position)` — including
+the §1.3(a) case that could not be expressed at all before —
+`ends_with(end_position)`, the `Pattern` trait through a `str` literal,
+`byte_at`/`Index` (which must NOT have changed), `split("")` (which must stay
+rune-based), and the two §6.1 property tests: `is_char_boundary(i)` ⟺ `i` is a
+`char_indices()` key, and `substring(a, b)` round-tripping against
+`char_substring` over every pair of boundaries.
+
+**The discrimination table** — the same file, same compiler, against two `std`
+trees differing ONLY in `std/string/string.yo`:
+
+| | pre-flip `std` (parent commit) | flipped `std` |
+| --- | ---: | ---: |
+| `tests/string/string_byte_index.test.yo` | **4 pass / 15 fail** | **19 pass / 0 fail** |
+| `tests/fs/dir.test.yo` (§5.1's `mkdir_all` bug) | **13 pass / 1 fail** | **14 pass / 0 fail** |
+
+The 4 that pass on both are the ones that MUST: `substring`'s clamping policy
+(unchanged), `try_substring` (byte-based since PR 1), `byte_at`/`Index`
+(always bytes), and `split("")` (pinned to runes in PR 2).
+
+**The §6.1 item-3 cross-PR invariant is now written as two halves rather than
+an equality.** `tests/string/string_char_api.test.yo`'s golden test used to
+assert `char_len() == len()`; it now asserts the recorded pre-flip `char_len()`
+values literally (4/4/5/2/3/0, unchanged) AND the new `len()` values
+(10/12/6/8/3/0), so it discriminates in both directions instead of going
+vacuous the moment the two stop agreeing.
+
+**Panic policy, verified out-of-band.** A panic aborts the process and would
+take every other test in its batch with it, so `substring`'s non-boundary panic
+cannot be asserted from inside the runner. Two standalone `--release` drivers
+were compiled and run instead: `s.substring(1, 2)` on the subject exits 134 with
+`String.substring: end is not on a UTF-8 character boundary`, and
+`s.substring(2, 3)` exits 134 with the `start` message. What the test file
+asserts in their place is `try_substring` answering `.None` at exactly those
+indices.
+
+**METHOD TRAP, cost one full re-run:** `yo test --std-path ./std` **silently
+ignores the flag** (`issues/yo-test-std-path-not-forwarded-to-the-batch-compile.md`)
+— the batch compile is a child process. `tests/string/string.test.yo` scored a
+clean 253/253 that way against the flipped tree, because it had actually
+scored the INSTALLED std. `YO_STD=$PWD/std yo test ...` is the working lever,
+and it reported the 36 real failures. Any future std-facing measurement in this
+campaign must use `YO_STD`.
+
 ### 6.2 Which existing tests cannot catch this class
 
 Per-test measurement (a test counts only if the **same test body** contains
@@ -784,9 +910,21 @@ they guard the vocabulary and not yet the flipping methods. Consequences:
 - `imm.String.len()` → bytes is guarded by **one** test
   (`tests/imm_string.test.yo:129`, "Unicode rune count"). **Add a byte battery
   in PR 4.**
-- `tests/string/string.test.yo`'s **20** multibyte+index tests are the ones
-  that must be *rewritten* (not deleted) in PR 3 — they are the strongest
-  existing signal and their expected values all change. Named in the survey:
+- ~~`tests/string/string.test.yo`'s **20** multibyte+index tests are the ones
+  that must be *rewritten* (not deleted) in PR 3~~ — **DONE 2026-08-26, and the
+  count was 36, not 20.** Running the file against the flipped `std` reported
+  36 failures; every one was rewritten to byte offsets with the byte layout in
+  a comment, and the rune assertion each one used to make was KEPT under
+  `char_len()` / `char_substring()` rather than deleted, so the file now pins
+  both bases. Three more files outside the survey's list also asserted rune
+  lengths on multibyte content and were rewritten the same way:
+  `tests/encoding/utf8.test.yo` (2 tests), `tests/string_multibyte_literal.test.yo`
+  (1), and `tests/string/string_char_api.test.yo`'s cross-PR golden, which had
+  been written as `char_len() == len()` and is now the two halves stated
+  separately (rune values unchanged, byte values asserted). A repo-wide
+  re-detection (every test block holding both a non-ASCII literal and an
+  index-basis call on that same variable) found **nothing else** — the rest of
+  the corpus is genuinely basis-invariant. The original list of 20 was:
   `String substring UTF-8 characters`, `… mixed ASCII and UTF-8`,
   `… with emojis`, `String index_of UTF-8 characters`, `… mixed …`,
   `… with emojis`, `String index_of with from_index UTF-8`,
@@ -885,9 +1023,21 @@ Stated so nothing here reads as more certain than it is.
   commits, so it is scheduled last (PR 9) regardless.
 - **Runtime cost of the flip.** `len()` goes O(n) → O(1), which should be a net
   win in the compiler (it is called ~500-1000 times in `src/`), and regex loses
-  four O(n) walks per match. **Not measured.** Worth an A/B on
-  `compile src/main.yo --skip-c-compiler` before and after PR 3 — but measure
-  in tracked **live bytes / peak footprint**, not RSS.
-- **`tests/cli-cases` goldens.** Not checked for embedded lengths or offsets
-  that would move. Re-record and re-run the **full** scorecard if any case
-  shifts; a NO-GOLDEN vacuous match is a real bug, not a pass.
+  four O(n) walks per match. **STILL NOT MEASURED after PR 3** — no before/after
+  A/B was run, deliberately, because the machine was shared with a verification
+  battery and a footprint A/B is worthless under contention (see the metric-trap
+  note: measure in tracked live bytes, not RSS). The one datum PR 3 does have is
+  that a stage-2 emit took 2:24 and the full seed→stage-1 build 3:43, both
+  unremarkable. Note the flip also ADDS 8 bytes per `Token` (`byte_offset`) —
+  `Token` is an Rc object embedded in every `AstExpr`, so this is a real if
+  small footprint cost that an A/B would net against `len()`'s savings.
+- ~~**`tests/cli-cases` goldens.** Not checked for embedded lengths or offsets
+  that would move.~~ **CHECKED IN PR 3: nothing moved.** `gates_fast.sh` GATE 7
+  scored `PASS 52  GOLDEN-DIFF 0  NO-GOLDEN 0  SKIP 1 (total 53)` against the
+  flipped compiler, so no re-record was needed. The codegen corpus (GATE 2) did
+  report one GOLDEN-DIFF — `tests/codegen-bootstrap/template_multibyte.yo`,
+  whose whole purpose is to print a rune count and a byte count. It was fixed by
+  changing the SOURCE to say `char_len()` for the rune figure and `len()` for
+  the byte figure, which leaves the recorded golden (`chars=15 bytes=17`)
+  **byte-identical** — the file still discriminates, and no golden in the tree
+  was re-recorded for this PR.

--- a/plans/STD_API_AUDIT_HANDOVER.md
+++ b/plans/STD_API_AUDIT_HANDOVER.md
@@ -1,0 +1,289 @@
+# STD_API_AUDIT — handover
+
+**Written 2026-08-26.** Hand-off of the `plans/STD_API_AUDIT.md` campaign. Read
+this file, then `plans/STD_API_AUDIT.md` (the audit itself) and
+`plans/STD_API_AUDIT_D4_PLAN.md` (the string-indexing sub-plan, which is the
+only large piece still in flight).
+
+---
+
+## 0. THE ONE THING TO DO FIRST
+
+**Branch `s2/d4-pr3-flip` is finished and reviewed but has NOT had a full
+battery and is NOT merged.** It is the D4 byte-indexing flip — the change the
+audit says cannot be made after stability.
+
+```
+6ca247773 review(D4 PR 3): one live regression the flip introduced, one contract hole, and the measurements re-derived
+7466ca440 plans: strike the D4-indexing rows PR 3 closed in STD_API_AUDIT
+898705c8a tests: base64 decode_string's multibyte payload asserts both bases
+6efc980f0 std: D4 PR 3 — the flip. String is byte-indexed
+```
+
+It is currently **checked out in the main worktree** (`git branch --show-current`
+→ `s2/d4-pr3-flip`), tree clean.
+
+What it already has, self-reported and then independently re-derived by a second
+agent (see §6 for why that second pass matters):
+
+- `yo build` green, `fixpoint_only.sh` → `FIXPOINT_HOLDS` with `stage2 hollow=0`,
+  `gates_fast.sh` → `T1_DONE failures=0`, cli-diff 52 PASS / 0 GOLDEN-DIFF,
+  `check ./std` 154/154, `check ./src` 262/262.
+- What it does **not** have: `hollow_sweep69.sh` (the full-corpus ratchet) and a
+  single end-to-end battery run over the merged result.
+
+**Action:** merge it into an integration branch off `develop`, run the battery in
+§1, and if green open a PR and admin-merge. Do not skip the sweep — it is the
+arm that catches a per-file regression the aggregate suite hides.
+
+Two findings from its review that should go in the PR body, because they are the
+argument for the change rather than footnotes:
+
+- **A live regression the flip introduced, now fixed on the branch.**
+  `src/codegen/exprs/async.yo:366` `_capitalize_last_segment` used
+  `substring(0, 1)` to take the first *character*. Yo identifiers may start with
+  a non-ASCII rune, so post-flip that is a continuation byte and `substring`
+  panics — the compiler would abort at rc=134 while emitting an effect setter.
+- **A contract hole, docs corrected and behaviour deliberately left alone.** The
+  empty needle: `index_of("", 2)` returns `Some(2)` — a continuation byte — and
+  `index_of("", 99)` returns `Some(99)`, past `len()`. Both are pre-D4
+  behaviours, verified at the parent commit. What was new was PR 3's doc comment
+  claiming *every* returned index is a rune boundary, which is false and matters
+  because the same comment invites feeding results straight into `substring`,
+  which now panics. Two tests pin it.
+
+---
+
+## 1. The battery — the gate every `.yo`-touching change must pass
+
+There is no shared script in the repo; this is the one that was used for every
+merge below. Write it to a scratch path, set the two paths at the top, run it
+detached, and read `/tmp/<P>.log`.
+
+```bash
+#!/bin/bash
+W=/private/tmp/yo-integ            # integration worktree
+P=local                            # prefix for /tmp artefacts
+cd "$W" || exit 2
+export YO_STD="$W/std"
+echo "check std + src"
+yo check ./std > /tmp/${P}_cstd.txt 2>&1; echo "check std rc=$? ($(tail -1 /tmp/${P}_cstd.txt))"
+yo check ./src > /tmp/${P}_csrc.txt 2>&1; echo "check src rc=$? ($(tail -1 /tmp/${P}_csrc.txt))"
+echo "build"
+yo build > /tmp/${P}_build.txt 2>&1; rc=$?; echo "build rc=$rc"
+[ $rc -ne 0 ] && { tail -8 /tmp/${P}_build.txt; exit 1; }
+unset YO_STD
+S1=$PWD/yo-out/aarch64-macos/bin/yo
+echo "full suite"
+"$S1" test ./tests --exclude tests/internal --exclude tests/cli-cases --bail --disable-sanitize > /tmp/${P}_suite.txt 2>&1
+echo "suite rc=$? :: $(tail -3 /tmp/${P}_suite.txt | tr '\n' ' ')"
+install -m 755 "$S1" /tmp/yo-${P}bin
+echo "goldens + scorecard"
+YO_SELF_BIN=/tmp/yo-${P}bin scripts/cli-diff-test.sh --record > /tmp/${P}_rec.txt 2>&1
+echo "record rc=$? :: $(tail -2 /tmp/${P}_rec.txt | tr '\n' ' ')"
+echo "GOLDEN DRIFT (stage ALL before merge):"; git status --short | sed 's/^/    /'; echo "END GOLDEN DRIFT"
+YO_SELF_BIN=/tmp/yo-${P}bin scripts/cli-diff-test.sh > /tmp/${P}_score.txt 2>&1
+echo "scorecard rc=$? :: $(tail -2 /tmp/${P}_score.txt | tr '\n' ' ')"
+echo "gates";     S1=/tmp/yo-${P}bin P=$P bash scripts/bootstrap/gates_fast.sh    > /tmp/${P}_gates.txt 2>&1; echo "gates rc=$? :: $(tail -2 /tmp/${P}_gates.txt | tr '\n' ' ')"
+echo "fixpoint";  S1=/tmp/yo-${P}bin P=$P bash scripts/bootstrap/fixpoint_only.sh > /tmp/${P}_fix.txt   2>&1; echo "fixpoint rc=$? :: $(grep -E 'STAGE3_RC|FIXPOINT|hollow' /tmp/${P}_fix.txt | tr '\n' ' ')"
+echo "hollow";    BIN=/tmp/yo-${P}bin OUT=/tmp/${P}_hsweep bash scripts/bootstrap/hollow_sweep69.sh > /tmp/${P}_hollow.txt 2>&1; echo "hollow rc=$? :: $(tail -2 /tmp/${P}_hollow.txt | tr '\n' ' ')"
+echo "DONE"
+```
+
+Roughly 90 minutes on a Mac Mini M4. **Never run two batteries at once** — 16 GB
+is not enough and the swapping manufactures failures that do not reproduce.
+
+Green means: `check` both green, `build rc=0`, suite `N passed / N total`,
+scorecard `PASS 52 GOLDEN-DIFF 0 NO-GOLDEN 0`, gates `failures=0`, fixpoint
+`stage2 hollow=0 STAGE3_RC=0 FIXPOINT_HOLDS`, hollow `SWEEP_GATE_OK`.
+
+**Golden drift is normal and must be committed**, not reverted — but only after
+the *full* scorecard passes over the re-recorded set. A drift line that is only
+a type-id renumbering is expected whenever declarations are added or removed;
+confirm that by normalising the ids before believing it.
+
+---
+
+## 2. What is DONE (merged 2026-08-25/26, PRs #269–#289)
+
+S0 correctness, S1 (D1–D3 conventions + prelude traits), and **almost all of S2**:
+
+| audit section | state |
+| --- | --- |
+| §5 the rename sweep | **DONE** (chunks 1–4, plus sleep/Duration) |
+| §6 deletions, rounds 1 and 2 | **DONE** |
+| D1 error styles, D2 naming, D3 prelude traits | **DONE** |
+| D7 sync/concurrency | **DONE** (#287) |
+| D8 module layout | **DONE** (#283, #286) |
+| **D4 string indexing** | PRs 0–2 merged (#286, #288); **PR 3 awaiting battery**; PRs 4–9 open |
+| **D5 async io traits** | **UNBLOCKED** (#289) but not started |
+| D6 TLS | untouched, decided (O2) |
+
+---
+
+## 3. What is LEFT
+
+### 3.1 D4, PRs 4–9 — `plans/STD_API_AUDIT_D4_PLAN.md` §4 has the full table
+
+| PR | content | note |
+| --- | --- | --- |
+| 4 | `imm.String`: `len()` → bytes, `at()` aligned, `bytes_len()` aliased, `chars()`/`char_indices()`/`char_len()` wired | **low urgency, measured**: `imm.String` has ZERO production consumers and there are ZERO cross-type index feeds, so this is insurance, not a bug fix |
+| 5 | `imm.String` → `ImmString` rename | ~15 lines |
+| 6 | Regex: delete `_byte_to_char_index` and the three char→byte re-walks; `RegexMatch.index()` becomes a byte index | **PR 3 measured `std/regex` as basis-INDEPENDENT** (it works on `ArrayList(u8)` throughout), so this is a cleanup, not a repair. `RegexMatch.index()`'s basis change still needs a release note |
+| 7 | Comptime basis (O1c) — align `comptime_str.len()`/`slice`/`s[i]`, or document the split | measured safe from the seed's point of view: every `comptime_str` use in `std/`+`src/` is ASCII |
+| 8 | Docs + skills sweep, `docs/{en-US,zh-CN}` both | PR 3 already inverted `syntax-cheatsheet.md:1481` because leaving it would actively mislead; the rest remains |
+| 9 | Dedup the remaining hand-rolled UTF-8 decoders onto `std/encoding/utf8.yo` | includes `vendor/markdown_yo`, which needs **companion upstream commits + a pointer bump** |
+
+Not done and explicitly deferred by PR 3: **the UTF-16 half of §5.4** (LSP's
+position encoding). It is protocol-visible, wants a `positionEncoding`
+capability, and is a pre-existing defect unrelated to `String`'s basis. The
+rune⟷byte helpers PR 3 added to `src/lsp/protocol.yo` are the seam to build it
+on.
+
+### 3.2 D5 — async `Reader`/`Writer` traits
+
+Unblocked by #289 and **not started**. Content is in `plans/STD_API_AUDIT.md`
+§D5: async `Reader`/`Writer` with default methods (`read_to_end`,
+`read_to_string`, `write_all`, `lines()`), implemented by `File`, `TcpStream`,
+`BufReader`, `BufWriter`, `Stdin`/`Stdout`; `BufReader`/`BufWriter` move from
+`std/sys/bufio` to `std/io` and adopt `IoExn`; new `std/io/stdio.yo`.
+
+Carry-over that must land *with* it, not before: `File.read` and the bufio side
+still return `i32`/`Result(i32, IoError)` while net already returns
+`Future(usize, IoExn)`. Three error models, one conversion — the audit says do
+them together.
+
+`std/io/` is currently an **empty namespace** — its two orphaned sync traits were
+deleted in #283 and moved into `tests/io/reader_writer.test.yo`, which was their
+only implementor.
+
+### 3.3 §7 additions — S3 (P0) and S4 (P1)
+
+Untouched, and much larger than everything above combined. Ranked list is in
+`plans/STD_API_AUDIT.md` §7. P0: percent-encoding, `std/encoding/utf8` *(done)*,
+the io redesign *(= D5)*, `fs.copy`/`remove_dir_all`/`read_link`/
+`set_permissions`/`try_exists`, `process.Child`/`spawn`/`Stdio`, async
+combinators + async channel/mutex + `timeout`, crypto (HMAC, SHA-1, SHA-512,
+CRC32, `Digest`) + `std/rand`, `Duration` integration, `net.UnixStream`.
+
+### 3.4 S5 — the stability freeze
+
+Stable/unstable markers in `yo doc` output, additive-only policy written into
+`.github/instructions/yo-design.instructions.md`.
+
+### 3.5 Known seed-gated item
+
+`std/time/sleep.yo`'s `sleep_blocking` keeps a two-statement body **only**
+because `yo build` compiles `std/`+`src/` with the SEED, which predates the
+inline-alias codegen fix. Collapsing it to the natural one-expression form fails
+the bootstrap LOUDLY (clang rejects the seed's output), so just retry it at each
+seed bump. Parked in `plans/backlog/SEED_VERSION_AUTOMATION.md` with the three
+other generation-gated follow-ups.
+
+---
+
+## 4. Bugs found and fixed during the campaign (for context on what to expect)
+
+Every batch surfaced at least one real compiler bug. All are in `issues/fixed/`:
+
+- **inline-builtin wrappers re-emitted with the CALLER's arguments** — a wrapper
+  whose body is one inline-builtin call had its own argument expressions
+  discarded. Measured 202 ms for a requested 100 ms.
+- **`void* tmp = <void call>` at `R = unit`** — `Mutex.with_lock((v) => { … })`,
+  the flagship std/sync form, did not C-compile.
+- **a trait `?=` default evaluated under the impl block's ambient `EvalContext`**
+  instead of a function-body one, so `io.async` could not bind its effect
+  generic and the body hollowed. This was D5's blocker.
+- **`yo test --std-path` dropped for the batch compile** — the runner honoured
+  the flag, the spawned child did not.
+- **release builds discarded every C diagnostic** (`-w` is absolute in clang).
+- **`RwLock.write_unlock` never woke blocked readers.**
+- **the hollow detector was line-anchored**, so mid-line markers scored clean.
+- **`count-transpile-failures.sh` scored a MISSING file as `0 real`, exit 0** —
+  and `fixpoint_only.sh` gates on that exit code.
+
+`issues/` root still has **83 open** docs. Ones most likely to bite this work:
+`fmt-not-idempotent-call-wrapped-match-in-block.md`,
+`ftt-stub-in-live-closure-falls-off-non-void-function.md` (partially fixed; the
+`unit`-returning residue is described concretely enough to act on),
+`closure-nested-inside-io-async-closure-body-emits-abort-stub.md`,
+`generic-implementor-async-method-awaiting-self-emits-uncompilable-c.md`.
+
+---
+
+## 5. Traps that cost real time — read before measuring anything
+
+- **`yo check` has four blind spots**: macro `quote(...)` bodies, generic
+  trait-impl bodies, generic helpers in the defining module, and **async closure
+  bodies** (`io.async((e) => …)`) — the last fails SILENTLY. A green `check`
+  proves nothing about those. Compile to C and read it.
+- **`yo fmt` is NOT a syntax gate.** `{ single_expr }` with no trailing
+  semicolon is a STRUCT LITERAL, and fmt pretty-prints it happily. It is also
+  **not idempotent** — a `match` wrapped in a call inside a brace block needs two
+  passes, so `yo fmt f.yo && yo fmt --check f.yo` fails on a file just
+  formatted. Run fmt twice, then `yo check <file>`.
+- **In a worktree, always pass `YO_STD=<worktree>/std`.** Without it `yo check`
+  silently validates against the INSTALLED std. And `yo test --std-path` is
+  fixed in-tree but **a released `yo` on PATH still drops it** — D4 PR 3 lost a
+  full run to a vacuous `253/253` that way. Prefer `YO_STD` for `yo test`.
+- **"The suite is green" ≠ "this file is green."** Batch composition changes
+  behaviour; measured twice. Run the specific file too.
+- **Byte-identity of emitted C is NOT a usable gate for `std/` source
+  additions.** Generated identifiers embed a global declaration counter, so
+  adding declarations shifts every later id by a uniform amount — measured
+  +1004, including in files never touched. It remains the right gate for
+  `src/codegen/` edits where the `.yo` source is unchanged. For `std/` changes,
+  A/B the two trees with `--std-path` against a behavioural probe and diff the
+  program's OUTPUT (recipe in `STD_API_AUDIT_D4_PLAN.md` §6.1).
+- **`count-transpile-failures.sh` is structurally blind to the abort-stub
+  class.** Since #275 an untranspilable body in a value-returning function
+  carries no marker — it becomes `abort()`. The script prints a stub count
+  separately; read it whenever "0 real" is the claim.
+- **A `-O0` binary that SIGSEGVs on deep recursion is stack exhaustion**, not
+  heap corruption. Use `--release`, or `YO_MAIN_STACK_MB=4096`.
+- **Comptime-folded assertions pass vacuously.** Read values from a mutable
+  local so the assertion runs at RUNTIME.
+
+---
+
+## 6. The working method that actually caught things
+
+Every batch ran as: **N implementation agents in parallel worktrees → one
+skeptical reviewer per branch → merge all branches into one integration branch →
+ONE shared battery → PR → admin-merge.**
+
+The review pass earned its cost every single time. It refuted a central claim in
+four of five batches, and its two most valuable findings were things no battery
+could have caught:
+
+- the `void* tmp` hole, invisible because both the module header and the test
+  file had been written telling readers to avoid the shape;
+- eleven rune-column sites in six files the D4 plan never named, invisible
+  because they are *inert today* and only become wrong after the flip.
+
+Reviewers were told, specifically: re-measure rather than trust, hunt for claims
+of "verified" that were not, check the four `yo check` blind spots, grep for
+missed call sites across `std/ src/ tests/ docs/ .github/ vendor/`, and look for
+tests that pass vacuously. That prompt is worth reusing verbatim.
+
+**`plans/STD_API_AUDIT.md` is not reliable as a specification.** Roughly a dozen
+of its rows have been measured wrong so far — dead things that were alive
+(`WaitGroup`, `StringError`), live things that were dead (`MAX_SLOTS`),
+mis-stated mechanisms (`starts_with(position)` is a *broken char walk*, not
+byte-indexed), and gates that cannot be met (`byte-identity` for std additions).
+Re-measure every row before executing it, and correct the row in the same PR.
+
+---
+
+## 7. Housekeeping
+
+- `vendor/markdown_yo` is a submodule and is **EMPTY in a fresh worktree**. Run
+  `git -c protocol.file.allow=always submodule update --init` before any
+  `yo check ./src`, `yo build`, or vendor grep — a vendor grep in an
+  uninitialised worktree is vacuous, and one agent's load-bearing count was
+  taken that way.
+- The main worktree is currently on `s2/d4-pr3-flip`. Switch it back to
+  `develop` once that branch is merged.
+- A stale memory note in the operator's private store says
+  "`String.len()` = CHARACTER count". **PR 3 makes that false.** It is outside
+  the repo; flagging it here because it will otherwise mislead.

--- a/src/codegen/exprs/async.yo
+++ b/src/codegen/exprs/async.yo
@@ -357,14 +357,24 @@ _first_struct_effect_type :: (fn(future_trait_type : TypeValue) -> Option(TypeVa
   Option(TypeValue).None
 });
 /// The capitalized last dotted segment of `label` (e.g. `errors.raise` → `Raise`).
+///
+/// **Cuts by RUNE, not by byte.** `label` is a user-written effect-bundle field
+/// path (`io.async`, `exn.throw`, or any field name the user chose), and Yo
+/// identifiers may start with a non-ASCII rune (`src/token.yo`
+/// `is_identifier_start`: `c.char >= 0xA0`). Since
+/// `plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 made `substring` byte-indexed and
+/// non-boundary-PANICKING, `substring(0, 1)` on such a label aborted the whole
+/// compiler with `String.substring: end is not on a UTF-8 character boundary`
+/// and no source location. `char_substring` is the rune-indexed slice and
+/// restores exactly the pre-flip cut, which is what this function always meant.
 _capitalize_last_segment :: (fn(label : String) -> String)({
   parts := label.split(".");
   last := if(parts.len() > usize(0), match(parts.get(parts.len() - usize(1)), .Some(p) => p, .None => label.clone()), label.clone());
   if(last.len() == usize(0), {
     return(last);
   });
-  head := last.substring(usize(0), usize(1)).to_uppercase();
-  head.push_string(last.substring(usize(1), last.len()));
+  head := last.char_substring(usize(0), usize(1)).to_uppercase();
+  head.push_string(last.char_substring(usize(1), last.char_len()));
   head
 });
 /// Emit the future's `set_effect` callback: a `strcmp(field, …)` chain that copies

--- a/src/codegen/utils/index.yo
+++ b/src/codegen/utils/index.yo
@@ -1399,8 +1399,10 @@ get_enum_variant_c_name :: (
       // leading `.` of the `.Variant` source form (e.g. `.Green`); the match
       // path reads clean names from `EnumT.variant_names`, so this only bites
       // the value path. Strip it — a leading `.` is never part of a C
-      // identifier. Variant names are ASCII identifiers, so the rune-indexed
-      // substring(1, len) is byte-safe here.
+      // identifier. The `.` is one ASCII byte, so `substring(1, len)` names
+      // the same cut whether `substring` counts bytes (it does, since
+      // plans/STD_API_AUDIT_D4_PLAN.md D4 PR 3) or runes, and byte 1 is always
+      // a rune boundary here — this holds even for a non-ASCII variant name.
       clean := if(variant_name.starts_with("."), variant_name.substring(usize(1), variant_name.len()), variant_name.clone());
       result := enum_c_name.to_uppercase();
       result.push_str("_");

--- a/src/doc/builder.yo
+++ b/src/doc/builder.yo
@@ -230,8 +230,15 @@ _slice_token_text :: (
       return(String.new());
     }
   );
-  start := start_tok.character;
-  end := (end_tok.character + end_tok.value.len());
+  // BYTE offsets, both of them. `Token.character` is a RUNE offset and
+  // `input` is byte-indexed, so slicing with `character` cut at the wrong
+  // place on any source containing a multibyte character (the same defect as
+  // `issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md`).
+  // `Token.byte_offset` is that issue's named follow-up field; `value.len()`
+  // is the token's byte width, which is the matching unit
+  // (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S8).
+  start := start_tok.byte_offset;
+  end := (end_tok.byte_offset + end_tok.value.len());
   end_tok.input.substring(start, end).trim()
 });
 /// Skip one comma-delimited argument at any nesting depth. Returns the index

--- a/src/doc_command.yo
+++ b/src/doc_command.yo
@@ -217,29 +217,36 @@ _scan_quoted_value_after :: (fn(content : String, marker : String, connector : S
       }
     );
     (j : usize) = (idx + marker.len());
-    // Skip whitespace.
+    // Skip whitespace. These peeks read a BYTE rather than cutting a one-unit
+    // `substring`: `content` is byte-indexed since
+    // `plans/STD_API_AUDIT_D4_PLAN.md` D4, so a one-unit slice landing on the
+    // lead byte of a multibyte rune would split that rune — and `substring`
+    // panics rather than hand back invalid UTF-8. Everything being tested for
+    // here is ASCII (space, tab, CR, LF, the `:`/`=` connector, `"`), and an
+    // ASCII byte can only ever match a whole rune, so a byte compare is both
+    // safe and cheaper than allocating a one-rune String per position.
     (moved : bool) = true;
     while(moved && (j < content.len()), {
-      c := content.substring(j, j + usize(1));
-      if((c == ` `) || (c == String.from("\t")) || (c == String.from("\n")) || (c == String.from("\r")), {
+      b := content.byte_at(j);
+      if(((b == u8(32)) || (b == u8(9))) || ((b == u8(10)) || (b == u8(13))), {
         j = (j + usize(1));
       }, {
         moved = false;
       });
     });
     // Expect the connector (":" or "=").
-    if((j < content.len()) && (content.substring(j, j + usize(1)) == connector), {
-      j = (j + usize(1));
+    if((j < content.len()) && content.starts_with(connector, j), {
+      j = (j + connector.len());
       (moved2 : bool) = true;
       while(moved2 && (j < content.len()), {
-        c := content.substring(j, j + usize(1));
-        if((c == ` `) || (c == String.from("\t")) || (c == String.from("\n")) || (c == String.from("\r")), {
+        b2 := content.byte_at(j);
+        if(((b2 == u8(32)) || (b2 == u8(9))) || ((b2 == u8(10)) || (b2 == u8(13))), {
           j = (j + usize(1));
         }, {
           moved2 = false;
         });
       });
-      if((j < content.len()) && (content.substring(j, j + usize(1)) == `"`), {
+      if((j < content.len()) && (content.byte_at(j) == u8(34)), {
         j = (j + usize(1));
         end := match(
           content.index_of(`"`, j),

--- a/src/evaluator/builtins/contracts.yo
+++ b/src/evaluator/builtins/contracts.yo
@@ -237,6 +237,7 @@ _synth_atom :: (fn(value : String, kind : TokenKind, src_tok : Token) -> AstExpr
       row : src_tok.row,
       column : src_tok.column,
       character : src_tok.character,
+      byte_offset : src_tok.byte_offset,
       module_path : src_tok.module_path.clone(),
       input : src_tok.input.clone()
     )
@@ -361,6 +362,7 @@ _build_binding :: (fn(name : String, value : AstExpr, src_tok : Token, op : Stri
     row : src_tok.row,
     column : src_tok.column,
     character : src_tok.character,
+    byte_offset : src_tok.byte_offset,
     module_path : src_tok.module_path.clone(),
     input : src_tok.input.clone()
   );

--- a/src/evaluator/builtins/gensym.yo
+++ b/src/evaluator/builtins/gensym.yo
@@ -145,6 +145,7 @@ evaluate_gensym :: (
       row : tok.row,
       column : tok.column,
       character : tok.character,
+      byte_offset : tok.byte_offset,
       module_path : tok.module_path.clone(),
       input : tok.input.clone()
     )

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -650,6 +650,7 @@ _build_receiver_call_args :: (
           row : recv_tok.row,
           column : recv_tok.column,
           character : recv_tok.character,
+          byte_offset : recv_tok.byte_offset,
           module_path : recv_tok.module_path.clone(),
           input : recv_tok.input.clone()
         )
@@ -6181,6 +6182,7 @@ Fix: wrap the call:
                   row : recv_tok.row,
                   column : recv_tok.column,
                   character : recv_tok.character,
+                  byte_offset : recv_tok.byte_offset,
                   module_path : recv_tok.module_path.clone(),
                   input : recv_tok.input.clone()
                 )

--- a/src/evaluator/calls/numeric_type.yo
+++ b/src/evaluator/calls/numeric_type.yo
@@ -225,6 +225,7 @@ _make_yo_as_node :: (
       row : orig_tok.row,
       column : orig_tok.column,
       character : orig_tok.character,
+      byte_offset : orig_tok.byte_offset,
       module_path : orig_tok.module_path.clone(),
       input : orig_tok.input.clone()
     )

--- a/src/evaluator/calls/pointer_type.yo
+++ b/src/evaluator/calls/pointer_type.yo
@@ -149,6 +149,7 @@ try_to_convert_to_pointer_type :: (
       row : orig_tok.row,
       column : orig_tok.column,
       character : orig_tok.character,
+      byte_offset : orig_tok.byte_offset,
       module_path : orig_tok.module_path.clone(),
       input : orig_tok.input.clone()
     )

--- a/src/evaluator/values/string.yo
+++ b/src/evaluator/values/string.yo
@@ -42,8 +42,8 @@ _hex4 :: (fn(a : rune, b : rune, c : rune, d : rune) -> u32)(
 /// time, mirroring the template-string escape table in `lexer.yo`. Without this,
 /// a literal `"\n"` flows through the comptime-string subsystem as a backslash +
 /// `n` (two chars) instead of a single newline — which breaks `to_expr()` /
-/// `generate_expr_from_code` on derive-generated source and `len()`/`starts_with`
-/// char counts.
+/// `generate_expr_from_code` on derive-generated source and every downstream
+/// length/prefix test.
 decode_str_lit_escapes :: (fn(raw : String) -> String)({
   chars := ArrayList(rune).new();
   {

--- a/src/expr.yo
+++ b/src/expr.yo
@@ -886,6 +886,7 @@ _synth_desugar_tok :: (fn(kind : TokenKind, value : str, ref_tok : Token) -> Tok
     row : ref_tok.row,
     column : ref_tok.column,
     character : ref_tok.character,
+    byte_offset : ref_tok.byte_offset,
     // SHARE module_path and input — never .clone() them. String.clone()
     // deep-copies the buffer, and `input` is the ENTIRE SOURCE FILE: the
     // original desugar cloned it into every synthesized (and, worse, every
@@ -1148,6 +1149,7 @@ wrap_body_in_begin :: (fn(body : AstExpr) -> AstExpr)({
     row : tok.row,
     column : tok.column,
     character : tok.character,
+    byte_offset : tok.byte_offset,
     module_path : tok.module_path,
     input : tok.input
   );

--- a/src/formatter.yo
+++ b/src/formatter.yo
@@ -219,20 +219,20 @@ prefix_operator_needs_leading_space :: (
 /// closing delimiters and statement terminators to absorb the placeholder
 /// space added by `ensureSpace`-style helpers.
 _trim_trailing_h_ws :: (fn(s : String) -> String)({
-  // Count how many trailing space/tab BYTES there are. Space and tab are
-  // single-byte ASCII, so that count is also a CHARACTER count — which is what
-  // matters, because `String.substring` is CHAR-indexed.
+  // Count how many trailing space/tab BYTES there are, then cut that many
+  // units off the end. Space and tab are single-byte ASCII, so the count is
+  // the same number in either basis — which is why this shape survived D4's
+  // flip of `substring` from rune to byte indices unchanged.
   //
-  // Handing `substring` a BYTE index (the previous shape: walk `i` down from
-  // `bytes.len()` and slice `[0, i)`) made this a silent NO-OP for any buffer
-  // that already contained a multi-byte character: `i` then exceeded the
-  // character count, `substring` never found that character index and clamped
-  // to the whole string, so the trailing space survived. That is the entire
+  // It is written as a COUNT rather than an index deliberately. The earlier
+  // shape walked `i` down from `bytes.len()` and sliced `[0, i)`, feeding a
+  // BYTE index to a then-CHAR-indexed `substring`: on any buffer containing a
+  // multibyte character `i` exceeded the character count, `substring` clamped
+  // to the whole string, and the trailing space survived. That was the entire
   // remaining `fmt` divergence — `(== )`, `(.. )`, `(..= )`, `quote(&& )` and
-  // the C-variadic `... )` — and it only ever showed up in files with an em
-  // dash (or any non-ASCII) EARLIER in the output, which is why it looked like
-  // a "multiline paren frame" rule and never reproduced in an ASCII repro.
-  // Same class as the `read_raw_template_string` char-index-as-byte-offset bug.
+  // the C-variadic `... )` — visible only in files with an em dash (or any
+  // non-ASCII) EARLIER in the output, which is why it looked like a "multiline
+  // paren frame" rule and never reproduced in an ASCII repro.
   bytes := s.as_bytes();
   n := bytes.len();
   (k : usize) = usize(0);
@@ -1479,42 +1479,25 @@ normalize_multiline_block_comment :: (fn(raw : String) -> ArrayList(String))({
 /// Read a backtick template-string starting at byte offset `start` in `input`,
 /// returning the literal slice from `` ` `` to the matching closing `` ` ``.
 /// Mirrors `readRawTemplateString`.
-/// Convert a CHARACTER index into a BYTE offset within `bytes`.
+/// `start` is a BYTE offset into `input` — pass `Token.byte_offset`, never
+/// `Token.character`.
 ///
-/// `Token.character` is a CHARACTER index — the lexer walks `input.chars()` and
-/// stores that loop's counter (`lexer.yo:82` `char_idx := i`). Everything here
-/// slices `input.as_bytes()`. On ASCII input the two coincide exactly, which is
-/// why the mismatch survived every test: the whole test corpus is ASCII.
+/// This used to take `Token.character` (a RUNE index) and re-walk the byte
+/// buffer to convert it, because `Token` carried no byte offset. Handing the
+/// rune index straight to a byte slice is what
+/// `issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md` was: with
+/// any multibyte character earlier in the file the rune index is SMALLER than
+/// the byte offset, so the slice started early and swallowed the source before
+/// the backtick — `input.contains(\`&\`)` came out as `input.contains(s(\`))`,
+/// which does not parse, with `fmt` still exiting 0. Em dashes in doc comments
+/// made it fire across std: 23 of 40 sampled files with a backtick became
+/// non-parseable.
 ///
-/// With ANY multi-byte character earlier in the file the character index is
-/// SMALLER than the byte offset, so the slice started early and swallowed the
-/// source preceding the backtick — `input.contains(\`&\`)` was rewritten to
-/// `input.contains(s(\`))`, which does not parse, with `fmt` still exiting 0.
-/// Em dashes in doc comments made this fire across std: 23 of 40 sampled files
-/// with a backtick came out non-parseable.
-/// See issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md.
-///
-/// Counts UTF-8 LEAD bytes: a continuation byte matches `0b10xxxxxx`, i.e.
-/// `(b & 0xC0) == 0x80`, and never starts a character.
-_byte_offset_of_char_index :: (fn(bytes : ArrayList(u8), char_index : usize) -> usize)({
-  n := bytes.len();
-  (bi : usize) = usize(0);
-  (ci : usize) = usize(0);
-  while((ci < char_index) && (bi < n), {
-    bi = (bi + usize(1));
-    while((bi < n) && ((match(bytes.get(bi), .Some(x) => x, .None => u8(0)) & u8(0xC0)) == u8(0x80)), {
-      bi = (bi + usize(1));
-    });
-    ci = (ci + usize(1));
-  });
-  bi
-});
-/// `start` is a CHARACTER index (a `Token.character`); it is converted to a byte
-/// offset before any slicing — see `_byte_offset_of_char_index`.
-read_raw_template_string :: (fn(input : String, start_char : usize) -> String)({
+/// `Token.byte_offset` (added by `plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3) is
+/// that issue's named follow-up, and it removes the conversion walk entirely.
+read_raw_template_string :: (fn(input : String, start : usize) -> String)({
   bytes := input.as_bytes();
   n := bytes.len();
-  start := _byte_offset_of_char_index(bytes, start_char);
   (index : usize) = (start + usize(1));
   (brace_depth : usize) = usize(0);
   (end_index : usize) = n; // default: until EOF
@@ -1584,7 +1567,7 @@ raw_token_value :: (fn(input : String, tokens : ArrayList(Token), index : usize)
     tokens.get(index),
     .None => String.new(),
     .Some(t) => cond(
-      (t.kind == TokenKind.TemplateString) => read_raw_template_string(input, t.character),
+      (t.kind == TokenKind.TemplateString) => read_raw_template_string(input, t.byte_offset),
       true => t.value
     )
   )

--- a/src/lexer.yo
+++ b/src/lexer.yo
@@ -75,20 +75,32 @@ tokenize :: (
 )({
   tokens := ArrayList(Token).new();
   chars := ArrayList(rune).new();
+  // `char_byte_offsets(k)` is the BYTE offset in `input` at which `chars(k)`
+  // starts. `Token.character` is the rune index `k`, which is NOT a valid
+  // index into `input` now that `String` is byte-indexed — every consumer
+  // that slices `input` reads `Token.byte_offset` instead
+  // (issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md).
+  // One `char_indices()` pass fills both lists; `chars()` and `char_indices()`
+  // stop at the same byte on malformed input, so they stay in lockstep.
+  char_byte_offsets := ArrayList(usize).new();
   {
-    c_iter := input.chars();
+    c_iter := input.char_indices();
     while(true, {
       match(
         c_iter.next(),
         .None => {
           break;
         },
-        .Some(r) => {
-          chars.push(r);
+        .Some(pair) => {
+          char_byte_offsets.push(pair._0);
+          chars.push(pair._1);
         }
       );
     });
   };
+  // One-past-the-end byte offset, so a token that starts at EOF still gets a
+  // usable (empty-slice) offset rather than 0.
+  input_byte_len := input.len();
   null_rune := rune(u32(0));
   n := chars.len();
   i := usize(0);
@@ -98,6 +110,7 @@ tokenize :: (
     c := chars.get(i).unwrap_or(null_rune);
     col := (i - line_start);
     char_idx := i;
+    byte_idx := char_byte_offsets.get(i).unwrap_or(input_byte_len);
     next_c := chars.get(i + usize(1)).unwrap_or(null_rune);
     is_fwd_slash := (c.char == u32(0x2F));
     next_is_slash := (next_c.char == u32(0x2F));
@@ -130,7 +143,7 @@ tokenize :: (
         });
         dot_str := dot_sb.to_string();
         kind := cond(((j - i) == usize(1)) => TokenKind.Dot, true => TokenKind.Operator);
-        tokens.push(Token(kind : kind, value : dot_str, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : kind, value : dot_str, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = j;
       },
       // Non-comment operator characters
@@ -148,8 +161,10 @@ tokenize :: (
         });
         op_str := op_sb.to_string();
         // Closed-set split (see _is_two_char_operator above): greedy
-        // longest-match over the run; operator chars are all ASCII so byte
-        // offsets equal rune offsets for the column/character adjustment.
+        // longest-match over the run. Every operator char is ASCII, so one
+        // operator char is one byte AND one rune: the same `k` advances
+        // `column`, `character` and `byte_offset` alike, and `op_str`'s
+        // byte-indexed `slice_copy` cuts exactly `k` chars in.
         (k : usize) = usize(0);
         run_len := op_str.len();
         while(k < run_len, {
@@ -177,7 +192,7 @@ tokenize :: (
             );
             break;
           });
-          tokens.push(Token(kind : TokenKind.Operator, value : intern_token_str(op_str.slice_copy(k .. (k + tok_len))), row : line, column : (col + k), character : (char_idx + k), module_path : module_path, input : input));
+          tokens.push(Token(kind : TokenKind.Operator, value : intern_token_str(op_str.slice_copy(k .. (k + tok_len))), row : line, column : (col + k), character : (char_idx + k), byte_offset : (byte_idx + k), module_path : module_path, input : input));
           k = (k + tok_len);
         });
         i = j;
@@ -200,7 +215,7 @@ tokenize :: (
           k = (k + usize(1));
         });
         ws_str := ws_sb.to_string();
-        tokens.push(Token(kind : TokenKind.Whitespace, value : ws_str, row : ws_start_ln, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.Whitespace, value : ws_str, row : ws_start_ln, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = k;
       },
       // Line comment: //, ///, //!
@@ -223,7 +238,7 @@ tokenize :: (
           k = (k + usize(1));
         });
         cm_str := cm_sb.to_string();
-        tokens.push(Token(kind : comment_kind, value : cm_str, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : comment_kind, value : cm_str, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = k;
       },
       // Block comment: /*, /**, /*!
@@ -274,32 +289,32 @@ tokenize :: (
           exn.throw(dyn(LexerError(message : `unterminated block comment`, row : bc_start_ln, column : col, character : char_idx)));
         });
         cm_str := cm_sb.to_string();
-        tokens.push(Token(kind : block_kind, value : cm_str, row : bc_start_ln, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : block_kind, value : cm_str, row : bc_start_ln, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = k;
       },
       // ( ) [ ] { }
       (c.char == u32(0x28)) => {
-        tokens.push(Token(kind : TokenKind.LParen, value : `(`, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.LParen, value : `(`, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       (c.char == u32(0x29)) => {
-        tokens.push(Token(kind : TokenKind.RParen, value : `)`, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.RParen, value : `)`, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       (c.char == u32(0x5B)) => {
-        tokens.push(Token(kind : TokenKind.LBracket, value : `[`, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.LBracket, value : `[`, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       (c.char == u32(0x5D)) => {
-        tokens.push(Token(kind : TokenKind.RBracket, value : `]`, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.RBracket, value : `]`, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       (c.char == u32(0x7B)) => {
-        tokens.push(Token(kind : TokenKind.LCurlyBracket, value : `{`, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.LCurlyBracket, value : `{`, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       (c.char == u32(0x7D)) => {
-        tokens.push(Token(kind : TokenKind.RCurlyBracket, value : `}`, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.RCurlyBracket, value : `}`, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       // Char literal: '...'
@@ -355,7 +370,7 @@ tokenize :: (
         });
         val_sb.write_byte(u8(0x27));
         tok_val := val_sb.to_string();
-        tokens.push(Token(kind : TokenKind.CharLit, value : tok_val, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.CharLit, value : tok_val, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       // String literal: "..."
@@ -391,7 +406,7 @@ tokenize :: (
         str_closed;
         val_sb.write_byte(u8(0x22));
         tok_val := val_sb.to_string();
-        tokens.push(Token(kind : TokenKind.StringLit, value : tok_val, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.StringLit, value : tok_val, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       // Template string: `...`
@@ -508,16 +523,16 @@ tokenize :: (
           exn.throw(dyn(LexerError(message : `unterminated template string`, row : line, column : col, character : char_idx)));
         });
         ts_val := ts_sb.to_string();
-        tokens.push(Token(kind : TokenKind.TemplateString, value : ts_val, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.TemplateString, value : ts_val, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       // Comma and semicolon
       (c.char == u32(0x2C)) => {
-        tokens.push(Token(kind : TokenKind.Comma, value : `,`, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.Comma, value : `,`, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       (c.char == u32(0x3B)) => {
-        tokens.push(Token(kind : TokenKind.Semicolon, value : `;`, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : TokenKind.Semicolon, value : `;`, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = (i + usize(1));
       },
       // Number literals (integer and float)
@@ -667,7 +682,7 @@ tokenize :: (
         });
         num_str := num_sb.to_string();
         kind := cond(is_float => TokenKind.Float, true => TokenKind.Integer);
-        tokens.push(Token(kind : kind, value : num_str, row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : kind, value : num_str, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = j;
       },
       // Identifier or Bool keyword
@@ -711,7 +726,7 @@ tokenize :: (
           (id_str == `false`) => TokenKind.Bool,
           true => TokenKind.Identifier
         );
-        tokens.push(Token(kind : kind, value : intern_token_str(id_str), row : line, column : col, character : char_idx, module_path : module_path, input : input));
+        tokens.push(Token(kind : kind, value : intern_token_str(id_str), row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
         i = j;
       },
       // Unknown character: error

--- a/src/lsp/completion.yo
+++ b/src/lsp/completion.yo
@@ -43,7 +43,7 @@ open(import("std/error"));
 { type_id_or_empty, get_type_trait_methods_for_type } :: import("../evaluator/values/type_trait_methods.yo");
 { get_generic_impl_doc_entries } :: import("../evaluator/values/impl.yo");
 { JsonValue } :: import("std/encoding/json");
-{ jb, jstr, jnum } :: import("./protocol.yo");
+{ jb, jstr, jnum, rune_col_to_byte_offset, byte_offset_to_rune_col } :: import("./protocol.yo");
 { _find_token_at, _collect_candidates, _best_candidate, _select_best_variable } :: import("./hover.yo");
 
 // LSP CompletionItemKind constants (the protocol's numeric encoding).
@@ -868,10 +868,14 @@ handle_completion :: (
   lines := text.split(String.from("\n"));
   line_text := match(lines.get(line), .Some(l) => l, .None => String.new());
   bytes := line_text.as_bytes();
-  (cur : usize) = character;
-  if(cur > bytes.len(), {
-    cur = bytes.len();
-  });
+  // `character` is a RUNE column (what this server serves and receives — see
+  // `rune_col_to_byte_offset`), while `bytes` and `line_text` are BYTE
+  // indexed. Everything below this line works in BYTES; `dot_col` converts
+  // back before it is compared against `Token.column`
+  // (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S9). The previous shape clamped the
+  // rune column against a byte length and then sliced with it — two bases in
+  // one expression, wrong on any line containing a multibyte character.
+  (cur : usize) = rune_col_to_byte_offset(line_text, character);
   up_to := line_text.substring(usize(0), cur);
   // 1. Import-path completion (works even while the document fails analysis
   //    — typing inside the string literal usually breaks the parse).
@@ -895,7 +899,9 @@ handle_completion :: (
     true => false
   );
   if(dot_before, {
-    dot_col := (ws - usize(1));
+    // `ws - 1` is the BYTE offset of the `.`; `t.column` below is a RUNE
+    // column, so convert before comparing.
+    dot_col := byte_offset_to_rune_col(line_text, ws - usize(1));
     lex_exn := Exception(
       throw : (
         (_err) -> unwind(JsonValue.Array(items : ArrayList(JsonValue).new()))

--- a/src/lsp/diagnostics.yo
+++ b/src/lsp/diagnostics.yo
@@ -24,6 +24,7 @@ open(import("std/error"));
 { parse } :: import("../parser.yo");
 { AstExpr } :: import("../expr.yo");
 { ExprInfoTable, expr_info_table_new } :: import("../expr_info.yo");
+{ rune_col_to_byte_offset } :: import("./protocol.yo");
 {
   mm_resolve_entry_abs,
   mm_eval_entry_exprs,
@@ -68,16 +69,27 @@ _is_ident_byte :: (fn(b : u8) -> bool)(
     )
 );
 
-/// Length of the identifier starting at (row, col) in `text`, minimum 1.
+/// Length of the identifier starting at RUNE column `col` of row `row` in
+/// `text`, minimum 1. The answer is a RUNE count, because the caller adds it
+/// to `col` to build an LSP range.
+///
+/// `col` is a rune column (the formatted error text prints `token.column + 1`,
+/// and `Token.column` is a rune column) while `line.as_bytes()` is byte
+/// indexed — indexing one with the other put the underline in the wrong place
+/// on any line containing a multibyte character before the identifier
+/// (plans/STD_API_AUDIT_D4_PLAN.md §5.1, the `_ident_len_at` row). The count
+/// itself needs no conversion back: `_is_ident_byte` matches only ASCII, so
+/// every byte counted is exactly one rune.
 _ident_len_at :: (fn(text : String, row : usize, col : usize) -> usize)({
   lines := text.split(String.from("\n"));
   line := match(lines.get(row), .Some(l) => l, .None => return(usize(1)));
   bytes := line.as_bytes();
-  if(col >= bytes.len(), {
+  start := rune_col_to_byte_offset(line, col);
+  if(start >= bytes.len(), {
     return(usize(1));
   });
   (n : usize) = usize(0);
-  (i : usize) = col;
+  (i : usize) = start;
   while(i < bytes.len(), {
     b := match(bytes.get(i), .Some(x) => x, .None => u8(0));
     if(_is_ident_byte(b), {

--- a/src/lsp/protocol.yo
+++ b/src/lsp/protocol.yo
@@ -69,12 +69,75 @@ j_error_response :: (fn(id : JsonValue, code : i64, message : String) -> JsonVal
     jb().put("code", JsonValue.Number(value : f64(code))).put("message", jstr(message)).obj()
   ).obj()
 );
+/// BYTE offset within `line` of RUNE column `col`.
+///
+/// This server's positions are RUNE (UTF-32) columns: the lexer materializes
+/// `input.chars()` and stores that loop's counter as `Token.column`
+/// (`src/lexer.yo`), and every handler serves those straight to the client.
+/// `String` is BYTE-indexed (`plans/STD_API_AUDIT_D4_PLAN.md` D4), so a
+/// handler that SLICES a line — rather than just comparing columns — has to
+/// convert first, or it cuts at the wrong place (and, at a non-boundary,
+/// panics).
+///
+/// `col` at or past the line's rune count clamps to the line's byte length,
+/// which is a boundary.
+///
+/// **Pre-existing gap this does NOT fix:** the LSP spec's default
+/// `positionEncoding` is UTF-16, so a rune column is already the wrong unit on
+/// the wire for astral-plane characters (`plans/STD_API_AUDIT_D4_PLAN.md`
+/// §5.4). This pair keeps the server's INTERNAL basis coherent, which is what
+/// D4 requires; the UTF-16 correction is a separate, protocol-visible change.
+rune_col_to_byte_offset :: (fn(line : String, col : usize) -> usize)({
+  (seen : usize) = usize(0);
+  it := line.char_indices();
+  while(true, {
+    match(
+      it.next(),
+      .None => {
+        break;
+      },
+      .Some(p) => {
+        if(seen == col, {
+          return(p._0);
+        });
+        seen = (seen + usize(1));
+      }
+    );
+  });
+  line.len()
+});
+/// RUNE column within `line` of the first rune starting at or after BYTE
+/// offset `off` — the inverse of `rune_col_to_byte_offset` for any `off` that
+/// is a rune boundary.
+///
+/// An offset past the end clamps to the line's rune count.
+byte_offset_to_rune_col :: (fn(line : String, off : usize) -> usize)({
+  (col : usize) = usize(0);
+  it := line.char_indices();
+  while(true, {
+    match(
+      it.next(),
+      .None => {
+        break;
+      },
+      .Some(p) => {
+        if(p._0 >= off, {
+          return(col);
+        });
+        col = (col + usize(1));
+      }
+    );
+  });
+  col
+});
 /// A JSON-RPC notification.
 j_notification :: (fn(method : str, params : JsonValue) -> JsonValue)(
   jb().put("jsonrpc", jstr(String.from("2.0"))).put("method", jstr(String.from(method))).put("params", params).obj()
 );
 
 export(
+  rune_col_to_byte_offset,
+  byte_offset_to_rune_col,
   JsonObjBuilder,
   jb,
   jstr,

--- a/src/parser.yo
+++ b/src/parser.yo
@@ -191,6 +191,7 @@ impl(
       row : ref_tok.row,
       column : ref_tok.column,
       character : ref_tok.character,
+      byte_offset : ref_tok.byte_offset,
       module_path : ref_tok.module_path,
       input : ref_tok.input
     );
@@ -513,13 +514,12 @@ impl(
     _is_spec_char :: (fn(c : rune) -> bool)(
       (((((c.char >= u32(0x30)) && (c.char <= u32(0x39))) || ((c.char >= u32(0x41)) && (c.char <= u32(0x5A)))) || ((c.char >= u32(0x61)) && (c.char <= u32(0x7A)))) || (((c.char == u32(0x2E)) || (c.char == u32(0x3C))) || ((c.char == u32(0x3E)) || (c.char == u32(0x5E))))) || ((((c.char == u32(0x2B)) || (c.char == u32(0x2D))) || ((c.char == u32(0x23)) || (c.char == u32(0x2A)))) || (((c.char == u32(0x5F)) || (c.char == u32(0x3D))) || (c.char == u32(0x7E))))
     );
-    // `k` and `tn` are RUNE indices into `tc`, so the two cuts at the end have
-    // to be resolved through the rune->byte map `char_indices()` gives, not
-    // fed to `substring` and left to whatever basis it has. This is
-    // plans/STD_API_AUDIT_D4_PLAN.md §5.2 S4: today `substring` reads them as
-    // rune indices and agrees by accident; after D4's flip it would read them
-    // as byte offsets and cut a template string like `${名前:>8}` apart in the
-    // middle of a codepoint.
+    // `k` and `tn` are RUNE indices into `tc`, so the two cuts at the end are
+    // resolved through the rune->byte map `char_indices()` gives rather than
+    // handed to `substring`. This is plans/STD_API_AUDIT_D4_PLAN.md §5.2 S4:
+    // `substring` takes BYTE offsets since D4, so feeding it these rune
+    // indices would cut a template string like `${名前:>8}` apart in the
+    // middle of a codepoint (and panic on the non-boundary).
     _peel_spec :: (fn(text : String) -> _SpecSplit)({
       tc := ArrayList(rune).new();
       // `toff(i)` is the byte offset rune `i` starts at.
@@ -608,6 +608,7 @@ impl(
                 row : tok.row,
                 column : tok.column,
                 character : tok.character,
+                byte_offset : tok.byte_offset,
                 module_path : tok.module_path,
                 input : tok.input
               );
@@ -637,6 +638,7 @@ impl(
             row : tok.row,
             column : tok.column,
             character : tok.character,
+            byte_offset : tok.byte_offset,
             module_path : tok.module_path,
             input : tok.input
           );
@@ -772,6 +774,7 @@ impl(
         row : tok.row,
         column : tok.column,
         character : tok.character,
+        byte_offset : tok.byte_offset,
         module_path : tok.module_path,
         input : tok.input
       );
@@ -861,6 +864,7 @@ impl(
       row : tok.row,
       column : tok.column,
       character : tok.character,
+      byte_offset : tok.byte_offset,
       module_path : tok.module_path,
       input : tok.input
     );
@@ -953,6 +957,7 @@ impl(
       row : tok.row,
       column : tok.column,
       character : tok.character,
+      byte_offset : tok.byte_offset,
       module_path : tok.module_path,
       input : tok.input
     );
@@ -1059,6 +1064,7 @@ impl(
             row : last_tok.row,
             column : last_tok.column,
             character : last_tok.character,
+            byte_offset : last_tok.byte_offset,
             module_path : last_tok.module_path,
             input : last_tok.input
           );
@@ -1120,6 +1126,7 @@ impl(
                     row : tok.row,
                     column : tok.column,
                     character : tok.character,
+                    byte_offset : tok.byte_offset,
                     module_path : tok.module_path,
                     input : tok.input
                   );
@@ -1139,6 +1146,7 @@ impl(
           row : tok.row,
           column : tok.column,
           character : tok.character,
+          byte_offset : tok.byte_offset,
           module_path : tok.module_path,
           input : tok.input
         );
@@ -1155,6 +1163,7 @@ impl(
           row : tok.row,
           column : tok.column,
           character : tok.character,
+          byte_offset : tok.byte_offset,
           module_path : tok.module_path,
           input : tok.input
         );
@@ -1601,6 +1610,7 @@ impl(
               row : last_tok.row,
               column : last_tok.column,
               character : last_tok.character,
+              byte_offset : last_tok.byte_offset,
               module_path : last_tok.module_path,
               input : last_tok.input
             );

--- a/src/token.yo
+++ b/src/token.yo
@@ -35,7 +35,25 @@ Token :: ref(
     value : String,
     row : usize,
     column : usize,
+    /// RUNE offset of this token's first character within `input` — the
+    /// lexer's `input.chars()` loop counter. Used as an expression identity
+    /// key (`await_analysis`, `effect_analysis`) and served straight to the
+    /// LSP as a `character` position. **Never index `input` with it** — see
+    /// `byte_offset`.
     character : usize,
+    /// BYTE offset of this token's first character within `input`.
+    ///
+    /// `character` is a rune offset, so slicing `input` (which is byte-indexed
+    /// since `plans/STD_API_AUDIT_D4_PLAN.md` D4) with it corrupts any source
+    /// containing a multibyte character — that is exactly what
+    /// `issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md` was,
+    /// and that issue's "Fix direction" named this field as the follow-up.
+    /// Every consumer that INDEXES `input` reads this one.
+    ///
+    /// Defaults to 0 for the synthetic tokens the parser and evaluator mint:
+    /// they have no source text to index, and their `character` is 0 or copied
+    /// (in which case `byte_offset` is copied alongside it).
+    (byte_offset : usize) ?= usize(0),
     module_path : String,
     input : String
   )

--- a/src/utils.yo
+++ b/src/utils.yo
@@ -97,14 +97,15 @@ random_id :: (fn(_module_path : String) -> String)({
   `yo_id_${count.to_string()}`
 });
 /// Byte-exact StrLit unquote: drop the first and last BYTE (the ASCII `"`
-/// delimiters yo-self's StrLit convention keeps). The historical pattern
-/// `raw.substring(1, raw.len()-1)` mixed `len()` (BYTES) with `substring`
-/// (CHAR-indexed) — correct for ASCII, CORRUPTING for multibyte content
-/// (the em-dash template-segment corruption in the stage-2 binary). Only
-/// strips when both ends are `"`; anything else passes through unchanged.
+/// delimiters yo-self's StrLit convention keeps). It was written because the
+/// historical pattern `raw.substring(1, raw.len()-1)` mixed a BYTE length with
+/// a then-CHAR-indexed `substring` — correct for ASCII, CORRUPTING for
+/// multibyte content (the em-dash template-segment corruption in the stage-2
+/// binary). `substring` is byte-indexed since
+/// `plans/STD_API_AUDIT_D4_PLAN.md` D4, so that mismatch no longer exists;
+/// this stays as the explicit byte-level spelling. Only strips when both ends
+/// are `"`; anything else passes through unchanged.
 str_lit_unquote_bytes :: (fn(raw : String) -> String)({
-  // BYTE count — String.len() counts CHARACTERS (std skips UTF-8
-  // continuation bytes); this helper walks bytes.
   n := raw.as_bytes().len();
   if((n >= usize(2)) && ((raw.byte_at(usize(0)) == u8(34)) && (raw.byte_at(n - usize(1)) == u8(34))), {
     bytes := raw.as_bytes();

--- a/src/version_cache.yo
+++ b/src/version_cache.yo
@@ -472,8 +472,12 @@ _http_get :: (
       msg.push_string(url);
       e.exn.throw(dyn(msg));
     });
-    // stdout = body bytes + 3-digit status code. Split at the BYTE level:
-    // release JSON can contain non-ASCII, and String indices are rune-based.
+    // stdout = body bytes + 3-digit status code. Split at the BYTE level, on
+    // the raw `ArrayList(u8)`, before it is ever a String: release JSON can
+    // contain non-ASCII, and the split point must not depend on the decoded
+    // text at all. (Before plans/STD_API_AUDIT_D4_PLAN.md D4 PR 3 the reason
+    // was written as "String indices are rune-based" — `String` is byte-indexed
+    // now, but the byte-level split is still the right shape here.)
     n := out.stdout.len();
     if(n < usize(3), {
       e.exn.throw(dyn(`HTTP request failed for: ${url}`));

--- a/std/string/string.yo
+++ b/std/string/string.yo
@@ -585,9 +585,18 @@ impl(
   /// `from_index` needs no boundary check and gets none: UTF-8 is
   /// self-synchronizing, so a valid-UTF-8 needle can never match starting at a
   /// continuation byte. Starting the scan mid-rune therefore cannot invent a
-  /// match, and every index this returns is a rune boundary.
+  /// match, and for a NON-EMPTY needle every index this returns is a rune
+  /// boundary at or before `len()`.
   ///
-  /// An empty needle matches at `from_index` (Rust's `find("")` shape).
+  /// **The empty needle is the one exception, and it is deliberate.** It
+  /// matches everywhere, so `index_of(``, i)` answers `.Some(i)` verbatim —
+  /// including an `i` inside a rune and an `i` past `len()` (JavaScript's
+  /// `indexOf("")` clamps to the length; this does not, and neither did the
+  /// pre-D4 rune-indexed version). An offset past the end is harmless
+  /// downstream because `substring` clamps, but a MID-RUNE one is not:
+  /// `substring` panics there. Callers that feed a search result straight back
+  /// into a slice and can be handed an empty needle should go through
+  /// `try_substring`, or snap with `floor_char_boundary`.
   /// Not called directly — go through `index_of`.
   _index_of_impl : (fn(self : Self, substr : Self, (from_index : usize) ?= 0) -> Option(usize))(
     cond(
@@ -781,9 +790,13 @@ impl(
   /// **BYTE basis, in AND out** (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 —
   /// both were rune indices before the flip). `from_index` is the highest byte
   /// offset a match is allowed to START at; the default `usize.MAX` means
-  /// "anywhere". The result is the byte offset of the match.
+  /// "anywhere". The result is the byte offset of the match, and for a
+  /// non-empty needle it is always a rune boundary.
   ///
-  /// An empty needle matches at `len()` (Rust's `rfind("")` shape).
+  /// **The empty needle answers `len()` regardless of `from_index`** (Rust's
+  /// `rfind("")` shape), so it is the one case where the result can exceed the
+  /// cap the caller asked for. That is the pre-D4 behaviour carried over
+  /// unchanged — only the unit changed, from a rune count to a byte count.
   /// Not called directly — go through `last_index_of`.
   _last_index_of_impl : (fn(self : Self, substr : Self, (from_index : usize) ?= usize.MAX) -> Option(usize))(
     cond(

--- a/std/string/string.yo
+++ b/std/string/string.yo
@@ -145,44 +145,27 @@ impl(
     bytes_with_null.push(u8(0));
     return(bytes_with_null);
   }),
-  /**
-  * Get the length of the string in Unicode characters (runes)
-  * For "你好世界", this returns 4
-  */
-  len : (fn(self : Self) -> usize)({
-    (inner : Option(ArrayList(u8))) = self._bytes;
-    match(
-      inner,
-      .None => {
-        return(usize(0));
-      },
-      .Some(al) => {
-        count := usize(0);
-        byte_index := usize(0);
-        total_bytes := al.len();
-        while(byte_index < total_bytes, byte_index = (byte_index + usize(1)), {
-          byte_opt := al.get(byte_index);
-          match(
-            byte_opt,
-            .Some(byte) => {
-              cond(
-                utf8.is_boundary(byte) => {
-                  count = (count + usize(1));
-                },
-                true => ()
-              );
-            },
-            .None => ()
-          );
-        });
-        return(count);
-      }
-    )
-  }),
-  /// Number of Unicode scalar values (runes) in the string.
+  /// Number of BYTES in this string's UTF-8 encoding — O(1).
   ///
-  /// O(n) in the byte length. Identical to what `len()` returns today; it
-  /// stays a rune count after `len()` becomes a byte count.
+  /// **BYTE basis.** This is the unit every index-taking method on `String`
+  /// speaks: `at`, `substring`, the `s(a..b)` / `s(a..=b)` slice sugar,
+  /// `index_of`, `last_index_of`, `contains(from_index)`,
+  /// `starts_with(position)`, `ends_with(end_position)` and the `Pattern`
+  /// trait. It agrees with `str.len()`, `StringBuilder.len()`, `Index(usize)`
+  /// (which yields a `u8`) and Rust's `str::len()`.
+  ///
+  /// For "how many runes" use `char_len()` (O(n)); to walk runes together with
+  /// the byte offset each one starts at, use `char_indices()`.
+  /// (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 — this returned a RUNE count
+  /// before that flip.)
+  len : (fn(self : Self) -> usize)(
+    match(self._bytes, .Some(b) => b.len(), .None => usize(0))
+  ),
+  /// Number of Unicode scalar values (runes) in the string — O(n).
+  ///
+  /// **RUNE basis**, and the only length on `String` that is: `len()` counts
+  /// BYTES. Use this wherever a count is a display/character count rather
+  /// than a buffer size.
   char_len : (fn(self : Self) -> usize)(
     match(
       self._bytes,
@@ -295,47 +278,43 @@ impl(
         )
     )
   ),
-  /**
-  * Get the rune at the specified character index (0-based)
-  * Returns None if index is out of bounds
-  * For "你好世界", at(0) returns '你', at(1) returns '好', etc.
-  */
-  at : (fn(self : Self, index : usize) -> Option(rune))(
+  /// True when byte offset `index` sits on a rune boundary.
+  ///
+  /// `0` and `len()` are always boundaries; an index past the end never is.
+  /// Mirrors Rust's `str::is_char_boundary`. (Defined here, beside `at` and
+  /// `substring`, because an `impl` block cannot call forward into a later
+  /// one and both of those need it.)
+  is_char_boundary : (fn(self : Self, index : usize) -> bool)(
     match(
       self._bytes,
-      .None => {
-        return(.None);
-      },
+      .None => (index == usize(0)),
       .Some(al) => {
-        char_count := usize(0);
-        byte_index := usize(0);
-        total_bytes := al.len();
-        while(byte_index < total_bytes, byte_index = (byte_index + usize(1)), {
-          byte_opt := al.get(byte_index);
-          match(
-            byte_opt,
-            .Some(byte) => {
-              is_start := utf8.is_boundary(byte);
-              cond(
-                is_start => {
-                  cond(
-                    (char_count == index) => {
-                      return(Self._decode_rune_at(self, byte_index));
-                    },
-                    true => {
-                      char_count = (char_count + usize(1));
-                    }
-                  );
-                },
-                true => ()
-              );
-            },
-            .None => ()
-          );
-        });
-        return(.None);
+        n := al.len();
+        cond(
+          (index == usize(0)) => true,
+          (index == n) => true,
+          (index > n) => false,
+          true => match(
+            al.get(index),
+            .Some(b) => utf8.is_boundary(b),
+            .None => false
+          )
+        )
       }
     )
+  ),
+  /// Decode the rune that STARTS at byte offset `index`.
+  ///
+  /// **BYTE basis** (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 — this took a
+  /// rune index before the flip). `.None` is returned for the three ways a
+  /// byte offset can fail to name a rune: at or past `len()`, inside a rune
+  /// (a UTF-8 continuation byte), or on bytes that do not decode.
+  ///
+  /// `while(i < s.len(), { s.at(i) })` therefore visits continuation bytes and
+  /// yields `.None` at each of them — use `char_indices()` (or `chars()`) to
+  /// walk runes.
+  at : (fn(self : Self, index : usize) -> Option(rune))(
+    self._decode_rune_at(index)
   ),
   /**
   * Concatenate two strings (like JavaScript +)
@@ -451,13 +430,15 @@ impl(
   // (Inherent `clone` removed; the Clone trait impl below provides
   // the same semantics via inout(self) : Self after the Phase D
   // migration. Calling `s.clone()` resolves to the trait method.)
-  /// Get the number of bytes in the string (not Unicode characters).
-  /// Use `len()` for Unicode character count.
+  /// DEPRECATED alias for `len()`, which counts bytes since D4.
+  ///
+  /// It existed to say "bytes, not runes" back when `len()` meant runes.
+  /// Kept so pre-D4 spellings keep compiling; new code should say `len()`.
   bytes_len : (fn(self : Self) -> usize)(
-    match(self._bytes, .Some(b) => b.len(), .None => usize(0))
+    self.len()
   ),
   /// Get the byte at the given index. Panics if the index is out of
-  /// bounds (mirrors `str`'s byte indexing). Use `bytes_len()` for the
+  /// bounds (mirrors `str`'s byte indexing). Use `len()` for the
   /// valid range and `bytes()` for sequential iteration.
   byte_at : (fn(self : Self, index : usize) -> u8)(
     match(
@@ -470,33 +451,82 @@ impl(
       .None => __yo_panic("String.byte_at: index out of bounds")
     )
   ),
-  /**
-  * Owned copy of the characters in `[r.start, r.end)` — `s(a..b)` lowers
-  * to this (JS-style range slicing; rune indices like `substring`).
-  */
+  /// Owned copy of the BYTES in `[r.start, r.end)` — `s(a..b)` lowers to this.
+  ///
+  /// Same contract as `substring`, including the boundary policy: an endpoint
+  /// inside a rune panics.
   slice_copy : (fn(self : Self, r : Range(usize)) -> Self)(
     self.substring(r.start, r.end)
   ),
-  /// Inclusive-range companion (`s(a..=b)`).
+  /// Inclusive-range companion (`s(a..=b)`) — BYTE offsets, `r.end` included.
+  ///
+  /// Because `r.end` is the LAST byte kept, it must be the last byte of a
+  /// rune for `r.end + 1` to land on a boundary; otherwise this panics like
+  /// `substring`.
   slice_copy_inclusive : (fn(self : Self, r : RangeInclusive(usize)) -> Self)(
     self.substring(r.start, r.end + usize(1))
   ),
-  /**
-  * Extract a substring from start to end character indices (like JavaScript substring)
-  * Returns a new string containing characters from start (inclusive) to end (exclusive)
-  * If end is greater than length, it will substring to the end of the string
-  */
-  substring : (fn(self : Self, start : usize, end : usize) -> Self)(
-    self.char_substring(start, end)
-  ),
-  /// Slice by RUNE indices — what `substring` does today, under a name that
-  /// says so.
+  /// Owned copy of the bytes in `[start, end)`.
   ///
-  /// `plans/STD_API_AUDIT_D4_PLAN.md` moves `substring` to BYTE offsets; every
-  /// call site that genuinely means "runes" says `char_substring` instead, so
-  /// the flip cannot change it silently. Out-of-range indices clamp (a start
-  /// at or past the rune count, or `start >= end`, yields the empty string),
-  /// which is the behaviour `substring` has always had.
+  /// **BYTE basis** (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 — these were
+  /// rune indices before the flip; `char_substring` still is).
+  ///
+  /// **Boundary policy, in full:**
+  /// - Out-of-range CLAMPS. `start` and `end` past `len()` are pulled back to
+  ///   `len()`, and `start >= end` yields the empty string. This is the
+  ///   forgiving behaviour `substring` has always had, and it is kept.
+  /// - A non-boundary index PANICS. An endpoint inside a rune is a programmer
+  ///   error — a byte offset that came from the wrong basis — not a range
+  ///   condition, and honouring it would hand back invalid UTF-8.
+  /// - `try_substring(start, end)` is the non-panicking form: it returns
+  ///   `.None` for a bad range instead of clamping or panicking.
+  /// - `floor_char_boundary` / `ceil_char_boundary` snap an arbitrary offset
+  ///   onto a boundary first, for callers doing byte arithmetic.
+  /// - `char_substring(start, end)` is the rune-indexed slice.
+  substring : (fn(self : Self, start : usize, end : usize) -> Self)(
+    match(
+      self._bytes,
+      .None => {
+        return(Self(_bytes : .None));
+      },
+      .Some(al) => {
+        (total_bytes : usize) = al.len();
+        (start_byte : usize) = cond(
+          (start > total_bytes) => total_bytes,
+          true => start
+        );
+        (end_byte : usize) = cond(
+          (end > total_bytes) => total_bytes,
+          true => end
+        );
+        if(!(self.is_char_boundary(start_byte)), {
+          __yo_panic("String.substring: start is not on a UTF-8 character boundary");
+        });
+        if(!(self.is_char_boundary(end_byte)), {
+          __yo_panic("String.substring: end is not on a UTF-8 character boundary");
+        });
+        if(start_byte >= end_byte, {
+          return(Self(_bytes : .None));
+        });
+        (count : usize) = (end_byte - start_byte);
+        new_bytes := ArrayList(u8).with_capacity(count);
+        match(
+          al.ptr(),
+          .Some(src_p) => new_bytes.extend_from_ptr(src_p.add(start_byte), count),
+          .None => ()
+        );
+        Self(_bytes : .Some(new_bytes))
+      }
+    )
+  ),
+  /// Slice by RUNE indices — what `substring` meant before D4, under a name
+  /// that says so.
+  ///
+  /// `substring` now takes BYTE offsets; every call site that genuinely means
+  /// "runes" says `char_substring` instead, which is what kept that flip from
+  /// changing anything silently. Out-of-range indices clamp (a start at or
+  /// past the rune count, or `start >= end`, yields the empty string), and an
+  /// endpoint can never fall inside a rune, so this never panics.
   char_substring : (fn(self : Self, start : usize, end : usize) -> Self)(
     match(
       self._bytes,
@@ -545,11 +575,20 @@ impl(
       }
     )
   ),
-  /**
-  * Find the first occurrence of a substring (like JavaScript indexOf)
-  * Returns the character index of the first match, or None if not found
-  * from_index specifies the character index to start searching from
-  */
+  /// Byte offset of the first occurrence of `substr` at or after `from_index`.
+  ///
+  /// **BYTE basis, in AND out** (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 —
+  /// both were rune indices before the flip). `from_index` is a byte offset;
+  /// the returned index is the byte offset the match starts at, so it can be
+  /// fed straight back into `substring`.
+  ///
+  /// `from_index` needs no boundary check and gets none: UTF-8 is
+  /// self-synchronizing, so a valid-UTF-8 needle can never match starting at a
+  /// continuation byte. Starting the scan mid-rune therefore cannot invent a
+  /// match, and every index this returns is a rune boundary.
+  ///
+  /// An empty needle matches at `from_index` (Rust's `find("")` shape).
+  /// Not called directly — go through `index_of`.
   _index_of_impl : (fn(self : Self, substr : Self, (from_index : usize) ?= 0) -> Option(usize))(
     cond(
       substr.is_empty() => .Some(from_index),
@@ -558,6 +597,7 @@ impl(
         (sub_bytes : usize) = match(substr._bytes, .Some(b) => b.len(), .None => usize(0));
         cond(
           (sub_bytes > self_bytes) => .None,
+          (from_index > (self_bytes - sub_bytes)) => .None,
           true => match(
             self._bytes,
             .None => .None,
@@ -565,25 +605,9 @@ impl(
               substr._bytes,
               .None => .None,
               .Some(sub_al) => {
-                char_index := usize(0);
-                byte_index := usize(0);
-                while((byte_index < self_bytes) && (char_index < from_index), byte_index = (byte_index + usize(1)), {
-                  first_byte_opt := self_al.get(byte_index);
-                  match(
-                    first_byte_opt,
-                    .Some(first_byte) => {
-                      is_start := utf8.is_boundary(first_byte);
-                      cond(
-                        is_start => {
-                          char_index = (char_index + usize(1));
-                        },
-                        true => ()
-                      );
-                    },
-                    .None => ()
-                  );
-                });
-                while(byte_index <= (self_bytes - sub_bytes), byte_index = (byte_index + usize(1)), {
+                (last_start : usize) = (self_bytes - sub_bytes);
+                byte_index := from_index;
+                while(byte_index <= last_start, byte_index = (byte_index + usize(1)), {
                   matches := true;
                   j := usize(0);
                   while(j < sub_bytes, j = (j + usize(1)), {
@@ -616,23 +640,9 @@ impl(
                   });
                   cond(
                     matches => {
-                      return(.Some(char_index));
+                      return(.Some(byte_index));
                     },
                     true => ()
-                  );
-                  first_byte_opt := self_al.get(byte_index);
-                  match(
-                    first_byte_opt,
-                    .Some(first_byte) => {
-                      is_start := utf8.is_boundary(first_byte);
-                      cond(
-                        is_start => {
-                          char_index = (char_index + usize(1));
-                        },
-                        true => ()
-                      );
-                    },
-                    .None => ()
                   );
                 });
                 return(.None);
@@ -643,9 +653,11 @@ impl(
       }
     )
   ),
-  /**
-  * Check if the string contains a substring
-  */
+  /// Private: is `substr` present at or after BYTE offset `from_index`?
+  ///
+  /// **BYTE basis** for `from_index` (`plans/STD_API_AUDIT_D4_PLAN.md` D4
+  /// PR 3 — it was a rune index before the flip). Not called directly — go
+  /// through `contains`.
   _contains_impl : (fn(self : Self, substr : Self, (from_index : usize) ?= 0) -> bool)(
     match(
       self._index_of_impl(substr, from_index),
@@ -763,11 +775,16 @@ impl(
       )
     )
   }),
-  /**
-  * Find the last occurrence of a substring (like JavaScript lastIndexOf)
-  * Returns the character index of the last match, or None if not found
-  * from_index specifies the character index to start searching backwards from
-  */
+  /// Byte offset of the LAST occurrence of `substr` starting at or before
+  /// `from_index`.
+  ///
+  /// **BYTE basis, in AND out** (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 —
+  /// both were rune indices before the flip). `from_index` is the highest byte
+  /// offset a match is allowed to START at; the default `usize.MAX` means
+  /// "anywhere". The result is the byte offset of the match.
+  ///
+  /// An empty needle matches at `len()` (Rust's `rfind("")` shape).
+  /// Not called directly — go through `last_index_of`.
   _last_index_of_impl : (fn(self : Self, substr : Self, (from_index : usize) ?= usize.MAX) -> Option(usize))(
     cond(
       substr.is_empty() => .Some(self.len()),
@@ -783,92 +800,55 @@ impl(
             cond(
               (sub_bytes > self_bytes) => .None,
               true => {
-                char_positions := ArrayList(usize).new();
-                byte_positions := ArrayList(usize).new();
-                byte_idx := usize(0);
-                char_idx := usize(0);
-                while(byte_idx < self_bytes, byte_idx = (byte_idx + usize(1)), {
-                  byte_opt := self_al.get(byte_idx);
-                  match(
-                    byte_opt,
-                    .Some(byte) => {
-                      is_start := utf8.is_boundary(byte);
-                      cond(
-                        is_start => {
-                          char_positions.push(char_idx);
-                          byte_positions.push(byte_idx);
-                          char_idx = (char_idx + usize(1));
-                        },
-                        true => ()
-                      );
-                    },
-                    .None => ()
-                  );
-                });
-                max_char_index := cond(
-                  (from_index >= char_idx) => char_idx,
-                  true => (from_index + usize(1))
+                (last_start : usize) = (self_bytes - sub_bytes);
+                (highest : usize) = cond(
+                  (from_index > last_start) => last_start,
+                  true => from_index
                 );
-                (last_match : Option(usize)) = .None;
-                i := usize(0);
-                while(i < char_positions.len(), i = (i + usize(1)), {
-                  char_pos_opt := char_positions.get(i);
-                  byte_pos_opt := byte_positions.get(i);
-                  match(
-                    char_pos_opt,
-                    .Some(char_pos) =>
-                      match(
-                        byte_pos_opt,
-                        .Some(byte_pos) => {
-                          cond(
-                            (char_pos >= max_char_index) => break,
-                            ((byte_pos + sub_bytes) <= self_bytes) => {
-                              matches := true;
-                              j := usize(0);
-                              while(j < sub_bytes, j = (j + usize(1)), {
-                                self_byte_opt := self_al.get(byte_pos + j);
-                                sub_byte_opt := sub_al.get(j);
-                                match(
-                                  self_byte_opt,
-                                  .Some(self_byte) =>
-                                    match(
-                                      sub_byte_opt,
-                                      .Some(sub_byte) => {
-                                        cond(
-                                          (self_byte != sub_byte) => {
-                                            matches = false;
-                                            break;
-                                          },
-                                          true => ()
-                                        );
-                                      },
-                                      .None => {
-                                        matches = false;
-                                        break;
-                                      }
-                                    ),
-                                  .None => {
-                                    matches = false;
-                                    break;
-                                  }
-                                );
-                              });
-                              cond(
-                                matches => {
-                                  last_match = .Some(char_pos);
-                                },
-                                true => ()
-                              );
-                            },
-                            true => ()
-                          );
-                        },
-                        .None => ()
-                      ),
-                    .None => ()
+                // Walk DOWN from the highest allowed start, so the first hit is
+                // the last occurrence. `cursor` is one past the candidate so
+                // that candidate 0 is still examined without underflowing.
+                cursor := (highest + usize(1));
+                while(cursor > usize(0), {
+                  cursor = (cursor - usize(1));
+                  matches := true;
+                  j := usize(0);
+                  while(j < sub_bytes, j = (j + usize(1)), {
+                    self_byte_opt := self_al.get(cursor + j);
+                    sub_byte_opt := sub_al.get(j);
+                    match(
+                      self_byte_opt,
+                      .Some(self_byte) =>
+                        match(
+                          sub_byte_opt,
+                          .Some(sub_byte) => {
+                            cond(
+                              (self_byte != sub_byte) => {
+                                matches = false;
+                                break;
+                              },
+                              true => ()
+                            );
+                          },
+                          .None => {
+                            matches = false;
+                            break;
+                          }
+                        ),
+                      .None => {
+                        matches = false;
+                        break;
+                      }
+                    );
+                  });
+                  cond(
+                    matches => {
+                      return(.Some(cursor));
+                    },
+                    true => ()
                   );
                 });
-                return(last_match);
+                return(.None);
               }
             )
           }
@@ -876,17 +856,33 @@ impl(
       )
     )
   ),
-  /**
-  * Private: does this string have `prefix` (a String) starting at `position`?
-  * The UTF-8-aware byte-compare reused by the `Pattern` impls behind the generic
-  * `starts_with<P : Pattern>` (see plans/backlog/OVERLOADING_REDESIGN.md §4). Not called
-  * directly — go through `starts_with`.
-  */
+  /// Private: does this string have `prefix` starting at BYTE offset
+  /// `position`?
+  ///
+  /// **BYTE basis** (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3). Before the
+  /// flip `position` was walked rune-by-rune — and walked WRONG: the counter
+  /// advanced on a lead byte while the loop also stepped one byte, so
+  /// `"你好".starts_with("好", 1)` stopped at byte 1, in the middle of `你`.
+  /// That is §1.3(a) of the plan, and byte indexing removes the walk that
+  /// caused it rather than repairing it.
+  ///
+  /// `position` is never boundary-checked: a valid-UTF-8 prefix cannot match
+  /// starting at a continuation byte, so a mid-rune `position` simply answers
+  /// `false`. An empty prefix is present anywhere, including past the end.
+  ///
+  /// The UTF-8-aware byte-compare reused by the `Pattern` impls behind the
+  /// generic `starts_with<P : Pattern>` (see
+  /// plans/backlog/OVERLOADING_REDESIGN.md §4). Not called directly — go
+  /// through `starts_with`.
   _has_prefix : (fn(self : Self, prefix : Self, (position : usize) ?= 0) -> bool)({
     (prefix_bytes : usize) = match(prefix._bytes, .Some(b) => b.len(), .None => usize(0));
     (self_bytes : usize) = match(self._bytes, .Some(b) => b.len(), .None => usize(0));
     cond(
       (prefix_bytes == usize(0)) => true,
+      // Ordered so `position + prefix_bytes` cannot overflow: the first arm
+      // has already rejected every `position` beyond the byte length.
+      (position > self_bytes) => false,
+      ((position + prefix_bytes) > self_bytes) => false,
       true => match(
         self._bytes,
         .None => false,
@@ -894,76 +890,62 @@ impl(
           prefix._bytes,
           .None => true,
           .Some(prefix_al) => {
-            char_index := usize(0);
-            byte_index := usize(0);
-            while((byte_index < self_bytes) && (char_index < position), byte_index = (byte_index + usize(1)), {
-              byte_opt := self_al.get(byte_index);
+            i := usize(0);
+            matches := true;
+            while(i < prefix_bytes, i = (i + usize(1)), {
+              self_byte_opt := self_al.get(position + i);
+              prefix_byte_opt := prefix_al.get(i);
               match(
-                byte_opt,
-                .Some(byte) => {
-                  is_start := utf8.is_boundary(byte);
-                  cond(
-                    is_start => {
-                      byte_len := utf8.step_len(byte);
-                      byte_index = ((byte_index + byte_len) - usize(1));
-                      char_index = (char_index + usize(1));
-                    },
-                    true => ()
-                  );
-                },
-                .None => ()
-              );
-            });
-            cond(
-              ((byte_index + prefix_bytes) > self_bytes) => false,
-              true => {
-                i := usize(0);
-                matches := true;
-                while(i < prefix_bytes, i = (i + usize(1)), {
-                  self_byte_opt := self_al.get(byte_index + i);
-                  prefix_byte_opt := prefix_al.get(i);
+                self_byte_opt,
+                .Some(self_byte) =>
                   match(
-                    self_byte_opt,
-                    .Some(self_byte) =>
-                      match(
-                        prefix_byte_opt,
-                        .Some(prefix_byte) => {
-                          cond(
-                            (self_byte != prefix_byte) => {
-                              matches = false;
-                              break;
-                            },
-                            true => ()
-                          );
-                        },
-                        .None => {
+                    prefix_byte_opt,
+                    .Some(prefix_byte) => {
+                      cond(
+                        (self_byte != prefix_byte) => {
                           matches = false;
                           break;
-                        }
-                      ),
+                        },
+                        true => ()
+                      );
+                    },
                     .None => {
                       matches = false;
                       break;
                     }
-                  );
-                });
-                return(matches);
-              }
-            )
+                  ),
+                .None => {
+                  matches = false;
+                  break;
+                }
+              );
+            });
+            return(matches);
           }
         )
       )
     )
   }),
-  /**
-  * Check if the string ends with the specified substring (like JavaScript endsWith)
-  * end_position: The character length to consider (default is string length)
-  */
+  /// Private: does the first `end_position` BYTES of this string end with
+  /// `suffix`?
+  ///
+  /// **BYTE basis** (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 —
+  /// `end_position` was a rune count before the flip). The default
+  /// `usize.MAX` means "the whole string"; anything past `len()` clamps to it.
+  /// Like `_has_prefix`, a mid-rune `end_position` needs no rejection: a
+  /// valid-UTF-8 suffix cannot end there, so the answer is simply `false`.
+  ///
+  /// Not called directly — go through `ends_with`.
   _ends_with_impl : (fn(self : Self, suffix : Self, (end_position : usize) ?= usize.MAX) -> bool)({
     (suffix_bytes : usize) = match(suffix._bytes, .Some(b) => b.len(), .None => usize(0));
     (self_bytes : usize) = match(self._bytes, .Some(b) => b.len(), .None => usize(0));
+    (effective_end : usize) = cond(
+      (end_position > self_bytes) => self_bytes,
+      true => end_position
+    );
     cond(
       (suffix_bytes == usize(0)) => true,
+      (suffix_bytes > effective_end) => false,
       true => match(
         self._bytes,
         .None => false,
@@ -971,76 +953,38 @@ impl(
           suffix._bytes,
           .None => true,
           .Some(suffix_al) => {
-            string_char_len := self.len();
-            effective_end := cond(
-              (end_position == usize.MAX) => string_char_len,
-              (end_position > string_char_len) => string_char_len,
-              true => end_position
-            );
-            char_index := usize(0);
-            byte_index := usize(0);
-            end_byte_index := self_bytes;
-            while(byte_index < self_bytes, byte_index = (byte_index + usize(1)), {
-              byte_opt := self_al.get(byte_index);
+            offset := (effective_end - suffix_bytes);
+            i := usize(0);
+            matches := true;
+            while(i < suffix_bytes, i = (i + usize(1)), {
+              self_byte_opt := self_al.get(offset + i);
+              suffix_byte_opt := suffix_al.get(i);
               match(
-                byte_opt,
-                .Some(byte) => {
-                  is_start := utf8.is_boundary(byte);
-                  cond(
-                    is_start => {
-                      cond(
-                        (char_index == effective_end) => {
-                          end_byte_index = byte_index;
-                          break;
-                        },
-                        true => {
-                          char_index = (char_index + usize(1));
-                        }
-                      );
-                    },
-                    true => ()
-                  );
-                },
-                .None => ()
-              );
-            });
-            cond(
-              (suffix_bytes > end_byte_index) => false,
-              true => {
-                offset := (end_byte_index - suffix_bytes);
-                i := usize(0);
-                matches := true;
-                while(i < suffix_bytes, i = (i + usize(1)), {
-                  self_byte_opt := self_al.get(offset + i);
-                  suffix_byte_opt := suffix_al.get(i);
+                self_byte_opt,
+                .Some(self_byte) =>
                   match(
-                    self_byte_opt,
-                    .Some(self_byte) =>
-                      match(
-                        suffix_byte_opt,
-                        .Some(suffix_byte) => {
-                          cond(
-                            (self_byte != suffix_byte) => {
-                              matches = false;
-                              break;
-                            },
-                            true => ()
-                          );
-                        },
-                        .None => {
+                    suffix_byte_opt,
+                    .Some(suffix_byte) => {
+                      cond(
+                        (self_byte != suffix_byte) => {
                           matches = false;
                           break;
-                        }
-                      ),
+                        },
+                        true => ()
+                      );
+                    },
                     .None => {
                       matches = false;
                       break;
                     }
-                  );
-                });
-                return(matches);
-              }
-            )
+                  ),
+                .None => {
+                  matches = false;
+                  break;
+                }
+              );
+            });
+            return(matches);
           }
         )
       )
@@ -1580,8 +1524,8 @@ impl(
   String,
   Ord(String)(
     (<) : (fn(lhs : Self, rhs : Self) -> bool)({
-      lhs_len := lhs.bytes_len();
-      rhs_len := rhs.bytes_len();
+      lhs_len := lhs.len();
+      rhs_len := rhs.len();
       min_len := cond((lhs_len < rhs_len) => lhs_len, true => rhs_len);
       i := usize(0);
       while(i < min_len, i = (i + usize(1)), {
@@ -1613,11 +1557,25 @@ impl(
 /// match, so a single generic method per operation accepts any pattern type with no
 /// overload resolution. Implemented by `str` and `String` (and, later, `char`).
 /// See plans/backlog/OVERLOADING_REDESIGN.md §4.
+///
+/// **Every index in this trait is a BYTE offset into `haystack`**, in both
+/// directions (`plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3 — they were rune
+/// indices before the flip). No index is boundary-checked: UTF-8 is
+/// self-synchronizing, so a valid-UTF-8 pattern can only ever match at a rune
+/// boundary, and a mid-rune argument answers `false` / `.None` rather than
+/// producing a bogus hit.
 Pattern :: trait(
+  /// BYTE offset in `haystack` to test the prefix at.
   is_prefix_of : (fn(self : Self, haystack : String, position : usize) -> bool),
+  /// Number of BYTES of `haystack` to consider; `usize.MAX` means all of it.
   is_suffix_of : (fn(self : Self, haystack : String, end_position : usize) -> bool),
+  /// BYTE offset in `haystack` to start searching from.
   is_contained_in : (fn(self : Self, haystack : String, from_index : usize) -> bool),
+  /// BYTE offset in AND out: searches from byte `from_index`, answers with the
+  /// byte offset of the match.
   index_in : (fn(self : Self, haystack : String, from_index : usize) -> Option(usize)),
+  /// BYTE offset in AND out: the highest byte offset a match may start at,
+  /// answering with the byte offset of the last such match.
   last_index_in : (fn(self : Self, haystack : String, from_index : usize) -> Option(usize)),
   split_of : (fn(self : Self, haystack : String) -> ArrayList(String))
 );
@@ -1672,20 +1630,33 @@ impl(
 /// `X(arg : String)` + `StrPattern.X(arg : str)` overload pairs: `s.X("lit")`
 /// (P = str) and `s.X(other)` (P = String) both resolve to the one generic method via
 /// trait dispatch — no overload resolution. See plans/backlog/OVERLOADING_REDESIGN.md §4.
+///
+/// **Every index below is a BYTE offset** (`plans/STD_API_AUDIT_D4_PLAN.md`
+/// D4 PR 3), matching `len()` and `substring`, so `index_of`'s answer can be
+/// fed straight back into `substring` with nothing in between.
 impl(
   String,
+  /// Does `self` have `prefix` starting at BYTE offset `position` (default 0)?
   starts_with : (fn(generic(P : Type), self : Self, prefix : P, (position : usize) ?= 0, where(P <: Pattern)) -> bool)(
     prefix.is_prefix_of(self, position)
   ),
+  /// Does the first `end_position` BYTES of `self` end with `suffix`?
+  /// `end_position` defaults to `usize.MAX`, meaning the whole string, and
+  /// clamps to `len()`.
   ends_with : (fn(generic(P : Type), self : Self, suffix : P, (end_position : usize) ?= usize.MAX, where(P <: Pattern)) -> bool)(
     suffix.is_suffix_of(self, end_position)
   ),
+  /// Does `substr` occur at or after BYTE offset `from_index` (default 0)?
   contains : (fn(generic(P : Type), self : Self, substr : P, (from_index : usize) ?= 0, where(P <: Pattern)) -> bool)(
     substr.is_contained_in(self, from_index)
   ),
+  /// BYTE offset of the first occurrence of `substr` at or after BYTE offset
+  /// `from_index` (default 0), or `.None`.
   index_of : (fn(generic(P : Type), self : Self, substr : P, (from_index : usize) ?= 0, where(P <: Pattern)) -> Option(usize))(
     substr.index_in(self, from_index)
   ),
+  /// BYTE offset of the last occurrence of `substr` starting at or before BYTE
+  /// offset `from_index` (default `usize.MAX`, meaning anywhere), or `.None`.
   last_index_of : (fn(generic(P : Type), self : Self, substr : P, (from_index : usize) ?= usize.MAX, where(P <: Pattern)) -> Option(usize))(
     substr.last_index_in(self, from_index)
   ),
@@ -1862,58 +1833,39 @@ impl(
 /// === Rune-aware indexing (D4 vocabulary) ===
 ///
 /// Everything in this block is stated in **BYTE** offsets, except `char_len`
-/// which counts runes. That is deliberate: `plans/STD_API_AUDIT_D4_PLAN.md`
-/// moves `String`'s index basis from characters to bytes, and these names are
-/// the vocabulary that migration is written in. They are new, so they carry
-/// the final contract from the start rather than flipping under callers later.
+/// and `truncate_chars` which count runes. `plans/STD_API_AUDIT_D4_PLAN.md`
+/// moved `String`'s index basis from characters to bytes, and these names are
+/// the vocabulary that migration was written in — so they carried the final
+/// contract from the start rather than flipping under their callers.
 ///
-/// Until that flip lands, `char_len()` returns the same number as `len()` —
-/// use `char_len()` at any site that genuinely means "how many runes", so the
-/// intent survives the flip.
+/// Now that the flip has landed, the division of labour is: `len()` and every
+/// index-taking method speak bytes; `char_len()` / `char_indices()` /
+/// `char_substring()` / `truncate_chars()` speak runes; and
+/// `is_char_boundary` / `floor_char_boundary` / `ceil_char_boundary` /
+/// `try_substring` are how byte arithmetic stays on boundaries.
 ///
 /// `char_len` and `char_indices` are built on `std/encoding/utf8`, and inherit
-/// its handling of malformed input: `char_len` counts non-continuation bytes
-/// (byte-for-byte what `len()` does today), while `char_indices` — like
-/// `chars()` — stops at the first byte sequence that will not decode.
-/// The three boundary functions and `try_substring` are pure byte
-/// classification (`utf8.is_boundary`) and cannot fail.
+/// its handling of malformed input: `char_len` counts non-continuation bytes,
+/// while `char_indices` — like `chars()` — stops at the first byte sequence
+/// that will not decode. The boundary functions and `try_substring` are pure
+/// byte classification (`utf8.is_boundary`) and cannot fail.
+///
+/// (`is_char_boundary` is NOT defined here — it lives beside `at` in the main
+/// `impl` block, because an `impl` block cannot call forward into a later one
+/// and `at`/`substring` need it.)
 impl(
   String,
   /// Iterate `(byte_offset, rune)` pairs — Rust's `char_indices()`.
   ///
   /// `_0` is the byte offset the rune starts at, `_1` is the rune. This is
-  /// the replacement for the `while(i < s.len()) { s.at(i) }` shape, which is
-  /// O(n²) today and, once `at()` takes a byte offset, hands back `.None` at
-  /// every continuation byte.
+  /// the replacement for the `while(i < s.len()) { s.at(i) }` shape, which
+  /// now visits continuation bytes and hands back `.None` at each of them.
   char_indices : (fn(self : Self) -> StringCharIndices)(
     StringCharIndices(_string : self, _byte_index : usize(0))
   ),
-  /// True when byte offset `index` sits on a rune boundary.
-  ///
-  /// `0` and `bytes_len()` are always boundaries; an index past the end never
-  /// is. Mirrors Rust's `str::is_char_boundary`.
-  is_char_boundary : (fn(self : Self, index : usize) -> bool)(
-    match(
-      self._bytes,
-      .None => (index == usize(0)),
-      .Some(al) => {
-        n := al.len();
-        cond(
-          (index == usize(0)) => true,
-          (index == n) => true,
-          (index > n) => false,
-          true => match(
-            al.get(index),
-            .Some(b) => utf8.is_boundary(b),
-            .None => false
-          )
-        )
-      }
-    )
-  ),
   /// The largest byte offset `<= index` that sits on a rune boundary.
   ///
-  /// `index` is clamped to `bytes_len()` first, so the answer is always a
+  /// `index` is clamped to `len()` first, so the answer is always a
   /// boundary of THIS string. Pair it with `ceil_char_boundary` to widen or
   /// narrow a byte range onto boundaries before slicing.
   floor_char_boundary : (fn(self : Self, index : usize) -> usize)(
@@ -1941,8 +1893,8 @@ impl(
   ),
   /// The smallest byte offset `>= index` that sits on a rune boundary.
   ///
-  /// `index` at or past `bytes_len()` clamps to `bytes_len()`, which is a
-  /// boundary, so this always terminates on a valid one.
+  /// `index` at or past `len()` clamps to `len()`, which is a boundary, so
+  /// this always terminates on a valid one.
   ceil_char_boundary : (fn(self : Self, index : usize) -> usize)(
     match(
       self._bytes,
@@ -1969,11 +1921,11 @@ impl(
   /// Byte-range slice that REFUSES a bad range instead of guessing —
   /// Rust's `s.get(start..end)`.
   ///
-  /// **BYTE offsets**, unlike `substring`, which takes character offsets and
-  /// clamps them. `.None` is returned for the three ranges a byte slice
-  /// cannot honour: `start > end`, `end` past `bytes_len()`, or an endpoint
-  /// inside a rune (which would produce invalid UTF-8). An empty but valid
-  /// range yields `.Some` of the empty string.
+  /// Same BYTE basis as `substring`, but REFUSING where `substring` clamps or
+  /// panics: `.None` is returned for each of the three ranges a byte slice
+  /// cannot honour — `start > end`, `end` past `len()`, or an endpoint inside
+  /// a rune (which would produce invalid UTF-8). An empty but valid range
+  /// yields `.Some` of the empty string.
   try_substring : (fn(self : Self, start : usize, end : usize) -> Option(Self))({
     (n : usize) = match(self._bytes, .Some(b) => b.len(), .None => usize(0));
     if(start > end, {
@@ -2116,7 +2068,7 @@ impl(
       (n == usize(0)) => Self(_bytes : .None),
       self.is_empty() => Self(_bytes : .None),
       true => {
-        self_byte_len := self.bytes_len();
+        self_byte_len := self.len();
         total := (self_byte_len * n);
         buf := ArrayList(u8).with_capacity(total);
         i := usize(0);
@@ -2162,7 +2114,7 @@ impl(
     cond(
       (count == usize(0)) => Self(_bytes : .None),
       true => {
-        sep_byte_len := self.bytes_len();
+        sep_byte_len := self.len();
         total_bytes := usize(0);
         k := usize(0);
         while(k < count, k = (k + usize(1)), {
@@ -2170,7 +2122,7 @@ impl(
           match(
             item_opt,
             .Some(item) => {
-              total_bytes = (total_bytes + item.bytes_len());
+              total_bytes = (total_bytes + item.len());
             },
             .None => ()
           );

--- a/tests/codegen-bootstrap/effect_label_non_ascii.yo
+++ b/tests/codegen-bootstrap/effect_label_non_ascii.yo
@@ -1,0 +1,46 @@
+open(import("std/string"));
+open(import("std/fmt"));
+
+// A non-ASCII effect label reaching the future's `set_effect` emitter.
+//
+// `generate_future_effect_setter` (src/codegen/exprs/async.yo) calls
+// `_capitalize_last_segment` on EVERY injectable effect label so the emitted
+// `strcmp(field, …)` chain also accepts the capitalized alias. Yo identifiers
+// may start with a non-ASCII rune (src/token.yo `is_identifier_start`:
+// `c.char >= 0xA0`), so that label can be multibyte — and after
+// plans/STD_API_AUDIT_D4_PLAN.md D4 PR 3 made `substring` byte-indexed AND
+// non-boundary-PANICKING, the `substring(0, 1)` that took the first character
+// aborted the COMPILER with
+// `String.substring: end is not on a UTF-8 character boundary`, no source
+// location, before emitting anything. The cut is by rune (`char_substring`)
+// again; this file is the ratchet.
+//
+// The shape is load-bearing: the effect must be FUNCTION-typed (so the label
+// is the effect TYPE's name rather than a struct field path) and the future
+// must be awaited from another future (so the injectable-mapping loop runs at
+// all). A struct-typed bundle with a non-ASCII FIELD name reaches the same
+// code but cannot be used as a regression test — it hits a separate,
+// pre-existing C-name-mangling gap
+// (issues/async-effect-setter-emits-a-raw-non-ascii-identifier-as-a-c-member-name.md).
+Éraise :: (fn(msg : String) -> i32);
+inner :: (fn(h : Éraise, io : Io) -> Impl(Future(i32, Éraise)))(
+  io.async((e) => {
+    return(h(`x`));
+  })
+);
+work :: (fn(h : Éraise, io : Io) -> Impl(Future(i32, Éraise)))(
+  io.async((e) => {
+    r := io.await(inner(h, io), e);
+    return(r);
+  })
+);
+main :: (fn(io : Io) -> unit)({
+  (h : Éraise) = (
+    (m) -> {
+      return(i32(7));
+    }
+  );
+  r := io.await(work(h, io), h);
+  println(`r=${r}`);
+});
+export(main);

--- a/tests/codegen-bootstrap/goldens/effect_label_non_ascii.yo.golden
+++ b/tests/codegen-bootstrap/goldens/effect_label_non_ascii.yo.golden
@@ -1,0 +1,2 @@
+mode=run compile_rc=0 rc=0
+r=7

--- a/tests/codegen-bootstrap/template_multibyte.yo
+++ b/tests/codegen-bootstrap/template_multibyte.yo
@@ -2,13 +2,18 @@ open(import("std/fmt"));
 open(import("std/string"));
 
 // Multibyte (em-dash) content in a template-string segment: byte loops in
-// codegen must bound by as_bytes().len() (BYTES), not String.len()
-// (CHARACTERS) — a char-counted bound truncated the segment's tail bytes and
-// skipped the quote-strip (the stage-2-binary corruption family).
+// codegen must bound by the BYTE length, never a rune count — a char-counted
+// bound truncated the segment's tail bytes and skipped the quote-strip (the
+// stage-2-binary corruption family).
+//
+// Since plans/STD_API_AUDIT_D4_PLAN.md D4 PR 3, `String.len()` IS the byte
+// length and `char_len()` is the rune count; the two figures printed below are
+// therefore unchanged in VALUE (15 runes, 17 bytes) while the spellings that
+// produce them swapped. That keeps this golden a live check on both.
 main :: (fn() -> unit)({
   path := String.from("abc.yo");
   println(`check: ${path} — evaluator OK`);
   s := String.from(" — evaluator OK");
-  println(`chars=${s.len()} bytes=${s.as_bytes().len()}`);
+  println(`chars=${s.char_len()} bytes=${s.len()}`);
 });
 export(main);

--- a/tests/encoding/base64.test.yo
+++ b/tests/encoding/base64.test.yo
@@ -218,5 +218,7 @@ test("decode_string accepts a multi-byte UTF-8 payload", {
   // "w6k=" is 0xC3 0xA9 — U+00E9, valid UTF-8, so validation must not reject it.
   result := base64_decode_string(`w6k=`);
   assert(result.is_ok(), "valid multi-byte UTF-8 should still decode");
-  assert(result.unwrap().len() == usize(1), "the payload is one rune");
+  // `len()` counts BYTES since plans/STD_API_AUDIT_D4_PLAN.md D4 PR 3.
+  assert(result.unwrap().char_len() == usize(1), "the payload is one rune");
+  assert(result.unwrap().len() == usize(2), "and two bytes");
 });

--- a/tests/encoding/utf8.test.yo
+++ b/tests/encoding/utf8.test.yo
@@ -494,11 +494,15 @@ test("validate_range checks a sub-range and never reads past it", {
 // ============================================================================
 test("String round-trips through the shared decoder", {
   s := `aé€😀`;
-  assert(s.len() == usize(4), "four runes");
+  // `len()` counts BYTES and `at()` takes a BYTE offset since
+  // plans/STD_API_AUDIT_D4_PLAN.md D4 PR 3; `char_len()` is the rune count.
+  // a@0 (1B) é@1 (2B) €@3 (3B) 😀@6 (4B).
+  assert(s.char_len() == usize(4), "four runes");
+  assert(s.len() == usize(10), "1 + 2 + 3 + 4 bytes");
   assert(s.as_bytes().len() == usize(10), "1 + 2 + 3 + 4 bytes");
   assert(_valid_kind(validate(s.as_bytes())) == "ok", "the template string is valid UTF-8");
   assert(
-    match(s.at(usize(3)), .Some(r) => r.to_u32(), .None => u32(0)) == u32(0x1F600),
+    match(s.at(usize(6)), .Some(r) => r.to_u32(), .None => u32(0)) == u32(0x1F600),
     "the last rune is U+1F600"
   );
 });
@@ -507,7 +511,8 @@ test("String.from_utf8 validates and from_bytes does not", {
   match(
     String.from_utf8(good),
     .Ok(s) => {
-      assert(s.len() == usize(1), "e-acute is one rune");
+      assert(s.char_len() == usize(1), "e-acute is one rune");
+      assert(s.len() == usize(2), "and two bytes");
     },
     .Err(_) => assert(false, "valid bytes must be accepted")
   );

--- a/tests/fs/dir.test.yo
+++ b/tests/fs/dir.test.yo
@@ -117,6 +117,35 @@ test("create_dir_all creates nested directories", {
   io.await(fs_dir.remove_dir(Path.new(path_join(path_join(tmp, `yo_fs_dir_all`), `sub1`)), io), IoExn(io : io, exn : exn));
   io.await(fs_dir.remove_dir(Path.new(path_join(tmp, `yo_fs_dir_all`)), io), IoExn(io : io, exn : exn));
 });
+test("create_dir_all creates nested directories with a multibyte component", {
+  // The ENOENT recovery path walks `path_s.as_bytes()` and hands each
+  // separator's BYTE offset to `substring`. While `substring` was rune-indexed
+  // that cut the prefix in the wrong place for any non-ASCII component, so
+  // `create_dir_all` created the WRONG parent and then failed or built the
+  // wrong tree (issues/fixed/mkdir-all-uses-a-byte-index-as-a-rune-index.md,
+  // plans/STD_API_AUDIT_D4_PLAN.md §5.1). Byte-indexing `substring` (D4 PR 3)
+  // makes the two agree. This test is ASCII-invariant by construction — it
+  // only discriminates because the component is multibyte.
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  tmp := temp_dir();
+  root := path_join(tmp, `yo_fs_dir_all_日本語`);
+  lvl1 := path_join(root, `sub1`);
+  nested := Path.new(path_join(lvl1, `sub2`));
+  io.await(fs_dir.create_dir_all(nested, io), IoExn(io : io, exn : exn));
+  assert(io.await(fs_file.exists(nested, io), io), "the full nested path must exist");
+  assert(io.await(fs_file.exists(Path.new(lvl1), io), io), "the middle level must exist");
+  assert(io.await(fs_file.exists(Path.new(root), io), io), "the multibyte root must exist");
+  io.await(fs_dir.remove_dir(nested, io), IoExn(io : io, exn : exn));
+  io.await(fs_dir.remove_dir(Path.new(lvl1), io), IoExn(io : io, exn : exn));
+  io.await(fs_dir.remove_dir(Path.new(root), io), IoExn(io : io, exn : exn));
+});
 test("create_dir_all on existing directory succeeds", {
   exn := Exception(
     throw : (

--- a/tests/internal/formatter.test.yo
+++ b/tests/internal/formatter.test.yo
@@ -94,3 +94,28 @@ test("format_yo_source: fixture corpus from formatter.test.ts", {
   assert(failed == usize(0), "some formatter fixtures diverged (see above)");
   assert(checked >= usize(46), "fixture corpus missing (cwd must be the repo root)");
 });
+test("format_yo_source: a template string AFTER a multibyte character survives", {
+  // `read_raw_template_string` re-reads the template literal out of `input`
+  // by byte offset. It used to be handed `Token.character` — a RUNE index —
+  // and re-walked the buffer to convert; D4 PR 3 gave `Token` a real
+  // `byte_offset` and deleted that walk. Either way the failure mode is the
+  // same class: with a multibyte character EARLIER in the file the slice
+  // starts early and swallows the source before the backtick, producing
+  // non-parseable output at rc=0
+  // (issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md — 23 of
+  // 40 sampled std files with a backtick came out broken).
+  //
+  // The em dash below is what makes this test discriminating; the same source
+  // with an ASCII hyphen passes under a broken conversion.
+  src := String.from("//! doc — with an em dash\nf :: (fn(x : String) -> String)(`v=${x}`);\nexport(f);\n");
+  out := _fmt(src);
+  assert(out.contains(String.from("`v=${x}`")), "the template literal is intact");
+  assert(!(out.contains(String.from("`v=${x}`;\n`"))), "no duplicated tail");
+  assert(_fmt(out) == out, "and formatting is idempotent");
+});
+test("format_yo_source: multibyte content inside a template string is preserved", {
+  src := String.from("g :: (fn() -> String)(`名前 → ${String.new()}`);\nexport(g);\n");
+  out := _fmt(src);
+  assert(out.contains(String.from("名前 → ${String.new()}")), "multibyte body intact");
+  assert(_fmt(out) == out, "idempotent");
+});

--- a/tests/internal/lexer.test.yo
+++ b/tests/internal/lexer.test.yo
@@ -912,3 +912,82 @@ test("closed operator set: unknown operator run is a lex error", {
   _toks := tokenize(`a @@ b`, `test.yo`, exn);
   assert(false, "expected a LexerError for '@@'");
 });
+// ─── Token.byte_offset (D4 PR 3) ─────────────────────────────────────────────
+test("Token.byte_offset is a BYTE offset while character stays a rune index", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected error");
+        unwind(());
+      }
+    )
+  );
+  // `名` and `前` are 3 bytes each, so every token after the string literal
+  // has byte_offset > character. `Token.character` is the lexer's
+  // `input.chars()` counter; `Token.byte_offset` is what may index `input`
+  // (issues/fixed/yo-self-formatter-corrupts-files-with-non-ascii.md).
+  src := `a := "名前"; b := 1;`;
+  toks := non_ws(lex_or_panic(src, exn));
+  // a  :=  "名前"  ;  b  :=  1  ;  → 8 tokens
+  assert(toks.len() == usize(8), "expected 8 non-whitespace tokens");
+  match(
+    toks.get(usize(2)),
+    .None => assert(false, "no token at 2"),
+    .Some(tok) => {
+      assert(tok.kind == TokenKind.StringLit, "token 2 is the string literal");
+      assert(tok.character == usize(5), "rune index of the opening quote");
+      assert(tok.byte_offset == usize(5), "byte offset agrees before any multibyte");
+    }
+  );
+  match(
+    toks.get(usize(3)),
+    .None => assert(false, "no token at 3"),
+    .Some(tok) => {
+      assert(tok.value == `;`, "token 3 is the semicolon");
+      // "a := \"名前\"" is 5 + 1 + 6 + 1 = 13 bytes but 5 + 1 + 2 + 1 = 9 runes.
+      assert(tok.character == usize(9), "rune index after the literal");
+      assert(tok.byte_offset == usize(13), "byte offset after the literal");
+    }
+  );
+  // Every token's byte_offset must index `input` back to its own first byte.
+  (i : usize) = usize(0);
+  while(i < toks.len(), {
+    match(
+      toks.get(i),
+      .None => (),
+      .Some(tok) => {
+        assert(tok.input.is_char_boundary(tok.byte_offset), "byte_offset is a rune boundary");
+        assert(
+          tok.input.starts_with(tok.value.substring(usize(0), usize(1)), tok.byte_offset),
+          "byte_offset points at the token's own first byte"
+        );
+      }
+    );
+    i = (i + usize(1));
+  });
+});
+test("Token.byte_offset tracks a multibyte operator run correctly", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected error");
+        unwind(());
+      }
+    )
+  );
+  // The operator-run splitter advances `column`, `character` and
+  // `byte_offset` by the same `k`, which is only sound because every
+  // operator char is one ASCII byte.
+  src := `名 <= 名`;
+  toks := non_ws(lex_or_panic(src, exn));
+  assert(toks.len() == usize(3), "名 <= 名");
+  match(
+    toks.get(usize(1)),
+    .None => assert(false, "no token at 1"),
+    .Some(tok) => {
+      assert(tok.value == `<=`, "the operator token");
+      assert(tok.character == usize(2), "rune index 2");
+      assert(tok.byte_offset == usize(4), "byte offset 4 (名 is 3 bytes + space)");
+    }
+  );
+});

--- a/tests/string/string.test.yo
+++ b/tests/string/string.test.yo
@@ -66,7 +66,11 @@ test("String UTF-8 2-byte character length", {
   bytes.push(u8(0xC2));
   bytes.push(u8(0xA9));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(1));
+  // U+00A9 © is one rune in two bytes. `len()` counts BYTES since D4
+  // (plans/STD_API_AUDIT_D4_PLAN.md PR 3); `char_len()` is the rune count
+  // this used to assert.
+  assert(s.len() == usize(2));
+  assert(s.char_len() == usize(1));
 });
 test("String UTF-8 2-byte character decode", {
   bytes := ArrayList(u8).new();
@@ -86,16 +90,21 @@ test("String UTF-8 2-byte multiple characters", {
   bytes.push(u8(0xC3));
   bytes.push(u8(0xB1));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(3));
+  // é ç ñ — three 2-byte runes at byte offsets 0, 2, 4.
+  assert(s.len() == usize(6));
+  assert(s.char_len() == usize(3));
   first := s.at(usize(0));
   assert(first.is_some());
   assert(first.unwrap().to_u32() == u32(0xE9));
-  second := s.at(usize(1));
+  second := s.at(usize(2));
   assert(second.is_some());
   assert(second.unwrap().to_u32() == u32(0xE7));
-  third := s.at(usize(2));
+  third := s.at(usize(4));
   assert(third.is_some());
   assert(third.unwrap().to_u32() == u32(0xF1));
+  // A continuation byte is not the start of a rune, so `at` answers `.None`.
+  assert(s.at(usize(1)).is_none());
+  assert(s.at(usize(3)).is_none());
 });
 // ===== UTF-8 3-byte Character Tests =====
 test("String UTF-8 3-byte character length", {
@@ -104,7 +113,9 @@ test("String UTF-8 3-byte character length", {
   bytes.push(u8(0xB8));
   bytes.push(u8(0xAD));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(1));
+  // U+4E2D 中 is one rune in three bytes.
+  assert(s.len() == usize(3));
+  assert(s.char_len() == usize(1));
 });
 test("String UTF-8 3-byte character decode", {
   bytes := ArrayList(u8).new();
@@ -125,11 +136,13 @@ test("String UTF-8 3-byte multiple characters", {
   bytes.push(u8(0x96));
   bytes.push(u8(0x87));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(2));
+  // 中 文 — two 3-byte runes at byte offsets 0 and 3.
+  assert(s.len() == usize(6));
+  assert(s.char_len() == usize(2));
   first := s.at(usize(0));
   assert(first.is_some());
   assert(first.unwrap().to_u32() == u32(0x4E2D));
-  second := s.at(usize(1));
+  second := s.at(usize(3));
   assert(second.is_some());
   assert(second.unwrap().to_u32() == u32(0x6587));
 });
@@ -141,7 +154,9 @@ test("String UTF-8 4-byte character length", {
   bytes.push(u8(0x98));
   bytes.push(u8(0x80));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(1));
+  // U+1F600 😀 is one rune in four bytes.
+  assert(s.len() == usize(4));
+  assert(s.char_len() == usize(1));
 });
 test("String UTF-8 4-byte character decode", {
   bytes := ArrayList(u8).new();
@@ -165,11 +180,13 @@ test("String UTF-8 4-byte multiple characters", {
   bytes.push(u8(0x98));
   bytes.push(u8(0x81));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(2));
+  // 😀 😁 — two 4-byte runes at byte offsets 0 and 4.
+  assert(s.len() == usize(8));
+  assert(s.char_len() == usize(2));
   first := s.at(usize(0));
   assert(first.is_some());
   assert(first.unwrap().to_u32() == u32(0x1F600));
-  second := s.at(usize(1));
+  second := s.at(usize(4));
   assert(second.is_some());
   assert(second.unwrap().to_u32() == u32(0x1F601));
 });
@@ -185,14 +202,16 @@ test("String mixed ASCII and UTF-8", {
   bytes.push(u8(0x96));
   bytes.push(u8(0x87));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(4));
+  // "He中文" — H@0 e@1 中@2..5 文@5..8.
+  assert(s.len() == usize(8));
+  assert(s.char_len() == usize(4));
   first := s.at(usize(0));
   assert(first.unwrap().to_u32() == u32(72));
   second := s.at(usize(1));
   assert(second.unwrap().to_u32() == u32(101));
   third := s.at(usize(2));
   assert(third.unwrap().to_u32() == u32(0x4E2D));
-  fourth := s.at(usize(3));
+  fourth := s.at(usize(5));
   assert(fourth.unwrap().to_u32() == u32(0x6587));
 });
 test("String mixed 1,2,3,4 byte characters", {
@@ -208,14 +227,16 @@ test("String mixed 1,2,3,4 byte characters", {
   bytes.push(u8(0x98));
   bytes.push(u8(0x80));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(4));
+  // "A©中😀" — A@0 (1B), ©@1 (2B), 中@3 (3B), 😀@6 (4B); 10 bytes, 4 runes.
+  assert(s.len() == usize(10));
+  assert(s.char_len() == usize(4));
   char0 := s.at(usize(0));
   assert(char0.unwrap().to_u32() == u32(65));
   char1 := s.at(usize(1));
   assert(char1.unwrap().to_u32() == u32(0xA9));
-  char2 := s.at(usize(2));
+  char2 := s.at(usize(3));
   assert(char2.unwrap().to_u32() == u32(0x4E2D));
-  char3 := s.at(usize(3));
+  char3 := s.at(usize(6));
   assert(char3.unwrap().to_u32() == u32(0x1F600));
 });
 // ===== Concat Tests =====
@@ -271,9 +292,11 @@ test("String concat UTF-8 strings", {
   str1 := String.from_bytes(bytes1);
   str2 := String.from_bytes(bytes2);
   result := str1.concat(str2);
-  assert(result.len() == usize(2));
+  // 中 @0, 文 @3.
+  assert(result.len() == usize(6));
+  assert(result.char_len() == usize(2));
   assert(result.at(usize(0)).unwrap().to_u32() == u32(0x4E2D));
-  assert(result.at(usize(1)).unwrap().to_u32() == u32(0x6587));
+  assert(result.at(usize(3)).unwrap().to_u32() == u32(0x6587));
 });
 test("String concat preserves original strings", {
   bytes1 := ArrayList(u8).new();
@@ -325,7 +348,7 @@ test("String at() on single character", {
   invalid := s.at(usize(1));
   assert(invalid.is_none());
 });
-test("String length with continuation bytes only counts starts", {
+test("String len counts bytes while char_len only counts rune starts", {
   bytes := ArrayList(u8).new();
   bytes.push(u8(0xE4));
   bytes.push(u8(0xB8));
@@ -335,9 +358,11 @@ test("String length with continuation bytes only counts starts", {
   bytes.push(u8(0x87));
   s := String.from_bytes(bytes);
   byte_count := s.as_bytes().len();
-  char_count := s.len();
   assert(byte_count == usize(6));
-  assert(char_count == usize(2));
+  // `len()` IS the byte count since D4; `char_len()` is the one that skips
+  // UTF-8 continuation bytes.
+  assert(s.len() == byte_count);
+  assert(s.char_len() == usize(2));
 });
 test("String multiple concat operations", {
   bytes1 := ArrayList(u8).new();
@@ -428,7 +453,9 @@ test("String.from_cstr with UTF-8", {
   match(
     result,
     .Ok(s) => {
-      assert(s.len() == usize(8));
+      // "Hello " is 6 ASCII bytes, 世界 is 3 + 3 → 12 bytes, 8 runes.
+      assert(s.len() == usize(12));
+      assert(s.char_len() == usize(8));
     },
     .Err(_) => assert(false, "Should handle UTF-8 in C string")
   );
@@ -460,13 +487,15 @@ test("String.from with empty string literal", {
 });
 test("String.from with UTF-8 literal", {
   s := String.from("你好");
-  assert(s.len() == usize(2));
+  assert(s.len() == usize(6));
+  assert(s.char_len() == usize(2));
 });
 test("String.from with emoji literal", {
   s := String.from("😀😁");
-  assert(s.len() == usize(2));
+  assert(s.len() == usize(8));
+  assert(s.char_len() == usize(2));
   assert(s.at(usize(0)).unwrap().to_u32() == u32(0x1F600));
-  assert(s.at(usize(1)).unwrap().to_u32() == u32(0x1F601));
+  assert(s.at(usize(4)).unwrap().to_u32() == u32(0x1F601));
 });
 // ===== Large String Tests =====
 test("String with many ASCII characters", {
@@ -519,12 +548,14 @@ test("String Greek characters", {
   bytes.push(u8(0xCE));
   bytes.push(u8(0xB3));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(3));
+  // α β γ — three 2-byte runes at byte offsets 0, 2, 4.
+  assert(s.len() == usize(6));
+  assert(s.char_len() == usize(3));
   alpha := s.at(usize(0));
   assert(alpha.unwrap().to_u32() == u32(0x3B1));
-  beta := s.at(usize(1));
+  beta := s.at(usize(2));
   assert(beta.unwrap().to_u32() == u32(0x3B2));
-  gamma := s.at(usize(2));
+  gamma := s.at(usize(4));
   assert(gamma.unwrap().to_u32() == u32(0x3B3));
 });
 test("String Cyrillic characters", {
@@ -536,12 +567,14 @@ test("String Cyrillic characters", {
   bytes.push(u8(0xD0));
   bytes.push(u8(0xB8));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(3));
+  // П р и — three 2-byte runes at byte offsets 0, 2, 4.
+  assert(s.len() == usize(6));
+  assert(s.char_len() == usize(3));
   p := s.at(usize(0));
   assert(p.unwrap().to_u32() == u32(0x41F));
-  r := s.at(usize(1));
+  r := s.at(usize(2));
   assert(r.unwrap().to_u32() == u32(0x440));
-  i := s.at(usize(2));
+  i := s.at(usize(4));
   assert(i.unwrap().to_u32() == u32(0x438));
 });
 test("String Arabic characters", {
@@ -551,10 +584,12 @@ test("String Arabic characters", {
   bytes.push(u8(0xD9));
   bytes.push(u8(0x84));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(2));
+  // ا ل — two 2-byte runes at byte offsets 0 and 2.
+  assert(s.len() == usize(4));
+  assert(s.char_len() == usize(2));
   alef := s.at(usize(0));
   assert(alef.unwrap().to_u32() == u32(0x627));
-  lam := s.at(usize(1));
+  lam := s.at(usize(2));
   assert(lam.unwrap().to_u32() == u32(0x644));
 });
 test("String Hebrew characters", {
@@ -564,10 +599,12 @@ test("String Hebrew characters", {
   bytes.push(u8(0xD7));
   bytes.push(u8(0x9C));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(2));
+  // ש ל — two 2-byte runes at byte offsets 0 and 2.
+  assert(s.len() == usize(4));
+  assert(s.char_len() == usize(2));
   shin := s.at(usize(0));
   assert(shin.unwrap().to_u32() == u32(0x5E9));
-  lamed := s.at(usize(1));
+  lamed := s.at(usize(2));
   assert(lamed.unwrap().to_u32() == u32(0x5DC));
 });
 test("String Japanese Hiragana", {
@@ -579,10 +616,12 @@ test("String Japanese Hiragana", {
   bytes.push(u8(0x81));
   bytes.push(u8(0x84));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(2));
+  // あ い — two 3-byte runes at byte offsets 0 and 3.
+  assert(s.len() == usize(6));
+  assert(s.char_len() == usize(2));
   a := s.at(usize(0));
   assert(a.unwrap().to_u32() == u32(0x3042));
-  i := s.at(usize(1));
+  i := s.at(usize(3));
   assert(i.unwrap().to_u32() == u32(0x3044));
 });
 test("String Korean Hangul", {
@@ -594,10 +633,12 @@ test("String Korean Hangul", {
   bytes.push(u8(0xB8));
   bytes.push(u8(0x80));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(2));
+  // 한 글 — two 3-byte runes at byte offsets 0 and 3.
+  assert(s.len() == usize(6));
+  assert(s.char_len() == usize(2));
   han := s.at(usize(0));
   assert(han.unwrap().to_u32() == u32(0xD55C));
-  gul := s.at(usize(1));
+  gul := s.at(usize(3));
   assert(gul.unwrap().to_u32() == u32(0xAE00));
 });
 // ===== More Emoji Tests =====
@@ -616,12 +657,14 @@ test("String various emojis", {
   bytes.push(u8(0x8E));
   bytes.push(u8(0x89));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(3));
+  // 😀 👍 🎉 — three 4-byte runes at byte offsets 0, 4, 8.
+  assert(s.len() == usize(12));
+  assert(s.char_len() == usize(3));
   grinning := s.at(usize(0));
   assert(grinning.unwrap().to_u32() == u32(0x1F600));
-  thumbsup := s.at(usize(1));
+  thumbsup := s.at(usize(4));
   assert(thumbsup.unwrap().to_u32() == u32(0x1F44D));
-  tada := s.at(usize(2));
+  tada := s.at(usize(8));
   assert(tada.unwrap().to_u32() == u32(0x1F389));
 });
 // ===== Whitespace and Special Character Tests =====
@@ -655,7 +698,9 @@ test("String concat with special characters", {
   str1 := String.from("Hello");
   str2 := String.from(" 世界");
   result := str1.concat(str2);
-  assert(result.len() == usize(8));
+  // 5 ASCII + 1 space + 3 + 3 = 12 bytes, 8 runes.
+  assert(result.len() == usize(12));
+  assert(result.char_len() == usize(8));
 });
 test("String concat three strings", {
   str1 := String.from("A");
@@ -705,13 +750,16 @@ test("String + operator UTF-8 strings", {
   str1 := String.from("你");
   str2 := String.from("好");
   result := (str1 + str2);
-  assert(result.len() == usize(2));
+  assert(result.len() == usize(6));
+  assert(result.char_len() == usize(2));
 });
 test("String + operator mixed ASCII and UTF-8", {
   str1 := String.from("Hello ");
   str2 := String.from("世界");
   result := (str1 + str2);
-  assert(result.len() == usize(8));
+  // 6 ASCII + 3 + 3 = 12 bytes, 8 runes.
+  assert(result.len() == usize(12));
+  assert(result.char_len() == usize(8));
 });
 test("String + operator chain", {
   str1 := String.from("A");
@@ -839,12 +887,14 @@ test("String alternating ASCII and UTF-8", {
   bytes.push(u8(0x87));
   bytes.push(u8(67));
   s := String.from_bytes(bytes);
-  assert(s.len() == usize(5));
+  // "A中B文C" — A@0, 中@1..4, B@4, 文@5..8, C@8; 9 bytes, 5 runes.
+  assert(s.len() == usize(9));
+  assert(s.char_len() == usize(5));
   assert(s.at(usize(0)).unwrap().to_u32() == u32(65));
   assert(s.at(usize(1)).unwrap().to_u32() == u32(0x4E2D));
-  assert(s.at(usize(2)).unwrap().to_u32() == u32(66));
-  assert(s.at(usize(3)).unwrap().to_u32() == u32(0x6587));
-  assert(s.at(usize(4)).unwrap().to_u32() == u32(67));
+  assert(s.at(usize(4)).unwrap().to_u32() == u32(66));
+  assert(s.at(usize(5)).unwrap().to_u32() == u32(0x6587));
+  assert(s.at(usize(8)).unwrap().to_u32() == u32(67));
 });
 // ===== substring Tests =====
 test("String substring ASCII basic", {
@@ -878,34 +928,41 @@ test("String substring from middle to end", {
   assert(sub == expected);
 });
 test("String substring UTF-8 characters", {
+  // 你@0..3 好@3..6 世@6..9 界@9..12 — BYTE offsets since D4.
   s := String.from("你好世界");
-  sub1 := s.substring(usize(0), usize(2));
+  sub1 := s.substring(usize(0), usize(6));
   expected1 := String.from("你好");
   assert(sub1 == expected1);
-  sub2 := s.substring(usize(2), usize(4));
+  sub2 := s.substring(usize(6), usize(12));
   expected2 := String.from("世界");
   assert(sub2 == expected2);
-  sub3 := s.substring(usize(1), usize(3));
+  sub3 := s.substring(usize(3), usize(9));
   expected3 := String.from("好世");
   assert(sub3 == expected3);
+  // `char_substring` keeps the pre-D4 rune indexing.
+  assert(s.char_substring(usize(1), usize(3)) == expected3);
 });
 test("String substring mixed ASCII and UTF-8", {
+  // "Hello "@0..6, 世@6..9, 界@9..12, "!"@12.
   s := String.from("Hello 世界!");
   sub1 := s.substring(usize(0), usize(5));
   expected1 := String.from("Hello");
   assert(sub1 == expected1);
-  sub2 := s.substring(usize(6), usize(8));
+  sub2 := s.substring(usize(6), usize(12));
   expected2 := String.from("世界");
   assert(sub2 == expected2);
+  assert(s.char_substring(usize(6), usize(8)) == expected2);
 });
 test("String substring with emojis", {
+  // 😀@0..4 😁@4..8 😂@8..12.
   s := String.from("😀😁😂");
-  sub1 := s.substring(usize(0), usize(2));
+  sub1 := s.substring(usize(0), usize(8));
   expected1 := String.from("😀😁");
   assert(sub1 == expected1);
-  sub2 := s.substring(usize(1), usize(3));
+  sub2 := s.substring(usize(4), usize(12));
   expected2 := String.from("😁😂");
   assert(sub2 == expected2);
+  assert(s.char_substring(usize(1), usize(3)) == expected2);
 });
 test("String substring beyond end", {
   s := String.from("Hello");
@@ -959,16 +1016,18 @@ test("String index_of substring longer than string", {
   assert(result.is_none());
 });
 test("String index_of UTF-8 characters", {
+  // BYTE offsets out, so the answer feeds straight back into `substring`.
   s := String.from("你好世界");
   result1 := s.index_of(String.from("世界"));
   assert(result1.is_some());
-  assert(result1.unwrap() == usize(2));
+  assert(result1.unwrap() == usize(6));
   result2 := s.index_of(String.from("你好"));
   assert(result2.is_some());
   assert(result2.unwrap() == usize(0));
   result3 := s.index_of(String.from("好世"));
   assert(result3.is_some());
-  assert(result3.unwrap() == usize(1));
+  assert(result3.unwrap() == usize(3));
+  assert(s.substring(result3.unwrap(), result3.unwrap() + usize(6)) == String.from("好世"));
 });
 test("String index_of mixed ASCII and UTF-8", {
   s := String.from("Hello 世界!");
@@ -980,7 +1039,7 @@ test("String index_of with emojis", {
   s := String.from("😀😁😂");
   result := s.index_of(String.from("😁"));
   assert(result.is_some());
-  assert(result.unwrap() == usize(1));
+  assert(result.unwrap() == usize(4));
 });
 test("String index_of case sensitive", {
   s := String.from("Hello World");
@@ -1192,13 +1251,17 @@ test("String index_of with from_index beyond string", {
   assert(result.is_none());
 });
 test("String index_of with from_index UTF-8", {
+  // 你@0 好@3 世@6 界@9 你@12 好@15 — 18 bytes.
   s := String.from("你好世界你好");
   result1 := s.index_of(String.from("你好"), usize(0));
   assert(result1.is_some());
   assert(result1.unwrap() == usize(0));
+  // `from_index` is a BYTE offset, and it need not be a rune boundary:
+  // a valid-UTF-8 needle can never match starting inside a rune, so
+  // starting the scan at byte 1 skips the match at 0 and finds the one at 12.
   result2 := s.index_of(String.from("你好"), usize(1));
   assert(result2.is_some());
-  assert(result2.unwrap() == usize(4));
+  assert(result2.unwrap() == usize(12));
 });
 // ===== last_index_of Tests =====
 test("String last_index_of finds last occurrence", {
@@ -1234,7 +1297,12 @@ test("String last_index_of UTF-8", {
   s := String.from("你好世界你好");
   result := s.last_index_of(String.from("你好"));
   assert(result.is_some());
-  assert(result.unwrap() == usize(4));
+  assert(result.unwrap() == usize(12));
+  // Capping the start at byte 11 excludes the last occurrence and finds the
+  // first one instead.
+  capped := s.last_index_of(String.from("你好"), usize(11));
+  assert(capped.is_some());
+  assert(capped.unwrap() == usize(0));
 });
 test("String last_index_of multiple same characters", {
   s := String.from("aaaa");
@@ -1625,10 +1693,16 @@ test("String starts_with position skips prefix", {
   assert(s.starts_with(String.from("def"), usize(3)));
 });
 test("String starts_with position UTF-8", {
+  // `position` is a BYTE offset. Before D4 this was a rune walk that stopped
+  // one byte past a lead byte, so `starts_with("世界", 2)` could not be
+  // expressed at all (plans/STD_API_AUDIT_D4_PLAN.md §1.3(a)).
   s := String.from("你好世界");
   assert(s.starts_with(String.from("你好"), usize(0)));
-  assert(s.starts_with(String.from("世界"), usize(2)));
-  assert(s.starts_with(String.from("好世"), usize(1)));
+  assert(s.starts_with(String.from("世界"), usize(6)));
+  assert(s.starts_with(String.from("好世"), usize(3)));
+  // A mid-rune position simply cannot match — no panic, just `false`.
+  assert(not(s.starts_with(String.from("世界"), usize(5))));
+  assert(not(s.starts_with(String.from("好世"), usize(1))));
 });
 test("String starts_with position beyond length", {
   s := String.from("Hello");
@@ -1637,8 +1711,8 @@ test("String starts_with position beyond length", {
 test("String starts_with position with emojis", {
   s := String.from("😀😁😂");
   assert(s.starts_with(String.from("😀"), usize(0)));
-  assert(s.starts_with(String.from("😁"), usize(1)));
-  assert(s.starts_with(String.from("😂"), usize(2)));
+  assert(s.starts_with(String.from("😁"), usize(4)));
+  assert(s.starts_with(String.from("😂"), usize(8)));
 });
 test("String starts_with position empty prefix", {
   s := String.from("Hello");
@@ -1668,11 +1742,14 @@ test("String ends_with end_position middle", {
   assert(s.ends_with(String.from("c"), usize(3)));
 });
 test("String ends_with end_position UTF-8", {
+  // `end_position` is how many BYTES of `s` to consider.
   s := String.from("你好世界");
-  assert(s.ends_with(String.from("你好"), usize(2)));
-  assert(s.ends_with(String.from("好"), usize(2)));
-  assert(s.ends_with(String.from("你"), usize(1)));
-  assert(s.ends_with(String.from("世界"), usize(4)));
+  assert(s.ends_with(String.from("你好"), usize(6)));
+  assert(s.ends_with(String.from("好"), usize(6)));
+  assert(s.ends_with(String.from("你"), usize(3)));
+  assert(s.ends_with(String.from("世界"), usize(12)));
+  // Cutting mid-rune cannot match a valid-UTF-8 suffix.
+  assert(not(s.ends_with(String.from("好"), usize(5))));
 });
 test("String ends_with end_position zero", {
   s := String.from("Hello");
@@ -1685,9 +1762,9 @@ test("String ends_with end_position beyond length", {
 });
 test("String ends_with end_position with emojis", {
   s := String.from("😀😁😂");
-  assert(s.ends_with(String.from("😀"), usize(1)));
-  assert(s.ends_with(String.from("😀😁"), usize(2)));
-  assert(s.ends_with(String.from("😂"), usize(3)));
+  assert(s.ends_with(String.from("😀"), usize(4)));
+  assert(s.ends_with(String.from("😀😁"), usize(8)));
+  assert(s.ends_with(String.from("😂"), usize(12)));
 });
 test("String ends_with end_position empty suffix", {
   s := String.from("Hello");
@@ -1695,9 +1772,10 @@ test("String ends_with end_position empty suffix", {
   assert(s.ends_with(String.from(""), usize(3)));
 });
 test("String ends_with end_position mixed ASCII and UTF-8", {
+  // "Hello "@0..6, 世@6..9, 界@9..12.
   s := String.from("Hello 世界");
   assert(s.ends_with(String.from("Hello"), usize(5)));
-  assert(s.ends_with(String.from(" 世"), usize(7)));
+  assert(s.ends_with(String.from(" 世"), usize(9)));
   assert(not(s.ends_with(String.from("世界"), usize(5))));
 });
 test("String ends_with end_position single character", {

--- a/tests/string/string_byte_index.test.yo
+++ b/tests/string/string_byte_index.test.yo
@@ -250,6 +250,50 @@ test("String contains from_index is a byte offset", {
   assert(!(s.contains(`é`, usize(2))), "past é's start");
 });
 // ===========================================================================
+// The EMPTY needle — the one documented hole in "every index this returns is
+// a rune boundary". Pinned here because a search result is documented as safe
+// to feed straight back into `substring`, and `substring` PANICS at a
+// non-boundary, so the exception has to be visible rather than folklore.
+// ===========================================================================
+test("String index_of with an empty needle answers from_index verbatim", {
+  s := _subject();
+  e := String.new();
+  // Boundary case: the ordinary answer.
+  assert(s.index_of(e.clone(), usize(0)).unwrap() == usize(0), "empty needle at 0");
+  assert(s.index_of(e.clone(), usize(3)).unwrap() == usize(3), "empty needle at a boundary");
+  // NOT a boundary — `index_of` hands the offset straight back, so this is the
+  // one result that must NOT be fed to `substring` unchecked.
+  assert(s.index_of(e.clone(), usize(2)).unwrap() == usize(2), "empty needle mid-rune");
+  assert(!(s.is_char_boundary(usize(2))), "and byte 2 really is inside a rune");
+  assert(s.try_substring(usize(0), usize(2)).is_none(), "which try_substring refuses");
+  // And past the end: unclamped (JavaScript's indexOf("") would clamp to len).
+  assert(s.index_of(e.clone(), usize(99)).unwrap() == usize(99), "empty needle past the end");
+  assert(s.contains(e.clone(), usize(2)), "contains agrees with index_of");
+  // last_index_of's empty-needle arm ignores from_index entirely.
+  assert(s.last_index_of(e.clone()).unwrap() == usize(10), "empty needle is at len()");
+  assert(s.last_index_of(e.clone(), usize(2)).unwrap() == usize(10), "even under a lower cap");
+});
+// ===========================================================================
+// floor / ceil char boundary — the arithmetic escape hatch named by
+// substring's boundary policy
+// ===========================================================================
+test("String floor and ceil char boundary snap onto rune starts", {
+  s := _subject();
+  // a@0 é@1 中@3 𝄞@6, len 10.
+  assert(s.floor_char_boundary(usize(0)) == usize(0), "0 is already a boundary");
+  assert(s.floor_char_boundary(usize(2)) == usize(1), "inside é snaps back to 1");
+  assert(s.floor_char_boundary(usize(5)) == usize(3), "inside 中 snaps back to 3");
+  assert(s.floor_char_boundary(usize(9)) == usize(6), "inside 𝄞 snaps back to 6");
+  assert(s.floor_char_boundary(usize(10)) == usize(10), "len is a boundary");
+  assert(s.ceil_char_boundary(usize(2)) == usize(3), "inside é snaps up to 中");
+  assert(s.ceil_char_boundary(usize(4)) == usize(6), "inside 中 snaps up to 𝄞");
+  assert(s.ceil_char_boundary(usize(7)) == usize(10), "inside 𝄞 snaps up to len");
+  // Snapping first is what makes an arbitrary byte offset safe to slice with.
+  a := s.floor_char_boundary(usize(2));
+  b := s.ceil_char_boundary(usize(5));
+  assert(s.substring(a, b) == `é中`, "snapped endpoints slice cleanly");
+});
+// ===========================================================================
 // starts_with(position) / ends_with(end_position)
 // ===========================================================================
 test("String starts_with position is a byte offset — the 1.3(a) fix", {

--- a/tests/string/string_byte_index.test.yo
+++ b/tests/string/string_byte_index.test.yo
@@ -1,0 +1,321 @@
+//! The BYTE index basis of `String` — `plans/STD_API_AUDIT_D4_PLAN.md` D4 PR 3.
+//!
+//! Every assertion here is against multibyte content with HAND-COMPUTED byte
+//! offsets, and every one of them has a DIFFERENT answer under the pre-D4
+//! rune basis. That is the point: a basis error is invisible to ASCII input by
+//! construction, so an ASCII test of these methods proves nothing
+//! (`plans/STD_API_AUDIT_D4_PLAN.md` §6.1-§6.2). The pre-D4 answer is written
+//! beside each assertion that has one, so the discrimination is auditable
+//! without running the old code.
+//!
+//! The canonical subject covers all four UTF-8 widths in one string:
+//!
+//! ```text
+//!   rune   a      é         中           𝄞
+//!   width  1B     2B        3B           4B          10 bytes, 4 runes
+//!   bytes  61     C3 A9     E4 B8 AD     F0 9D 84 9E
+//!   offset 0      1  2      3  4  5      6  7  8  9
+//! ```
+//!
+//! Boundary policy under test (`String.substring`'s doc comment is the
+//! contract): out-of-range CLAMPS, a non-boundary index PANICS, and
+//! `try_substring` is the non-panicking form. The panic arm cannot be
+//! asserted from inside a test batch — a panic aborts the process and takes
+//! every other test in the file with it — so it is covered by a standalone
+//! driver instead; `try_substring`'s `.None` at the same indices is what is
+//! asserted here.
+{ assert } :: import("std/assert");
+open(import("std/fmt"));
+open(import("std/string"));
+open(import("std/collections/array_list"));
+/// The four-width subject string, rebuilt per test so nothing is shared.
+_subject :: (fn() -> String)(
+  `aé中𝄞`
+);
+// ===========================================================================
+// len — BYTES, O(1)
+// ===========================================================================
+test("String len counts bytes, not runes", {
+  s := _subject();
+  // pre-D4: 4
+  assert(s.len() == usize(10), "10 bytes");
+  assert(s.char_len() == usize(4), "4 runes");
+  assert(s.len() == s.as_bytes().len(), "len IS the buffer length");
+  // pre-D4: 2 / 2 / 3
+  assert(`你好`.len() == usize(6), "two 3-byte runes");
+  assert(`😀😁`.len() == usize(8), "two 4-byte runes");
+  assert(`abc`.len() == usize(3), "ASCII agrees in both bases");
+  assert(String.new().len() == usize(0), "empty");
+});
+test("String bytes_len is a deprecated alias of len", {
+  s := _subject();
+  assert(s.bytes_len() == s.len(), "alias tracks len");
+  assert(s.bytes_len() == usize(10), "and is still the byte count");
+});
+// ===========================================================================
+// at — decode the rune STARTING at a byte offset
+// ===========================================================================
+test("String at takes a byte offset and refuses continuation bytes", {
+  s := _subject();
+  // pre-D4: at(1) was 'é' (rune index 1); now byte 1 is where 'é' STARTS,
+  // so the value coincides — but at(2) diverges hard.
+  assert(s.at(usize(0)).unwrap().to_u32() == u32(0x61), "byte 0 -> 'a'");
+  assert(s.at(usize(1)).unwrap().to_u32() == u32(0xE9), "byte 1 -> 'é'");
+  // pre-D4: at(2) was '中'; it is now the SECOND byte of 'é'.
+  assert(s.at(usize(2)).is_none(), "byte 2 is inside 'é'");
+  assert(s.at(usize(3)).unwrap().to_u32() == u32(0x4E2D), "byte 3 -> '中'");
+  assert(s.at(usize(4)).is_none(), "byte 4 is inside '中'");
+  assert(s.at(usize(5)).is_none(), "byte 5 is inside '中'");
+  assert(s.at(usize(6)).unwrap().to_u32() == u32(0x1D11E), "byte 6 -> '𝄞'");
+  assert(s.at(usize(7)).is_none(), "byte 7 is inside '𝄞'");
+  assert(s.at(usize(8)).is_none(), "byte 8 is inside '𝄞'");
+  assert(s.at(usize(9)).is_none(), "byte 9 is inside '𝄞'");
+  assert(s.at(usize(10)).is_none(), "byte 10 is past the end");
+  assert(s.at(usize(99)).is_none(), "far past the end");
+});
+test("String at agrees with char_indices at every rune start", {
+  s := _subject();
+  it := s.char_indices();
+  (n : usize) = usize(0);
+  while(true, {
+    match(
+      it.next(),
+      .None => {
+        break;
+      },
+      .Some(p) => {
+        assert(s.at(p._0).is_some(), "char_indices offsets decode");
+        assert(s.at(p._0).unwrap().to_u32() == p._1.to_u32(), "same rune");
+        n = (n + usize(1));
+      }
+    );
+  });
+  assert(n == usize(4), "walked all four runes");
+});
+// ===========================================================================
+// substring — BYTE range, clamping out of range
+// ===========================================================================
+test("String substring slices by byte offsets", {
+  s := _subject();
+  // pre-D4: substring(1, 3) was "é中"; it is now exactly "é".
+  assert(s.substring(usize(1), usize(3)) == `é`, "bytes 1..3 是 'é'");
+  // pre-D4: substring(3, 6) was the empty string (rune 3..6 past the end
+  // after clamping start=3 to the last rune); it is now "中".
+  assert(s.substring(usize(3), usize(6)) == `中`, "bytes 3..6");
+  assert(s.substring(usize(6), usize(10)) == `𝄞`, "bytes 6..10");
+  assert(s.substring(usize(0), usize(1)) == `a`, "byte 0..1");
+  assert(s.substring(usize(0), usize(10)) == s, "the whole string");
+});
+test("String substring clamps out-of-range endpoints", {
+  s := _subject();
+  assert(s.substring(usize(0), usize(999)) == s, "end past the buffer clamps");
+  assert(s.substring(usize(999), usize(1000)) == String.new(), "start past the buffer");
+  assert(s.substring(usize(6), usize(3)) == String.new(), "start >= end is empty");
+  assert(s.substring(usize(3), usize(3)) == String.new(), "empty range");
+});
+test("String substring round-trips through char_indices", {
+  // §6.1 item 2: for every pair of boundaries produced by char_indices, the
+  // slice between them must be exactly the runes in that span.
+  s := _subject();
+  offsets := ArrayList(usize).new();
+  {
+    it := s.char_indices();
+    while(true, {
+      match(
+        it.next(),
+        .None => {
+          break;
+        },
+        .Some(p) => offsets.push(p._0)
+      );
+    });
+  };
+  offsets.push(s.len());
+  (i : usize) = usize(0);
+  while(i < offsets.len(), {
+    (j : usize) = i;
+    while(j < offsets.len(), {
+      a := offsets(i);
+      b := offsets(j);
+      piece := s.substring(a, b);
+      assert(piece.char_len() == (j - i), "rune count of the span");
+      assert(piece.len() == (b - a), "byte count of the span");
+      assert(piece == s.char_substring(i, j), "agrees with the rune slice");
+      j = (j + usize(1));
+    });
+    i = (i + usize(1));
+  });
+});
+test("String is_char_boundary agrees with char_indices, byte for byte", {
+  // §6.1 item 2: `is_char_boundary(i)` must be true exactly at the offsets
+  // char_indices yields, plus len().
+  s := _subject();
+  starts := ArrayList(bool).new();
+  (k : usize) = usize(0);
+  while(k <= s.len(), {
+    starts.push(false);
+    k = (k + usize(1));
+  });
+  {
+    it := s.char_indices();
+    while(true, {
+      match(
+        it.next(),
+        .None => {
+          break;
+        },
+        .Some(p) => {
+          starts(p._0) = true;
+        }
+      );
+    });
+  };
+  starts(s.len()) = true;
+  (i : usize) = usize(0);
+  while(i <= s.len(), {
+    assert(s.is_char_boundary(i) == starts(i), `boundary disagreement at ${i}`);
+    i = (i + usize(1));
+  });
+});
+// ===========================================================================
+// try_substring — the non-panicking form of the same contract
+// ===========================================================================
+test("String try_substring refuses exactly what substring panics on", {
+  s := _subject();
+  assert(s.try_substring(usize(3), usize(6)).is_some(), "boundary range is fine");
+  assert(s.try_substring(usize(1), usize(2)).is_none(), "end inside 'é'");
+  assert(s.try_substring(usize(2), usize(3)).is_none(), "start inside 'é'");
+  assert(s.try_substring(usize(4), usize(6)).is_none(), "start inside '中'");
+  assert(s.try_substring(usize(0), usize(11)).is_none(), "end past the buffer");
+  assert(s.try_substring(usize(6), usize(3)).is_none(), "start > end");
+  assert(s.try_substring(usize(10), usize(10)).unwrap() == String.new(), "empty at the end");
+});
+// ===========================================================================
+// slice_copy — the `s(a..b)` / `s(a..=b)` sugar
+// ===========================================================================
+test("String range slicing uses the same byte offsets", {
+  s := _subject();
+  // pre-D4: s(3 .. 6) was empty; s(1 .. 3) was "é中".
+  assert(s(usize(3) .. usize(6)) == `中`, "exclusive range");
+  assert(s(usize(1) .. usize(3)) == `é`, "exclusive range, 2-byte rune");
+  // Inclusive form keeps the LAST byte, so `..=` must end on a rune's last
+  // byte for `end + 1` to be a boundary.
+  assert(s(usize(3) ..= usize(5)) == `中`, "inclusive range");
+  assert(s(usize(0) ..= usize(0)) == `a`, "inclusive ASCII");
+});
+// ===========================================================================
+// index_of / last_index_of / contains — BYTE offsets in AND out
+// ===========================================================================
+test("String index_of answers a byte offset that feeds back into substring", {
+  s := _subject();
+  // pre-D4: 2 (rune index)
+  m := s.index_of(`中`);
+  assert(m.is_some(), "found");
+  assert(m.unwrap() == usize(3), "byte offset of 中");
+  assert(s.substring(m.unwrap(), m.unwrap() + `中`.len()) == `中`, "round trip");
+  // pre-D4: 3
+  assert(s.index_of(`𝄞`).unwrap() == usize(6), "byte offset of 𝄞");
+  assert(s.index_of(`a`).unwrap() == usize(0), "byte offset of a");
+  assert(s.index_of(`é`).unwrap() == usize(1), "byte offset of é");
+  assert(s.index_of(`zz`).is_none(), "absent");
+});
+test("String index_of from_index is a byte offset", {
+  s := `你好世界你好`;
+  // 你@0 好@3 世@6 界@9 你@12 好@15 — 18 bytes, 6 runes.
+  assert(s.len() == usize(18), "18 bytes");
+  // pre-D4: index_of("你好", 1) was 4 (rune index of the second occurrence)
+  assert(s.index_of(`你好`, usize(1)).unwrap() == usize(12), "second occurrence");
+  assert(s.index_of(`你好`, usize(0)).unwrap() == usize(0), "first occurrence");
+  assert(s.index_of(`你好`, usize(13)).is_none(), "past the last start");
+  // A mid-rune from_index cannot invent a match: UTF-8 is self-synchronizing.
+  assert(s.index_of(`好`, usize(4)).unwrap() == usize(15), "skips the match at 3");
+});
+test("String last_index_of answers a byte offset", {
+  s := `你好世界你好`;
+  // pre-D4: 4
+  assert(s.last_index_of(`你好`).unwrap() == usize(12), "last occurrence");
+  // pre-D4 `from_index` was a rune cap; it is now a byte cap.
+  assert(s.last_index_of(`你好`, usize(11)).unwrap() == usize(0), "capped before the last");
+  assert(s.last_index_of(`你好`, usize(12)).unwrap() == usize(12), "cap ON the last start");
+  assert(s.last_index_of(``).unwrap() == s.len(), "empty needle is at len()");
+});
+test("String contains from_index is a byte offset", {
+  s := _subject();
+  // pre-D4: contains(中, 2) was true (rune 2 IS 中); byte 2 is inside é, and
+  // the byte scan from there still finds 中 at 3.
+  assert(s.contains(`中`, usize(3)), "at the byte it starts on");
+  // pre-D4: contains(中, 3) was FALSE (rune 3 is 𝄞, past 中).
+  assert(s.contains(`𝄞`, usize(6)), "4-byte rune at its own offset");
+  assert(!(s.contains(`中`, usize(4))), "past 中's start");
+  assert(!(s.contains(`é`, usize(2))), "past é's start");
+});
+// ===========================================================================
+// starts_with(position) / ends_with(end_position)
+// ===========================================================================
+test("String starts_with position is a byte offset — the 1.3(a) fix", {
+  // Before D4 `_has_prefix` advanced a rune counter and ALSO stepped one byte
+  // per iteration, so `"你好".starts_with("好", 1)` stopped at byte 1 — the
+  // middle of 你 — and answered false. `position` was neither a rune index
+  // nor a byte offset (plans/STD_API_AUDIT_D4_PLAN.md §1.3(a)). It is now
+  // plainly a byte offset, and the walk that caused the defect is gone.
+  s := `你好`;
+  assert(s.len() == usize(6), "6 bytes");
+  assert(s.starts_with(`你`, usize(0)), "prefix at 0");
+  // pre-D4: FALSE for every `position` — the defect.
+  assert(s.starts_with(`好`, usize(3)), "prefix at the second rune");
+  assert(!(s.starts_with(`好`, usize(1))), "mid-rune position cannot match");
+  assert(!(s.starts_with(`好`, usize(2))), "mid-rune position cannot match");
+  t := _subject();
+  assert(t.starts_with(`中`, usize(3)), "3-byte rune at byte 3");
+  assert(t.starts_with(`𝄞`, usize(6)), "4-byte rune at byte 6");
+  assert(t.starts_with(``, usize(999)), "empty prefix is everywhere");
+  assert(!(t.starts_with(`a`, usize(999))), "position past the end");
+});
+test("String ends_with end_position counts bytes", {
+  s := _subject();
+  // pre-D4: ends_with('é', 2) — 2 runes of "aé" — was true; the byte form is 3.
+  assert(s.ends_with(`é`, usize(3)), "first 3 bytes end with é");
+  assert(!(s.ends_with(`é`, usize(2))), "cutting inside é cannot match");
+  assert(s.ends_with(`中`, usize(6)), "first 6 bytes end with 中");
+  assert(s.ends_with(`𝄞`, usize(10)), "the whole string ends with 𝄞");
+  assert(s.ends_with(`𝄞`), "default end_position is the whole string");
+  assert(s.ends_with(`𝄞`, usize(999)), "end_position past the end clamps");
+  assert(s.ends_with(``, usize(4)), "empty suffix is everywhere");
+});
+// ===========================================================================
+// The Pattern trait — a `str` literal pattern must answer the same offsets
+// ===========================================================================
+test("Pattern methods answer byte offsets for str patterns too", {
+  s := _subject();
+  assert(s.index_of("中").unwrap() == usize(3), "str pattern index_of");
+  assert(s.last_index_of("中").unwrap() == usize(3), "str pattern last_index_of");
+  assert(s.contains("中", usize(3)), "str pattern contains");
+  assert(s.starts_with("中", usize(3)), "str pattern starts_with");
+  assert(s.ends_with("中", usize(6)), "str pattern ends_with");
+  // The String-pattern and str-pattern paths must not disagree.
+  assert(s.index_of("中") == s.index_of(`中`), "both Pattern impls agree");
+});
+// ===========================================================================
+// Byte access that was ALREADY byte-based must be unchanged
+// ===========================================================================
+test("String byte_at and Index still read raw bytes", {
+  s := _subject();
+  assert(s.byte_at(usize(1)) == u8(0xC3), "lead byte of é");
+  assert(s.byte_at(usize(2)) == u8(0xA9), "continuation byte of é");
+  assert(s(usize(0)) == u8(0x61), "Index yields a byte");
+  assert(s(usize(9)) == u8(0x9E), "last byte of 𝄞");
+});
+// ===========================================================================
+// split("") must STAY rune-based — it is pinned to the char vocabulary
+// ===========================================================================
+test("String split with an empty separator still splits into runes", {
+  // A byte split would hand back fragments that are not valid UTF-8
+  // (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S5).
+  s := _subject();
+  parts := s.split(``);
+  assert(parts.len() == usize(4), "4 runes, not 10 bytes");
+  assert(parts(usize(0)) == `a`, "a");
+  assert(parts(usize(1)) == `é`, "é");
+  assert(parts(usize(2)) == `中`, "中");
+  assert(parts(usize(3)) == `𝄞`, "𝄞");
+});

--- a/tests/string/string_char_api.test.yo
+++ b/tests/string/string_char_api.test.yo
@@ -43,20 +43,29 @@ test("String char_len counts runes across all four UTF-8 widths", {
   assert(s.byte_at(usize(8)) == u8(0x84), "byte 8 continues '𝄞'");
   assert(s.byte_at(usize(9)) == u8(0x9E), "byte 9 continues '𝄞'");
 });
-test("String char_len equals len() today — the D4 cross-PR golden", {
-  // PR 3 flips `len()` to bytes. `char_len()` must return the SAME number
-  // before and after that flip, so this is the regression gate that isolates
-  // "did the rune count change?" from "did len() change?".
+test("String char_len holds its pre-flip values — the D4 cross-PR golden", {
+  // PR 3 flipped `len()` to bytes. `char_len()` must return the SAME number
+  // it did before that flip, so this is the regression gate that isolates
+  // "did the rune count change?" (must be NO) from "did len() change?"
+  // (must be YES). Every value below was recorded in PR 1, when `char_len()`
+  // and `len()` still agreed, and is unchanged.
   // (plans/STD_API_AUDIT_D4_PLAN.md §6.1 item 3.)
-  assert(_subject().char_len() == _subject().len(), "four-width subject");
-  assert(`你好世界`.char_len() == `你好世界`.len(), "CJK");
-  assert(`héllo`.char_len() == `héllo`.len(), "latin-1 supplement");
-  assert(`😀🎉`.char_len() == `😀🎉`.len(), "astral emoji");
-  assert(`abc`.char_len() == `abc`.len(), "ASCII");
-  assert(String.new().char_len() == String.new().len(), "empty");
-  // And the absolute values, so the golden is readable without running len().
-  assert(`你好世界`.char_len() == usize(4), "4 CJK runes");
-  assert(`😀🎉`.char_len() == usize(2), "2 emoji runes");
+  assert(_subject().char_len() == usize(4), "four-width subject");
+  assert(`你好世界`.char_len() == usize(4), "CJK");
+  assert(`héllo`.char_len() == usize(5), "latin-1 supplement");
+  assert(`😀🎉`.char_len() == usize(2), "astral emoji");
+  assert(`abc`.char_len() == usize(3), "ASCII");
+  assert(String.new().char_len() == usize(0), "empty");
+  // The other half of the gate: `len()` now DIFFERS from `char_len()` on
+  // exactly the multibyte cases, and still agrees on the ASCII ones.
+  assert(_subject().len() == usize(10), "four-width subject is 10 bytes");
+  assert(`你好世界`.len() == usize(12), "CJK is 12 bytes");
+  assert(`héllo`.len() == usize(6), "latin-1 supplement is 6 bytes");
+  assert(`😀🎉`.len() == usize(8), "astral emoji is 8 bytes");
+  assert(`abc`.len() == usize(3), "ASCII agrees in both bases");
+  assert(String.new().len() == usize(0), "empty agrees in both bases");
+  // `bytes_len()` is a deprecated alias of `len()` and must track it exactly.
+  assert(`😀🎉`.bytes_len() == `😀🎉`.len(), "bytes_len is len");
   assert(`😀🎉`.bytes_len() == usize(8), "8 emoji bytes");
 });
 test("String char_len on the empty string", {

--- a/tests/string_multibyte_literal.test.yo
+++ b/tests/string_multibyte_literal.test.yo
@@ -19,6 +19,9 @@ test("multibyte strings as call arguments", {
   );
   out := describe(true, String.from("π ≈ 3.14159 → ok"));
   assert(out == "π ≈ 3.14159 → ok", "multibyte string arg roundtrip");
-  assert(out.len() == usize(16), "rune length of multibyte string");
+  // `len()` is the BYTE count since plans/STD_API_AUDIT_D4_PLAN.md D4 PR 3;
+  // `char_len()` is what this used to assert (π 2B, ≈ 3B, → 3B, rest ASCII).
+  assert(out.char_len() == usize(16), "rune length of multibyte string");
+  assert(out.len() == usize(21), "byte length of multibyte string");
   assert(out.as_bytes().len() == usize(21), "byte length of multibyte string");
 });


### PR DESCRIPTION
# std: D4 PR 3 — the flip. String is byte-indexed

`String.len()`, `at()`/`s[i]`, `substring`, `index_of`, `char_at` and every
other index-taking/index-returning method on `String` now work on the **byte**
basis, completing the D4 plan's PR 3 (`plans/STD_API_AUDIT_D4_PLAN.md`). The
additive `char_*` vocabulary and the pinning of every char-semantics call site
landed ahead of this in #288, so this PR is the basis change itself plus the
sites the flip exposed.

Two findings from the review pass are the argument for the change rather than
footnotes:

- **A live regression the flip introduced, now fixed on the branch.**
  `src/codegen/exprs/async.yo` `_capitalize_last_segment` used
  `substring(0, 1)` to take the first *character*. Yo identifiers may start
  with a non-ASCII rune, so post-flip that is a continuation byte and
  `substring` panics — the compiler would abort at rc=134 while emitting an
  effect setter. Pinned by `tests/codegen-bootstrap/effect_label_non_ascii.yo`.

- **A contract hole — docs corrected, behaviour deliberately left alone.**
  The empty needle: `index_of("", 2)` returns `Some(2)` — a continuation
  byte — and `index_of("", 99)` returns `Some(99)`, past `len()`. Both are
  pre-D4 behaviours, verified at the parent commit. What was new was this PR's
  doc comment claiming *every* returned index is a rune boundary, which is
  false, and matters because the same comment invites feeding results straight
  into `substring`, which now panics on non-boundaries. Two tests pin the
  actual behaviour.

Deferred, explicitly: the UTF-16 half of §5.4 (LSP position encoding) — it is
protocol-visible, wants a `positionEncoding` capability, and is a pre-existing
defect unrelated to `String`'s basis. The rune⟷byte helpers this PR adds to
`src/lsp/protocol.yo` are the seam to build it on.

## Battery (integration branch, full run)

- `yo check ./std` 154/154, `yo check ./src` 262/262
- `yo build` rc=0
- full suite: 3115 passed / 3115 total
- cli-diff goldens re-recorded: **zero drift**; scorecard PASS 52 / GOLDEN-DIFF 0 / NO-GOLDEN 0
- `gates_fast.sh`: T1_DONE failures=0
- `fixpoint_only.sh`: stage2 hollow=0, STAGE3_RC=0, FIXPOINT_HOLDS
- `hollow_sweep69.sh`: SWEEP_GATE_OK, allowlisted known-failing: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
