### PR TITLE
std: D5 slice 2 — read_to_end/read_to_string/write_all trait defaults + io copy, and the unit-tail-await codegen fix

### DIFF
--- a/issues/fixed/unit-tail-await-of-trait-default-reads-missing-await-result.md
+++ b/issues/fixed/unit-tail-await-of-trait-default-reads-missing-await-result.md
@@ -1,0 +1,76 @@
+# A unit-resolving tail await emitted `sm->await_result_N;` — a field the state struct never declares
+
+**Status: FIXED 2026-08-26.** Found implementing D5 slice 2
+(`plans/STD_API_AUDIT.md` §D5): the very first where-bound generic wrapper over
+the new `Writer.write_all` trait default failed to C-compile.
+
+## Symptom
+
+```
+/tmp/d5probe.c:13413:11: error: no member named 'await_result_0' in 'struct _file____priv_temp_11298_state_t_struct'
+13413 |       sm->await_result_0;
+```
+
+Loud (clang error), but the diagnostic names a minted temp and a generated
+field — nothing the user wrote.
+
+## Trigger shape
+
+An `io.async` body that IS a tail await of an **effectively-unit** future —
+unit, or an **unresolved SomeT** (which is what an `Impl(Future(unit, IoExn))`
+return reached through a `where(S <: Trait)` bound looks like at this point):
+
+```rust
+put_all_generic :: (
+  fn(generic(S : Type), s : S, v : u8, io : Io, where(S <: Sink)) -> Impl(Future(unit, IoExn))
+)(
+  io.async((e) => e.io.await(s.put_all(v, io), e))
+);
+```
+
+Reproducer: `issues/repros/unit-tail-await-of-trait-default-reads-missing-await-result.yo`
+(rc=1 on the pre-fix compiler with exactly the error above; compiles and runs
+rc=0 after). A REAL-unit tail await of a concrete async fn does NOT trigger it
+— that shape takes a different path and was already clean, which is why
+`io.async((e) => e.io.await(exists(...), e.io))`-style code never hit this.
+
+## Mechanism
+
+Three emitters must agree on when an await's result gets an `await_result_N`
+state-struct field, and two of them did:
+
+- **struct allocation** (`src/codegen/exprs/async.yo`): guards on
+  `_await_result_is_unit` — real unit OR unresolved SomeT ⇒ NO field;
+- **extraction** (`src/codegen/async/state_machine.yo`,
+  `_emit_prev_await_result_extraction`): same predicate inlined
+  (`is_prev_unit`) ⇒ never writes the field;
+- **the completion-segment substitution**
+  (`src/codegen/async/state_code_gen.yo`, `generate_state_segment_code`): a
+  standalone tail await is moved into the completion segment
+  (`split_into_state_segments`'s tail-move) and its await node is registered
+  to render as `sm->await_result_N` — **with no unit guard**. The completion
+  segment then emits the bare statement `sm->await_result_0;`, reading a
+  member the struct never got.
+
+## Fix
+
+`generate_state_segment_code` now skips the substitution registration for an
+effectively-unit hoisted await (same predicate as the other two sides).
+`generate_await` (codegen/exprs/await.yo) then renders `""` for the node —
+its documented in-state-machine fallback — and both emit paths already skip
+empty code, so nothing is emitted for the value that does not exist. The
+restore step is guarded the same way.
+
+Safe for the other hoisted-await positions: a `cond`/`while` condition is
+`bool` and a `match` scrutinee cannot be unit (the evaluator rejects it), so
+an effectively-unit hoisted await only ever occurs as a body result.
+
+## Verification
+
+- Red-first reproducer above (pre-fix rc=1, post-fix rc=0 compile AND run).
+- Regression test `tests/async_unit_tail_await.test.yo` (the repro shape plus
+  a concrete-unit tail-await control).
+- D5 slice-2 probe: `read_to_end`/`read_to_string`/`write_all` defaults +
+  `io.copy` over `File`, all green.
+- Full battery on the branch (suite, cli-diff goldens, gates, fixpoint,
+  hollow sweep).

--- a/issues/repros/unit-tail-await-of-trait-default-reads-missing-await-result.yo
+++ b/issues/repros/unit-tail-await-of-trait-default-reads-missing-await-result.yo
@@ -1,0 +1,47 @@
+// A where-bound generic whose io.async body TAIL-awaits a unit-resolving
+// trait-default method emitted `sm->await_result_N;` in the completion
+// segment — but the state struct never declares that field for an
+// effectively-unit result (real unit, or an unresolved SomeT), so clang
+// fails with "no member named 'await_result_0'".
+// Pre-fix: compile rc=1 (C error). Post-fix: compiles, runs rc=0.
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+{ IoExn } :: import("std/error");
+
+Sink :: trait(
+  put : (fn(self : Self, v : u8, io : Io) -> Impl(Future(usize, IoExn))),
+  (put_all : (fn(self : Self, v : u8, io : Io) -> Impl(Future(unit, IoExn)))) ?=
+    (
+      (self, v, io) ->
+        io.async((e) => {
+          n := e.io.await(Self.put(self, v, io), e);
+          assert(n == usize(1), "one put");
+          ()
+        })
+    )
+);
+Tally :: ref(struct(count : u8));
+impl(
+  Tally,
+  Sink(
+    put : (fn(self : Self, v : u8, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        self.count = (self.count + v);
+        usize(1)
+      })
+    )
+  )
+);
+// The failing shape: the closure body IS the tail await of the unit default.
+put_all_generic :: (
+  fn(generic(S : Type), s : S, v : u8, io : Io, where(S <: Sink)) -> Impl(Future(unit, IoExn))
+)(
+  io.async((e) => e.io.await(s.put_all(v, io), e))
+);
+main :: (fn(io : Io) -> unit)({
+  t := Tally(count : u8(0));
+  io.await(put_all_generic(t, u8(5), io), { io });
+  io.await(put_all_generic(t, u8(7), io), { io });
+  assert(t.count == u8(12), "both puts landed");
+});
+export(main);

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -82,6 +82,7 @@ records; mechanisms and reproducers are in the named `issues/fixed/` docs.
 | C22 | a closure defined INSIDE an `io.async` closure body makes that body untranspilable — compile exits 0, clang clean, binary is rc=134 (`abort()` stub), future is `_sync_fut_t` | **OPEN** — issues/closure-nested-inside-io-async-closure-body-emits-abort-stub.md |
 | C23 | generic implementor (`impl(generic(T), Wrap(T), …)`) awaiting `Self.<async method>` emitted uncompilable C — two defects: static-dot `-> Self` resolution clobbered SomeT returns with the receiver, and `substitute` was not capture-avoiding (the impl's `T := usize` rewrote `Io.async`'s own `T` binder) | **FIXED** 2026-08-26 — issues/fixed/generic-implementor-async-method-awaiting-self-emits-uncompilable-c.md, tests/generic_impl_async_self.test.yo |
 | C24 | **async loop over a buffer-taking await** (the D5 slice-2 blocker, found by D5 work): (a) a generic fn's `io.async` closure DROPPED the enclosing params from its capture (the `.AsyncBlock` classifier arm kept a generation-unsafe frame-level test); (b) the nullable-ptr match's payload binding (`.Some(q) => q` over `chunk.ptr()`) declared a C local while arm reads consulted the never-written hoisted `sm->var_N` slot — silent rc=139 on fully-transpiled C. Both **FIXED** 2026-08-26 (PRs #294 + #295; tests/async_generic_param_capture.test.yo, tests/async_loop_buffer_await.test.yo). REMAINING OPEN: the generic-impl face — the same loop inside `impl(generic(R), …)` resolves the binding to a never-declared minted temp (loud C failure) | partly **FIXED**, generic-impl face **OPEN** — issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md |
+| C25 | **a unit-resolving TAIL await emitted `sm->await_result_N;`** — a field the state struct never declares for an effectively-unit result (unit, or the unresolved SomeT a where-bound trait default's `Impl(Future(unit, IoExn))` return looks like), so clang failed with "no member named 'await_result_0'". Found by D5 slice 2's first `write_all` wrapper; the completion-segment substitution lacked the effectively-unit guard the struct allocator and the extraction both had | **FIXED** 2026-08-26 — issues/fixed/unit-tail-await-of-trait-default-reads-missing-await-result.md, tests/async_unit_tail_await.test.yo |
 
 ---
 
@@ -260,22 +261,37 @@ impls, and the byte-count unification (`File.read`/`write`/`write_string`/
 `write_bytes` → `usize`, closing the transient where net returned `usize` but
 file/bufio didn't). Tests: `tests/io/async_traits.test.yo`.
 
-**D5 SLICE 2 state:** the blocking compiler bug (C24 — async loop over a
-buffer-taking await) had its silent-segv facets **FIXED 2026-08-26**, so
-`read_to_end`/`read_to_string`/`write_all` as trait defaults or free generics,
-and `io.copy`, are now implementable (proven by
-`tests/async_loop_buffer_await.test.yo`, which runs both loop shapes).
-Still blocked: **generic `BufReader(R)`/`BufWriter(W)`** — C24's generic-impl
-face plus **C17** (the `Dyn(Reader)` spelling); the `std/sys/bufio` → `std/io`
-move waits for the wrappers to go generic. Cautions while implementing:
+**D5 SLICE 2 LANDED 2026-08-26** (unblocked by C24's fixes; C25 was found and
+fixed en route — its first `write_all` wrapper did not C-compile):
 
-- **C21** — two-implementor async defaults trip `-Wincompatible-pointer-types`
-  (benign today, watch it).
-- **C22** — do NOT write a nested closure inside an `io.async` body in these
-  defaults; it silently becomes `abort()`.
-- BufWriter's `Dispose` is a SYNC flush that cannot await an async
-  `Writer.write` (C12 note) — the structural tension in "BufWriter wraps any
-  Writer".
+- `Reader` gained `?=` defaults **`read_to_end`** (chunked loop over the raw
+  `read`, no caller pointers) and **`read_to_string`** (a default chained onto
+  a default — `Self.read_to_end` then `String.from_utf8`; malformed bytes
+  throw the NEW **`IoError.InvalidData`**). `Writer` gained **`write_all`**
+  (loops short counts; a 0-byte write throws the NEW **`IoError.WriteZero`**).
+  Both variants are Rust's names; `NetError.from_io` has a `_` catch-all so
+  the enum growth is safe.
+- **`copy(r, w, io) -> Future(u64, IoExn)`** — the free generic, draining any
+  `Reader` into any `Writer` via `write_all`; does not flush.
+- The INHERENT `File.read_to_string` (and with it the free
+  `fs read_to_string` family) now **validates UTF-8** and throws
+  `InvalidData`, so the inherent and trait surfaces agree — it had shipped on
+  the unchecked `from_bytes`.
+- Tests: `tests/io/async_traits.test.yo` 4 → 8 (chunk-looping read_to_end
+  through the bound AND as a direct method call, default-onto-default
+  read_to_string, copy with byte total, InvalidData throw), vacuity-probed;
+  `tests/async_unit_tail_await.test.yo` (C25 red-first).
+
+**D5 remaining:** generic `BufReader(R)`/`BufWriter(W)` — C24's generic-impl
+face plus **C17** (the `Dyn(Reader)` spelling); with them the
+`std/sys/bufio` → `std/io` move + its `IoExn` adoption, and a buffered
+`lines()`. Inherent-vs-trait NAME duplication (`File.read_bytes` vs the trait's
+`read_to_end`, the inherent `read_to_string`) is a D2 question to settle when
+the wrappers land. Cautions that still stand: **C21**
+(`-Wincompatible-pointer-types` across implementors — the two warnings are
+live in the slice-2 emit), **C22** (no nested closures inside `io.async`
+bodies), and the C12 note (BufWriter's SYNC `Dispose` flush cannot await an
+async `Writer.write`).
 
 ### D6 — TLS position
 
@@ -411,7 +427,7 @@ Open D7 items:
 | json | EXTEND | enum representation DECIDED externally-tagged (O3); `JsonValue.Object` O(n) parallel arrays → keep repr, add index map if profiling demands |
 | regex | POLISH | typed error + private internals DONE (D8); byte `index()` DONE (D4 PR 6); still: `Regex.escape`, optional-flags `new`, callback replace, lazy `find_iter`, group byte-spans |
 | url | EXTEND | percent-encode/decode integration, `query_pairs`/`SearchParams`, `join` (RFC 3986 §5 — needed by http redirects), builder/setters; punycode DELETED (§6) |
-| io | REDESIGN | D5 — slice 1 DONE, slice 2 in progress |
+| io | REDESIGN | D5 — slices 1–2 DONE; generic wrappers + bufio move remain |
 | fs | EXTEND + POLISH | wrappers: `copy`, `remove_dir_all` (compiler implements it TWICE as workaround — `src/fetch.yo:80`, `src/version_cache.yo:72`), `read_link`, `set_permissions`, `set_len`, `try_exists`, `watch` (sys/events exists); `OpenOptions` builder; `File.from_fd`; Metadata: real `btime`, `permissions()`, stop `metadata` re-stat by path; DirEntry `path()`; walker: lazy option + glob filter; collapse the `_str`/`_cstr` matrix with an `AsPath` trait |
 | path | FIX + EXTEND | `join(str)`, `push`, `Hash`/`Ord`/`Clone`, Windows separator in `to_string`, `ancestors`, PATH split/join; revisit eager `..` normalization (symlink semantics); `PathError` deleted (§6) — or make `new` fallible |
 | env | MERGE (D8) | + `remove`, `vars()` iteration, `str` keys |
@@ -544,7 +560,7 @@ declarations at runtime.
 **P0 — unblock real programs**
 1. `std/encoding/percent.yo` (percent-encode/decode) + URL/query integration
 2. ~~`std/encoding/utf8.yo` (D8)~~ **DONE 2026-08-25** + `html_encode` (open)
-3. `std/io` redesign with stdio handles (D5) — slice 1 DONE, slice 2 in progress
+3. `std/io` redesign with stdio handles (D5) — slices 1–2 DONE; generic wrappers + bufio move remain
 4. `fs.copy`, `fs.remove_dir_all`, `read_link`, `set_permissions`, `try_exists`
 5. `process.Child`/`spawn`/`Stdio`
 6. async combinators + async channel/mutex + `timeout` (D7)
@@ -602,8 +618,8 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
 1. **S0 — correctness:** §2 — **DONE** (open compiler rows tracked in §2).
 2. **S1 — conventions ADR + prelude traits (D1–D3):** **DONE** (D3.9 blocked).
 3. **S2 — the breaking sweep (§5 + §6 + D4/D5/D7/D8):** **essentially DONE** —
-   remaining: D4 PR 9, D5 slice 2, D8 env-merge/EncodingError/glob rows, O7
-   bound.
+   remaining: D4 PR 9, D5's generic wrappers + bufio move, D8
+   env-merge/EncodingError/glob rows, O7 bound.
 4. **S3 — P0 additions.** ← next after D5 slice 2
 5. **S4 — P1 additions.**
 6. **S5 — stability freeze:** stable/unstable markers in `yo doc` output,

--- a/plans/STD_API_AUDIT_HANDOVER.md
+++ b/plans/STD_API_AUDIT_HANDOVER.md
@@ -108,16 +108,13 @@ on.
 ### 3.2 D5 — async `Reader`/`Writer` traits — SLICE 1 LANDED 2026-08-26
 
 Slice 1 (traits + stdio + File/TcpStream impls + the usize/IoExn unification)
-merged as #293. The slice-2 blocker
-(issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md)
-had its silent facets FIXED in #294 + #295, so **`read_to_end` /
-`read_to_string` / `write_all` as trait defaults or free generics, and
-`io.copy`, are now implementable** (tests/async_loop_buffer_await.test.yo
-proves both loop shapes). Still blocked: generic `BufReader(R)`/`BufWriter(W)`
-— the issue's generic-impl face (OPEN) plus C17 — and therefore the
-`std/sys/bufio` → `std/io` move. Cautions while implementing: C21
-(cross-implementor pointer-type warning) and C22 (no nested closures inside
-`io.async` bodies). Full current state: `plans/STD_API_AUDIT.md` §D5.
+merged as #293; slice 2 (the `read_to_end`/`read_to_string`/`write_all`
+defaults, `copy`, `IoError.InvalidData`/`WriteZero`, validating
+`File.read_to_string`) LANDED 2026-08-26 after #294/#295 unblocked it — C25
+(the unit tail await) was found and fixed en route. Still blocked: generic
+`BufReader(R)`/`BufWriter(W)` — the loop-await issue's generic-impl face
+(OPEN) plus C17 — and therefore the `std/sys/bufio` → `std/io` move and a
+buffered `lines()`. Full current state: `plans/STD_API_AUDIT.md` §D5.
 
 ### 3.3 §7 additions — S3 (P0) and S4 (P1)
 

--- a/src/codegen/async/state_code_gen.yo
+++ b/src/codegen/async/state_code_gen.yo
@@ -1160,8 +1160,31 @@ generate_state_segment_code :: (
   (had_substitution : bool) = false;
   (previous_substitution : String) = String.new();
   (substitution_key : usize) = usize(0);
+  (registered_substitution : bool) = false;
   match(
     segment.hoisted_await_point,
+    .Some(hp) => {
+      // An effectively-unit hoisted await has NO `await_result_N`: the state
+      // struct never allocates the field and the extraction never writes it
+      // (both guard on the same predicate — `_await_result_is_unit` in
+      // exprs/async.yo, inlined in state_machine.yo's extraction). Registering
+      // `sm->await_result_N` here anyway made the completion segment of
+      // `io.async((e) => e.io.await(<unit future>, e))` read a nonexistent
+      // struct member. Skip the substitution instead: `generate_await` then
+      // renders "", and both emit paths below skip empty code.
+      hp_is_unit := (
+        is_unit_type(hp.result_type) || (
+          is_some_type(hp.result_type) && match(hp.result_type, .SomeT({ id }) => lookup_some_resolved_concrete(id).is_none(), _ => false)
+        )
+      );
+      if(!(hp_is_unit), {
+        registered_substitution = true;
+      });
+    },
+    .None => ()
+  );
+  match(
+    if(registered_substitution, segment.hoisted_await_point, Option(AwaitPoint).None),
     .Some(hp) => {
       if(context.await_result_substitutions.is_none(), {
         context.await_result_substitutions = Option(HashMap(usize, String)).Some(HashMap(usize, String).new());
@@ -1244,9 +1267,10 @@ generate_state_segment_code :: (
     i = (i + usize(1));
   });
   // Restore the substitution — segments are generated in sequence and the map
-  // is shared across the whole async block.
+  // is shared across the whole async block. (Nothing to restore when the
+  // effectively-unit guard above skipped registration.)
   match(
-    segment.hoisted_await_point,
+    if(registered_substitution, segment.hoisted_await_point, Option(AwaitPoint).None),
     .Some(_) => match(
       context.await_result_substitutions,
       .Some(subs) => if(had_substitution, {

--- a/std/fs/file.yo
+++ b/std/fs/file.yo
@@ -194,11 +194,18 @@ impl(
       result
     })
   }),
-  /// Read the entire file contents into a `String`.
+  /// Read the entire file contents into a `String`. Validates UTF-8:
+  /// malformed bytes throw `IoError.InvalidData` (matching the D5
+  /// `Reader.read_to_string` default; use `read_bytes` + `String.from_utf8`
+  /// to see the exact offset).
   read_to_string : (fn(self : Self, io : Io) -> Impl(Future(String, IoExn)))(
     io.async((e) => {
       bytes := e.io.await(self.read_bytes(io), e);
-      String.from_bytes(bytes)
+      match(
+        String.from_utf8(bytes),
+        .Ok(s) => s,
+        .Err(_) => e.exn.throw(dyn(IoError.InvalidData))
+      )
     })
   ),
   /// Flush (fsync) file data to disk.

--- a/std/io/index.yo
+++ b/std/io/index.yo
@@ -10,25 +10,69 @@
 //! same shape `TcpStream.read` and the sys layer already speak. Raw
 //! pointers are not available in safe code, so IMPLEMENTING or calling the
 //! raw methods directly needs `pragma(Pragma.AllowUnsafe);`; safe code uses
-//! the pointer-free conveniences on each concrete type (`read_to_string`,
-//! `read_bytes`, `write_string`, `write_bytes`, ...).
+//! the pointer-free defaults (`read_to_end`, `read_to_string`) and the
+//! per-type conveniences on each concrete type.
 //!
-//! DEFERRED, blocked on a filed compiler bug
-//! (issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md):
-//! `read_to_end`/`read_to_string`/`write_all` as trait `?=` defaults or free
-//! generic functions, `copy(r, w)`, and the generic `BufReader(R)` /
-//! `BufWriter(W)` wrappers. An async body that LOOPS awaiting a
-//! buffer-taking method today either segfaults (concrete/default, free
-//! generic) or emits invalid C (generic impl). The per-type inherent
-//! conveniences dispatch directly and are unaffected.
+//! DEFERRED, blocked on the generic-impl face of a filed compiler bug
+//! (issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md)
+//! plus C17: the generic `BufReader(R)` / `BufWriter(W)` wrappers and the
+//! `std/sys/bufio` → `std/io` move, and with them a buffered `lines()`.
 pragma(Pragma.AllowUnsafe);
 { IoExn } :: import("../error");
+{ IoError } :: import("../sys/errors");
+{ ArrayList } :: import("../collections/array_list");
+{ String } :: import("../string");
 
 /// An async source of bytes.
 Reader :: trait(
   /// Read up to `size` bytes into `buf`. Resolves to the number of bytes
   /// actually read; `0` means end-of-stream. Throws `IoExn` on failure.
-  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn))),
+  /// Read until end-of-stream, resolving to all remaining bytes. Loops the
+  /// raw `read` with an internal chunk buffer, so implementors get it for
+  /// free and callers never touch a raw pointer.
+  (read_to_end : (fn(self : Self, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))) ?=
+    (
+      (self, io) ->
+        io.async((e) => {
+          out := ArrayList(u8).new();
+          chunk := ArrayList(u8).with_capacity(usize(4096));
+          (ci : usize) = usize(0);
+          while(ci < usize(4096), ci = (ci + usize(1)), {
+            chunk.push(u8(0));
+          });
+          p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+          (done : bool) = false;
+          while(!(done), {
+            n := e.io.await(Self.read(self, p, usize(4096), io), e);
+            if(n == usize(0), {
+              done = true;
+            }, {
+              (i : usize) = usize(0);
+              while(i < n, i = (i + usize(1)), {
+                out.push(chunk(i));
+              });
+            });
+          });
+          out
+        })
+    ),
+  /// Read until end-of-stream and decode as UTF-8. Unlike the UNCHECKED
+  /// per-type conveniences that predate D5, this validates: malformed bytes
+  /// throw `IoError.InvalidData` (use `read_to_end` + `String.from_utf8`
+  /// to see the exact offset).
+  (read_to_string : (fn(self : Self, io : Io) -> Impl(Future(String, IoExn)))) ?=
+    (
+      (self, io) ->
+        io.async((e) => {
+          bytes := e.io.await(Self.read_to_end(self, io), e);
+          match(
+            String.from_utf8(bytes),
+            .Ok(s) => s,
+            .Err(_) => e.exn.throw(dyn(IoError.InvalidData))
+          )
+        })
+    )
 );
 /// An async sink of bytes.
 Writer :: trait(
@@ -38,6 +82,52 @@ Writer :: trait(
   write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn))),
   /// Flush any buffered bytes through to the underlying sink. Unbuffered
   /// writers resolve immediately.
-  flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))
+  flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn))),
+  /// Write ALL `size` bytes from `buf`, looping the raw `write` over short
+  /// counts. Throws `IoError.WriteZero` if the sink stops accepting bytes
+  /// before everything is delivered.
+  (write_all : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(unit, IoExn)))) ?=
+    (
+      (self, buf, size, io) ->
+        io.async((e) => {
+          (written : usize) = usize(0);
+          while(written < size, {
+            n := e.io.await(Self.write(self, buf.add(written), size - written, io), e);
+            cond(
+              (n == usize(0)) => e.exn.throw(dyn(IoError.WriteZero)),
+              true => ()
+            );
+            written = (written + n);
+          });
+          ()
+        })
+    )
 );
