### PR TITLE
std: O7 — imm element types require Acyclic (closes C7) + D8 closure (temp_dir honors TMPDIR)

### DIFF
--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -64,7 +64,7 @@ records; mechanisms and reproducers are in the named `issues/fixed/` docs.
 | C4 | `DateTime.to_string` always emitted `Z`, ignoring `utc_offset_secs` | **FIXED** PR #229 |
 | C5 | `crypto.random_range` modulo-biased; `random_f64` closed `[0,1]` | **FIXED** PR #229 |
 | C6 | float bitwise / unsigned `Negate` prelude impls (the bool-arithmetic half of the row was stale — no such impls existed) | **FIXED** 2026-08-23 |
-| C7 | reclassified → **O7** (imm atomic-RC cycle leak): require `Acyclic` on imm element types. DECIDED; the breaking bound is still to land with imm work | decided, enforcement OPEN |
+| C7 | reclassified → **O7** (imm atomic-RC cycle leak): require `Acyclic` on imm element types. **LANDED 2026-08-27** (see O7 — enforcement verified both ways; sync-container residual recorded there) | **FIXED** |
 | C8 | `Channel.send` dropped the value on failure | **FIXED** 2026-08-23 |
 | C9 | `WalkOptions.follow_symlinks` declared, never read | **FIXED** PR #229 |
 | C10 | `clock_gettime` return code discarded (failing clock yields epoch) | **FIXED** 2026-08-23 (failure unreachable in test) |
