### PR TITLE
std: D5 slice 1 — async Reader/Writer traits, stdio handles, File/TcpStream impls

### DIFF
--- a/issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
+++ b/issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
@@ -1,0 +1,90 @@
+# An async loop awaiting a buffer-taking method emits a state machine that segfaults (or invalid C, in a generic impl)
+
+**Found 2026-08-26 while implementing STD_API_AUDIT D5** (async `Reader`/`Writer`).
+This is THE blocker for D5's `read_to_end`/`read_to_string`/`write_all`
+defaults, for `io.copy`, and (together with its generic-impl face) for
+`BufReader(R)`/`BufWriter(W)`. All measurements below are on a compiler built
+from develop@`87d34f9ed` (includes the C16 #289 and C23 #291 fixes).
+
+## The shape that breaks
+
+An `io.async` body that, **in a loop**, awaits a method taking a raw-pointer
+buffer argument (`read(buf : *(u8), size, io)`), where the buffer lives in an
+`ArrayList(u8)` local of the same async body:
+
+```rust
+io.async((e) => {
+  out := ArrayList(u8).new();
+  chunk := ArrayList(u8).with_capacity(usize(4));
+  // ...fill chunk...
+  p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+  (done : bool) = false;
+  while(!(done), {
+    n := e.io.await(<recv>.read(p, usize(4), io), e);
+    if(n == usize(0), { done = true; }, {
+      (i : usize) = usize(0);
+      while(i < n, i = (i + usize(1)), { out.push(chunk(i)); });
+    });
+  });
+  out
+})
+```
+
+Three hosts, three symptoms — one family:
+
+| host of the async body | symptom | repro |
+| --- | --- | --- |
+| a trait `?=` default (`<recv>` = `self`/`Self.read(self, …)`, CONCRETE implementor) | compiles clean, **0 stubs, 0 FTT markers — SIGSEGV (rc=139) at runtime** | `issues/repros/async-loop-buffer-await-default.yo` |
+| a FREE generic fn (`where(R <: Reader)`, `<recv>` = the `r : R` param) | same: clean compile, **rc=139** | `issues/repros/async-loop-buffer-await-free-generic.yo` |
+| a GENERIC inherent impl's method (`impl(generic(R), where(R <: Reader), BufReader(R), …)`, `<recv>` = `self._inner`) | **invalid C**: `use of undeclared identifier '_file____priv_temp_NNNN'` in the state machine | `issues/repros/async-loop-buffer-await-generic-impl.yo` |
+
+## The controls that PROVE the trigger (all green end-to-end)
+
+- **Same loop-until-done default, no buffer args** — awaited method is
+  `step(self, io)`, accumulation into an `ArrayList` local, both the
+  static-dot (`Self.step(self, io)`) and method (`self.step(io)`) call forms:
+  runs correctly (3+2+1=6).
+  `issues/repros/async-loop-noarg-await-default-CONTROL.yo`
+- **Same buffer-taking implementor called directly from `main` in a loop**
+  (four sequential awaits through the same `chunk`/`p`, EOF included): runs
+  correctly. So the implementor, the pointer idiom and repeated awaits are all
+  fine — only the loop *inside another async body* breaks.
+  `issues/repros/async-buffer-await-direct-CONTROL.yo`
+- A generic impl's async method awaiting a where-dispatched async method
+  with a pointer argument but NO ArrayList locals/loop: runs correctly.
+
+So the trigger needs ALL of: (an async body hosting the loop) + (ArrayList
+locals whose pointer is held across suspension) + (the awaited call carrying
+that pointer as an argument). Hoisting the `chunk.ptr()` match out of the loop
+does not help; swapping `self.read(...)`/`Self.read(self, ...)` does not help.
+
+## Notes for the fixer
+
+- The rc=139 binaries carry **zero** `Failed to transpile` markers and zero
+  `#275` abort stubs — the state machine is fully emitted and wrong: this is a
+  codegen/state-machine capture-or-restore fault, not the evaluator-hollow
+  family (C16/C22).
+- The generic-impl face's undeclared `_priv_temp` suggests a temp declared in
+  one resume state and referenced in another — likely the same
+  capture/restore split, surfacing earlier because the generic path renames
+  temps differently.
+- Related but distinct, discovered en route (diagnostics): an evaluation
+  error inside a trait field's TYPE or `?=` default is SWALLOWED and the
+  module env is corrupted, so the user sees `Variable "<next def>" not found`
+  at an unrelated line instead of the real error — `YO_DEBUG_SWALLOW=1`
+  reveals the true error and location. That alone cost this investigation an
+  hour and will hit users writing traits with unimported types; consider
+  promoting these swallows to real diagnostics at module level.
+
+## What this blocks (D5)
+
+- `Reader.read_to_end` / `read_to_string` / `Writer.write_all` as trait
+  `?=` defaults, and as free generic functions (both faces measured broken).
+- `io.copy(r, w)`.
+- `BufReader(R)`/`BufWriter(W)` wrapping any Reader/Writer (the generic-impl
+  face; also blocked by C17 for the `Dyn` spelling).
+
+The D5 slice that does NOT need this — the traits with required methods,
+concrete implementors (`File`, `TcpStream`, stdio handles), and per-type
+INHERENT convenience methods (which dispatch directly, not through the
+trait) — works and can land first.

--- a/issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
+++ b/issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
@@ -58,6 +58,25 @@ locals whose pointer is held across suspension) + (the awaited call carrying
 that pointer as an argument). Hoisting the `chunk.ptr()` match out of the loop
 does not help; swapping `self.read(...)`/`Self.read(self, ...)` does not help.
 
