### PR TITLE
std: S3 P0 crypto — Digest trait, SHA-1, SHA-512, streaming Md5, generic HMAC, CRC-32, constant_time_eq

### DIFF
--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -455,7 +455,7 @@ Open D7 items:
 | async | PROMOTE | combinator home: `join_all`, `race`, `any`, `timeout`, interval, cancellation for `JoinHandle` (`abort()`), async channel/mutex (D7). `sleep(Duration, io)` lives in `std/time/sleep.yo` — do NOT add a second one; re-export if wanted |
 | thread/worker/sync | REDESIGN (D7) | ThreadPool DONE; `join() -> T` + panic propagation blocked below std — see D7 |
 | time | EXTEND | `Duration`: `Add/Sub` operators, `Eq/Ord/Hash`, `from_secs_f64`, `subsec_*`, consts; **make std USE it** (timeouts, sleeps); `Instant` `add/sub`, `Eq/Ord`; `DateTime`: RFC3339 `parse`/`format`, component ctor, arithmetic, `Eq/Ord`; sleep unification DONE (§5) |
-| crypto | EXTEND | streaming `Digest` trait unifying Sha256/Md5; SHA-1, SHA-512, **HMAC** (blocks JWT/SigV4/webhooks), CRC32, constant-time compare; new `std/rand`: seedable PCG/xoshiro, `shuffle`, `choice`, ranges — infallible, non-crypto, separate from `crypto/random` |
+| crypto | EXTEND | `Digest` trait + SHA-1 + SHA-512 + streaming Md5 + HMAC + CRC32 + `constant_time_eq` DONE 2026-08-27; still: new `std/rand` (seedable PCG/xoshiro, `shuffle`, `choice`, ranges — infallible, non-crypto, separate from `crypto/random`) |
 | log | REWRITE (zero users = free window) | levels + `Off`, `ToString`-generic message, lazy eval, timestamps, target/module, writer sink, thread-safe; keep the free-function facade |
 | testing | EXTEND | `assert_eq`/`assert_ne`/`assert_approx` (diff-printing), `bench`: auto-calibration, black_box, stddev/percentiles |
 | gc/allocator | POLISH | `gc.stats()`; `CustomAllocator` deleted (O6) |
@@ -581,7 +581,7 @@ declarations at runtime.
 4. ~~`fs.copy`, `fs.remove_dir_all`, `read_link`, `set_permissions`, `try_exists`~~ **DONE 2026-08-27** — `copy` (contents + permission bits + byte count), `try_exists` (throws instead of lying `false` on a denied parent), `set_permissions` in `std/fs/file`; `read_link` in `std/fs/dir`; `remove_dir_all` in **`std/fs/walker`** (its implementation IS the walker, and `fs/walker` imports `fs/dir` — the reverse would cycle); `src/fetch` + `src/version_cache` dropped their private copies. En route: the libc `chmod`/`fchmod` bindings declared their mode as the OPAQUE `mode_t : Type`, which no Yo caller can construct (`mode_t(384)` is a SomeT-callee error — silently swallowed in async bodies); rebound as `u32`
 5. `process.Child`/`spawn`/`Stdio`
 6. async combinators + async channel/mutex + `timeout` (D7)
-7. `crypto`: HMAC, SHA-1, SHA-512, CRC32, `Digest` trait; `std/rand`
+7. ~~`crypto`: HMAC, SHA-1, SHA-512, CRC32, `Digest` trait~~ **DONE 2026-08-27** (streaming `Sha1`/`Sha512`/`Md5` on the Sha256 skeleton; the `Digest` trait — `new`/`update`/`digest_size`/`block_size`/`finish_bytes` + a `finish_hex` `?=` default — implemented by all four; generic `hmac` via `(D <: Digest)` statics + `hmac_sha{1,256,512}(_hex)` + `constant_time_eq`; bitwise reflected `crc32`; all pinned to FIPS 180-4 / RFC 2202 / RFC 4231 / CRC-catalog vectors). `std/rand` still open
 8. ~~prelude D3 items 1–8~~ **DONE** (D3.9 Hasher blocked, D3.10 done)
 9. `Duration` integration everywhere a timeout/interval appears
 10. `net.UnixStream`/`UnixListener`

--- a/std/crypto/crc32.yo
+++ b/std/crypto/crc32.yo
@@ -1,0 +1,28 @@
+//! CRC-32 (IEEE 802.3, reflected, polynomial 0xEDB88320) — the checksum
+//! zip/png/gzip use (`plans/STD_API_AUDIT.md` §7 P0 item 7). NOT a
+//! cryptographic hash — it detects accidental corruption only.
+{ ArrayList } :: import("../collections/array_list");
+
+/// One byte-step of the reflected CRC-32 (bitwise; the compiler folds the
+/// eight iterations — a 256-entry table would be a comptime win later, but
+/// correctness first and the byte loop is branch-free).
+_crc32_byte :: (fn(crc : u32, byte : u8) -> u32)({
+  (c : u32) = (crc ^ u32(byte));
+  (k : usize) = usize(0);
+  while(k < usize(8), k = (k + usize(1)), {
+    mask := (u32(0) - (c & u32(1)));
+    c = ((c >> u32(1)) ^ (u32(0xedb88320) & mask));
+  });
+  c
+});
+/// CRC-32 of `data` (init 0xFFFFFFFF, final xor 0xFFFFFFFF).
+crc32 :: (fn(data : ArrayList(u8)) -> u32)({
+  (crc : u32) = u32(0xffffffff);
+  (i : usize) = usize(0);
+  while(i < data.len(), i = (i + usize(1)), {
+    b := match(data.get(i), .Some(x) => x, .None => u8(0));
+    crc = _crc32_byte(crc, b);
+  });
+  crc ^ u32(0xffffffff)
+});
+export(crc32);

