### PR TITLE
std: S3 P0 — percent-encoding module + html_encode (and the D2 html_decode rename)

### DIFF
--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -440,7 +440,7 @@ Open D7 items:
 | collections/* | RENAME + EXTEND | §5 renames DONE; still: entry API, `retain/extend/drain`, `binary_search`, real `sort` (not O(n²) insertion), `sort_by`; HashSet = HashMap(T, unit) to kill ~500 duplicated SwissTable lines; hide pub `ctrl/data/…` fields; `BTreeMap` → real B-tree with `range()` (recommend: real B-tree, keep name); add `BTreeSet`; `PriorityQueue`: comparator ctor, DOCUMENT min-heap |
 | imm/* | KEEP (O4) + FIX | stays in std; `Acyclic` element bounds LANDED (O7, 2026-08-27); still: iteration + `Index` where doc'd, dedupe set pair, mark unstable until exercised |
 | string | FIX + EXTEND | D4 byte-indexing DONE (both types); still: Unicode-correct `to_lowercase` (+ `to_ascii_*`; see the locale issue), `Pattern` impl for `rune` + `Regex`, `replace*` Pattern-generic, `parse_f64`/radix, `split_once`, `strip_prefix/suffix`, move `panic_dyn`/`assert_dyn` to assert, delete one of `to_cstr`/`to_c_str`; `StringError` is live now (from_utf8) |
-| encoding | STANDARDIZE | utf8 DONE; still: one error style per D1 (base64's `Result(_, String)`), `html_encode` (XSS!), percent-encoding module (P0), base32, CSV (P1), toml floats/arrays/dates/serializer + derives (P1) |
+| encoding | STANDARDIZE | utf8, percent, `html_encode` + the `html_decode` rename DONE; still: one error style per D1 (base64's `Result(_, String)`), base32, CSV (P1), toml floats/arrays/dates/serializer + derives (P1) |
 | json | EXTEND | enum representation DECIDED externally-tagged (O3); `JsonValue.Object` O(n) parallel arrays → keep repr, add index map if profiling demands |
 | regex | POLISH | typed error + private internals DONE (D8); byte `index()` DONE (D4 PR 6); still: `Regex.escape`, optional-flags `new`, callback replace, lazy `find_iter`, group byte-spans |
 | url | EXTEND | percent-encode/decode integration, `query_pairs`/`SearchParams`, `join` (RFC 3986 §5 — needed by http redirects), builder/setters; punycode DELETED (§6) |
@@ -575,8 +575,8 @@ declarations at runtime.
 ## 7. Additions ranked (post-sweep, additive, batteries-included)
 
 **P0 — unblock real programs**
-1. `std/encoding/percent.yo` (percent-encode/decode) + URL/query integration
-2. ~~`std/encoding/utf8.yo` (D8)~~ **DONE 2026-08-25** + `html_encode` (open)
+1. ~~`std/encoding/percent.yo` (percent-encode/decode)~~ **DONE 2026-08-27** (RFC 3986 component codec: `percent_encode`, `percent_decode` (UTF-8-validated) + `percent_decode_bytes`, typed `PercentError` with byte indexes; `+` deliberately NOT a space — the form dialect can be added additively). URL/query integration still open (rides the `Url` extension work)
+2. ~~`std/encoding/utf8.yo` (D8)~~ **DONE 2026-08-25**; ~~`html_encode`~~ **DONE 2026-08-27** (the five XSS-critical characters; `html_decode(html_encode(s)) == s` pinned) — the D2 rename `decode_html` → `html_decode` landed with it
 3. `std/io` redesign with stdio handles (D5) — slices 1–2 DONE; generic wrappers + bufio move remain
 4. ~~`fs.copy`, `fs.remove_dir_all`, `read_link`, `set_permissions`, `try_exists`~~ **DONE 2026-08-27** — `copy` (contents + permission bits + byte count), `try_exists` (throws instead of lying `false` on a denied parent), `set_permissions` in `std/fs/file`; `read_link` in `std/fs/dir`; `remove_dir_all` in **`std/fs/walker`** (its implementation IS the walker, and `fs/walker` imports `fs/dir` — the reverse would cycle); `src/fetch` + `src/version_cache` dropped their private copies. En route: the libc `chmod`/`fchmod` bindings declared their mode as the OPAQUE `mode_t : Type`, which no Yo caller can construct (`mode_t(384)` is a SomeT-callee error — silently swallowed in async bodies); rebound as `u32`
 5. `process.Child`/`spawn`/`Stdio`

--- a/std/encoding/html.yo
+++ b/std/encoding/html.yo
@@ -6,9 +6,9 @@
 //! # Example
 //!
 //! ```rust
-//! { decode_html } :: import "std/encoding/html";
+//! { html_decode } :: import "std/encoding/html";
 //!
-//! result := decode_html(`&amp; &lt; &#38; &#x26;`);
+//! result := html_decode(`&amp; &lt; &#38; &#x26;`);
 //! assert((result == `& < & &`), "decoded entities");
 //! ```
 open(import("../string"));
@@ -76,7 +76,7 @@ _is_alpha_numeric :: (fn(c : rune) -> bool)(
 // ---------------------------------------------------------------------------
 // A rune-indexed view of the input.
 //
-// `decode_html` is a BACKTRACKING scanner: it seeks forward over digits and
+// `html_decode` is a BACKTRACKING scanner: it seeks forward over digits and
 // entity names, then walks `try_end` back down one rune at a time looking for
 // a legacy prefix. That needs random access by rune, which `chars()` alone
 // cannot give — so the input is materialized once as a table of
@@ -142,7 +142,7 @@ _slice_runes :: (
 ///
 /// Supports named (`&amp;`), decimal (`&#38;`), and hexadecimal (`&#x26;`) character
 /// references. Legacy mode — entities without trailing semicolons are also decoded.
-decode_html :: (fn(input : String) -> String)({
+html_decode :: (fn(input : String) -> String)({
   _ensure_init();
   if(input.chars().count() == usize(0), {
     return(input);
@@ -310,4 +310,28 @@ decode_html :: (fn(input : String) -> String)({
   });
   result
 });
-export(decode_html, is_valid_entity_code, from_code_point);
+/// Escape a string for safe embedding in HTML text or attribute values:
+/// the five XSS-critical characters become entities (`&` `<` `>` `"` `'` →
+/// `&amp;` `&lt;` `&gt;` `&quot;` `&#39;`). Everything else — including all
+/// multibyte UTF-8 — passes through byte-identically, so
+/// `html_decode(html_encode(s)) == s` for any `s`
+/// (plans/STD_API_AUDIT.md D2 + §7 P0).
+html_encode :: (fn(input : String) -> String)({
+  out := String.with_capacity(input.len());
+  bytes := input.as_bytes();
+  n := bytes.len();
+  (i : usize) = usize(0);
+  while(i < n, i = (i + usize(1)), {
+    b := match(bytes.get(i), .Some(x) => x, .None => u8(0));
+    cond(
+      (b == u8(38)) => out.push_str("&amp;"),
+      (b == u8(60)) => out.push_str("&lt;"),
+      (b == u8(62)) => out.push_str("&gt;"),
+      (b == u8(34)) => out.push_str("&quot;"),
+      (b == u8(39)) => out.push_str("&#39;"),
+      true => out.push_byte(b)
+    );
+  });
+  out
+});
+export(html_decode, html_encode, is_valid_entity_code, from_code_point);

--- a/std/encoding/html_entities.yo
+++ b/std/encoding/html_entities.yo
@@ -3,7 +3,7 @@
 //! Auto-generated from <https://html.spec.whatwg.org/entities.json>.
 //! Total: 2125 entities (93 decode to two code points).
 //!
-//! This module provides the entity name-to-string mapping used by `decode_html`.
+//! This module provides the entity name-to-string mapping used by `html_decode`.
 //!
 //! The table is STATIC DATA: one ASCII blob of `name,cp[,cp];` records
 //! (and a comma-joined name list for the legacy set), parsed by a small

--- a/std/encoding/percent.yo
+++ b/std/encoding/percent.yo
@@ -1,0 +1,123 @@
+//! Percent-encoding (RFC 3986) — the URI component codec
+//! (`plans/STD_API_AUDIT.md` §7 P0 item 1).
+//!
+//! `percent_encode` keeps the RFC 3986 UNRESERVED set (`A-Z a-z 0-9 - _ . ~`)
+//! and encodes every other BYTE as `%XX` (uppercase hex), so multibyte UTF-8
+//! is encoded byte-by-byte — the component form (`encodeURIComponent` /
+//! Rust's `percent-encoding` NON_ALPHANUMERIC minus the unreserved marks).
+//!
+//! `percent_decode` reverses it: `%XX` → byte, validated as UTF-8 on the way
+//! back into a `String` (D1 style 2: a pure fallible transform returning
+//! `Result(_, PercentError)`); `percent_decode_bytes` returns the raw bytes
+//! for callers decoding non-text data.
+//!
+//! `+` is NOT treated as a space: that is the `application/x-www-form-urlencoded`
+//! FORM dialect, not RFC 3986 — a form variant can be added additively.
+open(import("../string"));
+{ ArrayList } :: import("../collections/array_list");
+utf8 :: import("./utf8");
+
+/// Percent-decoding error — carries the byte index of the fault.
+PercentError :: enum(
+  /// A `%` with fewer than two following characters.
+  TruncatedEscape(index : usize),
+  /// A `%XY` whose `X` or `Y` is not a hex digit; carries the bad byte.
+  InvalidHexDigit(index : usize, byte : u8),
+  /// The decoded bytes are not valid UTF-8 (only from `percent_decode`;
+  /// `percent_decode_bytes` never yields it).
+  InvalidUtf8(cause : utf8.Utf8Error)
+);
+/// True for the RFC 3986 unreserved set: `A-Z a-z 0-9 - _ . ~`.
+_is_unreserved :: (fn(b : u8) -> bool)(
+  ((b >= u8(65)) && (b <= u8(90))) || (((b >= u8(97)) && (b <= u8(122))) || (((b >= u8(48)) && (b <= u8(57))) || ((b == u8(45)) || ((b == u8(95)) || ((b == u8(46)) || (b == u8(126)))))))
+);
+_HEX_UPPER :: "0123456789ABCDEF";
+/// The value of an ASCII hex digit, or `.None`.
+_hex_val :: (fn(b : u8) -> Option(u8))(
+  cond(
+    ((b >= u8(48)) && (b <= u8(57))) => Option(u8).Some(b - u8(48)),
+    ((b >= u8(65)) && (b <= u8(70))) => Option(u8).Some((b - u8(65)) + u8(10)),
+    ((b >= u8(97)) && (b <= u8(102))) => Option(u8).Some((b - u8(97)) + u8(10)),
+    true => Option(u8).None
+  )
+);
+/// Percent-encode `input` for use as a URI component.
+percent_encode :: (fn(input : String) -> String)({
+  bytes := input.as_bytes();
+  n := bytes.len();
+  out := String.with_capacity(n);
+  hex := _HEX_UPPER.to_string().as_bytes();
+  (i : usize) = usize(0);
+  while(i < n, i = (i + usize(1)), {
+    b := match(bytes.get(i), .Some(x) => x, .None => u8(0));
+    cond(
+      _is_unreserved(b) => out.push_byte(b),
+      true => {
+        out.push_byte(u8(37));
+        out.push_byte(match(hex.get(usize(b >> u8(4))), .Some(h) => h, .None => u8(48)));
+        out.push_byte(match(hex.get(usize(b & u8(15))), .Some(h) => h, .None => u8(48)));
+      }
+    );
+  });
+  out
+});
+/// Percent-decode `input` to raw bytes. `%XX` becomes one byte; every other
+/// byte passes through (including `+`, which stays `+` — RFC 3986, not the
+/// form dialect).
+percent_decode_bytes :: (fn(input : String) -> Result(ArrayList(u8), PercentError))({
+  bytes := input.as_bytes();
+  n := bytes.len();
+  out := ArrayList(u8).with_capacity(n);
+  (i : usize) = usize(0);
+  while(i < n, {
+    b := match(bytes.get(i), .Some(x) => x, .None => u8(0));
+    cond(
+      (b == u8(37)) => {
+        if((i + usize(2)) >= n, {
+          return(Result(ArrayList(u8), PercentError).Err(PercentError.TruncatedEscape(i)));
+        });
+        hi_b := match(bytes.get(i + usize(1)), .Some(x) => x, .None => u8(0));
+        lo_b := match(bytes.get(i + usize(2)), .Some(x) => x, .None => u8(0));
+        hi := match(
+          _hex_val(hi_b),
+          .Some(v) => v,
+          .None => {
+            return(Result(ArrayList(u8), PercentError).Err(PercentError.InvalidHexDigit(i + usize(1), hi_b)));
+          }
+        );
+        lo := match(
+          _hex_val(lo_b),
+          .Some(v) => v,
+          .None => {
+            return(Result(ArrayList(u8), PercentError).Err(PercentError.InvalidHexDigit(i + usize(2), lo_b)));
+          }
+        );
+        out.push((hi << u8(4)) | lo);
+        i = (i + usize(3));
+      },
+      true => {
+        out.push(b);
+        i = (i + usize(1));
+      }
+    );
+  });
+  Result(ArrayList(u8), PercentError).Ok(out)
+});
+/// Percent-decode `input` to a `String`, validating the decoded bytes as
+/// UTF-8.
+percent_decode :: (fn(input : String) -> Result(String, PercentError))(
+  match(
+    percent_decode_bytes(input),
+    .Err(e) => Result(String, PercentError).Err(e),
+    .Ok(bytes) => match(
+      String.from_utf8(bytes),
+      .Ok(s) => Result(String, PercentError).Ok(s),
+      .Err(se) => match(
+        se,
+        .InvalidUtf8(cause) => Result(String, PercentError).Err(PercentError.InvalidUtf8(cause)),
+        _ => Result(String, PercentError).Err(PercentError.TruncatedEscape(usize(0)))
+      )
+    )
+  )
+);
+export(PercentError, percent_encode, percent_decode, percent_decode_bytes);

--- a/tests/encoding/html.test.yo
+++ b/tests/encoding/html.test.yo
@@ -1,82 +1,92 @@
 { assert } :: import("std/assert");
 open(import("std/string"));
-{ decode_html, from_code_point } :: import("std/encoding/html");
+{ html_decode, html_encode, from_code_point } :: import("std/encoding/html");
 test("named entities decode", {
-  assert(decode_html(String.from("a &amp; b")) == `a & b`, "amp");
-  assert(decode_html(String.from("&lt;p&gt;")) == `<p>`, "lt/gt");
-  assert(decode_html(String.from("&quot;x&quot;")) == `"x"`, "quot");
+  assert(html_decode(String.from("a &amp; b")) == `a & b`, "amp");
+  assert(html_decode(String.from("&lt;p&gt;")) == `<p>`, "lt/gt");
+  assert(html_decode(String.from("&quot;x&quot;")) == `"x"`, "quot");
 });
 test("entities from the static table decode", {
-  assert(decode_html(String.from("&forall;x")) == `∀x`, "forall (was mangled to `generic` in the old table)");
-  assert(decode_html(String.from("&AElig;")) == `Æ`, "first table entry");
-  assert(decode_html(String.from("&zwnj;")) == from_code_point(i32(8204)), "last table entry");
+  assert(html_decode(String.from("&forall;x")) == `∀x`, "forall (was mangled to `generic` in the old table)");
+  assert(html_decode(String.from("&AElig;")) == `Æ`, "first table entry");
+  assert(html_decode(String.from("&zwnj;")) == from_code_point(i32(8204)), "last table entry");
   assert(
-    decode_html(String.from("&NotEqualTilde;")) == (from_code_point(i32(8770)) + from_code_point(i32(824))),
+    html_decode(String.from("&NotEqualTilde;")) == (from_code_point(i32(8770)) + from_code_point(i32(824))),
     "two-code-point entity"
   );
 });
 test("legacy entities decode without semicolon by longest prefix", {
-  assert(decode_html(String.from("&amp!")) == `&!`, "legacy amp, no semicolon");
-  assert(decode_html(String.from("&notin")) == `¬in`, "notin is not legacy; not is - longest legacy prefix wins");
-  assert(decode_html(String.from("&bogus")) == `&bogus`, "unknown name with no legacy prefix stays literal");
+  assert(html_decode(String.from("&amp!")) == `&!`, "legacy amp, no semicolon");
+  assert(html_decode(String.from("&notin")) == `¬in`, "notin is not legacy; not is - longest legacy prefix wins");
+  assert(html_decode(String.from("&bogus")) == `&bogus`, "unknown name with no legacy prefix stays literal");
 });
 test("decimal numeric entities decode", {
-  assert(decode_html(String.from("&#65;")) == `A`, "decimal with semicolon");
-  assert(decode_html(String.from("&#65&#66;")) == `AB`, "unterminated decimal still decodes");
-  assert(decode_html(String.from("x&#65Zy")) == `xAZy`, "decimal terminated by non-digit");
+  assert(html_decode(String.from("&#65;")) == `A`, "decimal with semicolon");
+  assert(html_decode(String.from("&#65&#66;")) == `AB`, "unterminated decimal still decodes");
+  assert(html_decode(String.from("x&#65Zy")) == `xAZy`, "decimal terminated by non-digit");
 });
 test("hex numeric entities decode", {
-  assert(decode_html(String.from("&#x41;")) == `A`, "hex with semicolon");
-  assert(decode_html(String.from("&#X41;")) == `A`, "capital X form");
-  assert(decode_html(String.from("x&#x41Zy")) == `xAZy`, "hex terminated by non-digit");
-  assert(decode_html(String.from("&#x1F600;")) == `😀`, "supplementary-plane hex");
+  assert(html_decode(String.from("&#x41;")) == `A`, "hex with semicolon");
+  assert(html_decode(String.from("&#X41;")) == `A`, "capital X form");
+  assert(html_decode(String.from("x&#x41Zy")) == `xAZy`, "hex terminated by non-digit");
+  assert(html_decode(String.from("&#x1F600;")) == `😀`, "supplementary-plane hex");
 });
 test("digits running to end of input decode", {
-  assert(decode_html(String.from("&#65")) == `A`, "decimal at EOF");
-  assert(decode_html(String.from("&#x41")) == `A`, "hex at EOF");
+  assert(html_decode(String.from("&#65")) == `A`, "decimal at EOF");
+  assert(html_decode(String.from("&#x41")) == `A`, "hex at EOF");
 });
 test("malformed numeric entities stay literal", {
-  assert(decode_html(String.from("&#x;")) == `&#x;`, "hex marker with no digits");
-  assert(decode_html(String.from("&#;")) == `&#;`, "no digits at all");
-  assert(decode_html(String.from("a & b")) == `a & b`, "bare ampersand passes through");
-  assert(decode_html(String.from("&")) == `&`, "trailing ampersand");
-  assert(decode_html(String.from("&#")) == `&#`, "trailing numeric marker");
+  assert(html_decode(String.from("&#x;")) == `&#x;`, "hex marker with no digits");
+  assert(html_decode(String.from("&#;")) == `&#;`, "no digits at all");
+  assert(html_decode(String.from("a & b")) == `a & b`, "bare ampersand passes through");
+  assert(html_decode(String.from("&")) == `&`, "trailing ampersand");
+  assert(html_decode(String.from("&#")) == `&#`, "trailing numeric marker");
 });
 test("invalid code points keep the original entity text", {
-  assert(decode_html(String.from("&#xD800;")) == `&#xD800;`, "surrogate kept literal");
+  assert(html_decode(String.from("&#xD800;")) == `&#xD800;`, "surrogate kept literal");
 });
 // D4 (plans/STD_API_AUDIT_D4_PLAN.md §5.2 S1). Every test above puts multibyte
 // content only in the DECODER'S OUTPUT; the INPUT is pure ASCII, so the
-// scanner's rune arithmetic is never exercised. `decode_html` is the
+// scanner's rune arithmetic is never exercised. `html_decode` is the
 // highest-risk file in the tree for the byte flip — it scans arbitrary HTML by
 // index — so these run multibyte text through the scanner itself, on both
 // sides of every entity form and in every backtracking arm.
 test("entities decode with multibyte text around them", {
-  assert(decode_html(String.from("中文 &amp; 日本語")) == `中文 & 日本語`, "named, CJK on both sides");
-  assert(decode_html(String.from("é&lt;é&gt;é")) == `é<é>é`, "2-byte runes between entities");
-  assert(decode_html(String.from("𝄞&#65;𝄞")) == `𝄞A𝄞`, "decimal between 4-byte runes");
-  assert(decode_html(String.from("𝄞&#x41;𝄞")) == `𝄞A𝄞`, "hex between 4-byte runes");
-  assert(decode_html(String.from("aé中𝄞&amp;aé中𝄞")) == `aé中𝄞&aé中𝄞`, "all four widths");
-  assert(decode_html(String.from("😀&#x1F600;😀")) == `😀😀😀`, "astral in and out");
-  assert(decode_html(String.from("é&#x4E2D;é")) == `é中é`, "hex naming a 3-byte rune");
+  assert(html_decode(String.from("中文 &amp; 日本語")) == `中文 & 日本語`, "named, CJK on both sides");
+  assert(html_decode(String.from("é&lt;é&gt;é")) == `é<é>é`, "2-byte runes between entities");
+  assert(html_decode(String.from("𝄞&#65;𝄞")) == `𝄞A𝄞`, "decimal between 4-byte runes");
+  assert(html_decode(String.from("𝄞&#x41;𝄞")) == `𝄞A𝄞`, "hex between 4-byte runes");
+  assert(html_decode(String.from("aé中𝄞&amp;aé中𝄞")) == `aé中𝄞&aé中𝄞`, "all four widths");
+  assert(html_decode(String.from("😀&#x1F600;😀")) == `😀😀😀`, "astral in and out");
+  assert(html_decode(String.from("é&#x4E2D;é")) == `é中é`, "hex naming a 3-byte rune");
 });
 test("the legacy backtracking arm survives multibyte input", {
   // `&notin` decodes as `not` + `in`; the walk-back over `try_end` is the
   // rune-indexed loop that a byte basis would break.
-  assert(decode_html(String.from("中&notin中")) == `中¬in中`, "longest legacy prefix, CJK around it");
-  assert(decode_html(String.from("é&bogus;é")) == `é&bogus;é`, "unknown named entity stays literal");
-  assert(decode_html(String.from("中&amp!中")) == `中&!中`, "legacy amp with no semicolon");
+  assert(html_decode(String.from("中&notin中")) == `中¬in中`, "longest legacy prefix, CJK around it");
+  assert(html_decode(String.from("é&bogus;é")) == `é&bogus;é`, "unknown named entity stays literal");
+  assert(html_decode(String.from("中&amp!中")) == `中&!中`, "legacy amp with no semicolon");
 });
 test("invalid code points keep their original text with multibyte around them", {
   // The `keep original entity text` arm re-slices the INPUT between two
   // scanner positions — the one place a wrong basis would corrupt bytes it
   // never decoded.
-  assert(decode_html(String.from("𝄞&#xD800;𝄞")) == `𝄞&#xD800;𝄞`, "surrogate kept, astral around it");
-  assert(decode_html(String.from("中&#xDFFF;中")) == `中&#xDFFF;中`, "high surrogate kept");
+  assert(html_decode(String.from("𝄞&#xD800;𝄞")) == `𝄞&#xD800;𝄞`, "surrogate kept, astral around it");
+  assert(html_decode(String.from("中&#xDFFF;中")) == `中&#xDFFF;中`, "high surrogate kept");
 });
 test("truncated entities at the end of multibyte input", {
-  assert(decode_html(String.from("é&")) == `é&`, "trailing ampersand after a 2-byte rune");
-  assert(decode_html(String.from("中&#")) == `中&#`, "trailing numeric marker");
-  assert(decode_html(String.from("𝄞&#x")) == `𝄞&#x`, "trailing hex marker");
-  assert(decode_html(String.from("aé中𝄞")) == `aé中𝄞`, "no entity at all is returned unchanged");
+  assert(html_decode(String.from("é&")) == `é&`, "trailing ampersand after a 2-byte rune");
+  assert(html_decode(String.from("中&#")) == `中&#`, "trailing numeric marker");
+  assert(html_decode(String.from("𝄞&#x")) == `𝄞&#x`, "trailing hex marker");
+  assert(html_decode(String.from("aé中𝄞")) == `aé中𝄞`, "no entity at all is returned unchanged");
+});
+
+test("html_encode escapes the five XSS-critical characters and nothing else", {
+  assert(html_encode(`<a href="x">&'s</a>`.to_string()) == `&lt;a href=&quot;x&quot;&gt;&amp;&#39;s&lt;/a&gt;`, "all five escaped");
+  plain := `héllo 你好 plain-text_09.~`.to_string();
+  assert(html_encode(plain.clone()) == plain, "multibyte and unreserved pass through");
+});
+test("html_decode(html_encode(s)) is the identity", {
+  s := `<script>alert("x & 'y' < z >")</script> é你`.to_string();
+  assert(html_decode(html_encode(s.clone())) == s, "round trip");
 });

--- a/tests/encoding/percent.test.yo
+++ b/tests/encoding/percent.test.yo
@@ -1,0 +1,94 @@
+//! std/encoding/percent — RFC 3986 component percent-encoding
+//! (plans/STD_API_AUDIT.md §7 P0 item 1). Multibyte cases carry
+//! hand-computed byte sequences; error cases pin the INDEX.
+{ assert } :: import("std/assert");
+open(import("std/string"));
+{ percent_encode, percent_decode, percent_decode_bytes, PercentError } :: import("std/encoding/percent");
+
+test("unreserved characters pass through untouched", {
+  s := `AZaz09-_.~`.to_string();
+  assert(percent_encode(s.clone()) == s, "unreserved set identity");
+});
+test("reserved and space encode as uppercase %XX", {
+  assert(percent_encode(`a b&c=d`.to_string()) == `a%20b%26c%3Dd`, "space, amp, equals");
+  assert(percent_encode(`/?#[]@`.to_string()) == `%2F%3F%23%5B%5D%40`, "gen-delims all encode");
+  assert(percent_encode(`+`.to_string()) == `%2B`, "+ is encoded, not a space");
+});
+test("multibyte UTF-8 encodes byte-by-byte", {
+  assert(percent_encode(`é`.to_string()) == `%C3%A9`, "two-byte scalar");
+  assert(percent_encode(`你`.to_string()) == `%E4%BD%A0`, "three-byte scalar");
+});
+test("decode round-trips encode, case-insensitively", {
+  original := `héllo wörld/?&=+`.to_string();
+  enc := percent_encode(original.clone());
+  match(
+    percent_decode(enc),
+    .Ok(back) => assert(back == original, "round trip"),
+    .Err(_) => assert(false, "round trip must decode")
+  );
+  match(
+    percent_decode(`%c3%a9`.to_string()),
+    .Ok(low) => assert(low == `é`, "lowercase hex accepted"),
+    .Err(_) => assert(false, "lowercase hex must decode")
+  );
+});
+test("plus passes through decode unchanged (RFC 3986, not the form dialect)", {
+  match(
+    percent_decode(`a+b`.to_string()),
+    .Ok(s) => assert(s == `a+b`, "+ stays +"),
+    .Err(_) => assert(false, "must decode")
+  );
+});
+test("truncated escape reports its index", {
+  match(
+    percent_decode(`ab%4`.to_string()),
+    .Ok(_) => assert(false, "must fail"),
+    .Err(e) => match(
+      e,
+      .TruncatedEscape(index) => assert(index == usize(2), "index of the %"),
+      _ => assert(false, "wrong variant")
+    )
+  );
+  match(
+    percent_decode(`ab%`.to_string()),
+    .Ok(_) => assert(false, "must fail"),
+    .Err(e2) => match(
+      e2,
+      .TruncatedEscape(i2) => assert(i2 == usize(2), "bare trailing %"),
+      _ => assert(false, "wrong variant")
+    )
+  );
+});
+test("invalid hex digit reports index and byte", {
+  match(
+    percent_decode(`%GG`.to_string()),
+    .Ok(_) => assert(false, "must fail"),
+    .Err(e) => match(
+      e,
+      .InvalidHexDigit(index, byte) => {
+        assert(index == usize(1), "first bad digit position");
+        assert(byte == u8(71), "the G byte");
+      },
+      _ => assert(false, "wrong variant")
+    )
+  );
+});
+test("decoded non-UTF-8 is an error for Strings but fine as bytes", {
+  match(
+    percent_decode(`%FF%FE`.to_string()),
+    .Ok(_) => assert(false, "must fail UTF-8 validation"),
+    .Err(e) => match(
+      e,
+      .InvalidUtf8(cause) => assert(cause.index() == usize(0), "fault at byte 0"),
+      _ => assert(false, "wrong variant")
+    )
+  );
+  match(
+    percent_decode_bytes(`%FF%FE`.to_string()),
+    .Ok(bytes) => {
+      assert(bytes.len() == usize(2), "two raw bytes");
+      assert(bytes(usize(0)) == u8(255), "0xFF preserved");
+    },
+    .Err(_) => assert(false, "bytes form must succeed")
+  );
+});


### PR DESCRIPTION
§7 P0 items 1–2 (`plans/STD_API_AUDIT.md`).

- **`std/encoding/percent.yo`** — RFC 3986 component codec: `percent_encode` keeps the unreserved set and encodes every other byte as uppercase `%XX` (multibyte UTF-8 byte-by-byte); `percent_decode` validates the decoded bytes as UTF-8 (D1 style 2 — typed `PercentError` carrying byte indexes: `TruncatedEscape`/`InvalidHexDigit`/`InvalidUtf8(cause)`); `percent_decode_bytes` for non-text payloads. `+` is deliberately NOT a space (the form dialect is an additive follow-up). Tests (8): identity, gen-delims, multibyte, case-insensitive round trip, `+` passthrough, error indexes, raw-vs-validated split.
- **`html_encode`** — the five XSS-critical characters to entities, everything else byte-identical; `html_decode(html_encode(s)) == s` pinned. The D2 rename **`decode_html` → `html_decode`** lands with it (zero external consumers). html tests 12 → 14.

**Full battery**: check std 158/158 + src 262/262, build rc=0, suite **3189/3189**, cli-diff 52 PASS / 0 GOLDEN-DIFF (zero drift), gates `failures=0`, fixpoint `FIXPOINT_HOLDS stage2 hollow=0`, hollow sweep `SWEEP_GATE_OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)