### PR TITLE
std: S3 P0 — UnixListener/UnixStream over the fully-plumbed sys/unix layer

### DIFF
--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -450,7 +450,7 @@ Open D7 items:
 | env | MERGE (D8) | + `remove`, `vars()` iteration, `str` keys |
 | process | EXTEND | `Child`/`spawn`/`Stdio` piping, `env`/`current_dir` on Command, builder returns `Self`, `ExitStatus.code() -> Option(i32)`, hide `raw` |
 | cli | EXTEND or DROP-TO-PACKAGE | typed values, required enforcement, `--`, repeated opts, help-not-an-error; needs tty/color access (D8 wrappers). Recommendation: keep minimal-but-correct in std |
-| net | FIX + EXTEND | C2/C3 DONE; `Shutdown` enum DONE; usize counts DONE; still: `Reader`/`Writer` impls beyond TcpStream (D5), `incoming()`, UDP `connect` + typed `recv_from`, `UnixStream`/`UnixListener` (sys/unix.yo fully plumbed — lowest-effort high-value gap), `parse_v6`, `SocketAddr.parse`, `Eq`/`Hash` on addr types, RFC 5952 V6 formatting |
+| net | FIX + EXTEND | C2/C3 DONE; `Shutdown` enum DONE; usize counts DONE; UnixStream/UnixListener DONE 2026-08-27 (incl. their Reader/Writer impls); still: `incoming()`, UDP `connect` + typed `recv_from`, `parse_v6`, `SocketAddr.parse`, `Eq`/`Hash` on addr types, RFC 5952 V6 formatting |
 | http | FIX + EXTEND | C1 DONE; still: timeouts (dead `Timeout` variant becomes real), redirects (needs `Url.join`), chunked decoding, binary bodies, keep-alive; **server (P1)**: `parse_request`, `HttpServer` on `TcpListener`; collapse `FetchOptions` into `HttpRequest` |
 | async | PROMOTE | combinator home: `join_all`, `race`, `any`, `timeout`, interval, cancellation for `JoinHandle` (`abort()`), async channel/mutex (D7). `sleep(Duration, io)` lives in `std/time/sleep.yo` — do NOT add a second one; re-export if wanted |
 | thread/worker/sync | REDESIGN (D7) | ThreadPool DONE; `join() -> T` + panic propagation blocked below std — see D7 |
@@ -584,7 +584,7 @@ declarations at runtime.
 7. ~~`crypto`: HMAC, SHA-1, SHA-512, CRC32, `Digest` trait~~ **DONE 2026-08-27** (streaming `Sha1`/`Sha512`/`Md5` on the Sha256 skeleton; the `Digest` trait — `new`/`update`/`digest_size`/`block_size`/`finish_bytes` + a `finish_hex` `?=` default — implemented by all four; generic `hmac` via `(D <: Digest)` statics + `hmac_sha{1,256,512}(_hex)` + `constant_time_eq`; bitwise reflected `crc32`; all pinned to FIPS 180-4 / RFC 2202 / RFC 4231 / CRC-catalog vectors). `std/rand` **DONE 2026-08-27** (seedable PCG-XSH-RR 64/32 `Rng`: `new`/`with_stream`/`next_u32`/`next_u64`/`next_f64`/rejection-sampled `next_below`+`range`/Fisher–Yates `shuffle`/`choice`, pinned to the pcg-random.org reference sequence — landing it surfaced and fixed the 6-digit float-literal truncation, issues/fixed/float-literals-normalized-through-6-digit-percent-g.md)
 8. ~~prelude D3 items 1–8~~ **DONE** (D3.9 Hasher blocked, D3.10 done)
 9. `Duration` integration everywhere a timeout/interval appears