+## Two sharper facets, measured after filing (2026-08-26, same session)
+
+1. **A GENERIC fn's async closure DROPS the enclosing function's parameters
+   from its capture struct** — the emitted C references `buf`/`size`/`io` as
+   bare identifiers (loud clang failure: "use of undeclared identifier").
+   Workaround that works: hoist each param into a LOCAL before `io.async`
+   (`the_r := r; the_buf := buf; …` — locals capture correctly, the same
+   pattern std/fs/file.yo's `fd := self._fd` hoist uses), and reach the `io`
+   effect as `e.io` inside the body (the hoisted-`io` spelling was not
+   tried — `io`-named params are structurally special). With that
+   discipline a SINGLE-await generic helper works end-to-end:
+   `tests/io/async_traits.test.yo`'s `read_once`/`write_once` are the green
+   proof.
+2. **The LOOPING await segfaults even with the full hoist discipline**
+   (`issues/repros/async-loop-buffer-await-free-generic-hoisted.yo` — same
+   as the free-generic repro plus `the_r`/`e.io`; still rc=139). So the loop
+   case is a second, deeper state-machine fault, not just the dropped
+   capture.
+
 ## Notes for the fixer
 
 - The rc=139 binaries carry **zero** `Failed to transpile` markers and zero

--- a/issues/repros/async-buffer-await-direct-CONTROL.yo
+++ b/issues/repros/async-buffer-await-direct-CONTROL.yo
@@ -1,0 +1,44 @@
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ IoExn } :: import("std/error");
+
+Reader :: trait(
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))
+);
+TenSrc :: ref(struct(pos : u8));
+impl(
+  TenSrc,
+  Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        (n : usize) = usize(0);
+        while((n < size) && (self.pos < u8(10)), {
+          self.pos = (self.pos + u8(1));
+          (buf.add(n)).* = self.pos;
+          n = (n + usize(1));
+        });
+        n
+      })
+    )
+  )
+);
+main :: (fn(io : Io) -> unit)({
+  src := TenSrc(pos : u8(0));
+  chunk := ArrayList(u8).with_capacity(usize(4));
+  (ci : usize) = usize(0);
+  while(ci < usize(4), ci = (ci + usize(1)), {
+    chunk.push(u8(0));
+  });
+  p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+  n1 := io.await(src.read(p, usize(4), io), { io });
+  assert(n1 == usize(4), "first chunk");
+  assert(chunk(usize(0)) == u8(1), "byte 0");
+  n2 := io.await(src.read(p, usize(4), io), { io });
+  assert(n2 == usize(4), "second chunk");
+  n3 := io.await(src.read(p, usize(4), io), { io });
+  assert(n3 == usize(2), "tail");
+  n4 := io.await(src.read(p, usize(4), io), { io });
+  assert(n4 == usize(0), "eof");
+});
+export(main);

--- a/issues/repros/async-loop-buffer-await-default.yo
+++ b/issues/repros/async-loop-buffer-await-default.yo
@@ -1,0 +1,60 @@
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ IoExn } :: import("std/error");
+
+Reader :: trait(
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn))),
+  (read_to_end : (fn(self : Self, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))) ?=
+    (
+      (self, io) ->
+        io.async((e) => {
+          out := ArrayList(u8).new();
+          chunk := ArrayList(u8).with_capacity(usize(4));
+          (ci : usize) = usize(0);
+          while(ci < usize(4), ci = (ci + usize(1)), {
+            chunk.push(u8(0));
+          });
+          (done : bool) = false;
+          p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+          while(!(done), {
+            n := e.io.await(self.read(p, usize(4), io), e);
+            if(n == usize(0), {
+              done = true;
+            }, {
+              (i : usize) = usize(0);
+              while(i < n, i = (i + usize(1)), {
+                out.push(chunk(i));
+              });
+            });
+          });
+          out
+        })
+    )
+);
+// A source that yields 10 bytes (values 1..10) then EOF, at most 4 per read.
+TenSrc :: ref(struct(pos : u8));
+impl(
+  TenSrc,
+  Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        (n : usize) = usize(0);
+        while((n < size) && (self.pos < u8(10)), {
+          self.pos = (self.pos + u8(1));
+          (buf.add(n)).* = self.pos;
+          n = (n + usize(1));
+        });
+        n
+      })
+    )
+  )
+);
+main :: (fn(io : Io) -> unit)({
+  src := TenSrc(pos : u8(0));
+  all := io.await(src.read_to_end(io), { io });
+  assert(all.len() == usize(10), "ten bytes total");
+  assert(all(usize(0)) == u8(1), "first byte");
+  assert(all(usize(9)) == u8(10), "last byte");
+});
+export(main);

