### PR TITLE
std: assert_eq / assert_ne / assert_approx — diff-printing assertions

### DIFF
--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -463,7 +463,7 @@ Open D7 items:
 | time | EXTEND | `Duration`: `Add/Sub` operators, `Eq/Ord/Hash`, `from_secs_f64`, `subsec_*`, consts; **make std USE it** (timeouts, sleeps); `Instant` `add/sub`, `Eq/Ord`; `DateTime`: RFC3339 `parse`/`format`, component ctor, arithmetic, `Eq/Ord`; sleep unification DONE (§5) |
 | crypto | EXTEND | `Digest` trait + SHA-1 + SHA-512 + streaming Md5 + HMAC + CRC32 + `constant_time_eq` DONE 2026-08-27; `std/rand` DONE 2026-08-27 (PCG32) |
 | log | REWRITE (zero users = free window) | levels + `Off`, `ToString`-generic message, lazy eval, timestamps, target/module, writer sink, thread-safe; keep the free-function facade |
-| testing | EXTEND | `assert_eq`/`assert_ne`/`assert_approx` (diff-printing), `bench`: auto-calibration, black_box, stddev/percentiles |
+| testing | EXTEND | ~~`assert_eq`/`assert_ne`/`assert_approx` (diff-printing)~~ **DONE 2026-08-28** (std/assert: both-sides / shared-value / |diff|-vs-epsilon panics; optional msg; `Eq(A)+ToString` bounds; tests/assert_eq.test.yo); `bench`: auto-calibration, black_box, stddev/percentiles |
 | gc/allocator | POLISH | `gc.stats()`; `CustomAllocator` deleted (O6) |
 | build | KEEP (already coherent) | Zig-shaped, comptime-correct; only additive evolution |
 

--- a/std/assert.yo
+++ b/std/assert.yo
@@ -10,6 +10,7 @@
 //!   assert(opt.is_some(), "Expected Some");
 //!   panic("unexpected condition");
 { ToString } :: import("std/fmt/to_string");
+open(import("std/string"));
 /// Terminate the program with a message.
 ///
 /// `msg` must implement `ToString`.
@@ -27,4 +28,65 @@ assert :: (fn(generic(T : Type), flag : bool, (msg : T) ?= "Assertion failed.", 
   );
   ()
 });
-export(panic, assert);
+/// The `: <msg>` context suffix for the assert_* family ("" → none).
+_ctx :: (fn(msg : str) -> String)(
+  cond(
+    (String.from(msg).len() == usize(0)) => String.new(),
+    true => ` — ${msg}`
+  )
+);
+/// Assert two values are equal; on failure the panic PRINTS BOTH SIDES —
+/// the diff-printing upgrade over `assert(a == b, "...")`, whose message
+/// can't show what the values actually were.
+///
+///   assert_eq(got, i32(42));
+///   assert_eq(name, `yo`, "config name round-trip");
+assert_eq :: (
+  fn(generic(A : Type), left : A, right : A, (msg : str) ?= "", where(A <: (Eq(A), ToString))) -> unit
+)({
+  cond(
+    (left == right) => (),
+    true => panic(
+      `assertion failed: left == right${_ctx(msg)}
+  left : ${left.to_string()}
+  right: ${right.to_string()}`
+    )
+  );
+  ()
+});
+/// Assert two values are NOT equal; prints the (shared) value on failure.
+assert_ne :: (
+  fn(generic(A : Type), left : A, right : A, (msg : str) ?= "", where(A <: (Eq(A), ToString))) -> unit
+)({
+  cond(
+    (left != right) => (),
+    true => panic(
+      `assertion failed: left != right${_ctx(msg)}
+  both sides: ${left.to_string()}`
+    )
+  );
+  ()
+});
+/// Assert two floats are within `epsilon` of each other (absolute
+/// difference). The default epsilon (1e-9) suits values near 1.0; pass an
+/// explicit epsilon for very large or very small magnitudes.
+assert_approx :: (
+  fn(left : f64, right : f64, (epsilon : f64) ?= f64(0.000000001), (msg : str) ?= "") -> unit
+)({
+  diff := cond(
+    (left > right) => (left - right),
+    true => (right - left)
+  );
+  cond(
+    (diff <= epsilon) => (),
+    true => panic(
+      `assertion failed: |left - right| <= epsilon${_ctx(msg)}
+  left   : ${left.to_string()}
+  right  : ${right.to_string()}
+  |diff| : ${diff.to_string()}
+  epsilon: ${epsilon.to_string()}`
+    )
+  );
+  ()
+});
+export(panic, assert, assert_eq, assert_ne, assert_approx);

--- a/tests/assert_eq.test.yo
+++ b/tests/assert_eq.test.yo
@@ -1,0 +1,29 @@
+//! The assert_eq / assert_ne / assert_approx family (`plans/STD_API_AUDIT.md`
+//! §7 testing row: diff-printing assertions). Failure paths abort the
+//! process, so only the passing contracts are pinned here; the message
+//! format is exercised manually.
+{ assert, assert_eq, assert_ne, assert_approx } :: import("std/assert");
+open(import("std/string"));
+
+test("assert_eq passes on equal values across types", {
+  assert_eq(i32(42), i32(42));
+  assert_eq(u64(0), u64(0), "zeroes");
+  assert_eq(`yo`.to_string(), `yo`.to_string(), "strings");
+  assert_eq(true, true);
+  assert(true, "reached");
+});
+test("assert_ne passes on distinct values", {
+  assert_ne(i32(1), i32(2));
+  assert_ne(`a`.to_string(), `b`.to_string(), "strings differ");
+  assert(true, "reached");
+});
+test("assert_approx tolerates rounding at the default epsilon", {
+  third := (f64(1) / f64(3));
+  assert_approx(third * f64(3), f64(1));
+  assert_approx(f64(0.1) + f64(0.2), f64(0.3));
+  // Explicit epsilon for a large magnitude.
+  assert_approx(f64(1000000000), f64(1000000001), f64(2));
+  // Exact equality is trivially approx-equal.
+  assert_approx(f64(5), f64(5));
+  assert(true, "reached");
+});


### PR DESCRIPTION
## Summary

§7 testing row, first half: `assert(a == b, msg)` cannot show what the values were. The new family in `std/assert`:

- **`assert_eq(left, right, msg?)`** — panics printing BOTH sides.
- **`assert_ne(left, right, msg?)`** — panics printing the shared value.
- **`assert_approx(left, right, epsilon? = 1e-9, msg?)`** — absolute-difference check printing left/right/|diff|/epsilon.

Bounds `A <: (Eq(A), ToString)`; the optional message renders as a `— msg` suffix. Failure shape:

```
assertion failed: left == right — answer check
  left : 41
  right: 42
```

`tests/assert_eq.test.yo` pins the passing contracts (failures abort the process); the message format verified manually. The `bench` half of the row (auto-calibration, black_box, percentiles) stays open.

Local: seed checks 167/167 + 262/262 green, targeted tests 3/3. Full verification: this PR's own CI battery (all 26 checks — the required set repaired in #309).

🤖 Generated with [Claude Code](https://claude.com/claude-code)