### PR TITLE
std: fs.walker pattern option + glob() expansion

### DIFF
--- a/issues/async-tail-match-return-hangs-state-machine.md
+++ b/issues/async-tail-match-return-hangs-state-machine.md
@@ -1,0 +1,44 @@
+# A `match` arm with a mid-body `return(...)` at an async body's TAIL hangs the state machine
+
+**Found**: 2026-08-28 adding the walk-pattern filter to `std/fs/walker.yo`
+(branch `p1/glob-expansion`). **Status**: OPEN — std avoids the shape (the
+filter moved into a sync helper called as the tail expression); the shape
+itself remains a codegen hazard.
+
+## Shape
+
+At the very END of a large `io.async` body (walk_with's — a while loop with
+awaits above), this tail:
+
+```rust
+match(
+  options.pattern,
+  .Some(pat) => {
+    kept := ArrayList(WalkEntry).new();
+    // ... plain sync loop over `results` ...
+    return(kept);          // resume-with-value, the unix.yo mid-body style
+  },
+  .None => ()
+);
+results                     // tail expression for the None path
+```
+
+compiled clean but the produced state machine HANGS AT RUNTIME — even a walk
+that never takes the `.Some` arm (pattern `.None`) spins forever (`rc=124`
+under `timeout`, on the FIRST plain-walk call). Reverting to a single tail
+expression (`_filter_by_pattern(results, root_s, options.pattern)`, a sync
+call) fixes it with identical semantics.
+
+## Notes for the fix
+
+- The mid-body `return(...)` inside cond/match arms is a supported, widely
+  used shape (std/net/unix.yo). The differentiator here is the position —
+  the LAST statement group of the async body, after the awaiting while loop,
+  with the real tail expression following the match. Likely the completion
+  segment / final-state splitter mishandles a returning arm in the tail
+  segment (sibling territory to C25's effectively-unit tail handling and the
+  cond-branch dispatch machinery).
+- Repro recipe: take walk_with as of commit a39ab3777's parent, append the
+  match/return tail above, run any walk. A minimal standalone repro was not
+  distilled (the walker body is large); distilling one is the first step of
+  the fix.

--- a/issues/struct-literal-missing-field-silently-accepted.md
+++ b/issues/struct-literal-missing-field-silently-accepted.md
@@ -247,3 +247,18 @@ the evaluator, and codegen then emitted a C identifier with a Yo type expression
 spliced into it (`__yo_dyn_box_unknown_fn(T : Type) -> Type`), which fails the C
 compile with "expected ')'" rather than reporting a type error. That one is at
 least LOUD; this one is silent.
+
+
+## Live incident (2026-08-28, PR #315)
+
+`WalkOptions` gained a `pattern : Option(String)` field; the two TEST
+construction sites were updated, but `remove_dir_all`'s internal fieldwise
+`WalkOptions(...)` in the same module was missed. `yo check` stayed green
+(this bug), the uninitialized Option read as garbage on the Linux legs, and
+`tests/fs/fs_convenience.test.yo`'s remove_dir_all test ABORTED (exit 134)
+after its own asserts passed — five CI legs red. The fix was one field at
+one call site; the finding is that the ledger row's prediction ("adding a
+field to a stable struct silently breaks every construction site not
+updated") now has a measured in-tree casualty, which raises this bug's
+priority for the stability freeze: the §1 additive-only promise is
+unsound until construction sites are checked.

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -430,8 +430,14 @@ Open D7 items:
   `RegexError` is a closed 14-variant enum with `ToString`+`Error()`, no
   `Other(msg)` escape hatch. Filed en route:
   issues/template-string-backslash-before-interpolation-eats-both.md.
-- **OPEN:** `std/glob` stays the matcher; `fs.walker` gains `pattern` option +
-  a `glob(pattern, io)` expansion function (the Python/Node meaning).
+- ~~**OPEN:** `std/glob` stays the matcher; `fs.walker` gains `pattern` option +
+  a `glob(pattern, io)` expansion function (the Python/Node meaning).~~
+  **DONE 2026-08-28** (`WalkOptions.pattern` filters root-relative paths via
+  glob_match — dirs still descended so `**` finds deep files; `glob(pattern,
+  io)` walks from the pattern's static prefix. En route surfaced an OPEN
+  codegen hazard: a match/return tail after an awaiting loop hangs the state
+  machine — issues/async-tail-match-return-hangs-state-machine.md; the filter
+  lives in a sync helper instead).
 
 ---
 