-10. `net.UnixStream`/`UnixListener`
+10. ~~`net.UnixStream`/`UnixListener`~~ **DONE 2026-08-27** (`std/net/unix.yo` mirroring the Tcp pair one-to-one — bind/accept/connect/read/write family + `Reader`/`Writer` impls; the socket FILE is not unlinked on close, like Rust; echo round-trip + AddressInUse pinned)
 
 **P0+ — user-requested (2026-08-23), tracked with this campaign**
 - ~~`yo <subcommand> --help`~~ **DONE** (verified 2026-08-25;

--- a/std/net/unix.yo
+++ b/std/net/unix.yo
@@ -1,0 +1,244 @@
+//! Unix domain sockets — `UnixListener` / `UnixStream`
+//! (`plans/STD_API_AUDIT.md` §7 P0 item 10: the sys layer was fully plumbed
+//! with no typed wrapper). The API mirrors `TcpListener`/`TcpStream`
+//! one-to-one, with a filesystem `Path` where TCP has a `SocketAddr`.
+//!
+//! The LISTENER's socket file is NOT removed on `close` — like Rust, the
+//! caller unlinks it (`fs_dir.remove_file`); binding to a path that already
+//! exists throws `AddressInUse`.
+pragma(Pragma.AllowUnsafe);
+{ ArrayList } :: import("../collections/array_list");
+open(import("../string"));
+{ Path } :: import("../path");
+{ NetError } :: import("./errors");
+{ IoError } :: import("../sys/errors");
+{ Error, AnyError, Exception, IoExn } :: import("../error");
+IO_unix :: import("../sys/unix");
+IoTraits :: import("../io");
+{ GlobalAllocator } :: import("../allocator");
+{ malloc, free } :: GlobalAllocator;
+
+_throw_io :: (fn(errno_val : i32, exn : Exception) -> unit)(
+  exn.throw(dyn(NetError.from_io(IoError.from_errno(errno_val))))
+);
+/// A connected Unix-domain stream socket.
+UnixStream :: ref(
+  struct(
+    _fd : i32,
+    _is_closed : bool
+  )
+);
+/// A Unix-domain socket listening on a filesystem path.
+UnixListener :: ref(
+  struct(
+    _fd : i32,
+    _path : String,
+    _is_closed : bool
+  )
+);
+impl(
+  UnixListener,
+  /// Bind to a filesystem path and start listening. The path must not
+  /// already exist (`AddressInUse` otherwise) and is NOT unlinked on close.
+  bind : (fn(path : Path, io : Io) -> Impl(Future(UnixListener, IoExn)))(
+    io.async((e) => {
+      raw_fd := e.io.await(IO_unix.socket_stream(), e.io);
+      fd := NetError.check(raw_fd, e.exn);
+      path_s := path.to_string();
+      cstr_bytes := path_s.to_cstr();
+      addr := IO_unix.make_sockaddr_un(cstr_bytes.ptr().unwrap());
+      addr_buf := match(
+        addr.buf,
+        .Some(p) => p,
+        .None => {
+          e.io.await(IO_unix.close(fd), e.io);
+          e.exn.throw(dyn(NetError.from_io(IoError.NotSupported)));
+          *(u8)("")
+        }
+      );
+      bind_result := e.io.await(IO_unix.bind(fd, addr_buf, addr.len), e.io);
+      IO_unix.free_addr(addr);
+      cond(
+        (bind_result < i32(0)) => {
+          e.io.await(IO_unix.close(fd), e.io);
+          _throw_io(i32(0) - bind_result, e.exn);
+        },
+        true => ()
+      );
+      listen_result := e.io.await(IO_unix.listen(fd, i32(128)), e.io);
+      cond(
+        (listen_result < i32(0)) => {
+          e.io.await(IO_unix.close(fd), e.io);
+          _throw_io(i32(0) - listen_result, e.exn);
+        },
+        true => ()
+      );
+      return(UnixListener(_fd : fd, _path : path_s, _is_closed : false));
+    })
+  ),
+  /// Accept an incoming connection, returning a new `UnixStream`.
+  accept : (fn(self : Self, io : Io) -> Impl(Future(UnixStream, IoExn)))({
+    fd := self._fd;
+    io.async((e) => {
+      addr_buf := *(u8)(malloc(usize(128)).unwrap());
+      addr_len := *(u32)(malloc(usize(4)).unwrap());
+      addr_len.* = u32(128);
+      client_fd := e.io.await(IO_unix.accept(fd, addr_buf, addr_len), e.io);
+      free(.Some(*(void)(addr_buf)));
+      free(.Some(*(void)(addr_len)));
+      cond(
+        (client_fd < i32(0)) => _throw_io(i32(0) - client_fd, e.exn),
+        true => ()
+      );
+      return(UnixStream(_fd : client_fd, _is_closed : false));
+    })
+  }),
+  /// The filesystem path this listener is bound to.
+  local_path : (fn(self : Self) -> String)(
+    self._path
+  ),
+  /// Close the listener socket (the socket FILE stays — unlink it yourself).
+  close : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))({
+    fd := self._fd;
+    io.async((e) => {
+      cond(
+        self._is_closed => (),
+        true => {
+          r := e.io.await(IO_unix.close(fd), e.io);
+          self._is_closed = true;
+          cond(
+            (r < i32(0)) => {
+              _throw_io(i32(0) - r, e.exn);
+            },
+            true => ()
+          );
+        }
+      );
+    })
+  }),
+  /// Get the underlying file descriptor.
+  fd : (fn(self : Self) -> i32)(
+    self._fd
+  )
+);
+export(UnixListener);
+impl(
+  UnixStream,
+  /// Connect to a Unix-domain socket at `path`, returning a new stream.
+  connect : (fn(path : Path, io : Io) -> Impl(Future(UnixStream, IoExn)))(
+    io.async((e) => {
+      raw_fd := e.io.await(IO_unix.socket_stream(), e.io);
+      fd := NetError.check(raw_fd, e.exn);
+      path_s := path.to_string();
+      cstr_bytes := path_s.to_cstr();
+      addr := IO_unix.make_sockaddr_un(cstr_bytes.ptr().unwrap());
+      addr_buf := match(
+        addr.buf,
+        .Some(p) => p,
+        .None => {
+          e.io.await(IO_unix.close(fd), e.io);
+          e.exn.throw(dyn(NetError.from_io(IoError.NotSupported)));
+          *(u8)("")
+        }
+      );
+      conn_result := e.io.await(IO_unix.connect(fd, addr_buf, addr.len), e.io);
+      IO_unix.free_addr(addr);
+      cond(
+        (conn_result < i32(0)) => {
+          e.io.await(IO_unix.close(fd), e.io);
+          _throw_io(i32(0) - conn_result, e.exn);
+        },
+        true => ()
+      );
+      return(UnixStream(_fd : fd, _is_closed : false));
+    })
+  ),
+  /// Read bytes from the stream into `buf`.
+  /// Returns the number of bytes read, or 0 if the peer closed.
+  read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
+    fd := self._fd;
+    io.async((e) => {
+      r := e.io.await(IO_unix.recv(fd, buf, size, i32(0)), e.io);
+      usize(NetError.check(r, e.exn))
+    })
+  }),
+  /// Write up to `size` raw bytes from `buf` to the stream.
+  write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
+    fd := self._fd;
+    io.async((e) => {
+      r := e.io.await(IO_unix.send(fd, buf, size, i32(0)), e.io);
+      usize(NetError.check(r, e.exn))
+    })
+  }),
+  /// Write a `str` to the stream. Returns the number of bytes written.
+  write_str : (fn(self : Self, data : str, io : Io) -> Impl(Future(usize, IoExn)))({
+    fd := self._fd;
+    s := String.from(data);
+    s_bytes := s.as_bytes();
+    io.async((e) => {
+      r := e.io.await(IO_unix.send(fd, s_bytes.ptr().unwrap(), s_bytes.len(), i32(0)), e.io);
+      usize(NetError.check(r, e.exn))
+    })
+  }),
+  /// Write a `String` to the stream. Returns the number of bytes written.
+  write_string : (fn(self : Self, data : String, io : Io) -> Impl(Future(usize, IoExn)))({
+    fd := self._fd;
+    data_bytes := data.as_bytes();
+    io.async((e) => {
+      r := e.io.await(IO_unix.send(fd, data_bytes.ptr().unwrap(), data_bytes.len(), i32(0)), e.io);
+      usize(NetError.check(r, e.exn))
+    })
+  }),
+  /// Write raw bytes from an `ArrayList(u8)`. Returns the count written.
+  write_bytes : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(usize, IoExn)))({
+    fd := self._fd;
+    io.async((e) => {
+      r := e.io.await(IO_unix.send(fd, data.ptr().unwrap(), data.len(), i32(0)), e.io);
+      usize(NetError.check(r, e.exn))
+    })
+  }),
+  /// Close the stream.
+  close : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))({
+    fd := self._fd;
+    io.async((e) => {
+      cond(
+        self._is_closed => (),
+        true => {
+          r := e.io.await(IO_unix.close(fd), e.io);
+          self._is_closed = true;
+          cond(
+            (r < i32(0)) => {
+              _throw_io(i32(0) - r, e.exn);
+            },
+            true => ()
+          );
+        }
+      );
+    })
+  }),
+  /// Get the underlying file descriptor.
+  fd : (fn(self : Self) -> i32)(
+    self._fd
+  )
+);
+export(UnixStream);
+// === std/io async trait impls (STD_API_AUDIT D5) ===
+impl(
+  UnixStream,
+  IoTraits.Reader(
+    read : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.read(buf, size, io)
+    )
+  )
+);
+impl(
+  UnixStream,
+  IoTraits.Writer(
+    write : (fn(self : Self, buf : *(u8), size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.write(buf, size, io)
+    ),
+    flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))(
+      io.async((e) => ())
+    )
+  )
+);