--- a/std/crypto/digest.yo
+++ b/std/crypto/digest.yo
@@ -1,0 +1,30 @@
+//! The streaming `Digest` trait — one interface over `Sha256` / `Sha512` /
+//! `Sha1` / `Md5` (`plans/STD_API_AUDIT.md` §7 P0 item 7).
+//!
+//! The trait speaks `ArrayList(u8)` for the digest so one type covers every
+//! algorithm (the per-type inherent `finish()` keeps its fixed-size
+//! `Array(u8, N)` for callers that want it). `new` and the sizes are
+//! statics/constants of the implementor, which is what lets generic code —
+//! `hmac` (std/crypto/hmac.yo) is the flagship — construct and drive any
+//! hasher through a `where(D <: Digest)` bound.
+{ ArrayList } :: import("../collections/array_list");
+{ hex_encode } :: import("../encoding/hex");
+open(import("../string"));
+
+Digest :: trait(
+  /// A fresh hasher.
+  new : (fn() -> Self),
+  /// Feed more data.
+  update : (fn(self : Self, data : ArrayList(u8)) -> Self),
+  /// The digest length in bytes (32/64/20/16).
+  digest_size : (fn() -> usize),
+  /// The compression block size in bytes (64, or 128 for SHA-512) — what
+  /// HMAC pads keys to.
+  block_size : (fn() -> usize),
+  /// Finalise and return the digest as bytes.
+  finish_bytes : (fn(self : Self) -> ArrayList(u8)),
+  /// Finalise and return the lowercase hex digest.
+  (finish_hex : (fn(self : Self) -> String)) ?=
+    ((self) -> hex_encode(Self.finish_bytes(self)))
+);
+export(Digest);

--- a/std/crypto/hmac.yo
+++ b/std/crypto/hmac.yo
@@ -1,0 +1,81 @@
+//! HMAC (RFC 2104) — generic over any `Digest` implementor
+//! (`plans/STD_API_AUDIT.md` §7 P0 item 7: "blocks JWT/SigV4/webhooks").
+//!
+//! ```rust
+//! { hmac_sha256_hex } :: import "std/crypto/hmac";
+//! sig := hmac_sha256_hex(key_bytes, message_bytes);
+//! ```
+{ ArrayList } :: import("../collections/array_list");
+{ hex_encode } :: import("../encoding/hex");
+open(import("../string"));
+{ Digest } :: import("./digest");
+{ Sha256 } :: import("./sha256");
+{ Sha512 } :: import("./sha512");
+{ Sha1 } :: import("./sha1");
+
+/// HMAC over any `Digest`: `H((K' ^ opad) || H((K' ^ ipad) || message))`,
+/// with `K'` the key hashed down (if longer than the block) then
+/// zero-padded to the block size.
+hmac :: (
+  fn(comptime(D) : Type, key : ArrayList(u8), message : ArrayList(u8), where(D <: Digest)) -> ArrayList(u8)
+)({
+  block := (D <: Digest).block_size();
+  // K': hash an over-long key, then zero-pad to the block size.
+  (k : ArrayList(u8)) = key;
+  if(k.len() > block, {
+    k = (D <: Digest).finish_bytes((D <: Digest).update((D <: Digest).new(), k));
+  });
+  ikey := ArrayList(u8).with_capacity(block);
+  okey := ArrayList(u8).with_capacity(block);
+  (i : usize) = usize(0);
+  while(i < block, i = (i + usize(1)), {
+    kb := match(k.get(i), .Some(b) => b, .None => u8(0));
+    ikey.push(kb ^ u8(0x36));
+    okey.push(kb ^ u8(0x5c));
+  });
+  inner_h := (D <: Digest).update((D <: Digest).update((D <: Digest).new(), ikey), message);
+  inner := (D <: Digest).finish_bytes(inner_h);
+  (D <: Digest).finish_bytes((D <: Digest).update((D <: Digest).update((D <: Digest).new(), okey), inner))
+});
+/// HMAC-SHA256.
+hmac_sha256 :: (fn(key : ArrayList(u8), message : ArrayList(u8)) -> ArrayList(u8))(
+  hmac(Sha256, key, message)
+);
+/// HMAC-SHA256, lowercase hex.
+hmac_sha256_hex :: (fn(key : ArrayList(u8), message : ArrayList(u8)) -> String)(
+  hex_encode(hmac_sha256(key, message))
+);
+/// HMAC-SHA512.
+hmac_sha512 :: (fn(key : ArrayList(u8), message : ArrayList(u8)) -> ArrayList(u8))(
+  hmac(Sha512, key, message)
+);
+/// HMAC-SHA512, lowercase hex.
+hmac_sha512_hex :: (fn(key : ArrayList(u8), message : ArrayList(u8)) -> String)(
+  hex_encode(hmac_sha512(key, message))
+);
+/// HMAC-SHA1 (for protocols that still require it — see std/crypto/sha1's
+/// security note).
+hmac_sha1 :: (fn(key : ArrayList(u8), message : ArrayList(u8)) -> ArrayList(u8))(
+  hmac(Sha1, key, message)
+);
+/// HMAC-SHA1, lowercase hex.
+hmac_sha1_hex :: (fn(key : ArrayList(u8), message : ArrayList(u8)) -> String)(
+  hex_encode(hmac_sha1(key, message))
+);
+/// Constant-time byte comparison — verify MACs with this, never `==`:
+/// an early-exit compare leaks WHERE the first mismatch sits, which lets an
+/// attacker forge a MAC byte-by-byte over the network.
+constant_time_eq :: (fn(a : ArrayList(u8), b : ArrayList(u8)) -> bool)({
+  if(a.len() != b.len(), {
+    return(false);
+  });
+  (acc : u8) = u8(0);
+  (i : usize) = usize(0);
+  while(i < a.len(), i = (i + usize(1)), {
+    av := match(a.get(i), .Some(x) => x, .None => u8(0));
+    bv := match(b.get(i), .Some(x) => x, .None => u8(0));
+    acc = (acc | (av ^ bv));
+  });
+  acc == u8(0)
+});
+export(hmac, hmac_sha256, hmac_sha256_hex, hmac_sha512, hmac_sha512_hex, hmac_sha1, hmac_sha1_hex, constant_time_eq);

--- a/std/crypto/md5.yo
+++ b/std/crypto/md5.yo
@@ -11,6 +11,7 @@
 pragma(Pragma.AllowUnsafe);
 { ArrayList } :: import("../collections/array_list");
 { hex_encode } :: import("../encoding/hex");
