### PR TITLE
fix: async loop over a buffer-taking await segfaulted — the match payload binding never wrote its hoisted sm slot

### DIFF
--- a/issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
+++ b/issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md
@@ -19,11 +19,32 @@ already had (identifer_and_operator.yo). Red-first:
 `tests/async_generic_param_capture.test.yo` (undeclared-identifier clang
 failure before, 2/2 after).
 
-**FACET 2 REMAINS OPEN** — the LOOPING buffer-await still segfaults
-(rc=139) on all three loop reproducers and the generic-impl face still emits
-an undeclared `_priv_temp`; re-measured identically after the facet-1 fix,
-so it is a distinct state-machine capture/restore fault across loop
-suspensions. The controls stay green. This is what still blocks D5 slice 2.
+**FACET 2 (the three silent segvs) FIXED 2026-08-26** (branch
+fix/async-loop-state-restore). Mechanism, read straight off the emitted C:
+the nullable-pointer match's payload binding (`.Some(q) => q` over
+`chunk.ptr()`) declared `q` as a plain C LOCAL while the arm's reads —
+which consult `state_machine_variables` — emitted the hoisted
+`sm->var_N` slot, which no code ever wrote; the buffer pointer the loop
+awaited through was therefore uninitialized garbage. Two repairs:
+`codegen/exprs/match.yo`'s `_gen_nullable_ptr_match` binding now ALSO
+stores the hoisted slot (env-id resolution with owning-alias + remapping,
+then a name-scan over the hoister's map — pattern bindings are often
+absent from the recorded env entirely), and
+`codegen/async/state_code_gen.yo`'s `_resolve_pattern_binding_sm_field`
+no longer short-circuits past its name-scan fallback when the env lookup
+finds a stale-generation id (it also gained the owning-alias + remapping
+steps). Red-first: `tests/async_loop_buffer_await.test.yo` (both the
+trait-default and free-generic loop shapes; rc=1 on the pre-fix binary,
+2/2 after). All three loop reproducers now run rc=0; controls unchanged.
+
+**REMAINING OPEN — the generic-impl face only**: `BufReader(R)`-style
+generic inherent impls still fail LOUDLY at C compile — the arm's read of
+the pattern binding resolves to a MINTED TEMP name
+(`_file____priv_temp_NNNN`) that is never declared (a rename/remap on the
+read side the binding does not mirror), distinct from the fixed
+slot-store split. `issues/repros/async-loop-buffer-await-generic-impl.yo`
+still reproduces. This is the one remaining blocker for the generic
+`BufReader(R)`/`BufWriter(W)` (together with C17 for the Dyn spelling).
 
 
 **Found 2026-08-26 while implementing STD_API_AUDIT D5** (async `Reader`/`Writer`).