--- a/issues/repros/async-loop-buffer-await-free-generic-hoisted.yo
+++ b/issues/repros/async-loop-buffer-await-free-generic-hoisted.yo
@@ -1,0 +1,60 @@
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ IoExn } :: import("std/error");
+
+Reader :: trait(
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))
+);
+TenSrc :: ref(struct(pos : u8));
+impl(
+  TenSrc,
+  Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        (n : usize) = usize(0);
+        while((n < size) && (self.pos < u8(10)), {
+          self.pos = (self.pos + u8(1));
+          (buf.add(n)).* = self.pos;
+          n = (n + usize(1));
+        });
+        n
+      })
+    )
+  )
+);
+read_to_end :: (
+  fn(generic(R : Type), r : R, io : Io, where(R <: Reader)) -> Impl(Future(ArrayList(u8), IoExn))
+)({
+  the_r := r;
+  io.async((e) => {
+    out := ArrayList(u8).new();
+    chunk := ArrayList(u8).with_capacity(usize(4));
+    (ci : usize) = usize(0);
+    while(ci < usize(4), ci = (ci + usize(1)), {
+      chunk.push(u8(0));
+    });
+    p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+    (done : bool) = false;
+    while(!(done), {
+      n := e.io.await(the_r.read(p, usize(4), e.io), e);
+      if(n == usize(0), {
+        done = true;
+      }, {
+        (i : usize) = usize(0);
+        while(i < n, i = (i + usize(1)), {
+          out.push(chunk(i));
+        });
+      });
+    });
+    out
+  })
+});
+main :: (fn(io : Io) -> unit)({
+  src := TenSrc(pos : u8(0));
+  all := io.await(read_to_end(src, io), { io });
+  assert(all.len() == usize(10), "ten bytes total");
+  assert(all(usize(0)) == u8(1), "first byte");
+  assert(all(usize(9)) == u8(10), "last byte");
+});
+export(main);

--- a/issues/repros/async-loop-buffer-await-free-generic.yo
+++ b/issues/repros/async-loop-buffer-await-free-generic.yo
@@ -1,0 +1,59 @@
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ IoExn } :: import("std/error");
+
+Reader :: trait(
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))
+);
+TenSrc :: ref(struct(pos : u8));
+impl(
+  TenSrc,
+  Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        (n : usize) = usize(0);
+        while((n < size) && (self.pos < u8(10)), {
+          self.pos = (self.pos + u8(1));
+          (buf.add(n)).* = self.pos;
+          n = (n + usize(1));
+        });
+        n
+      })
+    )
+  )
+);
+read_to_end :: (
+  fn(generic(R : Type), r : R, io : Io, where(R <: Reader)) -> Impl(Future(ArrayList(u8), IoExn))
+)(
+  io.async((e) => {
+    out := ArrayList(u8).new();
+    chunk := ArrayList(u8).with_capacity(usize(4));
+    (ci : usize) = usize(0);
+    while(ci < usize(4), ci = (ci + usize(1)), {
+      chunk.push(u8(0));
+    });
+    p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+    (done : bool) = false;
+    while(!(done), {
+      n := e.io.await(r.read(p, usize(4), io), e);
+      if(n == usize(0), {
+        done = true;
+      }, {
+        (i : usize) = usize(0);
+        while(i < n, i = (i + usize(1)), {
+          out.push(chunk(i));
+        });
+      });
+    });
+    out
+  })
+);
+main :: (fn(io : Io) -> unit)({
+  src := TenSrc(pos : u8(0));
+  all := io.await(read_to_end(src, io), { io });
+  assert(all.len() == usize(10), "ten bytes total");
+  assert(all(usize(0)) == u8(1), "first byte");
+  assert(all(usize(9)) == u8(10), "last byte");
+});
+export(main);

--- a/issues/repros/async-loop-buffer-await-generic-impl.yo
+++ b/issues/repros/async-loop-buffer-await-generic-impl.yo
@@ -1,0 +1,45 @@
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ IoExn } :: import("std/error");
+
+Reader :: trait(
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))
+);
+FakeSrc :: struct(v : u8);
+impl(
+  FakeSrc,
+  Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        (n : usize) = usize(0);
+        if(size > usize(0), {
+          (buf.add(usize(0))).* = self.v;
+          n = usize(1);
+        });
+        n
+      })
+    )
+  )
+);
+BufReader :: (fn(comptime(R) : Type) -> comptime(Type))(struct(_inner : R));
+impl(
+  generic(R : Type),
+  where(R <: Reader),
+  BufReader(R),
+  fill : (fn(self : Self, io : Io) -> Impl(Future(usize, IoExn)))(
+    io.async((e) => {
+      tmp := ArrayList(u8).with_capacity(usize(8));
+      tmp.push(u8(0));
+      p := match(tmp.ptr(), .Some(q) => q, .None => *(u8)(""));
+      n := e.io.await(self._inner.read(p, usize(8), io), e);
+      n
+    })
+  )
+);
+main :: (fn(io : Io) -> unit)({
+  br := BufReader(FakeSrc)(_inner : FakeSrc(v : u8(42)));
+  n := io.await(br.fill(io), { io });
+  assert(n == usize(1), "one byte read through the generic wrapper");
+});
+export(main);