+{ Digest } :: import("./digest");
 open(import("../string"));
 // ============================================================================
 // MD5 implementation
@@ -193,6 +194,111 @@ _md5_block :: (fn(block : *(u8), h : *(u32)) -> unit)({
   (h.add(usize(3))).* = ((h.add(usize(3))).* + d);
 });
 // Compute an MD5 digest over `data`.
+/// MD5 streaming state (the Sha256 skeleton; little-endian length +
+/// little-endian digest extraction).
+Md5 :: ref(
+  struct(
+    _h : Array(u32, usize(4)),
+    _buf : Array(u8, usize(64)),
+    _buflen : usize,
+    _total : u64
+  )
+);
+impl(
+  Md5,
+  // Initialise a new hasher.
+  new : (fn() -> Self)(
+    Self(
+      _h : Array(u32, usize(4))(u32(0x67452301), u32(0xefcdab89), u32(0x98badcfe), u32(0x10325476)),
+      _buf : Array(u8, usize(64)).fill(u8(0)),
+      _buflen : usize(0),
+      _total : u64(0)
+    )
+  ),
+  // Feed more data into the hasher.
+  update : (fn(self : Self, data : ArrayList(u8)) -> Self)({
+    i := usize(0);
+    while(i < data.len(), i = (i + usize(1)), {
+      self._buf(self._buflen) = data(i);
+      self._buflen = (self._buflen + usize(1));
+      self._total = (self._total + u64(1));
+      cond(
+        (self._buflen == usize(64)) => {
+          buf_ptr := &(self._buf(usize(0)));
+          h_ptr := &(self._h(usize(0)));
+          _md5_block(buf_ptr, h_ptr);
+          self._buflen = usize(0);
+        },
+        true => ()
+      );
+    });
+    self
+  }),
+  // Finalise and return the 16-byte digest.
+  finish : (fn(self : Self) -> Array(u8, usize(16)))({
+    bit_len := (self._total * u64(8));
+    self._buf(self._buflen) = u8(0x80);
+    self._buflen = (self._buflen + usize(1));
+    cond(
+      (self._buflen > usize(56)) => {
+        while(self._buflen < usize(64), self._buflen = (self._buflen + usize(1)), {
+          self._buf(self._buflen) = u8(0);
+        });
+        buf_ptr := &(self._buf(usize(0)));
+        h_ptr := &(self._h(usize(0)));
+        _md5_block(buf_ptr, h_ptr);
+        self._buflen = usize(0);
+      },
+      true => ()
+    );
+    while(self._buflen < usize(56), self._buflen = (self._buflen + usize(1)), {
+      self._buf(self._buflen) = u8(0);
+    });
+    // LITTLE-endian 64-bit bit length (MD5, unlike the SHA family).
+    self._buf(usize(56)) = u8(bit_len);
+    self._buf(usize(57)) = u8(bit_len >> u64(8));
+    self._buf(usize(58)) = u8(bit_len >> u64(16));
+    self._buf(usize(59)) = u8(bit_len >> u64(24));
+    self._buf(usize(60)) = u8(bit_len >> u64(32));
+    self._buf(usize(61)) = u8(bit_len >> u64(40));
+    self._buf(usize(62)) = u8(bit_len >> u64(48));
+    self._buf(usize(63)) = u8(bit_len >> u64(56));
+    buf_ptr := &(self._buf(usize(0)));
+    h_ptr := &(self._h(usize(0)));
+    _md5_block(buf_ptr, h_ptr);
+    digest := Array(u8, usize(16)).fill(u8(0));
+    k := usize(0);
+    while(k < usize(4), k = (k + usize(1)), {
+      w := self._h(k);
+      digest(k * usize(4)) = u8(w);
+      digest((k * usize(4)) + usize(1)) = u8(w >> u32(8));
+      digest((k * usize(4)) + usize(2)) = u8(w >> u32(16));
+      digest((k * usize(4)) + usize(3)) = u8(w >> u32(24));
+    });
+    digest
+  })
+);
+export(Md5);
+// === Digest trait impl (std/crypto/digest) ===
+impl(
+  Md5,
+  Digest(
+    new : (fn() -> Self)(Self.new()),
+    update : (fn(self : Self, data : ArrayList(u8)) -> Self)(self.update(data)),
+    digest_size : (fn() -> usize)(usize(16)),
+    block_size : (fn() -> usize)(usize(64)),
+    finish_bytes : (fn(self : Self) -> ArrayList(u8))({
+      d := self.finish();
+      out := ArrayList(u8).with_capacity(usize(16));
+      (fbi : usize) = usize(0);
+      while(fbi < usize(16), fbi = (fbi + usize(1)), {
+        out.push(d(fbi));
+      });
+      out
+    })
+  )
+);
+
 md5 :: (fn(data : ArrayList(u8)) -> Array(u8, usize(16)))({
   h := Array(u32, usize(4))(
     u32(0x67452301),

--- a/std/crypto/sha1.yo
+++ b/std/crypto/sha1.yo
@@ -1,0 +1,195 @@
+//! SHA-1 (FIPS 180-4) — streaming hasher + one-shot helpers
+//! (`plans/STD_API_AUDIT.md` §7 P0 item 7).
+//!
+//! SHA-1 is cryptographically BROKEN for collision resistance (SHAttered,
+//! 2017) — do not use it for signatures or content addressing of untrusted
+//! input. It remains required by existing protocols (git object ids, HMAC-SHA1
+//! in OAuth 1 / AWS SigV2-era APIs), which is why std ships it.
+//!
+//! ```rust
+//! { sha1_hex } :: import "std/crypto/sha1";
+//! digest := sha1_hex(data); // 40-char lowercase hex
+//! ```
+pragma(Pragma.AllowUnsafe);
+{ ArrayList } :: import("../collections/array_list");
+{ hex_encode } :: import("../encoding/hex");
+{ Digest } :: import("./digest");
+open(import("../string"));
+_rotl32 :: (fn(x : u32, n : u32) -> u32)(
+  (x << n) | (x >> (u32(32) - n))
+);
+/// One 64-byte block: the 80-round compression over `h[0..5]`.
+_sha1_block :: (fn(block : *(u8), h : *(u32)) -> unit)({
+  w := Array(u32, usize(80)).fill(u32(0));
+  (t : usize) = usize(0);
+  while(t < usize(16), t = (t + usize(1)), {
+    b0 := u32((block.add(t * usize(4))).*);
+    b1 := u32((block.add((t * usize(4)) + usize(1))).*);
+    b2 := u32((block.add((t * usize(4)) + usize(2))).*);
+    b3 := u32((block.add((t * usize(4)) + usize(3))).*);
+    w(t) = ((b0 << u32(24)) | ((b1 << u32(16)) | ((b2 << u32(8)) | b3)));
+  });
+  while(t < usize(80), t = (t + usize(1)), {
+    w(t) = _rotl32((w(t - usize(3)) ^ w(t - usize(8))) ^ (w(t - usize(14)) ^ w(t - usize(16))), u32(1));
+  });
+  a := (h.add(usize(0))).*;
+  b := (h.add(usize(1))).*;
+  c := (h.add(usize(2))).*;
+  d := (h.add(usize(3))).*;
+  e := (h.add(usize(4))).*;
+  (i : usize) = usize(0);
+  while(i < usize(80), i = (i + usize(1)), {
+    (f : u32) = u32(0);
+    (k : u32) = u32(0);
+    cond(
+      (i < usize(20)) => {
+        f = ((b & c) | ((~(b)) & d));
+        k = u32(0x5a827999);
+      },
+      (i < usize(40)) => {
+        f = ((b ^ c) ^ d);
+        k = u32(0x6ed9eba1);
+      },
+      (i < usize(60)) => {
+        f = (((b & c) | (b & d)) | (c & d));
+        k = u32(0x8f1bbcdc);
+      },
+      true => {
+        f = ((b ^ c) ^ d);
+        k = u32(0xca62c1d6);
+      }
+    );
+    temp := ((_rotl32(a, u32(5)) + f) + ((e + k) + w(i)));
+    e = d;
+    d = c;
+    c = _rotl32(b, u32(30));
+    b = a;
+    a = temp;
+  });
+  (h.add(usize(0))).* = ((h.add(usize(0))).* + a);
+  (h.add(usize(1))).* = ((h.add(usize(1))).* + b);
+  (h.add(usize(2))).* = ((h.add(usize(2))).* + c);
+  (h.add(usize(3))).* = ((h.add(usize(3))).* + d);
+  (h.add(usize(4))).* = ((h.add(usize(4))).* + e);
+});
+/// SHA-1 streaming state (the Sha256 skeleton).
+Sha1 :: ref(
+  struct(
+    _h : Array(u32, usize(5)),
+    _buf : Array(u8, usize(64)),
+    _buflen : usize,
+    _total : u64
+  )
+);
+impl(
+  Sha1,
+  // Initialise a new hasher.
+  new : (fn() -> Self)(
+    Self(
+      _h : Array(u32, usize(5))(u32(0x67452301), u32(0xefcdab89), u32(0x98badcfe), u32(0x10325476), u32(0xc3d2e1f0)),
+      _buf : Array(u8, usize(64)).fill(u8(0)),
+      _buflen : usize(0),
+      _total : u64(0)
+    )
+  ),
+  // Feed more data into the hasher.
+  update : (fn(self : Self, data : ArrayList(u8)) -> Self)({
+    i := usize(0);
+    while(i < data.len(), i = (i + usize(1)), {
+      self._buf(self._buflen) = data(i);
+      self._buflen = (self._buflen + usize(1));
+      self._total = (self._total + u64(1));
+      cond(
+        (self._buflen == usize(64)) => {
+          buf_ptr := &(self._buf(usize(0)));
+          h_ptr := &(self._h(usize(0)));
+          _sha1_block(buf_ptr, h_ptr);
+          self._buflen = usize(0);
+        },
+        true => ()
+      );
+    });
+    self
+  }),
+  // Finalise and return the 20-byte digest.
+  finish : (fn(self : Self) -> Array(u8, usize(20)))({
+    bit_len := (self._total * u64(8));
+    self._buf(self._buflen) = u8(0x80);
+    self._buflen = (self._buflen + usize(1));
+    cond(
+      (self._buflen > usize(56)) => {
+        while(self._buflen < usize(64), self._buflen = (self._buflen + usize(1)), {
+          self._buf(self._buflen) = u8(0);
+        });
+        buf_ptr := &(self._buf(usize(0)));
+        h_ptr := &(self._h(usize(0)));
+        _sha1_block(buf_ptr, h_ptr);
+        self._buflen = usize(0);
+      },
+      true => ()
+    );
+    while(self._buflen < usize(56), self._buflen = (self._buflen + usize(1)), {
+      self._buf(self._buflen) = u8(0);
+    });
+    self._buf(usize(56)) = u8(bit_len >> u64(56));
+    self._buf(usize(57)) = u8(bit_len >> u64(48));
+    self._buf(usize(58)) = u8(bit_len >> u64(40));
+    self._buf(usize(59)) = u8(bit_len >> u64(32));
+    self._buf(usize(60)) = u8(bit_len >> u64(24));
+    self._buf(usize(61)) = u8(bit_len >> u64(16));
+    self._buf(usize(62)) = u8(bit_len >> u64(8));
+    self._buf(usize(63)) = u8(bit_len);
+    buf_ptr := &(self._buf(usize(0)));
+    h_ptr := &(self._h(usize(0)));
+    _sha1_block(buf_ptr, h_ptr);
+    digest := Array(u8, usize(20)).fill(u8(0));
+    j := usize(0);
+    while(j < usize(5), j = (j + usize(1)), {
+      word := self._h(j);
+      digest(j * usize(4)) = u8(word >> u32(24));
+      digest((j * usize(4)) + usize(1)) = u8(word >> u32(16));
+      digest((j * usize(4)) + usize(2)) = u8(word >> u32(8));
+      digest((j * usize(4)) + usize(3)) = u8(word);
+    });
+    digest
+  })
+);
+export(Sha1);
+// === Digest trait impl (std/crypto/digest) ===
+impl(
+  Sha1,
+  Digest(
+    new : (fn() -> Self)(Self.new()),
+    update : (fn(self : Self, data : ArrayList(u8)) -> Self)(self.update(data)),
+    digest_size : (fn() -> usize)(usize(20)),
+    block_size : (fn() -> usize)(usize(64)),
+    finish_bytes : (fn(self : Self) -> ArrayList(u8))({
+      d := self.finish();
+      out := ArrayList(u8).with_capacity(usize(20));
+      (fbi : usize) = usize(0);
+      while(fbi < usize(20), fbi = (fbi + usize(1)), {
+        out.push(d(fbi));
+      });
+      out
+    })
+  )
+);
+
+// ============================================================================
+// Convenience functions
+// ============================================================================
+// Hash data and return the 20-byte digest.
+sha1 :: (fn(data : ArrayList(u8)) -> Array(u8, usize(20)))(
+  Sha1.new().update(data).finish()
+);
+// Hash data and return the 40-character lowercase hex digest.
+sha1_hex :: (fn(data : ArrayList(u8)) -> String)({
+  digest := sha1(data);
+  bytes := ArrayList(u8).with_capacity(usize(20));
+  i := usize(0);
+  while(i < usize(20), i = (i + usize(1)), {
+    bytes.push(digest(i));
+  });
+  hex_encode(bytes)
+});
+export(sha1, sha1_hex);

--- a/std/crypto/sha256.yo
+++ b/std/crypto/sha256.yo
@@ -10,6 +10,7 @@
 pragma(Pragma.AllowUnsafe);
 { ArrayList } :: import("../collections/array_list");
 { hex_encode } :: import("../encoding/hex");
+{ Digest } :: import("./digest");
 open(import("../string"));
 // ============================================================================
 // SHA-256 constants
@@ -242,6 +243,26 @@ impl(
   })
 );
 export(Sha256);
+// === Digest trait impl (std/crypto/digest) ===
+impl(
+  Sha256,
+  Digest(
+    new : (fn() -> Self)(Self.new()),
+    update : (fn(self : Self, data : ArrayList(u8)) -> Self)(self.update(data)),
+    digest_size : (fn() -> usize)(usize(32)),
+    block_size : (fn() -> usize)(usize(64)),
+    finish_bytes : (fn(self : Self) -> ArrayList(u8))({
+      d := self.finish();
+      out := ArrayList(u8).with_capacity(usize(32));
+      (fbi : usize) = usize(0);
+      while(fbi < usize(32), fbi = (fbi + usize(1)), {
+        out.push(d(fbi));
+      });
+      out
+    })
+  )
+);
+
 // ============================================================================
 // Convenience functions
 // ============================================================================

--- a/std/crypto/sha512.yo
+++ b/std/crypto/sha512.yo
@@ -1,0 +1,279 @@
+//! SHA-512 (FIPS 180-4) — streaming hasher + one-shot helpers
+//! (`plans/STD_API_AUDIT.md` §7 P0 item 7).
+//!
+//! 64-bit words, 128-byte blocks, 80 rounds. The message-length field is
+//! 128 bits in the spec; this implementation tracks the total as a `u64`
+//! BYTE count (caps input at 2^61 bytes — two exbibytes) and writes the
+//! high 64 bits of the bit length as `total >> 61`.
+pragma(Pragma.AllowUnsafe);
+{ ArrayList } :: import("../collections/array_list");
+{ hex_encode } :: import("../encoding/hex");
+{ Digest } :: import("./digest");
+open(import("../string"));
+_K512 :: Array(u64, usize(80))(
+  u64(0x428a2f98d728ae22),
+  u64(0x7137449123ef65cd),
+  u64(0xb5c0fbcfec4d3b2f),
+  u64(0xe9b5dba58189dbbc),
+  u64(0x3956c25bf348b538),
+  u64(0x59f111f1b605d019),
+  u64(0x923f82a4af194f9b),
+  u64(0xab1c5ed5da6d8118),
+  u64(0xd807aa98a3030242),
+  u64(0x12835b0145706fbe),
+  u64(0x243185be4ee4b28c),
+  u64(0x550c7dc3d5ffb4e2),
+  u64(0x72be5d74f27b896f),
+  u64(0x80deb1fe3b1696b1),
+  u64(0x9bdc06a725c71235),
+  u64(0xc19bf174cf692694),
+  u64(0xe49b69c19ef14ad2),
+  u64(0xefbe4786384f25e3),
+  u64(0x0fc19dc68b8cd5b5),
+  u64(0x240ca1cc77ac9c65),
+  u64(0x2de92c6f592b0275),
+  u64(0x4a7484aa6ea6e483),
+  u64(0x5cb0a9dcbd41fbd4),
+  u64(0x76f988da831153b5),
+  u64(0x983e5152ee66dfab),
+  u64(0xa831c66d2db43210),
+  u64(0xb00327c898fb213f),
+  u64(0xbf597fc7beef0ee4),
+  u64(0xc6e00bf33da88fc2),
+  u64(0xd5a79147930aa725),
+  u64(0x06ca6351e003826f),
+  u64(0x142929670a0e6e70),
+  u64(0x27b70a8546d22ffc),
+  u64(0x2e1b21385c26c926),
+  u64(0x4d2c6dfc5ac42aed),
+  u64(0x53380d139d95b3df),
+  u64(0x650a73548baf63de),
+  u64(0x766a0abb3c77b2a8),
+  u64(0x81c2c92e47edaee6),
+  u64(0x92722c851482353b),
+  u64(0xa2bfe8a14cf10364),
+  u64(0xa81a664bbc423001),
+  u64(0xc24b8b70d0f89791),
+  u64(0xc76c51a30654be30),
+  u64(0xd192e819d6ef5218),
+  u64(0xd69906245565a910),
+  u64(0xf40e35855771202a),
+  u64(0x106aa07032bbd1b8),
+  u64(0x19a4c116b8d2d0c8),
+  u64(0x1e376c085141ab53),
+  u64(0x2748774cdf8eeb99),
+  u64(0x34b0bcb5e19b48a8),
+  u64(0x391c0cb3c5c95a63),
+  u64(0x4ed8aa4ae3418acb),
+  u64(0x5b9cca4f7763e373),
+  u64(0x682e6ff3d6b2b8a3),
+  u64(0x748f82ee5defb2fc),
+  u64(0x78a5636f43172f60),
+  u64(0x84c87814a1f0ab72),
+  u64(0x8cc702081a6439ec),
+  u64(0x90befffa23631e28),
+  u64(0xa4506cebde82bde9),
+  u64(0xbef9a3f7b2c67915),
+  u64(0xc67178f2e372532b),
+  u64(0xca273eceea26619c),
+  u64(0xd186b8c721c0c207),
+  u64(0xeada7dd6cde0eb1e),
+  u64(0xf57d4f7fee6ed178),
+  u64(0x06f067aa72176fba),
+  u64(0x0a637dc5a2c898a6),
+  u64(0x113f9804bef90dae),
+  u64(0x1b710b35131c471b),
+  u64(0x28db77f523047d84),
+  u64(0x32caab7b40c72493),
+  u64(0x3c9ebe0a15c9bebc),
+  u64(0x431d67c49c100d4c),
+  u64(0x4cc5d4becb3e42b6),
+  u64(0x597f299cfc657e2a),
+  u64(0x5fcb6fab3ad6faec),
+  u64(0x6c44198c4a475817)
+);
+_rotr64 :: (fn(x : u64, n : u64) -> u64)(
+  (x >> n) | (x << (u64(64) - n))
+);
+/// One 128-byte block: the 80-round compression over `h[0..8]`.
+_sha512_block :: (fn(block : *(u8), h : *(u64)) -> unit)({
+  w := Array(u64, usize(80)).fill(u64(0));
+  (t : usize) = usize(0);
+  while(t < usize(16), t = (t + usize(1)), {
+    (word : u64) = u64(0);
+    (bi : usize) = usize(0);
+    while(bi < usize(8), bi = (bi + usize(1)), {
+      word = ((word << u64(8)) | u64((block.add((t * usize(8)) + bi)).*));
+    });
+    w(t) = word;
+  });
+  while(t < usize(80), t = (t + usize(1)), {
+    s0 := ((_rotr64(w(t - usize(15)), u64(1)) ^ _rotr64(w(t - usize(15)), u64(8))) ^ (w(t - usize(15)) >> u64(7)));
+    s1 := ((_rotr64(w(t - usize(2)), u64(19)) ^ _rotr64(w(t - usize(2)), u64(61))) ^ (w(t - usize(2)) >> u64(6)));
+    w(t) = ((w(t - usize(16)) + s0) + (w(t - usize(7)) + s1));
+  });
+  a := (h.add(usize(0))).*;
+  b := (h.add(usize(1))).*;
+  c := (h.add(usize(2))).*;
+  d := (h.add(usize(3))).*;
+  e := (h.add(usize(4))).*;
+  f := (h.add(usize(5))).*;
+  g := (h.add(usize(6))).*;
+  hh := (h.add(usize(7))).*;
+  (i : usize) = usize(0);
+  while(i < usize(80), i = (i + usize(1)), {
+    ep1 := ((_rotr64(e, u64(14)) ^ _rotr64(e, u64(18))) ^ _rotr64(e, u64(41)));
+    ch := ((e & f) ^ ((~(e)) & g));
+    temp1 := ((hh + ep1) + ((ch + _K512(i)) + w(i)));
+    ep0 := ((_rotr64(a, u64(28)) ^ _rotr64(a, u64(34))) ^ _rotr64(a, u64(39)));
+    maj := (((a & b) ^ (a & c)) ^ (b & c));
+    temp2 := (ep0 + maj);
+    hh = g;
+    g = f;
+    f = e;
+    e = (d + temp1);
+    d = c;
+    c = b;
+    b = a;
+    a = (temp1 + temp2);
+  });
+  (h.add(usize(0))).* = ((h.add(usize(0))).* + a);
+  (h.add(usize(1))).* = ((h.add(usize(1))).* + b);
+  (h.add(usize(2))).* = ((h.add(usize(2))).* + c);
+  (h.add(usize(3))).* = ((h.add(usize(3))).* + d);
+  (h.add(usize(4))).* = ((h.add(usize(4))).* + e);
+  (h.add(usize(5))).* = ((h.add(usize(5))).* + f);
+  (h.add(usize(6))).* = ((h.add(usize(6))).* + g);
+  (h.add(usize(7))).* = ((h.add(usize(7))).* + hh);
+});
+/// SHA-512 streaming state (the Sha256 skeleton at 64-bit width).
+Sha512 :: ref(
+  struct(
+    _h : Array(u64, usize(8)),
+    _buf : Array(u8, usize(128)),
+    _buflen : usize,
+    _total : u64
+  )
+);
+impl(
+  Sha512,
+  // Initialise a new hasher.
+  new : (fn() -> Self)(
+    Self(
+      _h : Array(u64, usize(8))(
+        u64(0x6a09e667f3bcc908),
+        u64(0xbb67ae8584caa73b),
+        u64(0x3c6ef372fe94f82b),
+        u64(0xa54ff53a5f1d36f1),
+        u64(0x510e527fade682d1),
+        u64(0x9b05688c2b3e6c1f),
+        u64(0x1f83d9abfb41bd6b),
+        u64(0x5be0cd19137e2179)
+      ),
+      _buf : Array(u8, usize(128)).fill(u8(0)),
+      _buflen : usize(0),
+      _total : u64(0)
+    )
+  ),
+  // Feed more data into the hasher.
+  update : (fn(self : Self, data : ArrayList(u8)) -> Self)({
+    i := usize(0);
+    while(i < data.len(), i = (i + usize(1)), {
+      self._buf(self._buflen) = data(i);
+      self._buflen = (self._buflen + usize(1));
+      self._total = (self._total + u64(1));
+      cond(
+        (self._buflen == usize(128)) => {
+          buf_ptr := &(self._buf(usize(0)));
+          h_ptr := &(self._h(usize(0)));
+          _sha512_block(buf_ptr, h_ptr);
+          self._buflen = usize(0);
+        },
+        true => ()
+      );
+    });
+    self
+  }),
+  // Finalise and return the 64-byte digest.
+  finish : (fn(self : Self) -> Array(u8, usize(64)))({
+    bit_len_low := (self._total << u64(3));
+    bit_len_high := (self._total >> u64(61));
+    self._buf(self._buflen) = u8(0x80);
+    self._buflen = (self._buflen + usize(1));
+    cond(
+      (self._buflen > usize(112)) => {
+        while(self._buflen < usize(128), self._buflen = (self._buflen + usize(1)), {
+          self._buf(self._buflen) = u8(0);
+        });
+        buf_ptr := &(self._buf(usize(0)));
+        h_ptr := &(self._h(usize(0)));
+        _sha512_block(buf_ptr, h_ptr);
+        self._buflen = usize(0);
+      },
+      true => ()
+    );
+    while(self._buflen < usize(112), self._buflen = (self._buflen + usize(1)), {
+      self._buf(self._buflen) = u8(0);
+    });
+    // 128-bit big-endian bit length: high word then low word.
+    (wi : usize) = usize(0);
+    while(wi < usize(8), wi = (wi + usize(1)), {
+      shift := (u64(56) - (u64(8) * u64(wi)));
+      self._buf(usize(112) + wi) = u8(bit_len_high >> shift);
+      self._buf(usize(120) + wi) = u8(bit_len_low >> shift);
+    });
+    buf_ptr := &(self._buf(usize(0)));
+    h_ptr := &(self._h(usize(0)));
+    _sha512_block(buf_ptr, h_ptr);
+    digest := Array(u8, usize(64)).fill(u8(0));
+    j := usize(0);
+    while(j < usize(8), j = (j + usize(1)), {
+      word := self._h(j);
+      (bi2 : usize) = usize(0);
+      while(bi2 < usize(8), bi2 = (bi2 + usize(1)), {
+        shift2 := (u64(56) - (u64(8) * u64(bi2)));
+        digest((j * usize(8)) + bi2) = u8(word >> shift2);
+      });
+    });
+    digest
+  })
+);
+export(Sha512);
+// === Digest trait impl (std/crypto/digest) ===
+impl(
+  Sha512,
+  Digest(
+    new : (fn() -> Self)(Self.new()),
+    update : (fn(self : Self, data : ArrayList(u8)) -> Self)(self.update(data)),
+    digest_size : (fn() -> usize)(usize(64)),
+    block_size : (fn() -> usize)(usize(128)),
+    finish_bytes : (fn(self : Self) -> ArrayList(u8))({
+      d := self.finish();
+      out := ArrayList(u8).with_capacity(usize(64));
+      (fbi : usize) = usize(0);
+      while(fbi < usize(64), fbi = (fbi + usize(1)), {
+        out.push(d(fbi));
+      });
+      out
+    })
+  )
+);
+
+// ============================================================================
+// Convenience functions
+// ============================================================================
+// Hash data and return the 64-byte digest.
+sha512 :: (fn(data : ArrayList(u8)) -> Array(u8, usize(64)))(
+  Sha512.new().update(data).finish()
+);
+// Hash data and return the 128-character lowercase hex digest.
+sha512_hex :: (fn(data : ArrayList(u8)) -> String)({
+  digest := sha512(data);
+  bytes := ArrayList(u8).with_capacity(usize(64));
+  i := usize(0);
+  while(i < usize(64), i = (i + usize(1)), {
+    bytes.push(digest(i));
+  });
+  hex_encode(bytes)
+});
+export(sha512, sha512_hex);

--- a/tests/crypto/digest.test.yo
+++ b/tests/crypto/digest.test.yo
@@ -1,0 +1,119 @@
+//! std/crypto: SHA-1, SHA-512, streaming Md5, the Digest trait, HMAC and
+//! CRC-32 — all pinned to published vectors (FIPS 180-4, RFC 2202,
+//! RFC 4231, the CRC catalog check value). plans/STD_API_AUDIT.md §7 P0.
+{ assert } :: import("std/assert");
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ Digest } :: import("std/crypto/digest");
+{ Sha1, sha1_hex } :: import("std/crypto/sha1");
+{ Sha512, sha512_hex } :: import("std/crypto/sha512");
+{ Sha256, sha256_hex } :: import("std/crypto/sha256");
+{ Md5, md5_hex } :: import("std/crypto/md5");
+{ hmac_sha1_hex, hmac_sha256_hex, hmac_sha512_hex, constant_time_eq } :: import("std/crypto/hmac");
+{ crc32 } :: import("std/crypto/crc32");
+
+_b :: (fn(s : str) -> ArrayList(u8))(
+  String.from(s).as_bytes()
+);
+_rep :: (fn(byte : u8, count : usize) -> ArrayList(u8))({
+  out := ArrayList(u8).with_capacity(count);
+  (i : usize) = usize(0);
+  while(i < count, i = (i + usize(1)), {
+    out.push(byte);
+  });
+  out
+});
+test("SHA-1 FIPS vectors", {
+  assert(sha1_hex(_b("abc")) == `a9993e364706816aba3e25717850c26c9cd0d89d`, "abc");
+  assert(sha1_hex(_b("")) == `da39a3ee5e6b4b0d3255bfef95601890afd80709`, "empty");
+  assert(
+    sha1_hex(_b("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")) == `84983e441c3bd26ebaae4aa1f95129e5e54670f1`,
+    "two-block FIPS vector"
+  );
+});
+test("SHA-512 FIPS vectors", {
+  assert(
+    sha512_hex(_b("abc")) == `ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f`,
+    "abc"
+  );
+  assert(
+    sha512_hex(_b("")) == `cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e`,
+    "empty"
+  );
+  assert(
+    sha512_hex(_b("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")) == `8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909`,
+    "two-block FIPS vector"
+  );
+});
+test("streaming split updates equal the one-shot digest", {
+  whole := `the quick brown fox jumps over the lazy dog, repeatedly, across block boundaries`.to_string();
+  wb := whole.as_bytes();
+  half := usize(37);
+  first := ArrayList(u8).new();
+  second := ArrayList(u8).new();
+  (i : usize) = usize(0);
+  while(i < wb.len(), i = (i + usize(1)), {
+    b := wb(i);
+    cond(
+      (i < half) => first.push(b),
+      true => second.push(b)
+    );
+  });
+  split1 := Sha1.new().update(first).update(second).finish_hex();
+  assert(split1 == sha1_hex(whole.as_bytes()), "sha1 split == one-shot");
+  split512 := Sha512.new().update(first).update(second).finish_hex();
+  assert(split512 == sha512_hex(whole.as_bytes()), "sha512 split == one-shot");
+  split256 := Sha256.new().update(first).update(second).finish_hex();
+  assert(split256 == sha256_hex(whole.as_bytes()), "sha256 split == one-shot");
+  splitmd5 := Md5.new().update(first).update(second).finish_hex();
+  assert(splitmd5 == md5_hex(whole.as_bytes()), "md5 streaming == one-shot");
+});
+test("Md5 streaming type matches RFC 1321 vectors", {
+  assert(Md5.new().update(_b("abc")).finish_hex() == `900150983cd24fb0d6963f7d28e17f72`, "abc");
+  assert(Md5.new().finish_hex() == `d41d8cd98f00b204e9800998ecf8427e`, "empty");
+});
+// The trait surface: a where-bound generic drives ANY hasher and gets
+// `finish_hex` from the trait DEFAULT.
+_hash_with :: (
+  fn(comptime(D) : Type, data : ArrayList(u8), where(D <: Digest)) -> String
+)(
+  (D <: Digest).finish_hex((D <: Digest).update((D <: Digest).new(), data))
+);
+test("Digest trait: generic dispatch + the finish_hex default", {
+  assert(_hash_with(Sha1, _b("abc")) == `a9993e364706816aba3e25717850c26c9cd0d89d`, "sha1 through the trait");
+  assert(_hash_with(Sha256, _b("abc")) == `ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad`, "sha256 through the trait");
+  assert(_hash_with(Md5, _b("abc")) == `900150983cd24fb0d6963f7d28e17f72`, "md5 through the trait");
+  assert((Sha512 <: Digest).digest_size() == usize(64), "sha512 digest_size");
+  assert((Sha512 <: Digest).block_size() == usize(128), "sha512 block_size");
+});
+test("HMAC RFC 2202 / RFC 4231 case 1 (20-byte 0x0b key)", {
+  key := _rep(u8(0x0b), usize(20));
+  msg := _b("Hi There");
+  assert(hmac_sha1_hex(key.clone(), msg.clone()) == `b617318655057264e28bc0b6fb378c8ef146be00`, "HMAC-SHA1");
+  assert(
+    hmac_sha256_hex(key.clone(), msg.clone()) == `b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7`,
+    "HMAC-SHA256"
+  );
+  assert(
+    hmac_sha512_hex(key, msg) == `87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854`,
+    "HMAC-SHA512"
+  );
+});
+test("HMAC RFC 4231 case 6: key longer than the block hashes down first", {
+  key := _rep(u8(0xaa), usize(131));
+  msg := _b("Test Using Larger Than Block-Size Key - Hash Key First");
+  assert(
+    hmac_sha256_hex(key, msg) == `60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54`,
+    "HMAC-SHA256 long key"
+  );
+});
+test("crc32 catalog check value", {
+  assert(crc32(_b("123456789")) == u32(0xcbf43926), "the CRC-32/ISO-HDLC check value");
+  assert(crc32(_b("")) == u32(0), "empty is zero");
+  assert(crc32(_b("The quick brown fox jumps over the lazy dog")) == u32(0x414fa339), "fox");
+});
+test("constant_time_eq", {
+  assert(constant_time_eq(_b("secret"), _b("secret")), "equal");
+  assert(constant_time_eq(_b("secret"), _b("secreT")) == false, "one byte off");
+  assert(constant_time_eq(_b("short"), _b("longer")) == false, "length mismatch");
+});