-export(Reader, Writer);
+/// Copy everything from `r` to `w` until `r` reaches end-of-stream,
+/// resolving to the total number of bytes copied (`u64` so totals larger
+/// than a 32-bit `usize` cannot overflow). Does NOT flush `w`.
+copy :: (
+  fn(generic(R : Type, W : Type), r : R, w : W, io : Io, where(R <: Reader, W <: Writer)) -> Impl(Future(u64, IoExn))
+)(
+  io.async((e) => {
+    (total : u64) = u64(0);
+    chunk := ArrayList(u8).with_capacity(usize(4096));
+    (ci : usize) = usize(0);
+    while(ci < usize(4096), ci = (ci + usize(1)), {
+      chunk.push(u8(0));
+    });
+    p := match(chunk.ptr(), .Some(q) => q, .None => *(u8)(""));
+    (done : bool) = false;
+    while(!(done), {
+      n := e.io.await(r.read(p, usize(4096), e.io), e);
+      if(n == usize(0), {
+        done = true;
+      }, {
+        e.io.await(w.write_all(p, n, e.io), e);
+        total = (total + u64(n));
+      });
+    });
+    total
+  })
+);
+export(Reader, Writer, copy);

--- a/std/sys/errors.yo
+++ b/std/sys/errors.yo
@@ -72,6 +72,14 @@ IoError :: enum(
   NetworkDown,
   /// Already connected (EISCONN).
   AlreadyConnected,
+  /// The stream contained malformed data for the operation — e.g.
+  /// `Reader.read_to_string` over bytes that are not valid UTF-8. Not an
+  /// errno; the Rust `ErrorKind::InvalidData` counterpart.
+  InvalidData,
+  /// A `write` accepted 0 bytes, so the remaining data can never be
+  /// delivered (`Writer.write_all`). Not an errno; the Rust
+  /// `ErrorKind::WriteZero` counterpart.
+  WriteZero,
   /// Other error with raw errno code.
   Other(code : i32)
 );
