### PR TITLE
std: Duration operators/Eq/Ord/Hash/consts + Instant add/sub/Eq/Ord

### DIFF
--- a/std/time/duration.yo
+++ b/std/time/duration.yo
@@ -94,4 +94,110 @@ impl(
     })
   )
 );
+
+// ============================================================================
+// Operators, comparison, hashing, float/subsecond accessors, consts
+// (plans/STD_API_AUDIT.md §7 time row)
+// ============================================================================
+impl(
+  Duration,
+  /// One second.
+  SECOND : (fn() -> Self)(Self(secs : i64(1), nanos : i64(0))),
+  /// One millisecond.
+  MILLISECOND : (fn() -> Self)(Self(secs : i64(0), nanos : i64(1000000))),
+  /// One microsecond.
+  MICROSECOND : (fn() -> Self)(Self(secs : i64(0), nanos : i64(1000))),
+  /// One nanosecond.
+  NANOSECOND : (fn() -> Self)(Self(secs : i64(0), nanos : i64(1))),
+  /// One minute.
+  MINUTE : (fn() -> Self)(Self(secs : i64(60), nanos : i64(0))),
+  /// One hour.
+  HOUR : (fn() -> Self)(Self(secs : i64(3600), nanos : i64(0))),
+  /// From fractional seconds (`Duration.from_secs_f64(0.25)` = 250ms).
+  /// Sub-nanosecond precision truncates toward zero; negative inputs clamp
+  /// to zero (a Duration is a non-negative span, like `sub`'s saturation).
+  from_secs_f64 : (fn(secs : f64) -> Self)(
+    cond(
+      (secs <= f64(0)) => Self.zero(),
+      true => {
+        whole := i64(secs);
+        frac_nanos := i64((secs - f64(whole)) * f64(1000000000.0));
+        Self(secs : whole, nanos : frac_nanos)
+      }
+    )
+  ),
+  /// The sub-second part in milliseconds (0..999).
+  subsec_millis : (fn(inout(self) : Self) -> i64)(
+    self.nanos / i64(1000000)
+  ),
+  /// The sub-second part in microseconds (0..999_999).
+  subsec_micros : (fn(inout(self) : Self) -> i64)(
+    self.nanos / i64(1000)
+  ),
+  /// The sub-second part in nanoseconds (0..999_999_999).
+  subsec_nanos : (fn(inout(self) : Self) -> i64)(
+    self.nanos
+  )
+);
+/// `a + b` — same carry rule as `add`.
+impl(
+  Duration,
+  Add(Duration)(
+    Output : Duration,
+    (+) : (fn(self : Self, other : Self) -> Self.Output)(
+      self.add(other)
+    )
+  )
+);
+/// `a - b` — same zero-saturation as `sub`.
+impl(
+  Duration,
+  Sub(Duration)(
+    Output : Duration,
+    (-) : (fn(self : Self, other : Self) -> Self.Output)(
+      self.sub(other)
+    )
+  )
+);
+impl(
+  Duration,
+  Eq(Duration)(
+    (==) : (fn(lhs : Self, rhs : Self) -> bool)(
+      (lhs.secs == rhs.secs) && (lhs.nanos == rhs.nanos)
+    ),
+    (!=) : (fn(lhs : Self, rhs : Self) -> bool)(
+      !(lhs == rhs)
+    )
+  )
+);
+impl(
+  Duration,
+  Ord(Duration)(
+    (<) : (fn(lhs : Self, rhs : Self) -> bool)(
+      cond(
+        (lhs.secs != rhs.secs) => (lhs.secs < rhs.secs),
+        true => (lhs.nanos < rhs.nanos)
+      )
+    ),
+    (<=) : (fn(lhs : Self, rhs : Self) -> bool)(
+      !(rhs < lhs)
+    ),
+    (>) : (fn(lhs : Self, rhs : Self) -> bool)(
+      rhs < lhs
+    ),
+    (>=) : (fn(lhs : Self, rhs : Self) -> bool)(
+      !(lhs < rhs)
+    )
+  )
+);
+impl(
+  Duration,
+  Hash(
+    (hash) : (fn(inout(self) : Self) -> u64)(
+      // Total nanoseconds is the value's identity (secs/nanos are kept
+      // normalized by every constructor), so hashing it keeps Eq's contract.
+      u64(self.as_nanos()) * u64(1099511628211)
+    )
+  )
+);
 export(Duration);

--- a/std/time/instant.yo
+++ b/std/time/instant.yo
@@ -54,4 +54,64 @@ impl(
     current.duration_since(self)
   })
 );