### PR DESCRIPTION
§7 P0 item 7 (`plans/STD_API_AUDIT.md`), minus `std/rand` which follows separately.

- **`Digest` trait** (`std/crypto/digest.yo`): `new`/`update`/`digest_size`/`block_size`/`finish_bytes` + a `finish_hex` `?=` default — implemented by `Sha256`, `Sha512`, `Sha1`, `Md5` (delegating to their inherents).
- **`Sha1`** (loud collision-broken warning — shipped for git ids / legacy HMAC) and **`Sha512`** (64-bit words, 128-byte blocks; the 128-bit length field written from a `u64` byte total, documented 2^61-byte cap) — streaming hashers on the Sha256 skeleton with one-shot + `_hex` helpers.
- **Streaming `Md5`** next to the existing one-shots (little-endian length + extraction).
- **Generic HMAC** (RFC 2104) over any `Digest` via the `comptime(D)` + `(D <: Digest)` statics idiom (the `collect`/`FromIterator` precedent), with `hmac_sha{1,256,512}(_hex)` conveniences and **`constant_time_eq`** (verify MACs without leaking the first-mismatch position).
- **`crc32`** — bitwise reflected CRC-32. The first cut mis-mixed the table formulation into the bitwise one (`(crc>>8)^c`); the catalog check value caught it immediately.

Tests (`tests/crypto/digest.test.yo`, 9): FIPS 180-4 vectors (abc/empty/two-block) for SHA-1 + SHA-512; RFC 1321 Md5; split-update == one-shot across all four; trait dispatch through a where-bound generic including the `finish_hex` DEFAULT and the size statics; HMAC RFC 2202 + RFC 4231 case 1 and long-key case 6; CRC catalog check values; `constant_time_eq`. Regression: crypto md5 11, sha256 12, random 11.

**Full battery**: check std 163/163 + src 262/262, build rc=0, suite **3198/3198**, cli-diff 52 PASS / 0 GOLDEN-DIFF (zero drift), gates `failures=0`, fixpoint `FIXPOINT_HOLDS stage2 hollow=0`, hollow sweep `SWEEP_GATE_OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)