--- a/issues/repros/async-loop-noarg-await-default-CONTROL.yo
+++ b/issues/repros/async-loop-noarg-await-default-CONTROL.yo
@@ -1,0 +1,50 @@
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ IoExn } :: import("std/error");
+
+Stepper :: trait(
+  step : (fn(self : Self, io : Io) -> Impl(Future(usize, IoExn))),
+  (total : (fn(self : Self, io : Io) -> Impl(Future(usize, IoExn)))) ?=
+    (
+      (self, io) ->
+        io.async((e) => {
+          out := ArrayList(u8).new();
+          (done : bool) = false;
+          while(!(done), {
+            n := e.io.await(Self.step(self, io), e);
+            if(n == usize(0), {
+              done = true;
+            }, {
+              out.push(u8(n));
+            });
+          });
+          (sum : usize) = usize(0);
+          (i : usize) = usize(0);
+          while(i < out.len(), i = (i + usize(1)), {
+            sum = (sum + usize(out(i)));
+          });
+          sum
+        })
+    )
+);
+Cnt :: ref(struct(left : usize));
+impl(
+  Cnt,
+  Stepper(
+    step : (fn(self : Self, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        (n : usize) = self.left;
+        if(n > usize(0), {
+          self.left = (self.left - usize(1));
+        });
+        n
+      })
+    )
+  )
+);
+main :: (fn(io : Io) -> unit)({
+  c := Cnt(left : usize(3));
+  s := io.await(c.total(io), { io });
+  assert(s == usize(6), "3+2+1 through a loop-until-done default");
+});
+export(main);

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -757,6 +757,32 @@ section as written:
 - **C22** — do not write a nested closure inside an `io.async` body in these
   defaults; it silently becomes `abort()`.
 
+**D5 SLICE 1 LANDED (2026-08-26)** — what the probes proved landable, landed:
+`std/io/index.yo` (async `Reader`/`Writer` traits, required methods only —
+`read`/`write`/`flush`, `*(u8)`+len, `IoExn`), `std/io/stdio.yo`
+(`Stdin`/`Stdout`/`Stderr` handles over fds 0/1/2 with offset bookkeeping,
+implementing the traits — the typed replacement for `BufReader.new(i32(0))`),
+`File` and `TcpStream` trait impls (delegating to their inherent methods),
+`File.read` → `(buf, size : usize) -> Future(usize, IoExn)` plus a new raw
+`File.write`, and `File.write_string`/`write_bytes` → `usize` (the D5
+byte-count carry-over; zero external consumers of the old `i32` shapes —
+compiler-as-oracle plus the suite). Tests:
+`tests/io/async_traits.test.yo` (4) — a File round trip THROUGH where-bound
+generic helpers, usize counts, stdio writers, TcpStream registration.
+
+**D5 SLICE 2 is BLOCKED on a NEW filed compiler bug** —
+`issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md`
+(three faces + two sharpened facets, five reproducers, two green controls):
+an async body LOOPING over a buffer-taking await segfaults (defaults, free
+generics — even with the param-hoist discipline) or emits invalid C
+(generic impls); separately, a generic fn's async closure drops enclosing
+params from its capture (workaround: hoist to locals + `e.io`). Blocked
+items: `read_to_end`/`read_to_string`/`write_all` as defaults or free
+generics, `io.copy`, `BufReader(R)`/`BufWriter(W)`, and the
+`std/sys/bufio` → `std/io` move (pointless before the wrappers can go
+generic). The per-type INHERENT conveniences (`File.read_to_string`,
+`read_bytes`, ...) remain the safe surface meanwhile.
+
 ### D6 — TLS position
 
 No TLS in tree; C1 makes https throw for now. **DECIDED (O2, 2026-08-23):

--- a/plans/STD_API_AUDIT_HANDOVER.md
+++ b/plans/STD_API_AUDIT_HANDOVER.md
@@ -140,7 +140,14 @@ capability, and is a pre-existing defect unrelated to `String`'s basis. The
 rune⟷byte helpers PR 3 added to `src/lsp/protocol.yo` are the seam to build it
 on.
 
-### 3.2 D5 — async `Reader`/`Writer` traits
+### 3.2 D5 — async `Reader`/`Writer` traits — SLICE 1 LANDED 2026-08-26
+
+Slice 1 (traits + stdio + File/TcpStream impls + the usize/IoExn
+unification) landed; slice 2 (read_to_end family, io.copy, generic
+BufReader/BufWriter, the bufio move) is blocked on
+issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
+— fix that compiler bug first. Original section follows.
+
 
 Unblocked by #289 and **not started**. Content is in `plans/STD_API_AUDIT.md`
 §D5: async `Reader`/`Writer` with default methods (`read_to_end`,

--- a/std/fs/file.yo
+++ b/std/fs/file.yo
@@ -36,6 +36,7 @@ _metadata_mod :: import("./metadata");
 IO_path :: import("../sys/path");
 { OpenMode, FilePermission, SeekFrom, _open_mode_to_flags, _open_mode_needs_perm } :: import("./types");
 IO_file :: import("../sys/file");
+IoTraits :: import("../io");
 { AT_FDCWD, AT_STATX_SYNC_AS_STAT, STATX_BASIC_STATS, O_RDONLY, O_WRONLY, O_RDWR, O_CREAT, O_TRUNC, O_APPEND, O_CLOEXEC, DEFAULT_FILE_MODE } :: import("../sys/constants");
 // ============================================================================
 // File
@@ -109,45 +110,56 @@ impl(
   ),
   /// Read up to `size` bytes into the buffer `buf`.
   /// Returns the number of bytes actually read.
-  read : (fn(self : Self, buf : *(u8), size : u32, io : Io) -> Impl(Future(i32, IoExn)))({
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async((e) => {
-      result := e.io.await(IO_file.read(fd, buf, size, self._pos), e.io);
+      result := e.io.await(IO_file.read(fd, buf, u32(size), self._pos), e.io);
       n := IoError.check(result, e.exn);
       self._pos = (self._pos + u64(n));
-      n
+      usize(n)
+    })
+  }),
+  /// Write up to `size` raw bytes from `buf` at the file's current position.
+  /// Returns the number of bytes written.
+  write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
+    fd := self._fd;
+    io.async((e) => {
+      result := e.io.await(IO_file.write(fd, buf, u32(size), self._pos), e.io);
+      n := IoError.check(result, e.exn);
+      self._pos = (self._pos + u64(n));
+      usize(n)
     })
   }),
   /// Write a `String` to the file.
   /// Returns the number of bytes written.