@@ -160,6 +168,8 @@ impl(
           .HostUnreachable => String.from("host unreachable"),
           .NetworkDown => String.from("network is down"),
           .AlreadyConnected => String.from("socket already connected"),
+          .InvalidData => String.from("stream contained malformed data"),
+          .WriteZero => String.from("write returned zero bytes"),
           .Other(errno) => String.from("unknown I/O error")
         );
         return(s);

--- a/tests/async_unit_tail_await.test.yo
+++ b/tests/async_unit_tail_await.test.yo
@@ -1,0 +1,62 @@
+//! Regression
+//! (issues/fixed/unit-tail-await-of-trait-default-reads-missing-await-result.md):
+//! an `io.async` body that IS a tail await of an effectively-unit future —
+//! unit reached through a where-bound trait default, i.e. an unresolved SomeT
+//! — emitted `sm->await_result_N;` in the completion segment while the state
+//! struct (correctly) never declares that field for unit results, so clang
+//! failed with "no member named 'await_result_0'". Fixed by giving the
+//! completion-segment substitution the same effectively-unit guard the struct
+//! allocator and the extraction already had.
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+{ IoExn } :: import("std/error");
+
+Sink :: trait(
+  put : (fn(self : Self, v : u8, io : Io) -> Impl(Future(usize, IoExn))),
+  (put_all : (fn(self : Self, v : u8, io : Io) -> Impl(Future(unit, IoExn)))) ?=
+    (
+      (self, v, io) ->
+        io.async((e) => {
+          n := e.io.await(Self.put(self, v, io), e);
+          assert(n == usize(1), "one put");
+          ()
+        })
+    )
+);
+Tally :: ref(struct(count : u8));
+impl(
+  Tally,
+  Sink(
+    put : (fn(self : Self, v : u8, io : Io) -> Impl(Future(usize, IoExn)))(
+      io.async((e) => {
+        self.count = (self.count + v);
+        usize(1)
+      })
+    )
+  )
+);
+// THE pre-fix failing shape: the closure body IS the tail await of the unit
+// default, reached through a where bound (unresolved-SomeT result type).
+put_all_generic :: (
+  fn(generic(S : Type), s : S, v : u8, io : Io, where(S <: Sink)) -> Impl(Future(unit, IoExn))
+)(
+  io.async((e) => e.io.await(s.put_all(v, io), e))
+);
+// Concrete control: a REAL-unit tail await always worked — pin that the fix
+// did not disturb it.
+inner_unit :: (fn(io : Io) -> Impl(Future(unit)))(
+  io.async((e) => ())
+);
+outer_unit :: (fn(io : Io) -> Impl(Future(unit)))(
+  io.async((e) => e.io.await(inner_unit(io), e.io))
+);
+test("generic tail await of a unit trait default compiles and runs", {
+  t := Tally(count : u8(0));
+  io.await(put_all_generic(t, u8(5), io), { io });
+  io.await(put_all_generic(t, u8(7), io), { io });
+  assert(t.count == u8(12), "both puts landed");
+});
+test("concrete unit tail await control still works", {
+  io.await(outer_unit(io), { io });
+  assert(true, "completed");
+});