--- a/src/codegen/async/state_code_gen.yo
+++ b/src/codegen/async/state_code_gen.yo
@@ -2848,18 +2848,45 @@ _resolve_pattern_binding_sm_field :: (
       .Some(ei) => {
         vars := get_variables_from_env(ei.env, binding_name.clone());
         if(vars.len() > usize(0), {
-          env_id := match(vars.get(vars.len() - usize(1)), .Some(v) => v.id.to_string(), .None => String.from(""));
-          return(
-            match(
-              context.state_machine_variables,
-              .Some(m) => match(
-                m.get(env_id.clone()),
-                .Some(_) => Option(String).Some(env_id),
-                .None => Option(String).None
-              ),
-              .None => Option(String).None
-            )
+          // Owning-alias deref + id remapping, the same two steps the READ
+          // side (atom.yo) and init_assignment.yo:206 apply — without them
+          // an env hit resolved a different id spelling than the map key.
+          (env_id : String) = match(
+            vars.get(vars.len() - usize(1)),
+            .Some(v) => match(
+              v.is_owning_the_same_rc_value_as,
+              .Some(ob) => ob.*.id.to_string(),
+              .None => v.id.to_string()
+            ),
+            .None => String.from("")
           );
+          match(
+            context.variable_id_remapping,
+            .Some(rm) => match(
+              rm.get(env_id.clone()),
+              .Some(mapped) => {
+                env_id = mapped;
+              },
+              .None => ()
+            ),
+            .None => ()
+          );
+          env_hit := match(
+            context.state_machine_variables,
+            .Some(m) => m.get(env_id.clone()).is_some(),
+            .None => false
+          );
+          if(env_hit, {
+            return(Option(String).Some(env_id));
+          });
+          // A same-named env hit whose id is NOT in the map is a
+          // STALE-GENERATION binding (yo-self def-time envs are copies);
+          // fall through to the name scan instead of declaring a local the
+          // reads will never see — the facet-2 loop-await rc=139: the
+          // pattern binding declared `q` locally while the arm's reads
+          // consulted the hoisted `sm->var_N` slot, which stayed
+          // uninitialized
+          // (issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md).
         });
       },
       .None => ()

--- a/src/codegen/exprs/match.yo
+++ b/src/codegen/exprs/match.yo
@@ -636,6 +636,111 @@ _gen_nullable_ptr_match :: (fn(expr : AstExpr, indent : String, context : Functi
             decl.push_string(matched_value_code.clone());
             decl.push_str(";");
             em.emit_string_line(decl);
+            // STATE-MACHINE STORAGE PARITY: identifier READS of an
+            // sm-hoisted variable emit `sm->var_N` (atom.yo consults
+            // state_machine_variables), so when THIS pattern binding's
+            // variable was hoisted, the local decl above leaves the slot
+            // uninitialized and the arm's result reads garbage — the
+            // facet-2 loop-await rc=139
+            // (issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md).
+            // Resolve the binding's slot: env id (owning-alias + remapping,
+            // init_assignment.yo:206's steps) first, then a NAME scan over
+            // the hoister's map (_find_sm_var_id_by_name's recovery) —
+            // pattern bindings are often absent from the recorded env
+            // entirely, and env ids can be a different generation than the
+            // map keys.
+            if(context.in_async_state_machine.is_some() && context.state_machine_variables.is_some(), {
+              (smb_id : String) = String.new();
+              (smb_has : bool) = false;
+              match(
+                ptr_body,
+                .Some(smb_pb) => match(
+                  context.base.get_expr_info(smb_pb),
+                  .Some(smb_bei) => {
+                    smb_vars := get_variables_from_env(smb_bei.env, ast_expr_token(dvar).value.to_string());
+                    if(smb_vars.len() > usize(0), {
+                      match(
+                        smb_vars.get(smb_vars.len() - usize(1)),
+                        .Some(smb_var) => {
+                          smb_id = match(
+                            smb_var.is_owning_the_same_rc_value_as,
+                            .Some(ob) => ob.*.id.to_string(),
+                            .None => smb_var.id.to_string()
+                          );
+                          match(
+                            context.variable_id_remapping,
+                            .Some(rm) => match(
+                              rm.get(smb_id.clone()),
+                              .Some(mapped) => {
+                                smb_id = mapped;
+                              },
+                              .None => ()
+                            ),
+                            .None => ()
+                          );
+                          smb_has = match(
+                            context.state_machine_variables,
+                            .Some(smv) => smv.get(smb_id.clone()).is_some(),
+                            .None => false
+                          );
+                        },
+                        .None => ()
+                      );
+                    });
+                  },
+                  .None => ()
+                ),
+                .None => ()
+              );
+              if(!(smb_has), {
+                match(
+                  context.state_machine_variables,
+                  .Some(smv2) => {
+                    smb_it := smv2.keys();
+                    (smb_more : bool) = true;
+                    while(smb_more, {
+                      match(
+                        smb_it.next(),
+                        .None => {
+                          smb_more = false;
+                        },
+                        .Some(smb_k) => match(
+                          smv2.get(smb_k.clone()),
+                          .Some(smb_cv) => {
+                            smb_is_local := match(smb_cv.kind, .Local => true, .Outer => false);
+                            if(smb_is_local && (smb_cv.base.name == ast_expr_token(dvar).value.to_string()), {
+                              smb_id = smb_k.clone();
+                              smb_has = true;
+                              smb_more = false;
+                            });
+                          },
+                          .None => ()
+                        )
+                      );
+                    });
+                  },
+                  .None => ()
+                );
+              });
+              if(smb_has, {
+                smb_field := match(
+                  context.state_machine_field_aliases,
+                  .Some(al) => match(
+                    al.get(smb_id.clone()),
+                    .Some(af) => af,
+                    .None => `var_${smb_id.clone()}`
+                  ),
+                  .None => `var_${smb_id.clone()}`
+                );
+                smb_store := body_indent.clone();
+                smb_store.push_str("sm->");
+                smb_store.push_string(smb_field);
+                smb_store.push_str(" = ");
+                smb_store.push_string(dvn.clone());
+                smb_store.push_str(";");
+                em.emit_string_line(smb_store);
+              });
+            });
           }),
           .None => ()
         ),

--- a/tests/async_loop_buffer_await.test.yo
+++ b/tests/async_loop_buffer_await.test.yo
@@ -1,0 +1,101 @@
+//! Regression (facet 2 of
+//! issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md):
+//! an async body LOOPING over a buffer-taking await segfaulted (rc=139,
+//! fully-transpiled C). The nullable-pointer match's payload binding
+//! (`.Some(q) => q` over `chunk.ptr()`) declared `q` as a plain C local while
+//! the arm's reads consulted the sm-hoisted `sm->var_N` slot — which stayed
+//! uninitialized, so the buffer pointer the loop awaited through was garbage.
+//! Fixed by storing the slot at the binding (codegen/exprs/match.yo) and by
+//! repairing `_resolve_pattern_binding_sm_field`'s short-circuit past its
+//! name-scan fallback (codegen/async/state_code_gen.yo).
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ IoExn } :: import("std/error");
+
+Reader :: trait(
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn))),
+  (read_to_end : (fn(self : Self, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))) ?=
+    (
+      (self, io) ->
+        io.async((e) => {
+          out := ArrayList(u8).new();
+          chunk := ArrayList(u8).with_capacity(usize(4));
+          (ci : usize) = usize(0);
+          while(ci < usize(4), ci = (ci + usize(1)), {
+            chunk.push(u8(0));
+          });
+          (done : bool) = false;
+          p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+          while(!(done), {
+            n := e.io.await(Self.read(self, p, usize(4), io), e);
+            if(n == usize(0), {
+              done = true;
+            }, {
+              (i : usize) = usize(0);
+              while(i < n, i = (i + usize(1)), {
+                out.push(chunk(i));
+              });
+            });
+          });
+          out
+        })
+    )
+);
+TenSrc :: ref(struct(pos : u8));
+impl(
+  TenSrc,
+  Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        (n : usize) = usize(0);
+        while((n < size) && (self.pos < u8(10)), {
+          self.pos = (self.pos + u8(1));
+          (buf.add(n)).* = self.pos;
+          n = (n + usize(1));
+        });
+        n
+      })
+    )
+  )
+);
+read_to_end_free :: (
+  fn(generic(R : Type), r : R, io : Io, where(R <: Reader)) -> Impl(Future(ArrayList(u8), IoExn))
+)({
+  the_r := r;
+  io.async((e) => {
+    out := ArrayList(u8).new();
+    chunk := ArrayList(u8).with_capacity(usize(4));
+    (ci : usize) = usize(0);
+    while(ci < usize(4), ci = (ci + usize(1)), {
+      chunk.push(u8(0));
+    });
+    p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+    (done : bool) = false;
+    while(!(done), {
+      n := e.io.await(the_r.read(p, usize(4), e.io), e);
+      if(n == usize(0), {
+        done = true;
+      }, {
+        (i : usize) = usize(0);
+        while(i < n, i = (i + usize(1)), {
+          out.push(chunk(i));
+        });
+      });
+    });
+    out
+  })
+});
+test("trait-default read_to_end loops a buffer-taking await", {
+  src := TenSrc(pos : u8(0));
+  all := io.await(src.read_to_end(io), { io });
+  assert(all.len() == usize(10), "ten bytes total");
+  assert(all(usize(0)) == u8(1), "first byte");
+  assert(all(usize(9)) == u8(10), "last byte");
+});
+test("free generic read_to_end loops a buffer-taking await", {
+  src := TenSrc(pos : u8(0));
+  all := io.await(read_to_end_free(src, io), { io });
+  assert(all.len() == usize(10), "ten bytes total");
+  assert(all(usize(4)) == u8(5), "middle byte");
+});