-  write_string : (fn(self : Self, data : String, io : Io) -> Impl(Future(i32, IoExn)))({
+  write_string : (fn(self : Self, data : String, io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async((e) => {
       data_bytes := data.as_bytes();
       cond(
-        (data_bytes.len() == usize(0)) => i32(0),
+        (data_bytes.len() == usize(0)) => usize(0),
         true => {
           result := e.io.await(IO_file.write(fd, data_bytes.ptr().unwrap(), u32(data_bytes.len()), self._pos), e.io);
           n := IoError.check(result, e.exn);
           self._pos = (self._pos + u64(n));
-          n
+          usize(n)
         }
       )
     })
   }),
   /// Write bytes from an `ArrayList(u8)` to the file.
   /// Returns the number of bytes written.
-  write_bytes : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(i32, IoExn)))({
+  write_bytes : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async(
       (e) =>
         cond(
-          (data.len() == usize(0)) => i32(0),
+          (data.len() == usize(0)) => usize(0),
           true => {
             result := e.io.await(IO_file.write(fd, data.ptr().unwrap(), u32(data.len()), self._pos), e.io);
             n := IoError.check(result, e.exn);
             self._pos = (self._pos + u64(n));
-            n
+            usize(n)
           }
         )
     )
@@ -495,4 +507,26 @@ export(
   canonicalize,
   canonicalize_str,
   canonicalize_cstr
+);
+
+// === std/io async trait impls (STD_API_AUDIT D5) ===
+impl(
+  File,
+  IoTraits.Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.read(buf, size, io)
+    )
+  )
+);
+impl(
+  File,
+  IoTraits.Writer(
+    write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.write(buf, size, io)
+    ),
+    // fd writes are unbuffered — nothing to flush.
+    flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))(
+      io.async((e) => ())
+    )
+  )
 );

--- a/std/io/index.yo
+++ b/std/io/index.yo
@@ -1,0 +1,43 @@
+//! Async I/O traits — the D5 redesign (`plans/STD_API_AUDIT.md` §D5).
+//!
+//! `Reader` and `Writer` are the async byte-stream interfaces every I/O
+//! source/sink implements: `File` (std/fs), `TcpStream` (std/net), and the
+//! `Stdin`/`Stdout`/`Stderr` handles in `std/io/stdio`. All methods run on
+//! the single-threaded async event loop and report failure by throwing
+//! `IoExn` (D1 style 1 — everything on the `io` path throws).
+//!
+//! The raw `read`/`write` take a caller buffer as `*(u8)` + length — the
+//! same shape `TcpStream.read` and the sys layer already speak. Raw
+//! pointers are not available in safe code, so IMPLEMENTING or calling the
+//! raw methods directly needs `pragma(Pragma.AllowUnsafe);`; safe code uses
+//! the pointer-free conveniences on each concrete type (`read_to_string`,
+//! `read_bytes`, `write_string`, `write_bytes`, ...).
+//!
+//! DEFERRED, blocked on a filed compiler bug
+//! (issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md):
+//! `read_to_end`/`read_to_string`/`write_all` as trait `?=` defaults or free
+//! generic functions, `copy(r, w)`, and the generic `BufReader(R)` /
+//! `BufWriter(W)` wrappers. An async body that LOOPS awaiting a
+//! buffer-taking method today either segfaults (concrete/default, free
+//! generic) or emits invalid C (generic impl). The per-type inherent
+//! conveniences dispatch directly and are unaffected.
+pragma(Pragma.AllowUnsafe);
+{ IoExn } :: import("../error");
+
+/// An async source of bytes.
+Reader :: trait(
+  /// Read up to `size` bytes into `buf`. Resolves to the number of bytes
+  /// actually read; `0` means end-of-stream. Throws `IoExn` on failure.
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))
+);
+/// An async sink of bytes.
+Writer :: trait(
+  /// Write up to `size` bytes from `buf`. Resolves to the number of bytes
+  /// actually written (which may be less than `size`). Throws `IoExn` on
+  /// failure.
+  write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn))),
+  /// Flush any buffered bytes through to the underlying sink. Unbuffered
+  /// writers resolve immediately.
+  flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))
+);
+export(Reader, Writer);

