### PR TITLE
std: S3 P0 fs wrappers — copy, remove_dir_all, read_link, set_permissions, try_exists

### DIFF
--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -578,7 +578,7 @@ declarations at runtime.
 1. `std/encoding/percent.yo` (percent-encode/decode) + URL/query integration
 2. ~~`std/encoding/utf8.yo` (D8)~~ **DONE 2026-08-25** + `html_encode` (open)
 3. `std/io` redesign with stdio handles (D5) — slices 1–2 DONE; generic wrappers + bufio move remain
-4. `fs.copy`, `fs.remove_dir_all`, `read_link`, `set_permissions`, `try_exists`
+4. ~~`fs.copy`, `fs.remove_dir_all`, `read_link`, `set_permissions`, `try_exists`~~ **DONE 2026-08-27** — `copy` (contents + permission bits + byte count), `try_exists` (throws instead of lying `false` on a denied parent), `set_permissions` in `std/fs/file`; `read_link` in `std/fs/dir`; `remove_dir_all` in **`std/fs/walker`** (its implementation IS the walker, and `fs/walker` imports `fs/dir` — the reverse would cycle); `src/fetch` + `src/version_cache` dropped their private copies. En route: the libc `chmod`/`fchmod` bindings declared their mode as the OPAQUE `mode_t : Type`, which no Yo caller can construct (`mode_t(384)` is a SomeT-callee error — silently swallowed in async bodies); rebound as `u32`
 5. `process.Child`/`spawn`/`Stdio`
 6. async combinators + async channel/mutex + `timeout` (D7)
 7. `crypto`: HMAC, SHA-1, SHA-512, CRC32, `Digest` trait; `std/rand`

--- a/src/fetch.yo
+++ b/src/fetch.yo
@@ -19,7 +19,7 @@ open(import("std/string"));
   remove_file,
   rename
 } :: import("std/fs/dir");
