### PR TITLE
fix: generic-fn async closures dropped params from their capture (UnknownVal mis-port)

### DIFF
--- a/.github/instructions/debugging.instructions.md
+++ b/.github/instructions/debugging.instructions.md
@@ -120,3 +120,31 @@ Each `.test.yo` file has its own import set. Check whether a test file imports `
 - Files with `open(import("std/fmt"))` → `println` available
 - Files without it → use `assert` only, or add the import
 - Match the existing style of the test file when adding new tests
+
+## `YO_DEBUG_CAPTURE=1` — the closure-capture pipeline channels
+
+Added 2026-08-26 while fixing the generic-fn async-closure capture loss
+(issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md).
+All are stderr prints, active only with `YO_DEBUG_CAPTURE` set:
+
+- `[cap-fb]` (exprs/identifer_and_operator.yo) — every FunctionBody-arm
+  capture classification: name, the frame the lookup found it at, the ctx
+  snapshot's frame count, the stamped frame level, the inner verdict, plus
+  the eval_env/current-env top-frame ids (generation mismatches show here).
+- `[cap-track]` (context.yo) — track_variable_usage's gate decisions:
+  re-found frame, own-param top-frame exclusion, compile-time-only flag.
+- `[cap-enr]` (utils/closure.yo) — enrichment input per name: recorded
+  level, env frame count, how many same-named bindings were found and how
+  many are comptime.
+- `[cap-reg]` / `[fid-src]` (function_value.yo) — every capture-struct
+  registration (fid, source key, field list) and every fid→source-key mint.
+- `[fbctx-closure-call]` / `[fbctx-fnty-rp]` / `[fbctx-fnty-flow]`
+  (calls/closure_type.yo, calls/function_type.yo) — which site created a
+  FunctionBody evaluation context.
+
+Read them together: a name that is `inner=false` in `[cap-fb]`, survives
+`[cap-track]`, appears in `[cap-enr]`, and still misses the `[cap-reg]`
+field list pins the drop to capture-struct creation; a name missing from
+`[cap-track]` was never tracked (classifier); `cto=true` in `[cap-track]`
+against a runtime binding was the UnknownVal-argument mis-port this channel
+was built to catch.

--- a/issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
+++ b/issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
@@ -1,5 +1,31 @@
 # An async loop awaiting a buffer-taking method emits a state machine that segfaults (or invalid C, in a generic impl)
 
+**FACET 1 FIXED 2026-08-26** (branch fix/async-capture-and-swallows). Root
+cause of the dropped-parameter face, traced through the new
+`YO_DEBUG_CAPTURE=1` channels: the call-time param binding derived
+`is_compile_time_only` FROM THE ARGUMENT'S VALUE (`arg has a value && not a
+FuncVal`) — and **`UnknownVal` counted as a value**, so any param whose
+argument evaluated to a runtime unknown (e.g. `list.ptr().unwrap()`) was
+bound compile-time-only; capture tracking then excluded it as comptime and
+the async closure's C read it as a bare undeclared identifier. TS derives the
+flag from the DECLARED param alone (helper.ts:671) and its own comment calls
+UnknownValue "a runtime-only" value — the yo-self heuristic was a mis-port.
+Three fixes landed together: (1) `is_ct` no longer counts `UnknownVal`
+(calls/function.yo); (2) capture tracking's comptime gate judges the
+CALLER-RESOLVED binding, not a name-re-found stale one
+(`track_variable_usage_resolved`, context.yo); (3) the `.AsyncBlock`
+classifier arm gained the generation-safe inner test the `.FunctionBody` arm
+already had (identifer_and_operator.yo). Red-first:
+`tests/async_generic_param_capture.test.yo` (undeclared-identifier clang
+failure before, 2/2 after).
+
+**FACET 2 REMAINS OPEN** — the LOOPING buffer-await still segfaults
+(rc=139) on all three loop reproducers and the generic-impl face still emits
+an undeclared `_priv_temp`; re-measured identically after the facet-1 fix,
+so it is a distinct state-machine capture/restore fault across loop
+suspensions. The controls stay green. This is what still blocks D5 slice 2.
+
+
 **Found 2026-08-26 while implementing STD_API_AUDIT D5** (async `Reader`/`Writer`).
 This is THE blocker for D5's `read_to_end`/`read_to_string`/`write_all`
 defaults, for `io.copy`, and (together with its generic-impl face) for

--- a/src/evaluator/calls/closure_type.yo
+++ b/src/evaluator/calls/closure_type.yo
@@ -22,6 +22,8 @@
 //!   - No `attachTempVariableToExpr` for DynType (deferred to Phase 4).
 pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
+_(env : cap_dbg_env_closure_call) :: import("std/env");
+{ eprintln } :: import("std/fmt");
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 { AstExpr, ast_expr_token, ast_expr_id, make_err_expr }
@@ -245,6 +247,9 @@ try_to_implement_closure_by_fn_module_type :: (
   // time (mirrors anonymous_function.yo:806 `register_func_type(func_id, ...)`).
   register_func_type(closure_id.clone(), synthetic_func_ty.clone());
   // Create the function body evaluation context.
+  if(cap_dbg_env_closure_call.get(`YO_DEBUG_CAPTURE`).is_some(), {
+    eprintln(`[fbctx-closure-call]`);
+  });
   eval_ctx := create_function_body_evaluation_context(
     synthetic_func_ty,
     func_val_pre,

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -5256,7 +5256,18 @@ Fix: wrap the call:
           // the field → undeclared `get_info` in the emitted C). TS binds
           // isCompileTimeOnly from the PARAMETER declaration, never from
           // arg-value presence (helper.ts:573).
-          (is_ct : bool) = match(arg_info.value, .Some(av) => !(is_func_val(av)), .None => false);
+          // An UnknownVal argument is a RUNTIME value (type known, value not
+          // — the project-wide meaning of UnknownVal, and TS helper.ts:36's
+          // own words: "A runtime value is either undefined (no value) or a
+          // runtime-only UnknownValue"). Binding such a param compile-time-
+          // only excluded it from closure-capture tracking, so a generic
+          // fn's async closure emitted the param as a bare undeclared C
+          // identifier (issues/async-loop-awaiting-buffer-taking-method-
+          // state-machine-corruption.md, facet 1). TS derives the binding's
+          // isCompileTimeOnly from the DECLARED param flag alone
+          // (helper.ts:671); the value-derived heuristic here keeps genuine
+          // comptime VALUES comptime but must not claim runtime unknowns.
+          (is_ct : bool) = match(arg_info.value, .Some(av) => (!(is_func_val(av)) && !(is_unknown_val(av))), .None => false);
           if((is_comptime_string_type(arg_info.ty) && (!(is_some_type(resolved_decl_pt)))) && (!(is_comptime_string_type(resolved_decl_pt))), {
             bind_ty = resolved_decl_pt.clone();
             bind_val = Option(EvalValue).Some(create_unknown_val(resolved_decl_pt));

--- a/src/evaluator/calls/function_type.yo
+++ b/src/evaluator/calls/function_type.yo
@@ -26,6 +26,8 @@ open(import("std/string"));
 open(import("std/fmt"));
 _(env : fnty_env) :: import("std/env");
 { ArrayList } :: import("std/collections/array_list");
+_(env : cap_dbg_env_fnty_flow) :: import("std/env");
+_(env : cap_dbg_env_fnty_rp) :: import("std/env");
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
 { AstExpr, ast_expr_token, ast_expr_id, make_err_expr } :: import("../../expr.yo");
@@ -788,6 +790,9 @@ _rerun_pending_def_evals :: (fn(caller_env : Environment, ctx : EvalContext) -> 
           ),
           ArrayList(EvalValue).new()
         );
+        if(cap_dbg_env_fnty_rp.get(`YO_DEBUG_CAPTURE`).is_some(), {
+          eprintln(`[fbctx-fnty-rp]`);
+        });
         rp_ctx := create_function_body_evaluation_context(pd.function_type, rp_fv, rp_env, ctx);
         rp_out := ArrayList(AstExpr).new();
         rp_prev_trial := set_in_def_time_trial(true);
@@ -1225,6 +1230,9 @@ try_to_implement_function_by_function_type :: (
             ),
             ArrayList(EvalValue).new()
           );
+          if(cap_dbg_env_fnty_flow.get(`YO_DEBUG_CAPTURE`).is_some(), {
+            eprintln(`[fbctx-fnty-flow]`);
+          });
           flow_ctx := create_function_body_evaluation_context(function_type, flow_fv, flow_env, ctx);
           flow_out := ArrayList(AstExpr).new();
           // Thread the fn's where-constraint trait ids to the overload

--- a/src/evaluator/calls/pointer.yo
+++ b/src/evaluator/calls/pointer.yo
@@ -100,7 +100,7 @@ evaluate_raw_pointer_call :: (
           dyn(
             format_error_message(
               ptok,
-              `Raw pointer types ('*(${type_to_string(inner_ty)})') are not available in safe code.\n\nUse 'Slice(T)' for bounded byte/element views, 'inout(name) : T' parameters for in-place mutation, or wrap the underlying pointer in an 'object' type. If this file genuinely needs raw pointers, add 'pragma(Pragma.AllowUnsafe);' at the top — but consider whether the unsafe surface really belongs in this module.`,
+              `Raw pointer types ('*(${type_to_string(inner_ty)})') are not available in safe code.\n\nUse 'ArrayList(T)' (or 'Array(T, N)') for bounded byte/element storage, 'inout(name) : T' parameters for in-place mutation, or wrap the underlying pointer in an 'object' type. If this file genuinely needs raw pointers, add 'pragma(Pragma.AllowUnsafe);' at the top — but consider whether the unsafe surface really belongs in this module.`,
               false,
               .None
             )

--- a/src/evaluator/context.yo
+++ b/src/evaluator/context.yo
@@ -17,6 +17,8 @@
 //! * TypeScript `PathCollection` (Path[]) → `PathCollection :: ArrayList(ArrayList(String))`
 //!   imported from `src/expr_info.yo` (Phase 2k).
 open(import("std/string"));
+_(env : ctx_dbg_env) :: import("std/env");
+{ eprintln } :: import("std/fmt");
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
@@ -619,13 +621,27 @@ get_pointer_type_call_result :: (fn(ftc : FunctionToCall) -> Option(PointerTypeC
 /// - Promotes usage type: `own` > `write` > `read`.
 ///
 /// `context` is modified in-place.
-track_variable_usage :: (
+/// `track_variable_usage`, with the CALLER-RESOLVED binding's
+/// `is_compile_time_only` flag. The tracker re-finds the name in the
+/// closure ctx's `eval_env`, which for a DEFERRED generic fn is the
+/// DEF-TIME generation — where concrete-typed params are bound
+/// compile-time-only placeholders. Gating on THAT stale binding dropped
+/// runtime params (`buf`/`size`) from the closure capture while keeping
+/// `r`/`io` (whose def-time bindings happen to be runtime), so the emitted
+/// C read the dropped names as bare identifiers or garbage
+/// (issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md,
+/// facet 1). TS is immune: its envs are per-generation, so the re-found
+/// binding IS the resolved one. Pass `.Some(resolved.is_compile_time_only)`
+/// from identifier resolution; `.None` keeps the legacy stale-binding gate
+/// for callers that have no resolved binding at hand.
+track_variable_usage_resolved :: (
   fn(
     variable_name : String,
     frame_level : usize,
     usage : CaptureUsage,
     token : Token,
-    context : EvalContext
+    context : EvalContext,
+    resolved_is_comptime : Option(bool)
   ) -> unit
 )(
   // Only track when we are inside a function body or async block.
@@ -714,11 +730,18 @@ track_variable_usage :: (
           // referenced (issues/fixed/own-param-discard-leak.md). Mirrors
           // src/evaluator/context.ts trackVariableUsage.
           is_fn_body := match(sub_ctx.kind, .FunctionBody => true, _ => false);
+          if(ctx_dbg_env.get(`YO_DEBUG_CAPTURE`).is_some(), {
+            trk_top := (is_fn_body && (actual_frame_level == (eval_env.frame_count() - usize(1))));
+            eprintln(`[cap-track] name=${variable_name} actual_fl=${actual_frame_level.to_string()} ev_count=${eval_env.frame_count().to_string()} top_excl=${trk_top.to_string()} cto=${v.is_compile_time_only.to_string()}`);
+          });
           if(is_fn_body && (actual_frame_level == (eval_env.frame_count() - usize(1))), {
             return(());
           });
-          // Don't track compile-time-only variables.
-          if(v.is_compile_time_only, {
+          // Don't track compile-time-only variables — judged by the
+          // CALLER-RESOLVED binding when provided (current generation), not
+          // the re-found one (possibly a stale def-time placeholder).
+          effective_cto := match(resolved_is_comptime, .Some(rc) => rc, .None => v.is_compile_time_only);
+          if(effective_cto, {
             return(());
           });
           // Ensure the capturedVariables map exists.
@@ -913,6 +936,21 @@ create_function_body_evaluation_context :: (
   )
 });
 
+track_variable_usage :: (
+  fn(
+    variable_name : String,
+    frame_level : usize,
+    usage : CaptureUsage,
+    token : Token,
+    context : EvalContext
+  ) -> unit
+)(
+  // Legacy entry: no resolved-binding flag — the compile-time-only gate
+  // falls back to the re-found binding (see the note in the _resolved
+  // variant).
+  track_variable_usage_resolved(variable_name, frame_level, usage, token, context, Option(bool).None)
+);
+
 export(
   PathCollection,
   path_collection_new,
@@ -955,6 +993,7 @@ export(
   get_index_call_result,
   get_pointer_type_call_result,
   track_variable_usage,
+  track_variable_usage_resolved,
   set_rerun_pending_def_evals_fn,
   call_rerun_pending_def_evals,
   in_def_time_trial,

--- a/src/evaluator/exprs/identifer_and_operator.yo
+++ b/src/evaluator/exprs/identifer_and_operator.yo
@@ -24,7 +24,7 @@ _(env : ident_dbg_env) :: import("std/env");
 } :: import("../../expr_info.yo");
 { Token, string_is_operator } :: import("../../token.yo");
 { Environment, Variable, get_variables_from_env, find_variable_in_env, find_variable_in_env_at } :: import("../../env.yo");
-{ EvalContext, FuncOrAsyncBlockKind, CaptureUsage, track_variable_usage }
+{ EvalContext, FuncOrAsyncBlockKind, CaptureUsage, track_variable_usage, track_variable_usage_resolved }
 :: import("../context.yo");
 { TypeValue } :: import("../../types/definitions.yo");
 { t_str, t_unit, t_bool, t_void, t_i8, t_i16, t_i32, t_i64, t_u8, t_u16, t_u32, t_u64, t_f32, t_f64, t_usize, t_isize, t_comptime_int, t_comptime_float, t_comptime_string, t_type, t_type_1, t_expr_t, t_c_char, t_c_short, t_c_ushort, t_c_int, t_c_uint, t_c_long, t_c_ulong, t_c_longlong, t_c_ulonglong, t_c_longdouble } :: import("../../types/creators.yo");
@@ -288,13 +288,20 @@ evaluate_identifier_and_operator :: (
                 }),
                 .None => ()
               );
+              if(ident_dbg_env.get(`YO_DEBUG_CAPTURE`).is_some(), {
+                cap_dbg_fi := match(found_frame_idx_out.get(usize(0)), .Some(v) => v.to_string(), .None => `?`.to_string());
+                cap_dbg_ev_top := match(sub_ctx.eval_env.frames.get(closure_frame_level - usize(1)), .Some(fr) => fr.id.to_string(), .None => `?`.to_string());
+                cap_dbg_cur_top := match(env.frames.get(env.frames.len() - usize(1)), .Some(fr2) => fr2.id.to_string(), .None => `?`.to_string());
+                eprintln(`[cap-fb] name=${variable.name} found_fi=${cap_dbg_fi} closure_fl=${closure_frame_level.to_string()} var_fl=${variable.frame_level.to_string()} inner=${cap_is_inner.to_string()} ev_top=${cap_dbg_ev_top} cur_frames=${env.frames.len().to_string()} cur_top=${cap_dbg_cur_top}`);
+              });
               if(!(cap_is_inner) && (variable.frame_level < closure_frame_level), {
-                track_variable_usage(
+                track_variable_usage_resolved(
                   variable.name,
                   variable.frame_level,
                   CaptureUsage.Own,
                   token,
-                  ctx
+                  ctx,
+                  Option(bool).Some(variable.is_compile_time_only)
                 );
               });
               if(!(cap_is_inner) && (variable.frame_level >= closure_frame_level), {
@@ -306,12 +313,13 @@ evaluate_identifier_and_operator :: (
                 if(closure_frame_level > usize(0), {
                   cap_rec_level = (closure_frame_level - usize(1));
                 });
-                track_variable_usage(
+                track_variable_usage_resolved(
                   variable.name,
                   cap_rec_level,
                   CaptureUsage.Own,
                   token,
-                  ctx
+                  ctx,
+                  Option(bool).Some(variable.is_compile_time_only)
                 );
               });
             },
@@ -319,16 +327,62 @@ evaluate_identifier_and_operator :: (
           );
         },
         .AsyncBlock => {
-          async_frame_level := sub_ctx.eval_env.frame_count();
-          if(variable.frame_level < async_frame_level, {
-            track_variable_usage(
-              variable.name,
-              variable.frame_level,
-              CaptureUsage.Own,
-              token,
-              ctx
-            );
-          });
+          match(
+            ctx.captured_variables,
+            .Some(_) => {
+              async_frame_level := sub_ctx.eval_env.frame_count();
+              // Generation-safe INNER test — the SAME repair the FunctionBody
+              // arm above carries (the dyn+Impl(Fn) capture loss), which this
+              // arm never got: `variable.frame_level` is stamped at the
+              // variable's CREATION env, and for a SPECIALIZED generic fn's
+              // PARAMS that is a deep call-time generation, so the old
+              // `frame_level < async_frame_level` test wrongly classified
+              // them as inner and the async closure's capture struct dropped
+              // them — the emitted C then read `buf`/`size`/`io` as bare
+              // identifiers (loud clang failure) or garbage (rc=139).
+              // issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md.
+              // A variable is inner iff the frame the lookup FOUND it at is
+              // >= async_frame_level in the CURRENT env (same generation by
+              // construction).
+              (ab_is_inner : bool) = false;
+              match(
+                found_frame_idx_out.get(usize(0)),
+                .Some(ab_found_fi) => if(ab_found_fi >= async_frame_level, {
+                  ab_is_inner = true;
+                }),
+                .None => ()
+              );
+              if(!(ab_is_inner) && (variable.frame_level < async_frame_level), {
+                track_variable_usage_resolved(
+                  variable.name,
+                  variable.frame_level,
+                  CaptureUsage.Own,
+                  token,
+                  ctx,
+                  Option(bool).Some(variable.is_compile_time_only)
+                );
+              });
+              if(!(ab_is_inner) && (variable.frame_level >= async_frame_level), {
+                // Cross-generation outer variable: record it with a level
+                // inside the current generation so the enrichment /
+                // access-rewriting math stays in range (mirrors the
+                // FunctionBody arm).
+                (ab_rec_level : usize) = usize(0);
+                if(async_frame_level > usize(0), {
+                  ab_rec_level = (async_frame_level - usize(1));
+                });
+                track_variable_usage_resolved(
+                  variable.name,
+                  ab_rec_level,
+                  CaptureUsage.Own,
+                  token,
+                  ctx,
+                  Option(bool).Some(variable.is_compile_time_only)
+                );
+              });
+            },
+            .None => ()
+          );
         },
         _ => ()
       );

--- a/src/evaluator/utils/closure.yo
+++ b/src/evaluator/utils/closure.yo
@@ -11,6 +11,8 @@
 //!     explicit capture struct type deferred to Phase 4.
 //!   - `autoDeriveTraitsAndAddRcFunctions…`     → calls auto_derive_traits_for_struct_type
 open(import("std/string"));
+_(env : clo_dbg_env) :: import("std/env");
+{ eprintln } :: import("std/fmt");
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 {
@@ -162,6 +164,21 @@ enrich_captured_variables :: (
           .Some(cap_info) => {
             fl := cap_info.frame_level;
             n_frames := env.frames.len();
+            if(clo_dbg_env.get(`YO_DEBUG_CAPTURE`).is_some(), {
+              enr_found := get_variables_from_env(env, var_name.clone());
+              (enr_cto : usize) = usize(0);
+              (enr_k : usize) = usize(0);
+              while(enr_k < enr_found.len(), enr_k = (enr_k + usize(1)), {
+                match(
+                  enr_found.get(enr_k),
+                  .Some(ev) => if(ev.is_compile_time_only, {
+                    enr_cto = (enr_cto + usize(1));
+                  }),
+                  .None => ()
+                );
+              });
+              eprintln(`[cap-enr] name=${var_name} fl=${fl.to_string()} n_frames=${n_frames.to_string()} found=${enr_found.len().to_string()} cto=${enr_cto.to_string()}`);
+            });
             if(fl < n_frames, {
               vars := get_variables_from_env(env, var_name.clone());
               m := vars.len();

--- a/src/function_value.yo
+++ b/src/function_value.yo
@@ -18,6 +18,8 @@
 //! Both registries are keyed by `func_id : String` (the unique
 //! `FuncValueId` from src/function-value.ts).
 open(import("std/string"));
+_(env : fnval_dbg_env) :: import("std/env");
+{ eprintln } :: import("std/fmt");
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
 { Frame } :: import("./env.yo");
@@ -95,6 +97,9 @@ ClosureCaptureInfo :: ref(struct(capture_type : TypeValue, frame_level : usize))
 (g_closure_capture_by_source : HashMap(String, ClosureCaptureInfo)) = HashMap(String, ClosureCaptureInfo).new();
 /// Record the source key for a closure fid (at FuncVal mint).
 register_closure_fid_source :: (fn(func_id : String, src_key : String) -> unit)({
+  if(fnval_dbg_env.get(`YO_DEBUG_CAPTURE`).is_some(), {
+    eprintln(`[fid-src] fid=${func_id} src=${src_key}`);
+  });
   g_closure_fid_source.insert(func_id, src_key);
   ()
 });
@@ -102,6 +107,28 @@ _capture_struct_field_count :: (fn(t : TypeValue) -> usize)(
   match(t, .Struct({ field_labels : cfl }) => cfl.len(), _ => usize(0))
 );
 register_closure_capture_info :: (fn(func_id : String, info : ClosureCaptureInfo) -> unit)({
+  if(fnval_dbg_env.get(`YO_DEBUG_CAPTURE`).is_some(), {
+    (reg_flds : String) = String.new();
+    match(
+      info.capture_type,
+      .Struct({ field_labels : rfl }) => {
+        (rgi : usize) = usize(0);
+        while(rgi < rfl.len(), rgi = (rgi + usize(1)), {
+          match(
+            rfl.get(rgi),
+            .Some(rfn) => {
+              reg_flds.push_string(rfn);
+              reg_flds.push_str(",");
+            },
+            .None => ()
+          );
+        });
+      },
+      _ => ()
+    );
+    reg_src := match(g_closure_fid_source.get(func_id.clone()), .Some(sv) => sv, .None => `NO-SRC`.to_string());
+    eprintln(`[cap-reg] fid=${func_id} src=${reg_src} fields=${reg_flds}`);
+  });
   // KEEP-LARGER: a closure definition can be re-evaluated (def-time trial,
   // enclosing-fn specialization, deferred-generic completion) and each eval
   // re-registers its own capture struct — but the capture TRACKER records an

--- a/tests/async_generic_param_capture.test.yo
+++ b/tests/async_generic_param_capture.test.yo
@@ -1,0 +1,66 @@
+//! Regression: a GENERIC function's `io.async` closure DROPPED the enclosing
+//! function's PARAMETERS from its capture struct — the emitted C referenced
+//! them as bare identifiers (clang: "use of undeclared identifier") or read
+//! garbage. Root cause: the capture classifier's `.AsyncBlock` arm still used
+//! the generation-UNSAFE `variable.frame_level < async_frame_level` test that
+//! the `.FunctionBody` arm was already cured of (the dyn+Impl(Fn) capture
+//! loss) — a SPECIALIZED generic fn's params carry deep call-time generation
+//! stamps and were misclassified as inner.
+//! See issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
+//! (facet 1).
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ IoExn } :: import("std/error");
+{ Reader, Writer } :: import("std/io");
+{ File, OpenMode } :: import("std/fs/file");
+{ Path } :: import("std/path");
+{ remove_file } :: import("std/fs/dir");
+
+// The EXACT pre-fix failing shape: params used DIRECTLY inside the async
+// closure, no hoist-to-locals workaround.
+read_once_params :: (
+  fn(generic(R : Type), r : R, buf : *(u8), size : usize, io : Io, where(R <: Reader)) -> Impl(Future(usize, IoExn))
+)(io.async((e) => e.io.await(r.read(buf, size, io), e)));
+write_once_params :: (
+  fn(generic(W : Type), w : W, buf : *(u8), size : usize, io : Io, where(W <: Writer)) -> Impl(Future(usize, IoExn))
+)(io.async((e) => e.io.await(w.write(buf, size, io), e)));
+// Non-generic control of the same shape — always worked; pins that the fix
+// did not disturb the plain path.
+write_once_file :: (fn(f : File, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async((e) => e.io.await(f.write(buf, size, io), e))
+);
+
+test("generic fn async closure captures the enclosing params", {
+  path := Path.new(`/tmp/yo_generic_param_capture.bin`.to_string());
+  f := io.await(File.open(path, OpenMode.Write, io), { io });
+  payload := ArrayList(u8).new();
+  payload.push(u8(0x41));
+  payload.push(u8(0x42));
+  payload.push(u8(0x43));
+  wrote := io.await(write_once_params(f, payload.ptr().unwrap(), payload.len(), io), { io });
+  assert(wrote == usize(3), "generic write captured w/buf/size/io");
+  io.await(f.close(io), { io });
+  f2 := io.await(File.open(path, OpenMode.Read, io), { io });
+  buf := ArrayList(u8).with_capacity(usize(8));
+  (bi : usize) = usize(0);
+  while(bi < usize(8), bi = (bi + usize(1)), {
+    buf.push(u8(0));
+  });
+  got := io.await(read_once_params(f2, buf.ptr().unwrap(), usize(8), io), { io });
+  assert(got == usize(3), "generic read captured r/buf/size/io");
+  assert(buf(usize(0)) == u8(0x41), "byte 0 round-tripped");
+  assert(buf(usize(2)) == u8(0x43), "byte 2 round-tripped");
+  io.await(f2.close(io), { io });
+  io.await(remove_file(path, io), { io });
+});
+test("non-generic control of the same shape still works", {
+  path := Path.new(`/tmp/yo_generic_param_capture_ctl.bin`.to_string());
+  f := io.await(File.open(path, OpenMode.Write, io), { io });
+  payload := ArrayList(u8).new();
+  payload.push(u8(0x58));
+  wrote := io.await(write_once_file(f, payload.ptr().unwrap(), payload.len(), io), { io });
+  assert(wrote == usize(1), "plain fn param capture unchanged");
+  io.await(f.close(io), { io });
+  io.await(remove_file(path, io), { io });
+});


### PR DESCRIPTION
# fix: generic-fn async closures dropped params from their capture — the UnknownVal-argument mis-port

Found implementing D5; blocks were traced end-to-end with five new `YO_DEBUG_CAPTURE=1` channels through the whole capture pipeline (classifier → tracker gates → enrichment → registration), now documented in `debugging.instructions.md`.

**Root cause** (facet 1 of `issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md`): the call-time param binding derived `is_compile_time_only` from *the argument's value* — "has a value && not a FuncVal" — and **`UnknownVal` counted as a value**, despite being the project's own definition of a runtime value ("type known, value not"). Any param fed by a runtime unknown (e.g. `list.ptr().unwrap()`) bound compile-time-only; capture tracking then excluded it as comptime, and a generic fn's `io.async` closure emitted it as a **bare undeclared C identifier** (loud clang failure) or garbage. TS derives the flag from the DECLARED param alone (helper.ts:671) and its own comment calls UnknownValue "runtime-only" — the heuristic was a mis-port.

Three coordinated fixes:
1. `calls/function.yo` — `is_ct` no longer counts `UnknownVal`.
2. `context.yo` — new `track_variable_usage_resolved`: the comptime gate judges the binding identifier resolution ACTUALLY resolved, not one re-found by name in a possibly stale-generation ctx env (legacy entry point unchanged for other callers).
3. `identifer_and_operator.yo` — the `.AsyncBlock` classifier arm gets the generation-safe inner test the `.FunctionBody` arm already carried (the dyn+Impl(Fn) capture-loss repair, never applied to async blocks).

Also: the raw-pointer diagnostic recommended the **deleted** builtin `Slice(T)` (slice rework) — now points at `ArrayList`/`Array`.

**Red-first**: `tests/async_generic_param_capture.test.yo` — clang undeclared-identifier failure on develop, 2/2 after (generic write/read through where-bound Reader/Writer + a non-generic control).

**Facet 2 stays open, re-measured post-fix**: the LOOPING buffer-await still segfaults (all three loop reproducers rc=139; generic-impl face still emits an undeclared `_priv_temp`) — a distinct state-machine capture/restore fault across loop suspensions. It remains the D5 slice-2 blocker; the issue carries the full mechanism map and controls.

## Battery (full run)
- `yo check ./std` 156/156, `yo check ./src` 262/262, `yo build` rc=0
- full suite: 3148 passed / 3148 total
- goldens: zero drift; scorecard PASS 52 / GOLDEN-DIFF 0 / NO-GOLDEN 0
- gates failures=0; **fixpoint stage2 hollow=0, STAGE3_RC=0, FIXPOINT_HOLDS** — the compiler self-compiles to identical output through the changed call bindings
- hollow sweep SWEEP_GATE_OK
- regression: async_await 184, async_trait_default_await 4, generic_impl_async_self 4, algebraic_effects 74, io/async_traits 4, iterator_combinators 49

🤖 Generated with [Claude Code](https://claude.com/claude-code)
