### PR TITLE
test: the sleep-overlap assertion measured runner load, not overlap (develop's only red leg)

### DIFF
--- a/issues/fixed/sleep-overlap-test-measured-runner-load.md
+++ b/issues/fixed/sleep-overlap-test-measured-runner-load.md
@@ -1,0 +1,80 @@
+# The async-sleep overlap test measured runner load, not overlap
+
+**Found**: 2026-08-28 — `test (macos-latest)` failed on `develop@b8a24016e` (the
+`SEED_VERSION` bump), the only red leg in an otherwise 23-green run. **Fixed**:
+same day, by proving the property structurally instead of by wall clock.
+
+## Symptom
+
+```
+✗ sleep suspends the task instead of blocking the loop
+    overlapped sleeps took 350 ms (order=11)
+    the two sleeps must overlap
+```
+
+The same test on the same run, on `ubuntu-latest`:
+
+```
+  overlapped sleeps took 200 ms (order=11)
+```
+
+The macOS runner was ~3× slow on timers that run — its own sibling line reads
+`sleep(60ms) took 198 ms`, against `60 ms` on ubuntu. So a 200 ms timer plus a
+20 ms timer measuring 350 ms is the box, not the scheduler: `order=11` was
+identical on both legs.
+
+## Why the assertion could not work
+
+`tests/time/sleep.test.yo` spawned a 200 ms sleeper and a 20 ms sleeper and
+asserted `elapsed.as_millis() < 350`, with the comment "serialized (blocking)
+sleeps would need >= 220ms plus scheduling slop".
+
+That is the whole problem. The two outcomes it had to separate are:
+
+| execution | elapsed |
+| --- | --- |
+| overlapped | ~200 ms (the longer sleep) |
+| serialized, fast first | ~220 ms (20 + 200) |
+
+**20 ms of discriminating power**, which is far below ordinary jitter on a shared
+runner. And the accompanying `order == 11` check does not close the gap: with
+`fast` running first, `order` reaches 11 through a fully SERIAL execution too
+(fast sleeps, sees `order == 0`, adds 1; slow then sleeps and adds 10). So the
+test was simultaneously flaky (fails on a slow box that is behaving correctly)
+and weak (a serial fast-then-slow implementation passes it whenever the box is
+quick).
+
+## Fix
+
+Prove the overlap with the marks themselves, so no clock is involved. The slow
+task now marks `order` BEFORE its sleep as well as after:
+
+```rust
+slow: order += 100;  await sleep(200ms);  order += 10
+fast:                await sleep(20ms);   assert(order == 100);  order += 1
+```
+
+`order == 100` at the fast task's check means the slow task had *started* and had
+*not finished* — that is overlap, at any timer speed. The three outcomes are now
+distinguishable by value: `0` (slow never started — serial, fast first), `110`
+(slow finished first — serial, slow first), `100` (overlap). The final assertion
+is `order == 111`.
+
+Wall clock is demoted to a hang guard (`< 2000 ms`), matching what the sibling
+`sleep_blocking` and `sleep` tests in the same file already use.
+
+## Verification
+
+- Passes locally with `order=111`, twice, at 201 ms and 209 ms.
+- **Catches serialization**: removing the two `io.spawn` calls so the awaits run
+  the tasks in sequence makes it fail with `fast task must finish while the slow
+  one sleeps`. The old wall-clock assertion could not have caught that at all on
+  a fast machine — 220 ms passes a `< 350 ms` bound.
+
+## Rule this is an instance of
+
+A timing assertion whose two branches differ by less than the platform's jitter
+is not a test, it is a coin flip — and it fails on the slow, correct machine
+rather than on the wrong implementation. Where a concurrency property can be
+observed through shared state, observe it there and keep wall clock for
+"did not hang".

--- a/tests/time/sleep.test.yo
+++ b/tests/time/sleep.test.yo
@@ -39,14 +39,30 @@ test("sleep waits at least the requested Duration", {
 test("sleep suspends the task instead of blocking the loop", {
   // A short sleep on one task must complete while a long sleep on another is
   // still pending — that is the whole difference from sleep_blocking.
+  //
+  // The overlap is proven STRUCTURALLY, not by wall clock. The slow task marks
+  // `order` BEFORE it sleeps and again after, so the fast task observing
+  // exactly the pre-sleep mark means the slow task had started and had not
+  // finished — which is overlap, whatever the machine's timers are doing.
+  //
+  // The previous version inferred overlap from `elapsed < 350ms`, and that was
+  // flaky in both directions: serial fast-then-slow ALSO leaves order == 11, so
+  // the discriminator was 200ms (overlapped) vs 220ms (serial) — 20ms, less
+  // than ordinary runner jitter. It failed on macos-latest for
+  // develop@b8a24016e with `350 ms (order=11)` on a box where a 60ms sleep
+  // measured 198ms, while ubuntu on the same run measured `200 ms (order=11)`
+  // (issues/fixed/sleep-overlap-test-measured-runner-load.md).
   order := Box(i32)(0);
   slow := io.async((io : Io) => {
+    order.* = (order.* + i32(100));
     io.await(sleep(Duration.from_millis(i64(200)), io), io);
     order.* = (order.* + i32(10));
   });
   fast := io.async((io : Io) => {
     io.await(sleep(Duration.from_millis(i64(20)), io), io);
-    assert(order.* == i32(0), "fast task must finish while the slow one sleeps");
+    // 100 = the slow task started and has NOT finished. 0 would mean it never
+    // started (fast ran first, serially); 110 would mean it finished first.
+    assert(order.* == i32(100), "fast task must finish while the slow one sleeps");
     order.* = (order.* + i32(1));
   });
   start := Instant.now();
@@ -56,7 +72,9 @@ test("sleep suspends the task instead of blocking the loop", {
   io.await(fast, io);
   elapsed := start.elapsed();
   unsafe(printf("  overlapped sleeps took %lld ms (order=%d)\n", elapsed.as_millis(), order.*));
-  assert(order.* == i32(11), "both tasks must have run");
-  // Serialized (blocking) sleeps would need >= 220ms plus scheduling slop.
-  assert(elapsed.as_millis() < i64(350), "the two sleeps must overlap");
+  assert(order.* == i32(111), "both tasks must have run, fast finishing mid-sleep");
+  // Wall clock is now only a hang guard, matching the sibling tests: a loaded
+  // shared runner can dilate a 200ms timer several-fold without the async
+  // scheduler being wrong about anything.
+  assert(elapsed.as_millis() < i64(2000), "overlapped sleeps should not hang");
 });


### PR DESCRIPTION
`test (macos-latest)` is the only red leg on `develop@b8a24016e` (the
`SEED_VERSION` bump — 23 other jobs green):

```
✗ sleep suspends the task instead of blocking the loop
    overlapped sleeps took 350 ms (order=11)
    the two sleeps must overlap
```

Same test, same run, `ubuntu-latest`: `200 ms (order=11)`. The macOS runner was
~3× slow on timers — its own sibling line reads `sleep(60ms) took 198 ms` against
ubuntu's `60 ms` — so 350 ms for a 200 ms plus a 20 ms sleep is the box, not the
scheduler. `order` was identical on both legs.

## The assertion could not have worked anywhere

It had to separate two outcomes:

| execution | elapsed |
| --- | --- |
| overlapped | ~200 ms (the longer sleep) |
| serialized, fast first | ~220 ms (20 + 200) |

**20 ms of discriminating power**, far below ordinary jitter on a shared runner.
And the companion `order == 11` check does not close the gap: with `fast` first,
a fully SERIAL execution also reaches 11 (fast sleeps, sees `order == 0`, adds 1;
slow then sleeps and adds 10). So the test was flaky against a correct-but-slow
machine *and* blind to a serial implementation on a quick one.

## Fix: prove the overlap through the marks, not the clock

The slow task now marks `order` before its sleep as well as after:

```rust
slow: order += 100;  await sleep(200ms);  order += 10
fast:                await sleep(20ms);   assert(order == 100);  order += 1
```

`order == 100` at the fast task's check means the slow task had started and had
not finished — overlap, at any timer speed. The outcomes now separate by value:
`0` never started, `110` finished first, `100` overlap; final assertion
`order == 111`. Wall clock is demoted to a hang guard (`< 2000 ms`), which is
what the two sibling tests in this file already use.

## Verified both directions

- Passes with `order=111` on two runs (201 ms, 209 ms).
- **Catches serialization**: removing the two `io.spawn` calls so the awaits run
  in sequence fails with `fast task must finish while the slow one sleeps`. The
  old bound could not catch that on a fast machine at all — 220 ms passes
  `< 350 ms`.

Recorded as `issues/fixed/sleep-overlap-test-measured-runner-load.md`, with the
general rule: a timing assertion whose two branches differ by less than the
platform's jitter is a coin flip that fails on the slow correct machine rather
than the wrong implementation.