--- a/std/io/stdio.yo
+++ b/std/io/stdio.yo
@@ -1,0 +1,99 @@
+//! Typed standard-stream handles — `stdin()` / `stdout()` / `stderr()`
+//! (`plans/STD_API_AUDIT.md` §D5).
+//!
+//! Each handle wraps its well-known file descriptor (0/1/2) and implements
+//! the async `Reader`/`Writer` traits from `std/io`, so code written against
+//! the traits works on the standard streams the same way it works on a
+//! `File` or a `TcpStream`. This is the typed replacement for the
+//! `BufReader.new(i32(0))` magic number.
+//!
+//! The handles are UNBUFFERED: every `read`/`write` is one async syscall.
+//! Each handle keeps a sequential offset the way `std/sys/bufio` does —
+//! required when a standard stream is REDIRECTED to a regular file (the
+//! async runtime writes positionally there); for pipes and terminals the
+//! offset is ignored.
+pragma(Pragma.AllowUnsafe);
+{ Reader, Writer } :: import("./index");
+{ IoExn } :: import("../error");
+{ IoError } :: import("../sys/errors");
+IO_file :: import("../sys/file");
+
+/// The process's standard input (fd 0).
+Stdin :: ref(struct(_offset : u64));
+/// The process's standard output (fd 1).
+Stdout :: ref(struct(_offset : u64));
+/// The process's standard error (fd 2).
+Stderr :: ref(struct(_offset : u64));
+/// Handle to standard input.
+stdin :: (fn() -> Stdin)(Stdin(_offset : u64(0)));
+/// Handle to standard output.
+stdout :: (fn() -> Stdout)(Stdout(_offset : u64(0)));
+/// Handle to standard error.
+stderr :: (fn() -> Stderr)(Stderr(_offset : u64(0)));
+impl(
+  Stdin,
+  /// fd 0, for interop with fd-based APIs (e.g. `BufReader.new`).
+  fd : (fn(self : Self) -> i32)(
+    i32(0)
+  )
+);
+impl(
+  Stdout,
+  /// fd 1, for interop with fd-based APIs (e.g. `BufWriter.new`).
+  fd : (fn(self : Self) -> i32)(
+    i32(1)
+  )
+);
+impl(
+  Stderr,
+  /// fd 2, for interop with fd-based APIs.
+  fd : (fn(self : Self) -> i32)(
+    i32(2)
+  )
+);
+impl(
+  Stdin,
+  Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        result := e.io.await(IO_file.read(i32(0), buf, u32(size), self._offset), e.io);
+        n := IoError.check(result, e.exn);
+        self._offset = (self._offset + u64(n));
+        usize(n)
+      })
+    )
+  )
+);
+impl(
+  Stdout,
+  Writer(
+    write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        result := e.io.await(IO_file.write(i32(1), buf, u32(size), self._offset), e.io);
+        n := IoError.check(result, e.exn);
+        self._offset = (self._offset + u64(n));
+        usize(n)
+      })
+    ),
+    flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))(
+      io.async((e) => ())
+    )
+  )
+);
+impl(
+  Stderr,
+  Writer(
+    write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        result := e.io.await(IO_file.write(i32(2), buf, u32(size), self._offset), e.io);
+        n := IoError.check(result, e.exn);
+        self._offset = (self._offset + u64(n));
+        usize(n)
+      })
+    ),
+    flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))(
+      io.async((e) => ())
+    )
+  )
+);
+export(Stdin, Stdout, Stderr, stdin, stdout, stderr);

--- a/std/net/tcp.yo
+++ b/std/net/tcp.yo
@@ -26,6 +26,7 @@ open(import("../fmt"));
 { IpAddr, SocketAddr } :: import("./addr");
 { Error, AnyError, Exception, IoExn } :: import("../error");
 IO_tcp :: import("../sys/tcp");
+IoTraits :: import("../io");
 SockInfo :: import("../sys/sockinfo");
 { AF_INET, AF_INET6, SOCK_STREAM, SOL_SOCKET, SO_REUSEADDR, IPPROTO_TCP, TCP_NODELAY, SO_KEEPALIVE, SHUT_RD, SHUT_WR, SHUT_RDWR } :: import("../sys/socket");
 // ============================================================================
@@ -297,6 +298,15 @@ impl(
       usize(NetError.check(r, e.exn))
     })
   }),
+  /// Write up to `size` raw bytes from `buf` to the stream.
+  /// Returns the number of bytes written.
+  write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
+    fd := self._fd;
+    io.async((e) => {
+      r := e.io.await(IO_tcp.send(fd, buf, size, i32(0)), e.io);
+      usize(NetError.check(r, e.exn))
+    })
+  }),
   /// Write a `str` to the stream.
   /// Returns the number of bytes written.
   write_str : (fn(self : Self, data : str, io : Io) -> Impl(Future(usize, IoExn)))({
@@ -447,3 +457,28 @@ impl(
   )
 );
 export(TcpStream);
+
+// === std/io async trait impls (STD_API_AUDIT D5) ===
+//
+// The trait methods DELEGATE to the inherent `read`/`write` above (inherent-
+// first resolution keeps direct calls on the fast path); `flush` resolves
+// immediately — a TCP socket has no userspace buffer here.
+impl(
+  TcpStream,
+  IoTraits.Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.read(buf, size, io)
+    )
+  )
+);
+impl(
+  TcpStream,
+  IoTraits.Writer(
+    write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.write(buf, size, io)
+    ),
+    flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))(
+      io.async((e) => ())
+    )
+  )
+);