### PR DESCRIPTION
Facet 2 of `issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md` — an async body **looping** over a buffer-taking await (`e.io.await(r.read(p, size, io), e)` inside `while`) segfaulted with rc=139 on a **fully-transpiled** binary (zero markers, zero stubs). This was the bug blocking D5 slice 2's `read_to_end`/`write_all`/`io.copy`.

## Mechanism (read off the emitted C)

The nullable-pointer match's payload binding (`.Some(q) => q` over `chunk.ptr()`) declared `q` as a plain C local, while the arm's reads consulted `state_machine_variables` and emitted the hoisted `sm->var_N` slot — which was **never written**. The buffer pointer the loop awaited through was garbage.

## Two repairs

- **`src/codegen/exprs/match.yo` (`_gen_nullable_ptr_match`)** — the binding now also stores the hoisted slot. Resolution follows `init_assignment.yo:206`'s steps: env id with owning-alias deref + `variable_id_remapping`, then a **name scan** over the hoister's map — pattern bindings are often absent from the recorded env entirely, so the scan must be reachable when the env lookup finds nothing.
- **`src/codegen/async/state_code_gen.yo` (`_resolve_pattern_binding_sm_field`)** — an env hit whose id is not in the map (stale generation) no longer short-circuits past the name-scan fallback; the env id also gets the owning-alias + remapping steps.

## Verification

- Red-first: `tests/async_loop_buffer_await.test.yo` — trait-default AND free-generic `read_to_end` loop shapes; **rc=1 on the pre-fix binary, 2/2 after**.
- All three loop reproducers (`issues/repros/async-loop-buffer-await-{default,free-generic,free-generic-hoisted}.yo`) now run rc=0; the two controls unchanged.
- Regression: async_await 184, async_trait_default_await 4, generic_impl_async_self 4, async_generic_param_capture 2, algebraic_effects 74, io/async_traits 4, string 253 — all green.
- Full battery: `yo check` std 156/156 + src 262/262, `yo build` rc=0, full suite 3150/3150, cli-diff scorecard 52 PASS / 0 GOLDEN-DIFF / 0 NO-GOLDEN (zero golden drift), gates T1_DONE failures=0, fixpoint stage2 hollow=0 STAGE3_RC=0 FIXPOINT_HOLDS, hollow sweep SWEEP_GATE_OK, 0 allowlisted known-failing.

Still open (documented in the same issue): the **generic-impl face** — `impl(generic(R), BufReader(R), …)` with the same loop shape emits a read of a never-declared minted temp (loud C failure, repro kept at `issues/repros/async-loop-buffer-await-generic-impl.yo`). That plus C17 is what still holds back generic `BufReader(R)`/`BufWriter(W)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