--- a/std/fs/walker.yo
+++ b/std/fs/walker.yo
@@ -328,7 +328,7 @@ export(walk, walk_cstr, walk_with, walk_with_cstr, glob);
 /// (src/fetch.yo) before it moved into std.
 remove_dir_all :: (fn(path : Path, io : Io) -> Impl(Future(unit, IoExn)))(
   io.async((e : IoExn) => {
-    opts := WalkOptions(max_depth : .None, follow_symlinks : false, include_dirs : true);
+    opts := WalkOptions(max_depth : .None, follow_symlinks : false, include_dirs : true, pattern : .None);
     entries := e.io.await(walk_with(path, opts, e.io), e);
     n := entries.len();
     // Delete deepest entries first (reverse order from walk output).

--- a/std/fs/walker.yo
+++ b/std/fs/walker.yo
@@ -20,6 +20,7 @@ pragma(Pragma.AllowUnsafe);
 { HashSet } :: import("../collections/hash_set");
 open(import("../string"));
 { Path } :: import("../path");
+{ glob_match } :: import("../glob");
 _file :: import("./file");
 /// follow_symlinks support gate. On Windows the follow path's
 /// canonical/is_dir through a DIRECTORY symlink dies with an unknown I/O
@@ -49,7 +50,12 @@ export(WalkEntry);
 WalkOptions :: struct(
   max_depth : Option(u32),
   follow_symlinks : bool,
-  include_dirs : bool
+  include_dirs : bool,
+  /// When set, only entries whose path RELATIVE TO THE WALK ROOT matches
+  /// this glob (std/glob semantics; `**` crosses separators) are returned.
+  /// Directories are still DESCENDED regardless, so `**/x.txt` finds deep
+  /// files even though intermediate dirs do not match.
+  pattern : Option(String)
 );
 impl(
   WalkOptions,
@@ -57,7 +63,8 @@ impl(
     Self(
       max_depth : .None,
       follow_symlinks : false,
-      include_dirs : true
+      include_dirs : true,
+      pattern : .None
     )
   )
 );
@@ -93,6 +100,36 @@ _canon_dir_target :: (fn(lp : String, io : Io) -> Impl(Future(String, IoExn)))(
 // Walk functions
 // ============================================================================
 // Walk a directory tree with custom options.
+/// Keep the entries whose ROOT-RELATIVE path matches `pattern` (byte prefix
+/// strip is exact — every entry path is `_join_path(root_s, ...)`). `.None`
+/// passes everything through.
+_filter_by_pattern :: (fn(results : ArrayList(WalkEntry), root_s : String, pattern : Option(String)) -> ArrayList(WalkEntry))({
+  pat := match(
+    pattern,
+    .Some(p) => p,
+    .None => {
+      return(results);
+    }
+  );
+  kept := ArrayList(WalkEntry).new();
+  prefix_len := (root_s.len() + usize(1));
+  (fi : usize) = usize(0);
+  while(fi < results.len(), fi = (fi + usize(1)), {
+    wentry := results(fi);
+    full := wentry.path.to_string();
+    rel := cond(
+      (full.len() > prefix_len) => full.substring(prefix_len, full.len()),
+      true => wentry.name.clone()
+    );
+    cond(
+      glob_match(pat.clone(), rel) => {
+        kept.push(wentry);
+      },
+      true => ()
+    );
+  });
+  kept
+});
 walk_with :: (fn(root : Path, options : WalkOptions, io : Io) -> Impl(Future(ArrayList(WalkEntry), IoExn)))({
   root_s := root.to_string();
   io.async((e) => {
@@ -198,7 +235,10 @@ walk_with :: (fn(root : Path, options : WalkOptions, io : Io) -> Impl(Future(Arr
         true => ()
       );
     });
-    results
+    // Pattern post-filter runs in a SYNC helper: adding match/return control
+    // flow at this async body's tail reshaped the state machine into a hang
+    // (rc=124 on a plain walk) — the tail stays a single expression.
+    _filter_by_pattern(results, root_s, options.pattern)
   })
 });
 walk_with_cstr :: (fn(root : *(u8), options : WalkOptions, io : Io) -> Impl(Future(ArrayList(WalkEntry), IoExn)))(
@@ -207,7 +247,76 @@ walk_with_cstr :: (fn(root : *(u8), options : WalkOptions, io : Io) -> Impl(Futu
 /// Walk a directory tree with default options.
 walk :: (fn(root : Path, io : Io) -> Impl(Future(ArrayList(WalkEntry), IoExn)))(walk_with(root, WalkOptions.defaults(), io));
 walk_cstr :: (fn(root : *(u8), io : Io) -> Impl(Future(ArrayList(WalkEntry), IoExn)))(walk(Path.from_cstr(root), io));
-export(walk, walk_cstr, walk_with, walk_with_cstr);
+/// Split a glob pattern into (static base dir, relative pattern): the base
+/// is everything up to the last `/` BEFORE the first metacharacter
+/// (`*`, `?`, `[`), or `.` when the pattern is relative with no static dir.
+_glob_split :: (fn(pattern : String) -> struct(base : String, rest : String))({
+  bs := pattern.as_bytes();
+  n := bs.len();
+  // First metacharacter position (n = none).
+  (meta : usize) = n;
+  (i : usize) = usize(0);
+  while((i < n) && (meta == n), {
+    b := match(bs.get(i), .Some(x) => x, .None => u8(0));
+    cond(
+      ((b == u8(42)) || ((b == u8(63)) || (b == u8(91)))) => {
+        meta = i;
+      },
+      true => ()
+    );
+    i = (i + usize(1));
+  });
+  // Last '/' before the first metacharacter.
+  (cut : Option(usize)) = Option(usize).None;
+  (j : usize) = usize(0);
+  while(j < meta, {
+    b := match(bs.get(j), .Some(x) => x, .None => u8(0));
+    cond(
+      (b == u8(47)) => {
+        cut = Option(usize).Some(j);
+      },
+      true => ()
+    );
+    j = (j + usize(1));
+  });
+  match(
+    cut,
+    .Some(at) => {
+      base0 := pattern.substring(usize(0), at);
+      base := cond(
+        base0.is_empty() => `/`.to_string(),
+        true => base0
+      );
+      { base : base, rest : pattern.substring(at + usize(1), n) }
+    },
+    .None => { base : `.`.to_string(), rest : pattern.clone() }
+  )
+});
+/// Expand a glob pattern against the filesystem — the Python/Node meaning:
+/// walk from the pattern's static prefix and return every matching path
+/// (files, dirs and symlinks alike; `**` crosses directories). Throws the
+/// walker's IoExn when the static base directory cannot be read.
+glob :: (fn(pattern : String, io : Io) -> Impl(Future(ArrayList(Path), IoExn)))({
+  parts := _glob_split(pattern);
+  io.async((e) => {
+    opts := WalkOptions(
+      max_depth : .None,
+      follow_symlinks : false,
+      include_dirs : true,
+      pattern : Option(String).Some(parts.rest)
+    );
+    entries := e.io.await(walk_with(Path.new(parts.base), opts, e.io), e);
+    out := ArrayList(Path).new();
+    (i : usize) = usize(0);
+    while(runtime(i < entries.len()), {
+      wentry := entries(i);
+      out.push(wentry.path);
+      i = (i + usize(1));
+    });
+    out
+  })
+});
+export(walk, walk_cstr, walk_with, walk_with_cstr, glob);
 /// Recursively remove a directory and everything under it
 /// (`std::fs::remove_dir_all`). Does NOT follow symlinks — a symlinked
 /// directory is removed as a LINK, its target untouched.

--- a/tests/fs/walker.test.yo
+++ b/tests/fs/walker.test.yo
@@ -92,7 +92,8 @@ test("walk_with max_depth limits traversal", {
   opts := WalkOptions(
     max_depth : .Some(u32(0)),
     follow_symlinks : false,
-    include_dirs : true
+    include_dirs : true,
+    pattern : .None
   );
   entries := io.await(fs_walker.walk_with(Path.new(root), opts, io), IoExn(io : io, exn : exn));
   unsafe(printf("  entries at depth 0 = %lld\n", i64(entries.len())));
@@ -124,7 +125,8 @@ test("walk_with include_dirs false excludes directories", {
   opts := WalkOptions(
     max_depth : .None,
     follow_symlinks : false,
-    include_dirs : false
+    include_dirs : false,
+    pattern : .None
   );
   entries := io.await(fs_walker.walk_with(Path.new(root), opts, io), IoExn(io : io, exn : exn));
   unsafe(printf("  file-only entries = %lld\n", i64(entries.len())));
@@ -235,7 +237,7 @@ test("walk_with follow_symlinks descends through directory symlinks", {
       io.await(fs_dir.create_dir_all(Path.new(real), io), IoExn(io : io, exn : exn));
       io.await(fs_file.write_string(Path.new(path_join(real, `inner.txt`)), String.from("x"), io), IoExn(io : io, exn : exn));
       io.await(fs_dir.symlink(Path.new(real), Path.new(lnk), io), IoExn(io : io, exn : exn));
-      opts := WalkOptions(max_depth : .None, follow_symlinks : true, include_dirs : true);
+      opts := WalkOptions(max_depth : .None, follow_symlinks : true, include_dirs : true, pattern : .None);
       entries := io.await(fs_walker.walk_with(Path.new(root), opts, io), IoExn(io : io, exn : exn));
       found_via_link := false;
       i := usize(0);
@@ -259,4 +261,39 @@ test("walk_with follow_symlinks descends through directory symlinks", {
       io.await(fs_dir.remove_dir(Path.new(root), io), IoExn(io : io, exn : exn));
     }
   );
+});
+// ============================================================================
+// pattern option + glob() expansion (plans/STD_API_AUDIT.md D8 glob row)
+// ============================================================================
+test("walk_with pattern filters relative paths; glob() expands", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  base := temp_dir();
+  root := path_join(base, `yo_glob_root`.to_string());
+  io.await(fs_dir.create_dir_all(Path.new(path_join(root.clone(), `sub/inner`.to_string())), io), e);
+  io.await(fs_file.write_string(Path.new(path_join(root.clone(), `a.txt`.to_string())), `a`.to_string(), io), e);
+  io.await(fs_file.write_string(Path.new(path_join(root.clone(), `b.log`.to_string())), `b`.to_string(), io), e);
+  io.await(fs_file.write_string(Path.new(path_join(root.clone(), `sub/inner/c.txt`.to_string())), `c`.to_string(), io), e);
+  // Shallow pattern: only the root-level .txt file.
+  opts := WalkOptions(max_depth : .None, follow_symlinks : false, include_dirs : true, pattern : .Some(`*.txt`.to_string()));
+  shallow := io.await(fs_walker.walk_with(Path.new(root.clone()), opts, io), e);
+  assert(shallow.len() == usize(1), "only a.txt matches *.txt");
+  assert(shallow(usize(0)).name == `a.txt`, "the right file");
+  // Deep pattern: ** crosses directories.
+  opts2 := WalkOptions(max_depth : .None, follow_symlinks : false, include_dirs : true, pattern : .Some(`**.txt`.to_string()));
+  deep := io.await(fs_walker.walk_with(Path.new(root.clone()), opts2, io), e);
+  assert(deep.len() == usize(2), "a.txt and sub/inner/c.txt");
+  // glob(): pattern carries the static base.
+  found := io.await(fs_walker.glob(`${root}/**.txt`.to_string(), io), e);
+  assert(found.len() == usize(2), "glob finds both txt files");
+  found2 := io.await(fs_walker.glob(`${root}/*.log`.to_string(), io), e);
+  assert(found2.len() == usize(1), "glob finds the log");
+  io.await(fs_walker.remove_dir_all(Path.new(root), io), e);
 });


### PR DESCRIPTION
## Summary

The D8 glob row: `std/glob` stays the matcher; the walker gains the filesystem side.

- **`WalkOptions.pattern`** — filters entries by their root-relative path against `std/glob` semantics (`**` crosses separators); directories are still descended so deep matches are found.
- **`glob(pattern, io)`** — the Python/Node expansion: walks from the pattern's static prefix, returns matching paths.

**Surfaced + filed (open codegen hazard)**: a `match` arm with a mid-body `return(...)` positioned at an async body's tail (after the awaiting loop) compiles clean but hangs the state machine at runtime — even when the returning arm is never taken (`issues/async-tail-match-return-hangs-state-machine.md`). The filter lives in a sync helper called as the tail expression instead.

Tests 7 → 8; local seed checks green. Full verification: this PR's CI battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)