--- a/tests/io/async_traits.test.yo
+++ b/tests/io/async_traits.test.yo
@@ -1,18 +1,17 @@
-//! STD_API_AUDIT D5: the async `Reader`/`Writer` traits and their concrete
-//! implementors — `File`, `TcpStream` (impl registration), `Stdout`/`Stderr`.
-//!
-//! What is deliberately NOT here, blocked on
-//! issues/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md:
-//! any generic helper that LOOPS awaiting `read`/`write` (read_to_end,
-//! io.copy) — an async body looping over a buffer-taking await miscompiles
-//! today. The generic helpers below make exactly ONE await, the shape the
-//! bug's control reproducers prove green.
+//! STD_API_AUDIT D5: the async `Reader`/`Writer` traits, their concrete
+//! implementors — `File`, `TcpStream` (impl registration), `Stdout`/`Stderr` —
+//! and the slice-2 surface: the `read_to_end`/`read_to_string`/`write_all`
+//! trait defaults and `copy`, unblocked by PRs #294/#295 (the loop-await
+//! state-machine fixes) and the unit-tail-await substitution fix
+//! (issues/fixed/unit-tail-await-of-trait-default-reads-missing-await-result.md).
+//! Still NOT here: generic `BufReader(R)`/`BufWriter(W)` (the filed bug's
+//! generic-impl face + C17).
 pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
 open(import("std/collections/array_list"));
 open(import("std/string"));