+
+// ============================================================================
+// add/sub(Duration) + Eq/Ord (plans/STD_API_AUDIT.md §7 time row)
+// ============================================================================
+impl(
+  Instant,
+  /// This instant shifted forward by `d`.
+  add : (fn(inout(self) : Self, d : Duration) -> Self)({
+    total := (self.nanos + (d.as_nanos() % i64(1000000000)));
+    carry := (total / i64(1000000000));
+    Self(
+      secs : ((self.secs + d.as_secs()) + carry),
+      nanos : (total % i64(1000000000))
+    )
+  }),
+  /// This instant shifted backward by `d` (clamps at the clock's zero, the
+  /// same non-negative stance as `duration_since`).
+  sub : (fn(inout(self) : Self, d : Duration) -> Self)({
+    self_ns := ((self.secs * i64(1000000000)) + self.nanos);
+    d_ns := d.as_nanos();
+    cond(
+      (self_ns <= d_ns) => Self(secs : i64(0), nanos : i64(0)),
+      true => {
+        left := (self_ns - d_ns);
+        Self(secs : (left / i64(1000000000)), nanos : (left % i64(1000000000)))
+      }
+    )
+  })
+);
+impl(
+  Instant,
+  Eq(Instant)(
+    (==) : (fn(lhs : Self, rhs : Self) -> bool)(
+      (lhs.secs == rhs.secs) && (lhs.nanos == rhs.nanos)
+    ),
+    (!=) : (fn(lhs : Self, rhs : Self) -> bool)(
+      !(lhs == rhs)
+    )
+  )
+);
+impl(
+  Instant,
+  Ord(Instant)(
+    (<) : (fn(lhs : Self, rhs : Self) -> bool)(
+      cond(
+        (lhs.secs != rhs.secs) => (lhs.secs < rhs.secs),
+        true => (lhs.nanos < rhs.nanos)
+      )
+    ),
+    (<=) : (fn(lhs : Self, rhs : Self) -> bool)(
+      !(rhs < lhs)
+    ),
+    (>) : (fn(lhs : Self, rhs : Self) -> bool)(
+      rhs < lhs
+    ),
+    (>=) : (fn(lhs : Self, rhs : Self) -> bool)(
+      !(lhs < rhs)
+    )
+  )
+);
 export(Instant);

--- a/tests/time/duration.test.yo
+++ b/tests/time/duration.test.yo
@@ -90,3 +90,41 @@ test("Duration.to_string", {
   assert(s.contains(`2s`), "should contain 2s");
   assert(s.contains(`500000000ns`), "should contain 500000000ns");
 });
+// ============================================================================
+// Operators, Eq/Ord/Hash, from_secs_f64, subsec_*, consts
+// (plans/STD_API_AUDIT.md §7 time row)
+// ============================================================================
+test("operators + and - with carry and saturation", {
+  a := Duration.from_millis(i64(750));
+  b := Duration.from_millis(i64(500));
+  s := (a + b);
+  assert(s.as_secs() == i64(1), "carry into secs");
+  assert(s.subsec_millis() == i64(250), "carry remainder");
+  d := (b - a);
+  assert(d.is_zero(), "subtraction saturates at zero");
+  d2 := (a - b);
+  assert(d2.as_millis() == i64(250), "normal subtraction");
+});
+test("Eq and Ord order spans", {
+  assert(Duration.from_millis(i64(1500)) == Duration.from_nanos(i64(1500000000)), "normalized equality");
+  assert(Duration.from_secs(i64(1)) < Duration.from_millis(i64(1001)), "nanos tiebreak");
+  assert(Duration.from_secs(i64(2)) > Duration.from_millis(i64(1999)), "secs dominate");
+  assert(Duration.zero() <= Duration.zero(), "reflexive");
+});
+test("from_secs_f64 and subsec accessors", {
+  q := Duration.from_secs_f64(f64(1.25));
+  assert(q.as_secs() == i64(1), "whole part");
+  assert(q.subsec_millis() == i64(250), "fraction to millis");
+  assert(q.subsec_micros() == i64(250000), "micros");
+  assert(q.subsec_nanos() == i64(250000000), "nanos");
+  assert(Duration.from_secs_f64(f64(-3)).is_zero(), "negative clamps to zero");
+});
+test("consts and hash contract", {
+  assert(Duration.SECOND() == Duration.from_millis(i64(1000)), "SECOND");
+  assert(Duration.MINUTE() == Duration.from_secs(i64(60)), "MINUTE");
+  assert(Duration.HOUR() == Duration.from_secs(i64(3600)), "HOUR");
+  assert(Duration.MILLISECOND().as_nanos() == i64(1000000), "MILLISECOND");
+  a := Duration.from_millis(i64(1500));
+  b := Duration.from_nanos(i64(1500000000));
+  assert(a.hash() == b.hash(), "Eq values hash equal");
+});

--- a/tests/time/instant.test.yo
+++ b/tests/time/instant.test.yo
@@ -49,3 +49,16 @@ test("Instant.duration_since earlier returns zero", {
   d := t1.duration_since(t2);
   assert(d.is_zero(), "earlier.duration_since(later) should be zero");
 });
+// ============================================================================
+// add/sub(Duration) + Eq/Ord (plans/STD_API_AUDIT.md §7 time row)
+// ============================================================================
+test("Instant add/sub shift and Eq/Ord order", {
+  base := Instant.now();
+  later := base.add(Duration.from_millis(i64(1500)));
+  assert(later > base, "add moves forward");
+  assert(base < later, "Ord symmetric");
+  assert(later.duration_since(base) == Duration.from_millis(i64(1500)), "shift distance exact");
+  round := later.sub(Duration.from_millis(i64(1500)));
+  assert(round == base, "add then sub round-trips");
+  assert(base >= base, "reflexive");
+});


### PR DESCRIPTION
## Summary

The remaining §7 time-row items apart from the cross-cutting "make std USE Duration" (P0 item 9):

- **Duration**: `+`/`-` operators (same carry / zero-saturation as `add`/`sub`), fieldwise `Eq`, secs-then-nanos `Ord`, `Hash` over total nanoseconds (Eq⇒hash-equal pinned), `from_secs_f64` (negatives clamp to the zero span), `subsec_millis/micros/nanos`, and `SECOND`/`MILLISECOND`/`MICROSECOND`/`NANOSECOND`/`MINUTE`/`HOUR` consts.
- **Instant**: `add`/`sub(Duration)` (`sub` clamps at the clock's zero, matching `duration_since`), `Eq`/`Ord`.

Tests: duration 12 → 16, instant 4 → 5; sleep suite re-run green. Local seed checks 167/167 + 262/262. Full verification: this PR's CI battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)