-{ walk, walk_with, WalkEntry, WalkOptions } :: import("std/fs/walker");
+{ remove_dir_all } :: import("std/fs/walker");
 { Sha256 } :: import("std/crypto/sha256");
 { hex_encode } :: import("std/encoding/hex");
 {
@@ -75,34 +75,6 @@ SIDECAR_FILENAME :: ".yo-content-hash";
 // ---------------------------------------------------------------------------
 // Utilities
 // ---------------------------------------------------------------------------
-/// Recursive directory removal.
-/// Walks the tree (parents first), then deletes in reverse order.
-remove_dir_all :: (fn(path : Path, io : Io, exn : Exception) -> Impl(Future(unit, IoExn)))(
-  io.async((e : IoExn) => {
-    opts := WalkOptions(max_depth : .None, follow_symlinks : false, include_dirs : true);
-    entries := e.io.await(walk_with(path, opts, e.io), e);
-    n := entries.len();
-    // Delete deepest entries first (reverse order from walk output)
-    while(n > usize(0), {
-      n = (n - usize(1));
-      match(
-        entries.get(n),
-        .None => (),
-        .Some(entry) =>
-          match(
-            entry.file_type,
-            .Directory => {
-              e.io.await(remove_dir(entry.path, e.io), e);
-            },
-            _ => {
-              e.io.await(remove_file(entry.path, e.io), e);
-            }
-          )
-      );
-    });
-    e.io.await(remove_dir(path, e.io), e);
-  })
-);
 /// Selection-sort a list of DirEntry values by name (ascending ASCII order).
 sort_dir_entries :: (fn(entries : ArrayList(DirEntry)) -> ArrayList(DirEntry))({
   n := entries.len();
@@ -586,7 +558,7 @@ clone_repo :: (
     };
     git_dir_exists := e.io.await(exists(Path.new(git_dir_path), e.io), e.io);
     if(git_dir_exists, {
-      e.io.await(remove_dir_all(Path.new(git_dir_path), e.io, e.exn), e);
+      e.io.await(remove_dir_all(Path.new(git_dir_path), e.io), e);
     });
     // Atomic rename to final location
     e.io.await(rename(Path.new(temp_dir), Path.new(target_dir), e.io), e);
@@ -704,7 +676,7 @@ fetch_dep :: (
       // Evict corrupt / hash-mismatch cache entry
       path_exists := e.io.await(exists(Path.new(state.cached_path), e.io), e.io);
       if(path_exists, {
-        e.io.await(remove_dir_all(Path.new(state.cached_path), e.io, e.exn), e);
+        e.io.await(remove_dir_all(Path.new(state.cached_path), e.io), e);
       });
     });
     // Clone the repo

--- a/src/main.yo
+++ b/src/main.yo
@@ -2969,7 +2969,7 @@ run_cache :: (
       present := io.await(exists(Path.new(cache_dir.clone()), io), io);
       cond(
         present => {
-          io.await(remove_dir_all(Path.new(cache_dir.clone()), io, exn), IoExn(io : io, exn : exn));
+          io.await(remove_dir_all(Path.new(cache_dir.clone()), io), IoExn(io : io, exn : exn));
           println(`Removed cache directory: ${cache_dir}`);
         },
         true => println(`Cache directory does not exist: ${cache_dir}`)

--- a/src/version_cache.yo
+++ b/src/version_cache.yo
@@ -32,7 +32,7 @@ open(import("std/fmt"));
   remove_file,
   rename
 } :: import("std/fs/dir");
-{ walk_with, WalkOptions } :: import("std/fs/walker");
+{ remove_dir_all } :: import("std/fs/walker");
 { TempDir } :: import("std/fs/temp");
 { env } :: import("std/env");
 {
@@ -68,38 +68,6 @@ _releases_download_url :: (fn() -> String)(`https://github.com/${_github_repo()}
 // ---------------------------------------------------------------------------
 // Local helpers
 // ---------------------------------------------------------------------------
-/// Recursively remove a directory and all its contents.
-_remove_dir_all :: (
-  fn(
-    path : Path,
-    io : Io,
-    exn : Exception
-  ) -> Impl(Future(unit, IoExn))
-)(
-  io.async((e : IoExn) => {
-    opts := WalkOptions(max_depth : .None, follow_symlinks : false, include_dirs : true);
-    entries := e.io.await(walk_with(path, opts, e.io), e);
-    n := entries.len();
-    while(n > usize(0), {
-      n = (n - usize(1));
-      match(
-        entries.get(n),
-        .None => (),
-        .Some(entry) =>
-          match(
-            entry.file_type,
-            .Directory => {
-              e.io.await(remove_dir(entry.path, e.io), e);
-            },
-            _ => {
-              e.io.await(remove_file(entry.path, e.io), e);
-            }
-          )
-      );
-    });
-    e.io.await(remove_dir(path, e.io), e);
-  })
-);
 /// Extract the string value of a JSON field named `key`.
 /// Handles both `"key":"value"` and `"key": "value"` forms.
 /// Returns `.None` if the field is not found.
@@ -426,14 +394,14 @@ clean_version_cache :: (
         version_dir := get_version_cache_dir(version);
         dir_exists := e.io.await(exists(Path.new(version_dir), e.io), e.io);
         if(dir_exists, {
-          e.io.await(_remove_dir_all(Path.new(version_dir), e.io, e.exn), e);
+          e.io.await(remove_dir_all(Path.new(version_dir), e.io), e);
         });
       },
       .None => {
         versions_dir := get_global_versions_cache_dir();
         dir_exists := e.io.await(exists(Path.new(versions_dir), e.io), e.io);
         if(dir_exists, {
-          e.io.await(_remove_dir_all(Path.new(versions_dir), e.io, e.exn), e);
+          e.io.await(remove_dir_all(Path.new(versions_dir), e.io), e);
         });
       }
     );
@@ -625,9 +593,9 @@ _cleanup_failed_download :: (
   io.async((e : IoExn) => {
     ver_exists := e.io.await(exists(Path.new(version_dir), e.io), e.io);
     if(ver_exists, {
-      e.io.await(_remove_dir_all(Path.new(version_dir), e.io, e.exn), e);
+      e.io.await(remove_dir_all(Path.new(version_dir), e.io), e);
     });
-    e.io.await(_remove_dir_all(tmp_path, e.io, e.exn), e);
+    e.io.await(remove_dir_all(tmp_path, e.io), e);
   })
 );
 /// Download a specific Yo version's native bundle from GitHub Releases and
@@ -656,7 +624,7 @@ download_version :: (
     (url : String) = `${_releases_download_url()}/v${version}/${bundle_name}.tar.gz`;
     (tarball_path : String) = `${tmp_path_str}/${bundle_name}.tar.gz`;
     println(`Downloading Yo v${version} (${bundle_name}) from GitHub Releases...`);
-    code_str := e.io.await(_download_file(url, tarball_path, e.io, e.exn), e);
+    code_str := e.io.await(_download_file(url, tarball_path, e.io), e);
     (code : i64) = match(code_str.parse_i64(), .None => i64(0), .Some(c) => c);
     // Linux glibc-era fallback: releases that predate the musl legs only
     // published `yo-v<v>-linux-<arch>` bundles. On a glibc host that bundle
@@ -668,18 +636,18 @@ download_version :: (
       bundle_name = legacy;
       url = `${_releases_download_url()}/v${version}/${bundle_name}.tar.gz`;
       tarball_path = `${tmp_path_str}/${bundle_name}.tar.gz`;
-      legacy_code_str := e.io.await(_download_file(url, tarball_path, e.io, e.exn), e);
+      legacy_code_str := e.io.await(_download_file(url, tarball_path, e.io), e);
       code = match(legacy_code_str.parse_i64(), .None => i64(0), .Some(c2) => c2);
     });
     if(code == i64(404), {
-      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
+      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io), e);
       msg := `Yo v${version} has no ${bundle_name}.tar.gz release asset.`;
       msg.push_string(String.from("\nRun `yo version list --remote` to see the published releases, or check "));
       msg.push_string(`https://github.com/${_github_repo()}/releases`);
       e.exn.throw(dyn(msg));
     });
     if(code >= i64(400), {
-      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
+      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io), e);
       e.exn.throw(dyn(`HTTP ${code.to_string()} downloading ${url}`));
     });
     // 2. Extract; the tarball root is a `<bundleName>/` directory holding
@@ -692,27 +660,27 @@ download_version :: (
     tar_cmd.arg(tmp_path_str);
     tar_out := e.io.await(tar_cmd.output(e.io), e);
     if(!(tar_out.status.success()), {
-      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
+      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io), e);
       e.exn.throw(dyn(`Failed to extract ${bundle_name}.tar.gz for Yo v${version}`));
     });
     extracted_dir := `${tmp_path_str}/${bundle_name}`;
     bin_exists := e.io.await(exists(Path.new(`${extracted_dir}/bin`), e.io), e.io);
     std_exists := e.io.await(exists(Path.new(`${extracted_dir}/std`), e.io), e.io);
     if(!(bin_exists && std_exists), {
-      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
+      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io), e);
       e.exn.throw(dyn(`Unexpected bundle layout in ${bundle_name}.tar.gz (missing bin/ or std/).`));
     });
     // 3. Remove any existing partial extraction (or a dead npm-shaped
     // entry), then MOVE the extracted bundle root to the version directory.
     ver_exists := e.io.await(exists(Path.new(version_dir), e.io), e.io);
     if(ver_exists, {
-      e.io.await(_remove_dir_all(Path.new(version_dir), e.io, e.exn), e);
+      e.io.await(remove_dir_all(Path.new(version_dir), e.io), e);
     });
     e.io.await(create_dir_all(Path.new(get_global_versions_cache_dir()), e.io), e);
     e.io.await(rename(Path.new(extracted_dir), Path.new(version_dir), e.io), e);
     println(`Installed Yo v${version} to ${version_dir}`);
     // 4. Clean up the temp directory (the tarball stays behind in it).