--- a/tests/net/unix.test.yo
+++ b/tests/net/unix.test.yo
@@ -1,0 +1,116 @@
+//! std/net/unix — UnixListener / UnixStream over a socket file
+//! (plans/STD_API_AUDIT.md §7 P0 item 10). Mirrors the tcp tests' shapes:
+//! connect BEFORE accept (the listen backlog holds it).
+pragma(Pragma.AllowUnsafe);
+pragma(Pragma.SkipWasm32Wasi); // no AF_UNIX in standalone WASI
+{ assert } :: import("std/assert");
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ Error, AnyError, Exception, IoExn } :: import("std/error");
+{ UnixListener, UnixStream } :: import("std/net/unix");
+{ Reader, Writer } :: import("std/io");
+{ Path } :: import("std/path");
+{ remove_file } :: import("std/fs/dir");
+{ temp_dir } :: import("std/env");
+
+_sock :: (fn(name : str) -> Path)(
+  Path.new((temp_dir() + `/yo_unix_`.to_string()) + String.from(name))
+);
+test("bind, connect, accept, echo round-trip", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  path := _sock("echo.sock");
+  listener := io.await(UnixListener.bind(path, io), e);
+  assert(listener.fd() >= i32(0), "listener fd valid");
+  assert(listener.local_path().contains(`yo_unix_echo.sock`), "local_path");
+  client := io.await(UnixStream.connect(path, io), e);
+  server := io.await(listener.accept(io), e);
+  assert(server.fd() >= i32(0), "accepted fd valid");
+  n := io.await(client.write_str("héllo unix", io), e);
+  assert(n == usize(11), "wrote 11 UTF-8 bytes");
+  buf := ArrayList(u8).new();
+  (i : usize) = usize(0);
+  while(i < usize(32), i = (i + usize(1)), {
+    buf.push(u8(0));
+  });
+  got := io.await(server.read(buf.ptr().unwrap(), usize(32), io), e);
+  assert(got == usize(11), "read the 11 bytes");
+  assert(buf(usize(0)) == u8(104), "h");
+  // Echo back through write_bytes.
+  reply := ArrayList(u8).new();
+  (j : usize) = usize(0);
+  while(j < got, j = (j + usize(1)), {
+    reply.push(buf(j));
+  });
+  wn := io.await(server.write_bytes(reply, io), e);
+  assert(wn == usize(11), "echoed 11");
+  buf2 := ArrayList(u8).new();
+  (k : usize) = usize(0);
+  while(k < usize(32), k = (k + usize(1)), {
+    buf2.push(u8(0));
+  });
+  rn := io.await(client.read(buf2.ptr().unwrap(), usize(32), io), e);
+  assert(rn == usize(11), "client read the echo");
+  io.await(server.close(io), e);
+  io.await(client.close(io), e);
+  io.await(listener.close(io), e);
+  io.await(remove_file(path, io), e);
+});
+test("UnixStream satisfies the Reader/Writer bounds (D5)", {
+  taker_r :: (fn(generic(R : Type), r : R, where(R <: Reader)) -> bool)(true);
+  taker_w :: (fn(generic(W : Type), w : W, where(W <: Writer)) -> bool)(true);
+  fake :: (fn() -> Option(UnixStream))(Option(UnixStream).None);
+  match(
+    fake(),
+    .Some(s) => {
+      assert(taker_r(s), "UnixStream satisfies Reader");
+      assert(taker_w(s), "UnixStream satisfies Writer");
+    },
+    .None => ()
+  );
+  assert(true, "trait registration type-checks");
+});
+test("binding an existing path throws AddressInUse", {
+  e0 := Exception(
+    throw : (
+      (err0) -> {
+        assert(false, "setup failed");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : e0);
+  path := _sock("dup.sock");
+  first := io.await(UnixListener.bind(path, io), e);
+  exn := Exception(
+    throw : (
+      (err) -> {
+        msg := err.to_string();
+        assert(msg.contains(`in use`) || msg.contains(`already`), `expected AddressInUse, got: ${msg}`);
+        unwind(());
+      }
+    )
+  );
+  second := io.await(UnixListener.bind(path, io), IoExn(io : io, exn : exn));
+  assert(false, "second bind must throw");
+});
+test("dup.sock cleanup", {
+  e0 := Exception(
+    throw : (
+      (err0) -> {
+        assert(true, "already clean");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : e0);
+  io.await(remove_file(_sock("dup.sock"), io), e);
+  assert(true, "cleaned");
+});


### PR DESCRIPTION
§7 P0 item 10 (`plans/STD_API_AUDIT.md`) — the audit called it "the lowest-effort high-value gap": the sys layer was fully plumbed with no typed wrapper.

`std/net/unix.yo` mirrors the Tcp pair one-to-one: `UnixListener.bind(path)` (the socket FILE is not unlinked on close, like Rust — a stale file throws `AddressInUse`) / `accept` / `local_path` / `close` / `fd`; `UnixStream.connect` / `read` / `write` / `write_str` / `write_string` / `write_bytes` / `close` / `fd`; plus the **D5 `Reader`/`Writer` impls**, so a `UnixStream` drives `read_to_end`/`write_all`/`copy`/`BufReader` like any other stream.

Tests (4): full echo round-trip (bind, connect-before-accept, `write_str`, `read`, `write_bytes` echo), Reader/Writer bound registration, `AddressInUse` on a duplicate bind, cleanup. Regression: net tcp 13, udp 6, addr 13.

**Full battery**: check std 165/165 + src 262/262, build rc=0, suite **3207/3207**, cli-diff 52 PASS / 0 GOLDEN-DIFF (zero drift), gates `failures=0`, fixpoint `FIXPOINT_HOLDS stage2 hollow=0`, hollow sweep `SWEEP_GATE_OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)