### PR TITLE
plans: D5 status — generic bufio implemented, blocked by the C21 escalation

### DIFF
--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -78,7 +78,7 @@ records; mechanisms and reproducers are in the named `issues/fixed/` docs.
 | C18 | **A struct literal that OMITS a required field is silently accepted** — `yo check` green, field uninitialised, program SIGSEGVs. Directly undermines §1's "additive-only" promise: adding a field to a stable struct silently breaks every construction site not updated | **OPEN** — issues/struct-literal-missing-field-silently-accepted.md |
 | C19 | C `int` passed where `i32` declared is accepted by the evaluator; codegen splices a Yo type expr into a C identifier, clang fails with a diagnostic naming nothing the user wrote | **OPEN** — issues/int-vs-i32-mismatch-reaches-codegen-and-emits-malformed-c.md |
 | C20 | generic-`R` callback with a unit-returning closure emitted `void* tmp = <void call>;` — `Mutex.with_lock((v) => { … })`, the flagship std/sync form, did not C-compile | **FIXED** 2026-08-26 — issues/fixed/generic-r-callback-with-unit-closure-emits-void-star-temp.md |
-| C21 | a materialized async trait `?=` default resolves its `Impl(Future(...))` return to ONE concrete state-machine type for ALL implementors — call sites for implementor A declare implementor B's `_state_t*` (`-Wincompatible-pointer-types`). Harmless today only because every async state struct shares a common prefix (verified with 56-byte-skewed implementors) — but this class has silently miscompiled before | **OPEN** — issues/async-trait-default-shares-one-impl-future-concrete-type.md |
+| C21 | a materialized async trait `?=` default resolves its `Impl(Future(...))` return to ONE concrete state-machine type for ALL implementors — call sites for implementor A declare implementor B's `_state_t*` (`-Wincompatible-pointer-types`). Harmless today only because every async state struct shares a common prefix (verified with 56-byte-skewed implementors) — but this class has silently miscompiled before. **ESCALATED 2026-08-26 to a hard C error** on D5's generic BufReader (abstract never-emitted state struct; incomplete-type), now the prerequisite for finishing D5 — see the issue's escalation section + two repros | **OPEN, load-bearing** — issues/async-trait-default-shares-one-impl-future-concrete-type.md |
 | C22 | a closure defined INSIDE an `io.async` closure body makes that body untranspilable — compile exits 0, clang clean, binary is rc=134 (`abort()` stub), future is `_sync_fut_t` | **OPEN** — issues/closure-nested-inside-io-async-closure-body-emits-abort-stub.md |
 | C23 | generic implementor (`impl(generic(T), Wrap(T), …)`) awaiting `Self.<async method>` emitted uncompilable C — two defects: static-dot `-> Self` resolution clobbered SomeT returns with the receiver, and `substitute` was not capture-avoiding (the impl's `T := usize` rewrote `Io.async`'s own `T` binder) | **FIXED** 2026-08-26 — issues/fixed/generic-implementor-async-method-awaiting-self-emits-uncompilable-c.md, tests/generic_impl_async_self.test.yo |
 | C24 | **async loop over a buffer-taking await** (the D5 slice-2 blocker, found by D5 work): (a) a generic fn's `io.async` closure DROPPED the enclosing params from its capture (the `.AsyncBlock` classifier arm kept a generation-unsafe frame-level test); (b) the nullable-ptr match's payload binding (`.Some(q) => q` over `chunk.ptr()`) declared a C local while arm reads consulted the never-written hoisted `sm->var_N` slot — silent rc=139 on fully-transpiled C. Both **FIXED** 2026-08-26 (PRs #294 + #295; tests/async_generic_param_capture.test.yo, tests/async_loop_buffer_await.test.yo). (c) the generic-impl face — a materialized generic-impl arm body read the match binding through an evaluator-stamped temp the nullable-ptr emitter never shadow-registered (`_shadow_add`, the mechanism the tagged-union path always used) — **FIXED** 2026-08-26 too. ALL THREE FACETS CLOSED; generic `BufReader(R)`/`BufWriter(W)` unblocked (C17 still blocks only the `Dyn(Reader)` spelling) | **FIXED** — issues/fixed/async-loop-awaiting-buffer-taking-method-state-machine-corruption.md |
@@ -282,11 +282,19 @@ fixed en route — its first `write_all` wrapper did not C-compile):
   read_to_string, copy with byte total, InvalidData throw), vacuity-probed;
   `tests/async_unit_tail_await.test.yo` (C25 red-first).
 