-    e.io.await(_remove_dir_all(tmp_dir.path(), e.io, e.exn), e);
+    e.io.await(remove_dir_all(tmp_dir.path(), e.io), e);
     version_dir
   })
 );
@@ -726,7 +694,7 @@ ensure_cached_version :: (
   ) -> Impl(Future(String, IoExn))
 )(
   io.async((e : IoExn) => {
-    cached := e.io.await(is_version_cached(version, e.io, e.exn), e);
+    cached := e.io.await(is_version_cached(version, e.io), e);
     if(cached, {
       return(get_version_cache_dir(version));
     });
@@ -749,7 +717,7 @@ fetch_remote_versions :: (
     done := false;
     while((page <= i64(3)) && (!(done)), {
       url := `${_releases_api_url()}?per_page=100&page=${page}`;
-      body := e.io.await(_http_get(url, e.io, e.exn), e);
+      body := e.io.await(_http_get(url, e.io), e);
       trimmed := body.trim();
       if(!(trimmed.starts_with(String.from("["))), {
         e.exn.throw(dyn(`Unexpected GitHub Releases API response shape.`));

--- a/std/fs/dir.yo
+++ b/std/fs/dir.yo
@@ -230,6 +230,35 @@ symlink :: (fn(src : Path, dst : Path, io : Io) -> Impl(Future(unit, IoExn)))(
   })
 );
 symlink_str :: (fn(src : str, dst : str, io : Io) -> Impl(Future(unit, IoExn)))(symlink(Path.new(String.from(src)), Path.new(String.from(dst)), io));
+/// Read a symlink's target (`std::fs::read_link`). Throws for a path that is
+/// not a symlink (EINVAL) — like Rust.
+read_link :: (fn(path : Path, io : Io) -> Impl(Future(Path, IoExn)))(
+  io.async((e) => {
+    cstr_bytes := path.to_string().to_cstr();
+    cstr := cstr_bytes.ptr().unwrap();
+    bufsize := usize(4096);
+    buf := *(u8)(malloc(bufsize).unwrap());
+    n := IO_dir.readlink(AT_FDCWD, cstr, buf, bufsize);
+    cond(
+      (n < i32(0)) => {
+        free(.Some(*(void)(buf)));
+        e.exn.throw(dyn(IoError.from_errno(i32(0) - n)))
+      },
+      true => {
+        target_bytes := ArrayList(u8).with_capacity(usize(n));
+        (rli : usize) = usize(0);
+        while(rli < usize(n), rli = (rli + usize(1)), {
+          target_bytes.push((buf.add(rli)).*);
+        });
+        free(.Some(*(void)(buf)));
+        Path.new(String.from_bytes(target_bytes))
+      }
+    )
+  })
+);
+/// `read_link` (`str` path variant).
+read_link_str :: (fn(path : str, io : Io) -> Impl(Future(Path, IoExn)))(read_link(Path.new(String.from(path)), io));
+
 // ============================================================================
 // Directory listing
 // ============================================================================
@@ -313,5 +342,7 @@ export(
   symlink,
   symlink_str,
   read_dir,
-  read_dir_str
+  read_dir_str,
+  read_link,
+  read_link_str
 );

--- a/std/fs/file.yo
+++ b/std/fs/file.yo
@@ -38,6 +38,9 @@ IO_path :: import("../sys/path");
 IO_file :: import("../sys/file");
 IoTraits :: import("../io");
 { AT_FDCWD, AT_STATX_SYNC_AS_STAT, STATX_BASIC_STATS, O_RDONLY, O_WRONLY, O_RDWR, O_CREAT, O_TRUNC, O_APPEND, O_CLOEXEC, DEFAULT_FILE_MODE } :: import("../sys/constants");
+{ ENOENT, ENOTDIR } :: import("../libc/errno");
+{ chmod } :: import("../libc/sys/stat");
+{ metadata } :: import("./metadata");
 // ============================================================================
 // File
 // ============================================================================
@@ -374,7 +377,10 @@ append_file_str :: (fn(path : str, data : str, io : Io) -> Impl(Future(unit, IoE
 );
 extern(
   "Yo",
-  __yo_statx_buf_size : (fn() -> usize)
+  __yo_statx_buf_size : (fn() -> usize),
+  // errno as a CALL — the C macro is an int LVALUE, not a pointer (same
+  // pattern as std/crypto/random.yo).
+  __yo_errno : (fn() -> i32)
 );
 /// Check if a path exists. Returns `false` for any error including file not found.
 /// Does not use the `Exception` effect.
@@ -397,6 +403,63 @@ exists_str :: (fn(path : str, io : Io) -> Impl(Future(bool, Io)))(
 exists_cstr :: (fn(path : *(u8), io : Io) -> Impl(Future(bool, Io)))(
   exists(Path.from_cstr(path), io)
 );
+/// Check if a path exists, PROPAGATING errors (`std::fs::try_exists`):
+/// `.false` only for a definitive not-there answer (ENOENT/ENOTDIR); a
+/// permission failure or any other error THROWS instead of masquerading as
+/// absence — the honest form `exists` cannot give
+/// (plans/STD_API_AUDIT.md §7 P0).
+try_exists :: (fn(path : Path, io : Io) -> Impl(Future(bool, IoExn)))(
+  io.async((e) => {
+    cstr_bytes := path.to_string().to_cstr();
+    cstr := cstr_bytes.ptr().unwrap();
+    buf_size := __yo_statx_buf_size();
+    buf := *(u8)(malloc(buf_size).unwrap());
+    result := e.io.await(IO_file.statx(AT_FDCWD, cstr, AT_STATX_SYNC_AS_STAT, STATX_BASIC_STATS, buf), e.io);
+    free(.Some(*(void)(buf)));
+    cond(
+      (result >= i32(0)) => true,
+      (((i32(0) - result) == i32(ENOENT)) || ((i32(0) - result) == i32(ENOTDIR))) => false,
+      true => e.exn.throw(dyn(IoError.from_errno(i32(0) - result)))
+    )
+  })
+);
+/// `try_exists` (`str` path variant).
+try_exists_str :: (fn(path : str, io : Io) -> Impl(Future(bool, IoExn)))(
+  try_exists(Path.new(String.from(path)), io)
+);
+/// Set a path's POSIX permission bits.
+set_permissions :: (fn(path : Path, perm : FilePermission, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async((e) => {
+    cstr_bytes := path.to_string().to_cstr();
+    cstr := cstr_bytes.ptr().unwrap();
+    r := unsafe(chmod(*(char)(cstr), perm.mode));
+    cond(
+      (r < int(0)) => e.exn.throw(dyn(IoError.from_errno(__yo_errno()))),
+      true => ()
+    )
+  })
+);
+/// `set_permissions` (`str` path variant).
+set_permissions_str :: (fn(path : str, perm : FilePermission, io : Io) -> Impl(Future(unit, IoExn)))(
+  set_permissions(Path.new(String.from(path)), perm, io)
+);
+/// Copy a file's CONTENTS and permission bits from `from` to `to`
+/// (`std::fs::copy`), resolving to the number of bytes copied. `to` is
+/// created or truncated.
+copy :: (fn(from : Path, to : Path, io : Io) -> Impl(Future(u64, IoExn)))(
+  io.async((e) => {
+    bytes := e.io.await(read(from, e.io), e);
+    e.io.await(write(to, bytes, e.io), e);
+    md := e.io.await(metadata(from, e.io), e);
+    e.io.await(set_permissions(to, FilePermission(mode : (md.mode() & u32(4095))), e.io), e);
+    u64(bytes.len())
+  })
+);
+/// `copy` (`str` path variant).
+copy_str :: (fn(from : str, to : str, io : Io) -> Impl(Future(u64, IoExn)))(
+  copy(Path.new(String.from(from)), Path.new(String.from(to)), io)
+);
+
 /// Check if a path is a regular file. Returns `false` for any error.
 is_file :: (fn(path : Path, io : Io) -> Impl(Future(bool, Io)))(
   io.async((io) => {
@@ -513,7 +576,13 @@ export(
   is_dir_cstr,
   canonicalize,
   canonicalize_str,
-  canonicalize_cstr
+  canonicalize_cstr,
+  try_exists,
+  try_exists_str,
+  set_permissions,
+  set_permissions_str,
+  copy,
+  copy_str
 );
 
 // === std/io async trait impls (STD_API_AUDIT D5) ===

--- a/std/fs/walker.yo
+++ b/std/fs/walker.yo
@@ -34,7 +34,7 @@ _FOLLOW_SUPPORTED :: cond(
 { IoError } :: import("../sys/errors");
 { Error, AnyError, Exception, IoExn } :: import("../error");
 { FileType } :: import("./dir");
-{ DirEntry } :: import("./dir");
+{ DirEntry, remove_dir, remove_file } :: import("./dir");
 _dir :: import("./dir");
 /// Entry returned by the directory walker.
 WalkEntry :: struct(
@@ -43,6 +43,7 @@ WalkEntry :: struct(
   depth : u32,
   file_type : FileType
 );
+
 export(WalkEntry);
 /// Options controlling directory walk behavior.
 WalkOptions :: struct(
@@ -207,3 +208,41 @@ walk_with_cstr :: (fn(root : *(u8), options : WalkOptions, io : Io) -> Impl(Futu
 walk :: (fn(root : Path, io : Io) -> Impl(Future(ArrayList(WalkEntry), IoExn)))(walk_with(root, WalkOptions.defaults(), io));
 walk_cstr :: (fn(root : *(u8), io : Io) -> Impl(Future(ArrayList(WalkEntry), IoExn)))(walk(Path.from_cstr(root), io));
 export(walk, walk_cstr, walk_with, walk_with_cstr);
+/// Recursively remove a directory and everything under it
+/// (`std::fs::remove_dir_all`). Does NOT follow symlinks — a symlinked
+/// directory is removed as a LINK, its target untouched.
+///
+/// Lives HERE rather than in `std/fs/dir` because the implementation is the
+/// walker (collect the whole tree, delete deepest-first) and `fs/walker`
+/// imports `fs/dir` — the reverse import would be a cycle. This is the same
+/// implementation the compiler ran in production as a private helper
+/// (src/fetch.yo) before it moved into std.
+remove_dir_all :: (fn(path : Path, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async((e : IoExn) => {
+    opts := WalkOptions(max_depth : .None, follow_symlinks : false, include_dirs : true);
+    entries := e.io.await(walk_with(path, opts, e.io), e);
+    n := entries.len();
+    // Delete deepest entries first (reverse order from walk output).
+    while(n > usize(0), {
+      n = (n - usize(1));
+      match(
+        entries.get(n),
+        .None => (),
+        .Some(entry) =>
+          match(
+            entry.file_type,
+            .Directory => {
+              e.io.await(remove_dir(entry.path, e.io), e);
+            },
+            _ => {
+              e.io.await(remove_file(entry.path, e.io), e);
+            }
+          )
+      );
+    });
+    e.io.await(remove_dir(path, e.io), e);
+  })
+);
+/// `remove_dir_all` (`str` path variant).
+remove_dir_all_str :: (fn(path : str, io : Io) -> Impl(Future(unit, IoExn)))(remove_dir_all(Path.new(String.from(path)), io));
+export(remove_dir_all, remove_dir_all_str);

--- a/std/libc/sys/stat.yo
+++ b/std/libc/sys/stat.yo
@@ -17,11 +17,14 @@ c_include(
   // Directory creation
   mkdir :
     (fn(pathname : *(char), mode : mode_t) -> int),
-  // File mode operations
+  // File mode operations. The mode parameter is bound as `u32`, not the
+  // opaque `mode_t : Type`: an opaque extern type has NO Yo-side
+  // constructor (`mode_t(384)` is a SomeT-callee error), so a caller could
+  // never produce a value for it — C implicitly converts the integer.
   chmod :
-    (fn(pathname : *(char), mode : mode_t) -> int),
+    (fn(pathname : *(char), mode : u32) -> int),
   fchmod :
-    (fn(fd : int, mode : mode_t) -> int),
+    (fn(fd : int, mode : u32) -> int),
   // File creation mask
   umask :
     (fn(mask : mode_t) -> mode_t),

--- a/tests/fs/fs_convenience.test.yo
+++ b/tests/fs/fs_convenience.test.yo
@@ -10,7 +10,23 @@ open(import("std/fmt"));
 fs_file :: import("std/fs/file");
 { File, OpenMode } :: import("std/fs/file");
 fs_dir :: import("std/fs/dir");
+fs_walker :: import("std/fs/walker");
+fs_metadata :: import("std/fs/metadata");
 { temp_dir, path_join } :: import("../helper");
+// Probe wrappers: the expected-throw tests await through a SEPARATE handler,
+// and a top-level await's IoExn arm needs a fn boundary for unwind to land in.
+read_link_probe :: (fn(p : Path, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async((e) => {
+    _t := e.io.await(fs_dir.read_link(p, e.io), e);
+    ()
+  })
+);
+try_exists_probe :: (fn(p : Path, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async((e) => {
+    _t := e.io.await(fs_file.try_exists(p, e.io), e);
+    ()
+  })
+);
 // ============================================================================
 // is_file tests
 // ============================================================================
@@ -161,4 +177,167 @@ test("canonical throws for nonexistent path", {
   );
   io.await(fs_file.canonicalize(fpath, io), IoExn(io : io, exn : exn));
   assert(false, "should have thrown");
+});
+
+// ============================================================================
+// S3 P0 wrappers: copy / remove_dir_all / read_link / set_permissions /
+// try_exists (plans/STD_API_AUDIT.md §7 P0 item 4)
+// ============================================================================
+test("copy copies contents, permission bits and returns the byte count", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  base := temp_dir();
+  src_p := Path.new(path_join(base.clone(), `s3_copy_src.txt`.to_string()));
+  dst_p := Path.new(path_join(base.clone(), `s3_copy_dst.txt`.to_string()));
+  io.await(fs_file.write_string(src_p, `copy me, préserve me`.to_string(), io), e);
+  io.await(fs_file.set_permissions(src_p, fs_file.FilePermission(mode : u32(384)), io), e);
+  n := io.await(fs_file.copy(src_p, dst_p, io), e);
+  assert(n == u64(21), "byte count (multibyte é = 2 bytes)");
+  got := io.await(fs_file.read_to_string(dst_p, io), e);
+  assert(got == `copy me, préserve me`, "contents copied");
+  md := io.await(fs_metadata.metadata(dst_p, io), e);
+  assert((md.mode() & u32(4095)) == u32(384), "0o600 permission bits copied");
+  io.await(fs_dir.remove_file(src_p, io), e);
+  io.await(fs_dir.remove_file(dst_p, io), e);
+});
+test("remove_dir_all removes a nested tree (files, subdirs, symlink as link)", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  base := temp_dir();
+  root := Path.new(path_join(base.clone(), `s3_rda_root`.to_string()));
+  sub := Path.new(path_join(base.clone(), `s3_rda_root/sub/deeper`.to_string()));
+  io.await(fs_dir.create_dir_all(sub, io), e);
+  io.await(fs_file.write_string(Path.new(path_join(base.clone(), `s3_rda_root/a.txt`.to_string())), `a`.to_string(), io), e);
+  io.await(fs_file.write_string(Path.new(path_join(base.clone(), `s3_rda_root/sub/deeper/b.txt`.to_string())), `b`.to_string(), io), e);
+  // A symlink to a file OUTSIDE the tree: it must be removed as a LINK.
+  outside := Path.new(path_join(base.clone(), `s3_rda_outside.txt`.to_string()));
+  io.await(fs_file.write_string(outside, `survives`.to_string(), io), e);
+  io.await(fs_dir.symlink(outside, Path.new(path_join(base.clone(), `s3_rda_root/sub/link`.to_string())), io), e);
+  io.await(fs_walker.remove_dir_all(root, io), e);
+  gone := io.await(fs_file.exists(root, io), io);
+  assert(gone == false, "tree fully removed");
+  still := io.await(fs_file.exists(outside, io), io);
+  assert(still, "symlink TARGET untouched");
+  io.await(fs_dir.remove_file(outside, io), e);
+});
+test("read_link returns the symlink target; a non-link throws", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  base := temp_dir();
+  target := Path.new(path_join(base.clone(), `s3_rl_target.txt`.to_string()));
+  link := Path.new(path_join(base.clone(), `s3_rl_link`.to_string()));
+  io.await(fs_file.write_string(target, `t`.to_string(), io), e);
+  io.await(fs_dir.symlink(target, link, io), e);
+  got := io.await(fs_dir.read_link(link, io), e);
+  assert(got.to_string() == target.to_string(), "target read back");
+  io.await(fs_dir.remove_file(link, io), e);
+  io.await(fs_dir.remove_file(target, io), e);
+});
+test("read_link on a non-link throws", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(true, "threw as expected (EINVAL)");
+        unwind(());
+      }
+    )
+  );
+  base := temp_dir();
+  plain := Path.new(path_join(base.clone(), `s3_rl_plain.txt`.to_string()));
+  e0 := Exception(
+    throw : (
+      (err0) -> {
+        assert(false, "setup failed");
+        unwind(());
+      }
+    )
+  );
+  io.await(fs_file.write_string(plain, `p`.to_string(), io), IoExn(io : io, exn : e0));
+  io.await(read_link_probe(plain, io), IoExn(io : io, exn : exn));
+  assert(false, "read_link on a regular file must throw");
+});
+test("try_exists: true, false for absent, THROWS for a denied parent", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  base := temp_dir();
+  here := Path.new(path_join(base.clone(), `s3_te_here.txt`.to_string()));
+  io.await(fs_file.write_string(here, `x`.to_string(), io), e);
+  assert(io.await(fs_file.try_exists(here, io), e), "present is true");
+  absent := Path.new(path_join(base.clone(), `s3_te_absent.txt`.to_string()));
+  assert(io.await(fs_file.try_exists(absent, io), e) == false, "absent is false, not an error");
+  io.await(fs_dir.remove_file(here, io), e);
+});
+test("try_exists THROWS for a denied parent instead of answering false", {
+  e0 := Exception(
+    throw : (
+      (err0) -> {
+        assert(false, "setup failed");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : e0);
+  base := temp_dir();
+  // 0o000 directory: plain exists() would lie `false`; try_exists throws.
+  denied_dir := Path.new(path_join(base.clone(), `s3_te_denied`.to_string()));
+  io.await(fs_dir.create_dir(denied_dir, io), e);
+  io.await(fs_file.set_permissions(denied_dir, fs_file.FilePermission(mode : u32(0)), io), e);
+  child := Path.new(path_join(base.clone(), `s3_te_denied/child.txt`.to_string()));
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(true, "threw as expected (EACCES)");
+        unwind(());
+      }
+    )
+  );
+  io.await(try_exists_probe(child, io), IoExn(io : io, exn : exn));
+  // NOTE: reached only if try_exists did NOT throw — restore perms so the
+  // temp dir stays removable either way, then fail.
+  io.await(fs_file.set_permissions(denied_dir, fs_file.FilePermission(mode : u32(448)), io), e);
+  assert(false, "denied parent must throw");
+});
+test("try_exists denied-dir cleanup", {
+  e0 := Exception(
+    throw : (
+      (err0) -> {
+        assert(true, "already clean");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : e0);
+  base := temp_dir();
+  denied_dir := Path.new(path_join(base.clone(), `s3_te_denied`.to_string()));
+  io.await(fs_file.set_permissions(denied_dir, fs_file.FilePermission(mode : u32(448)), io), e);
+  io.await(fs_dir.remove_dir(denied_dir, io), e);
+  assert(true, "cleaned");
 });


### PR DESCRIPTION
§7 P0 item 4 (`plans/STD_API_AUDIT.md`), plus the compiler dropping its two private `remove_dir_all` copies.

- **`copy(from, to, io) -> Future(u64, IoExn)`** — contents + permission bits (masked to 0o7777) + byte count, like `std::fs::copy`.
- **`try_exists`** — `false` only for a definitive ENOENT/ENOTDIR; a **denied parent throws** instead of masquerading as absence (`exists()` keeps its never-throws contract).
- **`set_permissions(path, FilePermission, io)`** — en route found+fixed: the libc `chmod`/`fchmod` bindings declared their mode as the OPAQUE `mode_t : Type`, which no Yo caller can construct — `mode_t(384)` is a SomeT-callee error that was **silently swallowed inside the async body** (set_permissions no-oped while compiling green). Rebound as `u32`.
- **`read_link(path, io) -> Future(Path, IoExn)`** — a non-link throws EINVAL, like Rust.
- **`remove_dir_all`** — homed in **`std/fs/walker`**: the implementation IS the walker (collect + delete deepest-first, the exact code `src/fetch` ran in production), and `fs/walker` imports `fs/dir`, so the reverse would cycle. Two from-scratch BFS attempts in `dir.yo` were abandoned honestly — an async `while` with a method-call CONDITION, and a match-arm await with a sibling field-read arg, both **silently FTT** (the filed `ftt-stub-in-live-closure` class); the proven walker shape does not. `src/fetch.yo` + `src/version_cache.yo` migrated (9 call sites), `src/main.yo` keeps its import via fetch's re-export.

Tests: `tests/fs/fs_convenience.test.yo` 9 → 16 (copy contents+perms+count; nested-tree removal with a symlink removed AS A LINK, target untouched; read_link round-trip + non-link throw; try_exists true/false/denied-parent-throw). Regression: fs/file 16, fs/temp 10, fs/walker 7, env 14.

**Full battery**: check std 157/157 + src 262/262, build rc=0, suite **3179/3179**, cli-diff 52 PASS / 0 GOLDEN-DIFF (zero drift), gates `failures=0`, fixpoint `FIXPOINT_HOLDS stage2 hollow=0`, hollow sweep `SWEEP_GATE_OK` (0 allowlisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)