### PR TITLE
std: HashMap entry-style accessors

### DIFF
--- a/std/collections/hash_map.yo
+++ b/std/collections/hash_map.yo
@@ -436,6 +436,50 @@ impl(
     self.size = usize(0);
   })
 );
+/// The entry-style accessors (plans/STD_API_AUDIT.md §7 collections row):
+/// Yo's pragmatic shape of Rust's Entry — no borrow object, just
+/// get-or-insert in one probe-and-settle call.
+impl(
+  generic(K : Type, V : Type),
+  where(K <: (Eq(K), Hash)),
+  HashMap(K, V),
+  /// The value for `key`, inserting `default` first when absent.
+  get_or_insert : (fn(self : Self, key : K, default : V) -> V)(
+    match(
+      self.get(key),
+      .Some(v) => v,
+      .None => {
+        _r := self.insert(key, default);
+        default
+      }
+    )
+  ),
+  /// The value for `key`, inserting `make()`'s result first when absent —
+  /// use over `get_or_insert` when constructing the default is costly.
+  get_or_insert_with : (fn(self : Self, key : K, make : Impl(Fn() -> V)) -> V)(
+    match(
+      self.get(key),
+      .Some(v) => v,
+      .None => {
+        made := make();
+        _r := self.insert(key, made);
+        made
+      }
+    )
+  ),
+  /// Update the value for `key` through `f` when present; no-op when absent.
+  /// Returns true when an update happened.
+  update_with : (fn(self : Self, key : K, f : Impl(Fn(v : V) -> V)) -> bool)(
+    match(
+      self.get(key),
+      .Some(v) => {
+        _r := self.insert(key, f(v));
+        true
+      },
+      .None => false
+    )
+  )
+);
 impl(
   generic(K : Type, V : Type),
   where(K <: (Eq(K), Hash)),

--- a/tests/collections/hash_map.test.yo
+++ b/tests/collections/hash_map.test.yo
@@ -1,6 +1,7 @@
 pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
 open(import("std/collections/hash_map"));
+open(import("std/string"));
 // ===== Construction Tests =====
 test("HashMap.new creates empty map", {
   map := HashMap(i32, i32).new();
@@ -587,4 +588,32 @@ test("HashMap values - manual next() iteration terminates", {
   });
   assert(steps == i32(2), "values() must terminate after yielding each value once");
   assert(val_sum == i32(31));
+});
+// ============================================================================
+// Entry-style accessors (plans/STD_API_AUDIT.md §7 collections row)
+// ============================================================================
+test("get_or_insert inserts once and reads thereafter", {
+  m := HashMap(String, i32).new();
+  a := m.get_or_insert(`hits`.to_string(), i32(1));
+  assert(a == i32(1), "inserted default");
+  b := m.get_or_insert(`hits`.to_string(), i32(99));
+  assert(b == i32(1), "existing wins over default");
+  assert(m.len() == usize(1), "one entry");
+});
+test("get_or_insert_with defers construction", {
+  m := HashMap(String, String).new();
+  v := m.get_or_insert_with(`k`.to_string(), () => `built`.to_string());
+  assert(v == `built`, "constructed on miss");
+  v2 := m.get_or_insert_with(`k`.to_string(), () => `never`.to_string());
+  assert(v2 == `built`, "hit skips make");
+});
+test("update_with maps present values only", {
+  m := HashMap(String, i32).new();
+  _i := m.insert(`n`.to_string(), i32(10));
+  did := m.update_with(`n`.to_string(), (v) => (v + i32(5)));
+  assert(did, "updated");
+  assert(match(m.get(`n`.to_string()), .Some(v) => (v == i32(15)), .None => false), "value mapped");
+  did2 := m.update_with(`absent`.to_string(), (v) => v);
+  assert(!(did2), "absent is a no-op");
+  assert(m.len() == usize(1), "no phantom insert");
 });


### PR DESCRIPTION
## Summary

The collections row's entry API, in Yo's shape (no borrow object — probe-and-settle calls):

- **`get_or_insert(key, default) -> V`** — the existing value, or `default` after inserting it.
- **`get_or_insert_with(key, make) -> V`** — same, constructing lazily on miss.
- **`update_with(key, f) -> bool`** — maps a present value through `f`; absent is a reported no-op.

Tests 61 → 64. Local seed checks green. Full verification: this PR's CI battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)