--- a/tests/fs/file.test.yo
+++ b/tests/fs/file.test.yo
@@ -316,12 +316,12 @@ test("File sequential read calls advance the position", {
   io.await(fs_file.write_string(fpath, `ABCDEF`, io), IoExn(io : io, exn : exn));
   f := io.await(File.open(fpath, .Read, io), IoExn(io : io, exn : exn));
   buf := *(u8)(malloc(usize(8)).unwrap());
-  n1 := io.await(f.read(buf, u32(3), io), IoExn(io : io, exn : exn));
-  assert(n1 == i32(3), "first read should return 3 bytes");
+  n1 := io.await(f.read(buf, usize(3), io), IoExn(io : io, exn : exn));
+  assert(n1 == usize(3), "first read should return 3 bytes");
   first := ((((buf).* == u8(65)) && ((buf.add(usize(1))).* == u8(66))) && ((buf.add(usize(2))).* == u8(67)));
   assert(first, "first read should be ABC");
-  n2 := io.await(f.read(buf, u32(3), io), IoExn(io : io, exn : exn));
-  assert(n2 == i32(3), "second read should return 3 bytes");
+  n2 := io.await(f.read(buf, usize(3), io), IoExn(io : io, exn : exn));
+  assert(n2 == usize(3), "second read should return 3 bytes");
   second := ((((buf).* == u8(68)) && ((buf.add(usize(1))).* == u8(69))) && ((buf.add(usize(2))).* == u8(70)));
   assert(second, "second read must be DEF — the position must advance");
   free(.Some(*(void)(buf)));
@@ -345,8 +345,8 @@ test("File.seek positions the next read", {
   moved := f.seek(i64(5), .Start, exn);
   assert(moved == i64(5), "seek should report the new offset");
   buf := *(u8)(malloc(usize(8)).unwrap());
-  n := io.await(f.read(buf, u32(3), io), IoExn(io : io, exn : exn));
-  assert(n == i32(3), "read after seek should return 3 bytes");
+  n := io.await(f.read(buf, usize(3), io), IoExn(io : io, exn : exn));
+  assert(n == usize(3), "read after seek should return 3 bytes");
   got := ((((buf).* == u8(53)) && ((buf.add(usize(1))).* == u8(54))) && ((buf.add(usize(2))).* == u8(55)));
   assert(got, "read after seek(5) must be 567, not 012");
   free(.Some(*(void)(buf)));

--- a/tests/io/async_traits.test.yo
+++ b/tests/io/async_traits.test.yo
@@ -1,0 +1,118 @@
+//! STD_API_AUDIT D5: the async `Reader`/`Writer` traits and their concrete
+//! implementors — `File`, `TcpStream` (impl registration), `Stdout`/`Stderr`.
+//!
+//! What is deliberately NOT here, blocked on
+//! issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md:
+//! any generic helper that LOOPS awaiting `read`/`write` (read_to_end,
+//! io.copy) — an async body looping over a buffer-taking await miscompiles
+//! today. The generic helpers below make exactly ONE await, the shape the
+//! bug's control reproducers prove green.
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+open(import("std/string"));
+{ IoExn } :: import("std/error");
+{ Reader, Writer } :: import("std/io");
+{ Stdout, Stderr, stdout, stderr } :: import("std/io/stdio");
+{ File, OpenMode } :: import("std/fs/file");
+{ TcpStream } :: import("std/net/tcp");
+{ Path } :: import("std/path");
+{ remove_file } :: import("std/fs/dir");
+
+// A generic single-await passthrough: proves the WHERE-BOUND trait dispatch
+// works for both traits (the control shape from the filed bug).
+read_once :: (
+  fn(generic(R : Type), r : R, buf : *(u8), size : usize, io : Io, where(R <: Reader)) -> Impl(Future(usize, IoExn))
+)({
+  // Hoist params into locals before io.async: a GENERIC fn's async closure
+  // drops enclosing PARAMETERS from its capture struct (same filed family;
+  // locals capture correctly — the pattern std/fs/file.yo's fd-hoist uses).
+  the_r := r;
+  the_buf := buf;
+  the_size := size;
+  io.async((e) => e.io.await(the_r.read(the_buf, the_size, e.io), e))
+});
+write_once :: (
+  fn(generic(W : Type), w : W, buf : *(u8), size : usize, io : Io, where(W <: Writer)) -> Impl(Future(usize, IoExn))
+)({
+  the_w := w;
+  the_buf := buf;
+  the_size := size;
+  io.async((e) => e.io.await(the_w.write(the_buf, the_size, e.io), e))
+});
+
+test("File implements Reader and Writer — trait-dispatched round trip", {
+  path := Path.new(`/tmp/yo_d5_traits_roundtrip.bin`.to_string());
+  f := io.await(File.open(path, OpenMode.Write, io), { io });
+  payload := ArrayList(u8).new();
+  payload.push(u8(0xDE));
+  payload.push(u8(0xAD));
+  payload.push(u8(0xBE));
+  payload.push(u8(0xEF));
+  // Write through the GENERIC Writer bound (one await).
+  wrote := io.await(write_once(f, payload.ptr().unwrap(), payload.len(), io), { io });
+  assert(wrote == usize(4), "wrote four bytes through the Writer bound");
+  io.await(f.flush(io), { io });
+  io.await(f.close(io), { io });
+  // Read back through the GENERIC Reader bound (one await).
+  f2 := io.await(File.open(path, OpenMode.Read, io), { io });
+  buf := ArrayList(u8).with_capacity(usize(8));
+  (bi : usize) = usize(0);
+  while(bi < usize(8), bi = (bi + usize(1)), {
+    buf.push(u8(0));
+  });
+  got := io.await(read_once(f2, buf.ptr().unwrap(), usize(8), io), { io });
+  assert(got == usize(4), "read the four bytes back through the Reader bound");
+  assert(buf(usize(0)) == u8(0xDE), "byte 0");
+  assert(buf(usize(3)) == u8(0xEF), "byte 3");
+  // A second read at EOF resolves 0 — the Reader EOF contract.
+  got2 := io.await(read_once(f2, buf.ptr().unwrap(), usize(8), io), { io });
+  assert(got2 == usize(0), "EOF is 0, not an error");
+  io.await(f2.close(io), { io });
+  io.await(remove_file(path, io), { io });
+});
+test("File.read/write_string/write_bytes count in usize now", {
+  path := Path.new(`/tmp/yo_d5_usize_counts.txt`.to_string());
+  f := io.await(File.open(path, OpenMode.Write, io), { io });
+  n1 := io.await(f.write_string(`héllo`.to_string(), io), { io });
+  assert(n1 == usize(6), "write_string returns a usize byte count (6 UTF-8 bytes)");
+  more := ArrayList(u8).new();
+  more.push(u8(0x21));
+  n2 := io.await(f.write_bytes(more, io), { io });
+  assert(n2 == usize(1), "write_bytes returns a usize count");
+  io.await(f.close(io), { io });
+  f2 := io.await(File.open(path, OpenMode.Read, io), { io });
+  s := io.await(f2.read_to_string(io), { io });
+  assert(s == `héllo!`, "round trip");
+  io.await(f2.close(io), { io });
+  io.await(remove_file(path, io), { io });
+});
+test("Stdout and Stderr implement Writer", {
+  msg := `d5 stdio writer ok\n`.to_string();
+  b := msg.as_bytes();
+  o := stdout();
+  n := io.await(write_once(o, b.ptr().unwrap(), b.len(), io), { io });
+  assert(n == b.len(), "stdout write count");
+  io.await(o.flush(io), { io });
+  e2 := stderr();
+  n2 := io.await(e2.write(b.ptr().unwrap(), b.len(), io), { io });
+  assert(n2 == b.len(), "stderr write count");
+});
+test("TcpStream carries the Reader and Writer impls", {
+  // Registration-level check without opening sockets: the where-bound
+  // helpers must ACCEPT a TcpStream-typed argument at compile time. The
+  // trait methods delegate to the inherent read/write, whose behavior the
+  // tcp tests cover.
+  taker_r :: (fn(generic(R : Type), r : R, where(R <: Reader)) -> bool)(true);
+  taker_w :: (fn(generic(W : Type), w : W, where(W <: Writer)) -> bool)(true);
+  fake :: (fn() -> Option(TcpStream))(Option(TcpStream).None);
+  match(
+    fake(),
+    .Some(s) => {
+      assert(taker_r(s), "TcpStream satisfies Reader");
+      assert(taker_w(s), "TcpStream satisfies Writer");
+    },
+    .None => ()
+  );
+  assert(true, "TcpStream trait registration type-checks");
+});


### PR DESCRIPTION
# std: D5 slice 1 — async Reader/Writer traits, stdio handles, File/TcpStream impls, usize unification

The landable half of STD_API_AUDIT §D5, scoped by compiled probes rather than by the plan text:

- **`std/io/index.yo`** — the async `Reader`/`Writer` traits (required methods only: `read`/`write`/`flush` over `*(u8)`+len, `IoExn` throws — D1 style 1).
- **`std/io/stdio.yo`** — `Stdin`/`Stdout`/`Stderr` typed fd handles implementing the traits, with per-handle offset bookkeeping (redirected streams write positionally). The typed replacement for the `BufReader.new(i32(0))` magic number.
- **`File` and `TcpStream`** implement both traits (delegating to inherent methods — inherent-first keeps direct calls on the fast path). `File.read` flips to `(buf, size : usize) -> Future(usize, IoExn)`, `File` gains a raw `write`, and `write_string`/`write_bytes` return `usize` — the D5 byte-count carry-over (zero external `i32` consumers; the one test file using the old shape migrated).
- **`tests/io/async_traits.test.yo`** (4): a File round trip **through where-bound generic Reader/Writer helpers**, the EOF-is-0 contract, usize counts, stdio writers, TcpStream registration.

## The other half is BLOCKED on a compiler bug found (and filed) while probing this

`issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md` — five reproducers, two green controls, two sharpened facets:
1. a GENERIC fn's async closure DROPS the enclosing params from its capture (bare identifiers in the C / garbage reads); workaround used by the new tests: hoist params to locals + reach the effect as `e.io`;
2. an async body LOOPING over a buffer-taking await segfaults (defaults, free generics — even hoisted) or emits invalid C (generic impls).

Blocked and deferred with the bug: `read_to_end`/`read_to_string`/`write_all` as trait defaults, `io.copy`, generic `BufReader(R)`/`BufWriter(W)`, and the `std/sys/bufio` → `std/io` move. The audit's D5 section and the handover record the split. The bug fix is the immediate next work item.

Also recorded en route: trait-field/default evaluation errors are swallowed into misleading downstream "Variable not found" diagnostics (`YO_DEBUG_SWALLOW=1` reveals the truth) — fix queued with the same branch.

## Battery (full run)
- `yo check ./std` 156/156, `yo check ./src` 262/262, `yo build` rc=0
- full suite: 3146 passed / 3146 total
- goldens: zero drift; scorecard PASS 52 / GOLDEN-DIFF 0 / NO-GOLDEN 0
- gates failures=0; fixpoint stage2 hollow=0, STAGE3_RC=0, FIXPOINT_HOLDS; hollow sweep SWEEP_GATE_OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