-{ IoExn } :: import("std/error");
-{ Reader, Writer } :: import("std/io");
+{ IoExn, Exception } :: import("std/error");
+{ Reader, Writer, copy } :: import("std/io");
 { Stdout, Stderr, stdout, stderr } :: import("std/io/stdio");
 { File, OpenMode } :: import("std/fs/file");
 { TcpStream } :: import("std/net/tcp");
@@ -41,6 +40,107 @@ write_once :: (
   io.async((e) => e.io.await(the_w.write(the_buf, the_size, e.io), e))
 });
 
+// Slice-2 generic helpers: the defaults reached through where bounds.
+read_all_generic :: (
+  fn(generic(R : Type), r : R, io : Io, where(R <: Reader)) -> Impl(Future(ArrayList(u8), IoExn))
+)(
+  io.async((e) => e.io.await(r.read_to_end(io), e))
+);
+read_string_generic :: (
+  fn(generic(R : Type), r : R, io : Io, where(R <: Reader)) -> Impl(Future(String, IoExn))
+)(
+  io.async((e) => e.io.await(r.read_to_string(io), e))
+);
+write_all_generic :: (
+  fn(generic(W : Type), w : W, buf : *(u8), size : usize, io : Io, where(W <: Writer)) -> Impl(Future(unit, IoExn))
+)(
+  io.async((e) => e.io.await(w.write_all(buf, size, io), e))
+);
+test("read_to_end default loops chunks; write_all default delivers everything", {
+  path := Path.new(`/tmp/yo_d5s2_defaults.bin`.to_string());
+  // 10000 bytes so read_to_end must loop three 4096-byte chunks.
+  payload := ArrayList(u8).new();
+  (i : usize) = usize(0);
+  while(i < usize(10000), i = (i + usize(1)), {
+    payload.push(u8(usize(65) + (i % usize(26))));
+  });
+  f := io.await(File.open(path, OpenMode.Write, io), { io });
+  io.await(write_all_generic(f, payload.ptr().unwrap(), payload.len(), io), { io });
+  io.await(f.close(io), { io });
+  // Through the where bound...
+  r1 := io.await(File.open(path, OpenMode.Read, io), { io });
+  all := io.await(read_all_generic(r1, io), { io });
+  io.await(r1.close(io), { io });
+  assert(all.len() == usize(10000), "read_to_end got all bytes");
+  assert(all(usize(0)) == u8(65), "first byte");
+  assert(all(usize(9999)) == u8(65 + (9999 % 26)), "last byte");
+  // ...and as a direct method call.
+  r2 := io.await(File.open(path, OpenMode.Read, io), { io });
+  all2 := io.await(r2.read_to_end(io), { io });
+  io.await(r2.close(io), { io });
+  assert(all2.len() == usize(10000), "direct read_to_end got all bytes");
+  io.await(remove_file(path, io), { io });
+});
+test("read_to_string default validates UTF-8 (default chained onto default)", {
+  path := Path.new(`/tmp/yo_d5s2_rts.txt`.to_string());
+  f := io.await(File.open(path, OpenMode.Write, io), { io });
+  n := io.await(f.write_string(`héllo world`.to_string(), io), { io });
+  assert(n == usize(12), "12 UTF-8 bytes written");
+  io.await(f.close(io), { io });
+  r := io.await(File.open(path, OpenMode.Read, io), { io });
+  s := io.await(read_string_generic(r, io), { io });
+  io.await(r.close(io), { io });
+  assert(s == `héllo world`, "round trip through the trait default");
+  io.await(remove_file(path, io), { io });
+});
+test("copy drains a Reader into a Writer and counts bytes", {
+  pa := Path.new(`/tmp/yo_d5s2_copy_a.bin`.to_string());
+  pb := Path.new(`/tmp/yo_d5s2_copy_b.bin`.to_string());
+  payload := ArrayList(u8).new();
+  (i : usize) = usize(0);
+  while(i < usize(5000), i = (i + usize(1)), {
+    payload.push(u8(i % usize(251)));
+  });
+  f := io.await(File.open(pa, OpenMode.Write, io), { io });
+  io.await(write_all_generic(f, payload.ptr().unwrap(), payload.len(), io), { io });
+  io.await(f.close(io), { io });
+  cr := io.await(File.open(pa, OpenMode.Read, io), { io });
+  cw := io.await(File.open(pb, OpenMode.Write, io), { io });
+  total := io.await(copy(cr, cw, io), { io });
+  io.await(cr.close(io), { io });
+  io.await(cw.close(io), { io });
+  assert(total == u64(5000), "copy resolves the byte total");
+  vb := io.await(File.open(pb, OpenMode.Read, io), { io });
+  copied := io.await(vb.read_to_end(io), { io });
+  io.await(vb.close(io), { io });
+  assert(copied.len() == usize(5000), "copied length");
+  assert(copied(usize(2500)) == payload(usize(2500)), "copied middle byte");
+  io.await(remove_file(pa, io), { io });
+  io.await(remove_file(pb, io), { io });
+});
+test("read_to_string throws IoError.InvalidData on malformed UTF-8", {
+  path := Path.new(`/tmp/yo_d5s2_badutf8.bin`.to_string());
+  bad := ArrayList(u8).new();
+  bad.push(u8(0xFF));
+  bad.push(u8(0xFE));
+  fw := io.await(File.open(path, OpenMode.Write, io), { io });
+  io.await(fw.write(bad.ptr().unwrap(), bad.len(), io), { io });
+  io.await(fw.close(io), { io });
+  exn := Exception(
+    throw : (
+      (err) -> {
+        msg := err.to_string();
+        assert(msg.contains(`malformed data`), `expected InvalidData, got: ${msg}`);
+        unwind(());
+      }
+    )
+  );
+  // The INHERENT File.read_to_string validates too (aligned with the trait
+  // default in the same change) — exercise it through the throw handler.
+  r := io.await(File.open(path, OpenMode.Read, io), { io });
+  s := io.await(r.read_to_string(io), IoExn(io : io, exn : exn));
+  assert(false, `read_to_string must throw on malformed UTF-8, got: ${s}`);
+});
 test("File implements Reader and Writer — trait-dispatched round trip", {
   path := Path.new(`/tmp/yo_d5_traits_roundtrip.bin`.to_string());
   f := io.await(File.open(path, OpenMode.Write, io), { io });


### PR DESCRIPTION
The `Reader`/`Writer` defaults the D5 redesign specified (`plans/STD_API_AUDIT.md` §D5), landable now that #294/#295 fixed the loop-await state machines — plus the compiler bug (**C25**) its first wrapper exposed.

## std surface

- **`Reader.read_to_end`** `?=` chunked loop over the raw `read` (4096-byte chunk, no caller pointers); **`Reader.read_to_string`** `?=` a default chained onto a default (`Self.read_to_end`, then `String.from_utf8` — malformed bytes throw the NEW **`IoError.InvalidData`**); **`Writer.write_all`** `?=` loops short counts, throwing the NEW **`IoError.WriteZero`** on a dead sink. Both variants are Rust's names; `NetError.from_io` has a `_` catch-all, so the enum growth is safe.
- **`copy(r, w, io) -> Future(u64, IoExn)`** — free generic draining any Reader into any Writer via `write_all`. Does not flush.
- The **inherent `File.read_to_string`** (and the free `fs read_to_string` family through it) now **validates UTF-8** and throws `InvalidData`, so the inherent and trait surfaces agree — it had shipped on the unchecked `from_bytes`.

## Compiler fix (C25) — issues/fixed/unit-tail-await-of-trait-default-reads-missing-await-result.md

An `io.async` body that IS a tail await of an **effectively-unit** future — the unresolved-SomeT shape a where-bound trait default's `Impl(Future(unit, IoExn))` return has — emitted `sm->await_result_N;` while the state struct (correctly) never declares that field for unit results: clang failed with `no member named 'await_result_0'`. Three emitters must agree on when an await gets an `await_result_N` field; the struct allocator and the extraction both guarded on effectively-unit, the completion-segment substitution did not. It now carries the same guard; `generate_await` renders `""` and both emit paths skip empty code.

## Verification

- **Red-first**: the minimal repro fails on the pre-fix binary with exactly that C error, runs rc=0 after; `tests/async_unit_tail_await.test.yo` pins it plus a concrete-unit control.
- `tests/io/async_traits.test.yo` 4 → 8 (chunk-looping read_to_end through the bound AND as a direct method call, default-onto-default read_to_string, copy with byte total, InvalidData throw), vacuity-probed (broken assert → rc=1).
- Regression: async_await 184, async_trait_default_await 4, generic_impl_async_self 4, async_generic_param_capture 2, async_loop_buffer_await 2, algebraic_effects 74, time/sleep 4, string 253.
- **Full battery**: check std 156/156 + src 262/262, build rc=0, suite **3156/3156**, cli-diff 52 PASS / 0 GOLDEN-DIFF / 0 NO-GOLDEN (zero golden drift), gates `T1_DONE failures=0`, fixpoint `stage2 hollow=0 STAGE3_RC=0 FIXPOINT_HOLDS`, hollow sweep `SWEEP_GATE_OK` (0 allowlisted).

Still ahead for D5 (documented in the plan): generic `BufReader(R)`/`BufWriter(W)` (the loop-await issue's generic-impl face + C17), the `std/sys/bufio` → `std/io` move, buffered `lines()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)