-**D5 remaining:** generic `BufReader(R)`/`BufWriter(W)` — **UNBLOCKED
-2026-08-26** (C24 facet 3 fixed; the loop-inside-generic-impl probe compiles
-and runs); **C17** still blocks only the `Dyn(Reader)` spelling. Next slice:
-the wrappers themselves, the `std/sys/bufio` → `std/io` move + its `IoExn`
-adoption, and a buffered `lines()`. Inherent-vs-trait NAME duplication (`File.read_bytes` vs the trait's
+**D5 remaining:** the generic wrappers are IMPLEMENTED on branch
+`d5/bufio-wrappers` (2026-08-26: `std/io/bufio.yo` — `BufReader(R)` with
+`read_line`/`read_exact` + a full `Reader` impl, `BufWriter(W)` batching with
+NO dispose-flush per the tokio contract; the three compiler consumers
+migrated off `std/sys/bufio`, which is deleted with its test re-expressed as
+`tests/io/bufio.test.yo`) — but the branch is **NOT MERGEABLE: C21 ESCALATED
+from a warning to a hard C error** on it (a materialized default's
+`Impl(Future)` return pinned to an ABSTRACT, never-emitted state struct;
+plus an abort-stub face on the bypass read). Both reproduce ONLY in test-arm
+context — green as plain main programs — with repros recorded in the C21
+issue. **Fixing C21 is now the prerequisite for finishing D5**; C17 still
+additionally blocks the `Dyn(Reader)` spelling, and a buffered `lines()`
+waits on an async iterator protocol (deliberately not faked). Inherent-vs-trait NAME duplication (`File.read_bytes` vs the trait's
 `read_to_end`, the inherent `read_to_string`) is a D2 question to settle when
 the wrappers land. Cautions that still stand: **C21**
 (`-Wincompatible-pointer-types` across implementors — the two warnings are

--- a/plans/STD_API_AUDIT_HANDOVER.md
+++ b/plans/STD_API_AUDIT_HANDOVER.md
@@ -111,11 +111,13 @@ Slice 1 (traits + stdio + File/TcpStream impls + the usize/IoExn unification)
 merged as #293; slice 2 (the `read_to_end`/`read_to_string`/`write_all`
 defaults, `copy`, `IoError.InvalidData`/`WriteZero`, validating
 `File.read_to_string`) LANDED 2026-08-26 after #294/#295 unblocked it — C25
-(the unit tail await) was found and fixed en route. The loop-await issue is now
-FIXED on all three facets (the generic-impl face closed 2026-08-26), so
-generic `BufReader(R)`/`BufWriter(W)`, the `std/sys/bufio` → `std/io` move
-and a buffered `lines()` are UNBLOCKED and are the next D5 slice; C17 still
-blocks only the `Dyn(Reader)` spelling. Full current state: `plans/STD_API_AUDIT.md` §D5.
+(the unit tail await) was found and fixed en route. The loop-await issue is
+FIXED on all three facets, and the generic wrappers + bufio move are
+IMPLEMENTED on branch `d5/bufio-wrappers` — but that branch is NOT MERGEABLE:
+**C21 escalated to a hard C error on it** (abstract never-emitted state
+struct for a materialized trait default; test-arm-only, repros in the C21
+issue). Fix C21 first, then land the branch. C17 still blocks only the
+`Dyn(Reader)` spelling. Full current state: `plans/STD_API_AUDIT.md` §D5.
 
 ### 3.3 §7 additions — S3 (P0) and S4 (P1)
 


### PR DESCRIPTION
Docs-only. Records where D5 actually stands after the d5/bufio-wrappers work: the generic wrappers + consumer migration + sys/bufio deletion are implemented and pushed on `d5/bufio-wrappers`, but C21 escalated from a warning to a hard C error there (abstract never-emitted state struct; test-arm-only; two repros recorded in the issue), so fixing C21 is now the prerequisite for finishing D5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)