@@ -436,7 +436,7 @@ Open D7 items:
 | fmt | FIX + EXTEND | `display.yo` deleted (§6); format specs DONE (D3.10); still: collapse 4 print bodies; dedupe 15 snprintf helpers |
 | spec/ | FREEZE AS DOC | identity stubs; mark experimental, exclude from stability promise |
 | collections/* | RENAME + EXTEND | §5 renames DONE; still: entry API, `retain/extend/drain`, `binary_search`, real `sort` (not O(n²) insertion), `sort_by`; HashSet = HashMap(T, unit) to kill ~500 duplicated SwissTable lines; hide pub `ctrl/data/…` fields; `BTreeMap` → real B-tree with `range()` (recommend: real B-tree, keep name); add `BTreeSet`; `PriorityQueue`: comparator ctor, DOCUMENT min-heap |
-| imm/* | KEEP (O4) + FIX | stays in std; **require `Acyclic` element bounds per O7 (still to land)**; iteration + `Index` where doc'd; `ImmString` rename DONE (D4 PR 5); dedupe set pair; mark unstable until exercised |
+| imm/* | KEEP (O4) + FIX | stays in std; `Acyclic` element bounds LANDED (O7, 2026-08-27); still: iteration + `Index` where doc'd, dedupe set pair, mark unstable until exercised |
 | string | FIX + EXTEND | D4 byte-indexing DONE (both types); still: Unicode-correct `to_lowercase` (+ `to_ascii_*`; see the locale issue), `Pattern` impl for `rune` + `Regex`, `replace*` Pattern-generic, `parse_f64`/radix, `split_once`, `strip_prefix/suffix`, move `panic_dyn`/`assert_dyn` to assert, delete one of `to_cstr`/`to_c_str`; `StringError` is live now (from_utf8) |
 | encoding | STANDARDIZE | utf8 DONE; still: one error style per D1 (base64's `Result(_, String)`), `html_encode` (XSS!), percent-encoding module (P0), base32, CSV (P1), toml floats/arrays/dates/serializer + derives (P1) |
 | json | EXTEND | enum representation DECIDED externally-tagged (O3); `JsonValue.Object` O(n) parallel arrays → keep repr, add index map if profiling demands |
@@ -625,16 +625,29 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
   already proves out), not a type parameter.
 - **O7**: **require `Acyclic` on imm element types, like `Arc`.** Atomic RC is
   only sound for acyclic data; `atomic(...)` of a non-`Acyclic` type is a BUG.
-  Breaking bound **still to land**; additionally audit that no other std
-  surface hands out atomic RC over non-`Acyclic` payloads.
+  **LANDED 2026-08-27**: every element/key/value bound across the imm family
+  (`List`/`Vec`/`Set`/`Map`/`SortedSet`/`SortedMap`, ~80 where-sites) now
+  requires `Acyclic` alongside `Send`; the public wrappers and `ImmString`
+  carry `Acyclic` impls so containers nest; module docs state the contract
+  instead of warning about the leak. Enforcement verified BOTH ways:
+  structurally-acyclic types derive the trait automatically (zero existing
+  consumers broke — all 212 imm tests pass unchanged), and a
+  SELF-REFERENTIAL element fails instantiation with "does not implement
+  required trait Acyclic" (pinned by a `comptime_expect_error` test in
+  `tests/imm_vec.test.yo`). **Audit residual, needs a decision:** the
+  `std/sync` atomic containers (`Channel(T)`/`Mutex(T)`/`RwLock(T)`/
+  `OnceCell(T)`) are still `Send`-only — the same hazard class (a cyclic
+  ATOMIC payload, e.g. `atomic(ref(struct(next : Option(Self))))`, leaks
+  through them). Requiring `Acyclic` there is a further breaking change to
+  decide separately.
 
 ## 9. Phasing
 
 1. **S0 — correctness:** §2 — **DONE** (open compiler rows tracked in §2).
 2. **S1 — conventions ADR + prelude traits (D1–D3):** **DONE** (D3.9 blocked).
 3. **S2 — the breaking sweep (§5 + §6 + D4/D5/D7/D8):** **essentially DONE** —
-   remaining: D4 PR 9, D5's generic wrappers + bufio move, D8
-   env-merge/EncodingError/glob rows, O7 bound.
+   remaining: D4 PR 9, the seed-gated bufio consumer migration, D8
+   env-merge/EncodingError/glob rows.
 4. **S3 — P0 additions.** ← next after D5 slice 2
 5. **S4 — P1 additions.**
 6. **S5 — stability freeze:** stable/unstable markers in `yo doc` output,

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -376,9 +376,11 @@ Open D7 items:
 
 ### D8 — module layout
 
-- **OPEN:** `std/os/env.yo` merges into `std/env.yo` (dir helpers return
-  `Path`); `std/os/` then holds only `signal.yo` — flatten. `fs/temp` uses the
-  merged `temp_dir()` (kills the 3rd copy; also consult `TMPDIR` on macOS).
+- ~~`std/os/env.yo` merges into `std/env.yo`; flatten `std/os/`~~ **ROW WAS
+  STALE (measured 2026-08-27): `std/os/` does not exist** — the merge
+  happened before this audit's execution reached it, and `fs/temp` already
+  uses the merged `temp_dir()`. The one live grain: `temp_dir()` ignored
+  `TMPDIR` on POSIX — fixed 2026-08-27 (`$TMPDIR` else `/tmp`).
 - **`std/encoding/utf8.yo` — DONE 2026-08-25** (#286). One shared UTF-8
   module (15 exported names), every private copy in `std/` routed through it
   (eleven files carried bit-twiddling, not the row's six — three were
@@ -412,7 +414,7 @@ Open D7 items:
   (every `${x}` — the bytes are snprintf output). One behaviour change
   measured: `${rune}` for NUL and hand-built surrogates (both previously
   broken outputs; no std behaviour moved).
-- **OPEN:** `EncodingError` moves out of `hex.yo` into `std/encoding/error.yo`.
+- ~~`EncodingError` moves out of `hex.yo` into `std/encoding/error.yo`~~ **ROW WAS STALE (measured 2026-08-27)** — it already lives in `std/encoding/error.yo`, imported by hex and base64.
 - **Regex internals private + typed `RegexError` — DONE 2026-08-25.** Findings
   against the row: "go private" has no language mechanism (Yo's only
   visibility control is `export(...)` and siblings must import each other) —
@@ -645,9 +647,11 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
 
 1. **S0 — correctness:** §2 — **DONE** (open compiler rows tracked in §2).
 2. **S1 — conventions ADR + prelude traits (D1–D3):** **DONE** (D3.9 blocked).
-3. **S2 — the breaking sweep (§5 + §6 + D4/D5/D7/D8):** **essentially DONE** —
-   remaining: D4 PR 9, the seed-gated bufio consumer migration, D8
-   env-merge/EncodingError/glob rows.
+3. **S2 — the breaking sweep (§5 + §6 + D4/D5/D7/D8):** **DONE 2026-08-27**
+   except two parked items: D4 PR 9 (vendor-gated) and the seed-gated bufio
+   consumer migration. (The D8 env-merge and EncodingError rows measured
+   STALE — already done; the glob row is an S3 addition, not a breaking
+   change.)
 4. **S3 — P0 additions.** ← next after D5 slice 2
 5. **S4 — P1 additions.**
 6. **S5 — stability freeze:** stable/unstable markers in `yo doc` output,

--- a/std/env.yo
+++ b/std/env.yo
@@ -429,7 +429,8 @@ cache_dir :: (fn() -> Option(String))(
 export(cache_dir);
 /// Return the system temporary directory.
 ///
-/// - Linux/macOS: `/tmp`
+/// - Linux/macOS: `$TMPDIR`, else `/tmp` (POSIX honors TMPDIR; on macOS it
+///   is a per-user confined directory — plans/STD_API_AUDIT.md D8)
 /// - Windows: `%TEMP%`, then `%TMP%`, else `C:\Temp`
 temp_dir :: (fn() -> String)(
   cond(
@@ -442,7 +443,11 @@ temp_dir :: (fn() -> String)(
         .None => `C:\Temp`
       )
     ),
-    true => `/tmp`
+    true => match(
+      env.get(`TMPDIR`),
+      .Some(t3) => t3,
+      .None => `/tmp`
+    )
   )
 );
 export(temp_dir);

--- a/std/imm/list.yo
+++ b/std/imm/list.yo
@@ -22,7 +22,7 @@ pragma(Pragma.AllowUnsafe);
 { malloc, free } :: GlobalAllocator;
 { memcpy } :: import("../libc/string.yo");
 /// Internal cons cell — atomic object for thread-safe structural sharing.
-ListNode :: (fn(comptime(T) : Type, where(T <: Send)) -> comptime(Type))(
+ListNode :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
   atomic(
     ref(
       struct(
@@ -35,21 +35,25 @@ ListNode :: (fn(comptime(T) : Type, where(T <: Send)) -> comptime(Type))(
 // SAFETY: Manual Acyclic impl — ListNode is self-referential, so auto-derivation skips it.
 // This is safe because ListNode is immutable: all operations create new nodes and never
 // mutate existing ones, making it impossible to form cycles at runtime.
-impl(generic(T : Type), where(T <: Send), ListNode(T), Acyclic());
+impl(generic(T : Type), where(T <: (Send, Acyclic)), ListNode(T), Acyclic());
 /// Persistent immutable singly-linked list.
 ///
 /// A value-type wrapper around an optional chain of `ListNode` atomic objects.
 /// Cheap to copy (just a pointer + length). All "modification" operations
 /// return a new `List` that shares structure with the original.
-List :: (fn(comptime(T) : Type, where(T <: Send)) -> comptime(Type))(
+List :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
   struct(
     _head : Option(ListNode(T)),
     _len : usize
   )
 );
+// The PUBLIC wrapper is Acyclic too (O7): an Acyclic element list cannot
+// form a cycle, and this is what lets a List nest as another imm
+// container's element.
+impl(generic(T : Type), where(T <: (Send, Acyclic)), List(T), Acyclic());
 impl(
   generic(T : Type),
-  where(T <: Send),
+  where(T <: (Send, Acyclic)),
   List(T),
   /// Create an empty list.
   new : (fn() -> Self)(
@@ -137,7 +141,7 @@ impl(
     result
   }),
   /// Apply a function to each element, producing a new list. O(n).
-  map : (fn(generic(U : Type), self : Self, f : Impl(Fn(a : T) -> U), where(U <: Send)) -> List(U))({
+  map : (fn(generic(U : Type), self : Self, f : Impl(Fn(a : T) -> U), where(U <: (Send, Acyclic))) -> List(U))({
     (result : List(U)) = List(U).new();
     (current : Option(ListNode(T))) = self._head;
     while(runtime(current.is_some()), {
@@ -214,7 +218,7 @@ impl(
 /// Equality: two lists are equal if they have the same length and elements.
 impl(
   generic(T : Type),
-  where(T <: (Send, Eq(T))),
+  where(T <: (Send, Acyclic, Eq(T))),
   List(T),
   Eq(List(T))(
     (==) : (fn(lhs : Self, rhs : Self) -> bool)({
@@ -255,7 +259,7 @@ impl(
 /// dereferences before any drop runs.
 impl(
   generic(T : Type),
-  where(T <: Send),
+  where(T <: (Send, Acyclic)),
   List(T),
   Index(usize)(
     Output : T,

--- a/std/imm/map.yo
+++ b/std/imm/map.yo
@@ -6,14 +6,13 @@
 //!
 //! Keys must implement `Eq`, `Hash`, and `Send`. Values must implement `Send`.
 //!
-//! # Cycle warning
+//! # Cycle safety
 //!
 //! Map nodes use ATOMIC reference counting, and the cycle collector does not
-//! scan atomic objects (the Arc pattern). A reference cycle routed through a
-//! `Map` is never reclaimed. Unlike `Arc(V)` (which requires `V <: Acyclic`),
-//! keys/values here are only required to be `Send` — storing a cycle-capable
-//! type is allowed today but LEAKS if a cycle forms
-//! (plans/STD_API_AUDIT.md O7).
+//! scan atomic objects (the Arc pattern) — so, like `Arc(V)`, keys and
+//! values must be `Acyclic` (plans/STD_API_AUDIT.md O7, landed 2026-08-27).
+//! Structurally-acyclic types satisfy the bound automatically; a
+//! self-referential type is rejected at instantiation.
 //!
 //! # Examples
 //!
@@ -47,7 +46,7 @@ MapLeaf :: (
   fn(
     comptime(K) : Type,
     comptime(V) : Type,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> comptime(Type)
 )(
   atomic(
@@ -65,7 +64,7 @@ MapCollision :: (
   fn(
     comptime(K) : Type,
     comptime(V) : Type,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> comptime(Type)
 )(
   atomic(
@@ -80,7 +79,7 @@ MapCollision :: (
 );
 impl(
   generic(K : Type, V : Type),
-  where(K <: (Eq(K), Hash, Send), V <: Send),
+  where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic)),
   MapCollision(K, V),
   Dispose(
     dispose : (fn(self : Self) -> unit)({
@@ -100,7 +99,7 @@ MapBranch :: (
   fn(
     comptime(K) : Type,
     comptime(V) : Type,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> comptime(Type)
 )(
   atomic(
@@ -118,7 +117,7 @@ MapNode :: (
   fn(
     comptime(K) : Type,
     comptime(V) : Type,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> comptime(Type)
 )(
   enum(
@@ -129,7 +128,7 @@ MapNode :: (
 );
 impl(
   generic(K : Type, V : Type),
-  where(K <: (Eq(K), Hash, Send), V <: Send),
+  where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic)),
   MapBranch(K, V),
   Dispose(
     dispose : (fn(self : Self) -> unit)({
@@ -147,7 +146,7 @@ Map :: (
   fn(
     comptime(K) : Type,
     comptime(V) : Type,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> comptime(Type)
 )(
   struct(
@@ -155,8 +154,16 @@ Map :: (
     _len : usize
   )
 );
+// O7: an Acyclic-element Map cannot form a cycle — lets a Map nest as
+// another imm container's element (and be an Arc payload).
+impl(
+  generic(K : Type, V : Type),
+  where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic)),
+  Map(K, V),
+  Acyclic()
+);
 // -- MapBranch helpers --
-_alloc_map_children :: (fn(comptime(K) : Type, comptime(V) : Type, count : u8, where(K <: (Eq(K), Hash, Send), V <: Send)) -> *(void))({
+_alloc_map_children :: (fn(comptime(K) : Type, comptime(V) : Type, count : u8, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> *(void))({
   sz := (sizeof(MapNode(K, V)) * usize(count));
   match(
     malloc(sz),
@@ -164,18 +171,18 @@ _alloc_map_children :: (fn(comptime(K) : Type, comptime(V) : Type, count : u8, w
     .None => __yo_panic("imm.Map: allocation failed")
   )
 });
-_branch_index_for :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, where(K <: (Eq(K), Hash, Send), V <: Send)) -> u8)(
+_branch_index_for :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> u8)(
   u8(popcount(branch.bitmap & (bit - u32(1))))
 );
-_branch_has_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, where(K <: (Eq(K), Hash, Send), V <: Send)) -> bool)(
+_branch_has_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> bool)(
   (branch.bitmap & bit) != u32(0)
 );
-_branch_child_at :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), idx : u8, where(K <: (Eq(K), Hash, Send), V <: Send)) -> MapNode(K, V))({
+_branch_child_at :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), idx : u8, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> MapNode(K, V))({
   offset := (sizeof(MapNode(K, V)) * usize(idx));
   target := *(MapNode(K, V))(branch._children_ptr.add(offset));
   target.*
 });
-_branch_set_child :: (fn(comptime(K) : Type, comptime(V) : Type, ptr : *(void), idx : u8, child : MapNode(K, V), where(K <: (Eq(K), Hash, Send), V <: Send)) -> unit)({
+_branch_set_child :: (fn(comptime(K) : Type, comptime(V) : Type, ptr : *(void), idx : u8, child : MapNode(K, V), where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> unit)({
   offset := (sizeof(MapNode(K, V)) * usize(idx));
   target := *(MapNode(K, V))(ptr.add(offset));
   target.* = child;
@@ -191,7 +198,7 @@ _copy_children :: (
     dst_offset : u8,
     src_offset : u8,
     count : u8,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> unit
 )({
   node_sz := sizeof(MapNode(K, V));
@@ -202,7 +209,7 @@ _copy_children :: (
     consume(dst_ptr.* = src_ptr.*);
   });
 });
-_branch_with_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, child : MapNode(K, V), where(K <: (Eq(K), Hash, Send), V <: Send)) -> MapBranch(K, V))({
+_branch_with_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, child : MapNode(K, V), where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> MapBranch(K, V))({
   idx := _branch_index_for(K, V, branch, bit);
   new_len := (branch._children_len + u8(1));
   new_ptr := _alloc_map_children(K, V, new_len);
@@ -218,14 +225,14 @@ _branch_with_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBr
   });
   MapBranch(K, V)(bitmap : (branch.bitmap | bit), _children_ptr : new_ptr, _children_len : new_len)
 });
-_branch_replace_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, child : MapNode(K, V), where(K <: (Eq(K), Hash, Send), V <: Send)) -> MapBranch(K, V))({
+_branch_replace_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, child : MapNode(K, V), where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> MapBranch(K, V))({
   idx := _branch_index_for(K, V, branch, bit);
   new_ptr := _alloc_map_children(K, V, branch._children_len);
   _copy_children(K, V, new_ptr, branch._children_ptr, u8(0), u8(0), branch._children_len);
   _branch_set_child(K, V, new_ptr, idx, child);
   MapBranch(K, V)(bitmap : branch.bitmap, _children_ptr : new_ptr, _children_len : branch._children_len)
 });
-_branch_without_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, where(K <: (Eq(K), Hash, Send), V <: Send)) -> MapBranch(K, V))({
+_branch_without_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : MapBranch(K, V), bit : u32, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> MapBranch(K, V))({
   idx := _branch_index_for(K, V, branch, bit);
   new_len := (branch._children_len - u8(1));
   alloc_len := cond((new_len == u8(0)) => u8(1), true => new_len);
@@ -240,7 +247,7 @@ _branch_without_child :: (fn(comptime(K) : Type, comptime(V) : Type, branch : Ma
   MapBranch(K, V)(bitmap : (branch.bitmap & (~(bit))), _children_ptr : new_ptr, _children_len : new_len)
 });
 // -- MapCollision helpers --
-_alloc_pairs :: (fn(comptime(K) : Type, comptime(V) : Type, count : usize, where(K <: (Eq(K), Hash, Send), V <: Send)) -> *(MapEntry(K, V)))({
+_alloc_pairs :: (fn(comptime(K) : Type, comptime(V) : Type, count : usize, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> *(MapEntry(K, V)))({
   sz := (sizeof(MapEntry(K, V)) * count);
   match(
     malloc(sz),
@@ -248,7 +255,7 @@ _alloc_pairs :: (fn(comptime(K) : Type, comptime(V) : Type, count : usize, where
     .None => __yo_panic("imm.Map: collision allocation failed")
   )
 });
-_coll_find_key :: (fn(comptime(K) : Type, comptime(V) : Type, coll : MapCollision(K, V), k : K, where(K <: (Eq(K), Hash, Send), V <: Send)) -> Option(usize))({
+_coll_find_key :: (fn(comptime(K) : Type, comptime(V) : Type, coll : MapCollision(K, V), k : K, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> Option(usize))({
   i := usize(0);
   while(i < coll._pairs_len, i = (i + usize(1)), {
     if((coll._pairs_ptr.add(i)).*.key == k, {
@@ -267,7 +274,7 @@ _copy_pairs :: (
     dst_offset : usize,
     src_offset : usize,
     count : usize,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> unit
 )({
   i := usize(0);
@@ -275,7 +282,7 @@ _copy_pairs :: (
     consume((dst.add(dst_offset + i)).* = (src.add(src_offset + i)).*);
   });
 });
-_coll_with_pair :: (fn(comptime(K) : Type, comptime(V) : Type, coll : MapCollision(K, V), k : K, v : V, where(K <: (Eq(K), Hash, Send), V <: Send)) -> MapCollision(K, V))(
+_coll_with_pair :: (fn(comptime(K) : Type, comptime(V) : Type, coll : MapCollision(K, V), k : K, v : V, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> MapCollision(K, V))(
   match(
     _coll_find_key(K, V, coll, k),
     .Some(idx) => {
@@ -293,7 +300,7 @@ _coll_with_pair :: (fn(comptime(K) : Type, comptime(V) : Type, coll : MapCollisi
     }
   )
 );
-_coll_without_key :: (fn(comptime(K) : Type, comptime(V) : Type, coll : MapCollision(K, V), k : K, where(K <: (Eq(K), Hash, Send), V <: Send)) -> Option(MapCollision(K, V)))(
+_coll_without_key :: (fn(comptime(K) : Type, comptime(V) : Type, coll : MapCollision(K, V), k : K, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> Option(MapCollision(K, V)))(
   match(
     _coll_find_key(K, V, coll, k),
     .Some(idx) => {
@@ -330,7 +337,7 @@ _make_branch :: (
     hash1 : u64,
     node2 : MapNode(K, V),
     hash2 : u64,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> MapNode(K, V)
 )({
   frag1 := _fragment(hash1, shift);
@@ -369,7 +376,7 @@ _make_branch :: (
     )
   )
 });
-InsertResult :: (fn(comptime(K) : Type, comptime(V) : Type, where(K <: (Eq(K), Hash, Send), V <: Send)) -> comptime(Type))(
+InsertResult :: (fn(comptime(K) : Type, comptime(V) : Type, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> comptime(Type))(
   struct(node : MapNode(K, V), added : bool)
 );
 _node_insert :: (
@@ -381,7 +388,7 @@ _node_insert :: (
     hash : u64,
     k : K,
     v : V,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> InsertResult(K, V)
 )(
   match(
@@ -465,7 +472,7 @@ _node_get :: (
     shift : usize,
     hash : u64,
     k : K,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> Option(V)
 )(
   match(
@@ -498,7 +505,7 @@ _node_get :: (
     }
   )
 );
-RemoveResult :: (fn(comptime(K) : Type, comptime(V) : Type, where(K <: (Eq(K), Hash, Send), V <: Send)) -> comptime(Type))(
+RemoveResult :: (fn(comptime(K) : Type, comptime(V) : Type, where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))) -> comptime(Type))(
   struct(node : Option(MapNode(K, V)), removed : bool)
 );
 _node_remove :: (
@@ -509,7 +516,7 @@ _node_remove :: (
     shift : usize,
     hash : u64,
     k : K,
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> RemoveResult(K, V)
 )(
   match(
@@ -609,7 +616,7 @@ _merge_from_node :: (
     comptime(V) : Type,
     acc : Map(K, V),
     node : MapNode(K, V),
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> Map(K, V)
 )(
   match(
@@ -640,7 +647,7 @@ _collect_keys :: (
     comptime(V) : Type,
     node : MapNode(K, V),
     acc : List(K),
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> List(K)
 )(
   match(
@@ -670,7 +677,7 @@ _collect_values :: (
     comptime(V) : Type,
     node : MapNode(K, V),
     acc : List(V),
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> List(V)
 )(
   match(
@@ -700,7 +707,7 @@ _collect_entries :: (
     comptime(V) : Type,
     node : MapNode(K, V),
     acc : List(MapEntry(K, V)),
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> List(MapEntry(K, V))
 )(
   match(
@@ -731,7 +738,7 @@ _map_values_node :: (
     comptime(U) : Type,
     node : MapNode(K, V),
     f : Impl(Fn(a : V) -> U),
-    where(K <: (Eq(K), Hash, Send), V <: Send, U <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic), U <: (Send, Acyclic))
   ) -> MapNode(K, U)
 )(
   match(
@@ -776,7 +783,7 @@ _filter_from_node :: (
     acc : Map(K, V),
     node : MapNode(K, V),
     f : Impl(Fn(k : K, v : V) -> bool),
-    where(K <: (Eq(K), Hash, Send), V <: Send)
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic))
   ) -> Map(K, V)
 )(
   match(
@@ -812,7 +819,7 @@ _all_entries_match :: (
     comptime(V) : Type,
     node : MapNode(K, V),
     target : Map(K, V),
-    where(K <: (Eq(K), Hash, Send), V <: (Send, Eq(V)))
+    where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic, Eq(V)))
   ) -> bool
 )(
   match(
@@ -856,7 +863,7 @@ _all_entries_match :: (
 // -- Public Map API --
 impl(
   generic(K : Type, V : Type),
-  where(K <: (Eq(K), Hash, Send), V <: Send),
+  where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic)),
   Map(K, V),
   /// Create an empty map.
   new : (fn() -> Self)(
@@ -941,7 +948,7 @@ impl(
     )
   ),
   /// Apply a function to each value, producing a new map.
-  map_values : (fn(generic(U : Type), self : Self, f : Impl(Fn(a : V) -> U), where(U <: Send)) -> Map(K, U))(
+  map_values : (fn(generic(U : Type), self : Self, f : Impl(Fn(a : V) -> U), where(U <: (Send, Acyclic))) -> Map(K, U))(
     match(
       self._root,
       .Some(root) => Map(K, U)(_root : .Some(_map_values_node(K, V, U, root, f)), _len : self._len),
@@ -974,7 +981,7 @@ impl(
 );
 impl(
   generic(K : Type, V : Type),
-  where(K <: (Eq(K), Hash, Send), V <: (Send, Eq(V))),
+  where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic, Eq(V))),
   Map(K, V),
   Eq(Map(K, V))(
     (==) : (fn(lhs : Self, rhs : Self) -> bool)({

--- a/std/imm/set.yo
+++ b/std/imm/set.yo
@@ -24,12 +24,14 @@ pragma(Pragma.AllowUnsafe);
 /// Persistent immutable hash set backed by a HAMT.
 ///
 /// Wraps `Map(T, bool)` internally. The bool values are always `true`.
-Set :: (fn(comptime(T) : Type, where(T <: (Eq(T), Hash, Send))) -> comptime(Type))(
+Set :: (fn(comptime(T) : Type, where(T <: (Eq(T), Hash, Send, Acyclic))) -> comptime(Type))(
   struct(_inner : Map(T, bool))
 );
+// O7: nesting support — see Map's impl.
+impl(generic(T : Type), where(T <: (Eq(T), Hash, Send, Acyclic)), Set(T), Acyclic());
 impl(
   generic(T : Type),
-  where(T <: (Eq(T), Hash, Send)),
+  where(T <: (Eq(T), Hash, Send, Acyclic)),
   Set(T),
   /// Create an empty set.
   new : (fn() -> Self)(
@@ -165,7 +167,7 @@ impl(
 );
 impl(
   generic(T : Type),
-  where(T <: (Eq(T), Hash, Send)),
+  where(T <: (Eq(T), Hash, Send, Acyclic)),
   Set(T),
   Eq(Set(T))(
     (==) : (fn(lhs : Self, rhs : Self) -> bool)(

--- a/std/imm/sorted_map.yo
+++ b/std/imm/sorted_map.yo
@@ -28,7 +28,7 @@ RBNode :: (
   fn(
     comptime(K) : Type,
     comptime(V) : Type,
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> comptime(Type)
 )(
   atomic(
@@ -46,19 +46,26 @@ RBNode :: (
 // SAFETY: Manual Acyclic impl — RBNode is self-referential, so auto-derivation skips it.
 // This is safe because RBNode is immutable: all tree operations create new nodes
 // and never mutate existing ones, making it impossible to form cycles at runtime.
-impl(generic(K : Type, V : Type), where(K <: (Eq(K), Ord(K), Send), V <: Send), RBNode(K, V), Acyclic());
+impl(generic(K : Type, V : Type), where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic)), RBNode(K, V), Acyclic());
 /// Persistent immutable sorted map backed by a left-leaning red-black tree.
 SortedMap :: (
   fn(
     comptime(K) : Type,
     comptime(V) : Type,
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> comptime(Type)
 )(
   struct(
     _root : Option(RBNode(K, V)),
     _len : usize
   )
+);
+// O7: an Acyclic-element SortedMap cannot form a cycle — nesting support.
+impl(
+  generic(K : Type, V : Type),
+  where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic)),
+  SortedMap(K, V),
+  Acyclic()
 );
 // ---------------------------------------------------------------------------
 // Helper standalone functions
@@ -68,7 +75,7 @@ _is_red :: (
     comptime(K) : Type,
     comptime(V) : Type,
     node : Option(RBNode(K, V)),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> bool
 )(
   match(
@@ -90,7 +97,7 @@ _new_node :: (
     color : Color,
     left : Option(RBNode(K, V)),
     right : Option(RBNode(K, V)),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )(
   RBNode(K, V)(
@@ -107,7 +114,7 @@ _rotate_left :: (
     comptime(K) : Type,
     comptime(V) : Type,
     h : RBNode(K, V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )({
   // x = h.right (must be Some)
@@ -125,7 +132,7 @@ _rotate_right :: (
     comptime(K) : Type,
     comptime(V) : Type,
     h : RBNode(K, V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )({
   (x : RBNode(K, V)) = match(
@@ -142,7 +149,7 @@ _flip_colors :: (
     comptime(K) : Type,
     comptime(V) : Type,
     h : RBNode(K, V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )({
   new_color := match(
@@ -182,7 +189,7 @@ _fixup :: (
     comptime(K) : Type,
     comptime(V) : Type,
     h : RBNode(K, V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )({
   (node : RBNode(K, V)) = h;
@@ -214,7 +221,7 @@ _node_insert :: (
     node : Option(RBNode(K, V)),
     key : K,
     value : V,
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )(
   match(
@@ -256,7 +263,7 @@ _node_get :: (
     comptime(V) : Type,
     node : Option(RBNode(K, V)),
     key : K,
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> Option(V)
 )(
   match(
@@ -276,7 +283,7 @@ _node_contains :: (
     comptime(V) : Type,
     node : Option(RBNode(K, V)),
     key : K,
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> bool
 )(
   match(
@@ -298,7 +305,7 @@ _move_red_left :: (
     comptime(K) : Type,
     comptime(V) : Type,
     h : RBNode(K, V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )({
   (node : RBNode(K, V)) = _flip_colors(K, V, h);
@@ -325,7 +332,7 @@ _move_red_right :: (
     comptime(K) : Type,
     comptime(V) : Type,
     h : RBNode(K, V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )({
   (node : RBNode(K, V)) = _flip_colors(K, V, h);
@@ -346,7 +353,7 @@ _node_min :: (
     comptime(K) : Type,
     comptime(V) : Type,
     h : RBNode(K, V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> RBNode(K, V)
 )(
   match(
@@ -361,7 +368,7 @@ _delete_min :: (
     comptime(K) : Type,
     comptime(V) : Type,
     h : RBNode(K, V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> Option(RBNode(K, V))
 )(
   match(
@@ -394,7 +401,7 @@ _node_remove :: (
     comptime(V) : Type,
     h : RBNode(K, V),
     key : K,
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> Option(RBNode(K, V))
 )({
   (node : RBNode(K, V)) = h;
@@ -486,7 +493,7 @@ _collect_keys :: (
     comptime(V) : Type,
     node : Option(RBNode(K, V)),
     acc : List(K),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> List(K)
 )(
   match(
@@ -506,7 +513,7 @@ _collect_values :: (
     comptime(V) : Type,
     node : Option(RBNode(K, V)),
     acc : List(V),
-    where(K <: (Eq(K), Ord(K), Send), V <: Send)
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
   ) -> List(V)
 )(
   match(
@@ -524,7 +531,7 @@ _collect_values :: (
 // ---------------------------------------------------------------------------
 impl(
   generic(K : Type, V : Type),
-  where(K <: (Eq(K), Ord(K), Send), V <: Send),
+  where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic)),
   SortedMap(K, V),
   /// Create an empty sorted map.
   new : (fn() -> Self)(
@@ -630,7 +637,7 @@ impl(
 );
 impl(
   generic(K : Type, V : Type),
-  where(K <: (Eq(K), Ord(K), Send), V <: (Eq(V), Send)),
+  where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Eq(V), Send, Acyclic)),
   SortedMap(K, V),
   Eq(SortedMap(K, V))(
     (==) : (fn(lhs : Self, rhs : Self) -> bool)({

--- a/std/imm/sorted_set.yo
+++ b/std/imm/sorted_set.yo
@@ -22,12 +22,14 @@ pragma(Pragma.AllowUnsafe);
 { ArrayList } :: import("../collections/array_list.yo");
 { List } :: import("./list.yo");
 /// Persistent immutable sorted set backed by a left-leaning red-black tree.
-SortedSet :: (fn(comptime(T) : Type, where(T <: (Eq(T), Ord(T), Send))) -> comptime(Type))(
+SortedSet :: (fn(comptime(T) : Type, where(T <: (Eq(T), Ord(T), Send, Acyclic))) -> comptime(Type))(
   struct(_inner : SortedMap(T, bool))
 );
+// O7: nesting support — see SortedMap's impl.
+impl(generic(T : Type), where(T <: (Eq(T), Ord(T), Send, Acyclic)), SortedSet(T), Acyclic());
 impl(
   generic(T : Type),
-  where(T <: (Eq(T), Ord(T), Send)),
+  where(T <: (Eq(T), Ord(T), Send, Acyclic)),
   SortedSet(T),
   /// Create an empty sorted set.
   new : (fn() -> Self)(
@@ -187,7 +189,7 @@ impl(
 );
 impl(
   generic(T : Type),
-  where(T <: (Eq(T), Ord(T), Send)),
+  where(T <: (Eq(T), Ord(T), Send, Acyclic)),
   SortedSet(T),
   Eq(SortedSet(T))(
     (==) : (fn(lhs : Self, rhs : Self) -> bool)(

--- a/std/imm/string.yo
+++ b/std/imm/string.yo
@@ -37,6 +37,9 @@ ImmString :: atomic(
     )
   )
 );
+// O7: raw bytes cannot reference anything — an ImmString is trivially
+// Acyclic, which is what admits it as an imm-container element / Arc payload.
+impl(ImmString, Acyclic());
 impl(
   ImmString,
   Dispose(

--- a/std/imm/vec.yo
+++ b/std/imm/vec.yo
@@ -6,14 +6,13 @@
 //!
 //! All elements must implement `Send` to guarantee thread safety.
 //!
-//! # Cycle warning
+//! # Cycle safety
 //!
 //! `Vec` uses ATOMIC reference counting, and the cycle collector does not
-//! scan atomic objects (the Arc pattern). A reference cycle routed through a
-//! `Vec` is never reclaimed. Unlike `Arc(V)` (which requires `V <: Acyclic`),
-//! elements here are only required to be `Send` — storing a cycle-capable
-//! type is allowed today but LEAKS if a cycle forms
-//! (plans/STD_API_AUDIT.md O7).
+//! scan atomic objects (the Arc pattern) — so, like `Arc(V)`, element types
+//! must be `Acyclic` (plans/STD_API_AUDIT.md O7, landed 2026-08-27).
+//! Structurally-acyclic types satisfy the bound automatically; a
+//! self-referential type is rejected at instantiation.
 //!
 //! # Examples
 //!
@@ -35,7 +34,7 @@ pragma(Pragma.AllowUnsafe);
 /// Backed by a shared flat array with copy-on-write semantics.
 /// All mutations create a new vector, sharing the backing buffer via
 /// atomic reference counting when possible.
-Vec :: (fn(comptime(T) : Type, where(T <: Send)) -> comptime(Type))(
+Vec :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
   atomic(
     ref(
       struct(
@@ -46,9 +45,12 @@ Vec :: (fn(comptime(T) : Type, where(T <: Send)) -> comptime(Type))(
     )
   )
 );
+// O7: an Acyclic-element Vec cannot form a cycle — lets Vec nest as another
+// imm container's element.
+impl(generic(T : Type), where(T <: (Send, Acyclic)), Vec(T), Acyclic());
 impl(
   generic(T : Type),
-  where(T <: Send),
+  where(T <: (Send, Acyclic)),
   Vec(T),
   Dispose(
     dispose : (fn(self : Self) -> unit)({
@@ -61,12 +63,12 @@ impl(
   )
 );
 /// Result of a pop operation.
-PopResult :: (fn(comptime(T) : Type, where(T <: Send)) -> comptime(Type))(
+PopResult :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
   struct(vec : Vec(T), value : Option(T))
 );
 impl(
   generic(T : Type),
-  where(T <: Send),
+  where(T <: (Send, Acyclic)),
   Vec(T),
   /// Allocate raw buffer without creating an intermediate atomic object.
   _raw_alloc : (fn(cap : usize) -> *(T))({
@@ -283,7 +285,7 @@ impl(
     result
   }),
   /// Apply a function to each element, producing a new vector.
-  map : (fn(generic(U : Type), self : Self, f : Impl(Fn(a : T) -> U), where(U <: Send)) -> Vec(U))({
+  map : (fn(generic(U : Type), self : Self, f : Impl(Fn(a : T) -> U), where(U <: (Send, Acyclic))) -> Vec(U))({
     new_ptr := Vec(U)._raw_alloc(self._len);
     i := usize(0);
     while(i < self._len, i = (i + usize(1)), {
@@ -412,7 +414,7 @@ impl(
     result
   }),
   /// Zip two vectors together using a combining function.
-  zip_with : (fn(generic(U : Type, V : Type), self : Self, other : Vec(U), f : Impl(Fn(a : T, b : U) -> V), where(U <: Send, V <: Send)) -> Vec(V))({
+  zip_with : (fn(generic(U : Type, V : Type), self : Self, other : Vec(U), f : Impl(Fn(a : T, b : U) -> V), where(U <: (Send, Acyclic), V <: (Send, Acyclic))) -> Vec(V))({
     min_len := cond(
       (self._len < other._len) => self._len,
       true => other._len
@@ -445,7 +447,7 @@ impl(
 /// Eq trait for Vec(T) — element-wise equality.
 impl(
   generic(T : Type),
-  where(T <: (Send, Eq(T))),
+  where(T <: (Send, Acyclic, Eq(T))),
   Vec(T),
   Eq(Vec(T))(
     (==) : (fn(lhs : Self, rhs : Self) -> bool)({
@@ -468,7 +470,7 @@ impl(
 /// passes the right C-ABI shape. See plans/archive/ITERATOR_REDESIGN.md.
 impl(
   generic(T : Type),
-  where(T <: Send),
+  where(T <: (Send, Acyclic)),
   Vec(T),
   Index(usize)(
     Output : T,

--- a/tests/imm_vec.test.yo
+++ b/tests/imm_vec.test.yo
@@ -364,3 +364,12 @@ test("Vec of ImmString with struct element", {
   assert(v.len() == usize(2), "length");
   assert(v(usize(0)).text == ImmString.from("item1"), "text 0");
 });
+test("O7: a cyclic element type is rejected — atomic RC cannot collect cycles", {
+  // Structurally-acyclic types derive Acyclic automatically; a
+  // SELF-REFERENTIAL element must be rejected at instantiation
+  // (plans/STD_API_AUDIT.md O7/C7: a cycle routed through an imm structure
+  // would leak silently and unavoidably).
+  CyclicNode :: ref(struct(v : i32, next : Option(Self)));
+  comptime_expect_error(Vec(CyclicNode));
+  assert(true, "rejected at comptime");
+});


### PR DESCRIPTION
The last two S2 items that were actually live.

## O7 — `Acyclic` element bounds on the imm family (closes C7)

Atomic RC does no cycle bookkeeping (the Arc pattern), so a reference cycle routed through an imm structure leaked silently and unavoidably. Per the decided O7:

- Every element/key/value bound across `std/imm` (`List`/`Vec`/`Set`/`Map`/`SortedSet`/`SortedMap`, ~80 where-sites, including the `map`/`zip_with` result binders) now requires **`Acyclic`** alongside `Send`.
- The public wrappers and `ImmString` gain `Acyclic` impls, so containers nest and serve as `Arc` payloads.
- Module docs state the contract instead of warning about the leak.

**Enforcement verified both ways**: structurally-acyclic types derive the trait automatically — all 212 existing imm tests pass unchanged — and a SELF-REFERENTIAL element (`ref(struct(next : Option(Self)))`) fails instantiation with `does not implement required trait Acyclic`, pinned by a `comptime_expect_error` test in `tests/imm_vec.test.yo`.

**Audit residual recorded in the plan (needs a separate decision)**: `Channel(T)`/`Mutex(T)`/`RwLock(T)`/`OnceCell(T)` are still `Send`-only — the same hazard class for a cyclic ATOMIC payload.

## D8 closure

The env-merge and EncodingError rows measured **stale** (already done — `std/os/` doesn't exist; `EncodingError` already lives in `std/encoding/error.yo`). The one live grain: `temp_dir()` ignored `TMPDIR` on POSIX — it now returns `$TMPDIR` else `/tmp` (macOS's per-user confined directory), matching Rust. `TempDir.new()`/`TempFile.new()` inherit it.

## Verification

imm suite 212 + 1 new rejection test, env 14/14, fs/temp 10/10. **Full battery**: check std 157/157 + src 262/262, build rc=0, suite **3172/3172**, cli-diff 52 PASS / 0 GOLDEN-DIFF (zero drift), gates `failures=0`, fixpoint `FIXPOINT_HOLDS stage2 hollow=0`, hollow sweep `SWEEP_GATE_OK` (0 allowlisted).

With this, **S2 is done** except the two parked items: D4 PR 9 (vendor-gated) and the seed-gated bufio consumer migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)