### PR TITLE
std: collapse sleep_blocking to one expression — the seed gate is gone

### DIFF
--- a/plans/HANDOVER_2026_08_28.md
+++ b/plans/HANDOVER_2026_08_28.md
@@ -1,0 +1,319 @@
+# Handover — 2026-08-28
+
+Written at hand-off. Read this, then `plans/STD_API_AUDIT.md` (the campaign) and
+`plans/STD_API_AUDIT_HANDOVER.md` (the older, still-valid method notes).
+
+The standing instruction driving all of it: **finish `plans/STD_API_AUDIT.md` and
+related tasks to stabilize the std API; document and fix any surfaced bug; no
+workarounds.**
+
+---
+
+## 1. State right now
+
+**v0.2.18 is published** (2026-08-28 00:28Z, all 13 assets, marked Latest, notes
+rewritten by hand to list the breaking changes). `SEED_VERSION` auto-bumped to
+v0.2.18 on develop in `b8a24016e`. That release is what unblocked the seed-gated
+audit items — two of them are now done (§3).
+
+**develop is green except one leg**, and that leg has a fix in flight: `test
+(macos-latest)` failed on `b8a24016e` in the sleep-overlap timing test → **PR
+#324**.
+
+### Open PRs — all mine, all with zero failing legs at hand-off
+
+| PR | what | state at hand-off |
+| --- | --- | --- |
+| **#321** | dead-surface audit: JSON garbage-as-0, unchecked capacity math, ThreadPool deadlock (C32/C34/C35) | **MERGED** |
+| **#323** | release assets renamed to canonical target triples | 23 green, 9 pending |
+| **#324** | the sleep-overlap test measured runner load — develop's only red leg | 13 green, 13 pending |
+| **#325** | D5 completes: compiler reads stdin via `BufReader(Stdin)`, `std/sys/bufio` deleted | 3 green, 14 pending |
+| **#326** | `sleep_blocking` collapsed to one expression (seed gate gone) | just opened |
+
+**First job for whoever picks this up:** watch those four to green and merge them
+(#323 → #326 have no interdependencies; #325 and #326 both touch `std/` so
+expect golden renumbering — see §5.4). Nothing else is in flight; the working
+tree in `/private/tmp/yo-integ` is clean and every branch is pushed.
+
+Note develop moves fast — several other agents/PRs landed during the day
+(#310–#320: assert_eq, DateTime/Duration/Instant, ArrayList sort/binary_search,
+HashMap entry API, fs glob, log rewrite, D6 TLS). Rebase before assuming a
+conflict is yours.
+
+---
+
+## 2. What landed today
+
+- **PR #309** — S3 P0 item 6 (async combinators, `std/async/channel`,
+  `std/async/mutex`, `JoinHandle` state/abort) **plus the five CI reds** that had
+  kept develop red since 2026-08-25. The big one was **C28**: `io.await`/`io.spawn`
+  accepted any effect argument and codegen then `memcpy`'d `sizeof(IoExn)` out of
+  a smaller record — an ASan stack-buffer-overflow on every test leg.
+- **v0.2.18 released** (see §1).
+- **PR #321** — the dead-surface audit and its three fixes (§2.1).
+- **#324/#325/#326** — see the table.
+
+### 2.1 The audit method that paid for itself twice
+
+Item 6 left one loose thread: `HttpError.Timeout` is declared but never
+constructed. Chasing *that* turned into a scripted sweep of the public surface,
+which found four defects in an hour. **Reuse the sweep** — both scripts are
+one-off Python, easy to rewrite:
+
+1. Enumerate every `X :: enum(...)` in `std/`, then grep `std/ src/ tests/` for
+   producers of each variant.
+2. Same for `export(...)` symbols vs mentions under `tests/`.
+
+Two rules make the output trustworthy:
+
+- **Count BARE `.Variant` production.** A unit variant is constructed with no
+  parens and no type prefix (`=> .PermissionDenied`), which a naive
+  `Enum.Variant` grep misses entirely. My first run reported 25 false dead
+  variants because of this.
+- **Separate library-produced ERROR variants from user-supplied INPUT variants.**
+  `Optimize.ReleaseFast` and `SeekFrom.Current` having no in-tree producer is
+  correct — user code produces them. An *error* variant with no producer is a
+  lie.
+
+What it found: **C34** (`json_parse` validated no number at all — `1.`, `1e`,
+`01`, `+1` all parsed, and any non-empty garbage such as an HTML error page came
+back as the **number 0**), **C35** (every collection multiplied
+`sizeof(T) * count` unchecked — `ArrayList(u64).with_capacity(2^61)` asked malloc
+for 0 bytes and pushed outside the allocation; `ensure_total_capacity` spun
+forever), **C32** (the `ThreadPool` deadlock), **C33** (three `HttpError` variants
+that cannot occur — still open, §4.1).
+
+---
+
+## 3. Seed-gated items: two done, two left
+
+v0.2.18 lifted the gates. **Verify a gate with the real seed before writing
+code** — it took two minutes and turned "should be fine now" into a fact:
+
+```bash
+curl -fsSL -o seed.tar.gz \
+  https://github.com/shd101wyy/Yo/releases/download/v0.2.18/yo-v0.2.18-macos-arm64.tar.gz
+mkdir -p seed && tar -xzf seed.tar.gz -C seed --strip-components=1
+YO_STD=$PWD/std ./seed/bin/yo compile <two-line probe>.yo --release -o /tmp/probe
+# then the real acceptance gate:
+YO_STD=$PWD/std ./seed/bin/yo build          # must be rc=0
+```
+
+- ~~bufio consumer migration + delete `std/sys/bufio`~~ **DONE, PR #325**
+- ~~`sleep_blocking` one-expression collapse~~ **DONE, PR #326**
+- **`Command.current_dir`** — still gated, and note it needs **two** generations,
+  not one. It wants `posix_spawn_file_actions_addchdir_np`/`addchdir` wired into
+  `__yo_async_spawn_start` as a new cwd parameter. The seed emits the *shim* from
+  its own codegen, so std cannot declare an extern the seed's shim lacks:
+  generation A adds the emission (compiler-side, unused, harmless), generation B
+  uses it from std. **Generation A is not done — that is the next step for this
+  item**, and it can land any time.
+- **Native `__yo_atomic_fetch_*` wrappers** — same two-generation shape, and
+  neither side exists (`grep __yo_atomic_fetch src/ std/` is empty). This is a
+  *performance* item only: 9 of the 10 integer atomic types currently run a
+  compare-exchange loop with identical semantics. Lowest priority of the four.
+
+---
+
+## 4. What is left in the audit
+
+### 4.1 C33 — `HttpError` promises three failures the client cannot produce
+
+**The next substantive item, and the design is already worked out.**
+`issues/http-client-error-variants-never-raised.md` has the detail;
+`std/http/client.yo` declares, documents and formats `Timeout`,
+`TooManyRedirects` and `ResponseTooLarge`, and constructs none of them —
+`FetchOptions` carries only `method`, `headers`, `body`, so there is no deadline,
+no redirect cap and no size ceiling anywhere in the request path. A hung server
+blocks `fetch` forever, a 3xx comes back verbatim, and an unbounded body streams
+into memory.
+
+Implementation notes gathered while reading the module:
+
+- `FetchOptions` gains `timeout : Option(Duration)`, `max_redirects : usize`
+  (default ~10) and `max_response_bytes : usize` (default 64 MiB, `0` =
+  unlimited) plus `with_*` builders. The default ceiling IS a behaviour change —
+  this client buffers the whole body into a `String`, so it is the right default,
+  and it belongs in the release notes.
+- **ResponseTooLarge** is the easy one: `_read_http_response` appends into an
+  `ArrayList(u8)` with no bound; thread the limit in and throw.
+- **TooManyRedirects**: `HttpResponse` already has `is_redirect()` and
+  `get_header()`, so the loop is straightforward. Two traps: resolve a relative
+  `Location` against the current host/port, and a redirect to `https://` must
+  throw `UnsupportedScheme` rather than silently downgrade (that is **C1**, which
+  was already fixed once). Use a `done` flag rather than `continue`/`break`
+  inside the awaiting loop — loop-with-await state machines have a history here
+  (C24).
+- **Timeout — read this before starting.** `std/async`'s `timeout(handle, limit,
+  io)` takes a `JoinHandle`, so the request body must be spawnable, and the body
+  currently IS `fetch_with`'s own `io.async` closure. It cannot be wrapped in
+  place: a closure nested inside an `io.async` body is **C22**
+  (`issues/closure-nested-inside-io-async-closure-body-emits-abort-stub.md`,
+  OPEN — compile exits 0, clang is clean, the binary is an `abort()` stub). The
+  shape that avoids C22 is to lift the body to a top-level
+  `_fetch_inner(url, opts, io) -> Impl(Future(HttpResponse, IoExn))` and have
+  `fetch_with` do `h := e.io.spawn(_fetch_inner(...), e)` then
+  `timeout(h, limit, e.io)`, throwing `.Timeout` on `.None`.
+  A cheaper alternative — checking elapsed time inside `_read_http_response`'s
+  loop — only fires BETWEEN awaits, so it cannot interrupt a hung
+  `TcpStream.connect` or a read that never returns, which is the case a timeout
+  exists for. Do it with the race.
+
+### 4.2 Open compiler rows blocking std work
+
+From `plans/STD_API_AUDIT.md` §2. Each has an issue file with a reproducer.
+
+| row | blocks | note |
+| --- | --- | --- |
+| **C17** | `Dyn(Reader)` spelling of the bufio wrappers — the ONLY D5 remainder now | emits the on-demand Future struct into the open vtable typedef; 7 clang errors |
+| **C18** | the §1 "additive-only" promise itself | a struct literal missing a field is accepted; the real error is computed and then SWALLOWED by codegen-time closure-body evaluation. **I left a cheap first step in the issue**: measure `grep -c "Failed to transpile"` on a healthy `src/main.yo` emit; if that is 0, codegen can just REPORT the error it already has when it emits a marker — no new rejection, so no over-rejection risk, and it closes the `unit`-returning hole that `-Werror=return-type` can never reach |
+| **C19** | — | C `int` where `i32` is declared reaches codegen and emits malformed C |
+| **C22** | C33's timeout (§4.1) | nested closure inside an `io.async` body → `abort()` stub |
+| **C27** | restoring `Mutex.with_lock` in `std/async/mutex` | generic-impl closure-param return-type collapse |
+| **C29** | — | generic call type vars re-resolve per argument (`pair_same(A, A)` accepts `(String, i32)`); the memory-safety face was closed by C28's gate, wrong-value faces remain |
+
+### 4.3 Everything else
+
+- **D4 PR 9** — dedup the remaining hand-rolled UTF-8 decoders onto
+  `std/encoding/utf8.yo`. Includes `vendor/markdown_yo`, so it needs companion
+  upstream commits plus a submodule pointer bump. The submodule may already speak
+  the new API — verify before planning work.
+- **P0+ curl → `std/http`** — was blocked on TLS. **D6 TLS landed in #318**, so
+  re-assess: `src/version_cache.yo` still shells out to `curl` twice (bundle
+  download, releases list). Doing it earlier would have downgraded the toolchain's
+  release channel to cleartext, which is why it waited.
+- **P1** — HTTP server, chunked/redirect/timeout client (overlaps C33), CSV,
+  `fs.watch`, log writer sink (deferred out of #319), tty/terminal-size wrappers,
+  glob (done), entry API (done), sort (done).
+- **S5 — the freeze.** Stable/unstable markers in `yo doc`, additive-only policy
+  written into `.github/instructions/yo-design.instructions.md`. **Two inputs are
+  already measured and recorded under §9 of the audit**: the dead-surface sweep
+  (including `HashMapError.KeyNotFound` / `HashSetError.ElementNotFound`, which
+  are dead BY DESIGN — lookups return `Option` — and want DELETING in §6 before
+  the freeze, plus `std/allocator`'s unconsumed `Layout`/`layout_of`), and the
+  measurement that 1132 of 1829 `std` exports are never named under `tests/`
+  (an upper bound: it is a name grep, `std/sys`+`std/libc` dominate it, and types
+  exercised only structurally score zero — but 183 outside those raw layers want
+  a real read before anything is marked stable).
+
+---
+
+## 5. Operational knowledge you will need
+
+### 5.1 The battery
+
+Run in `/private/tmp/yo-integ` (a worktree; the main checkout is
+`/Users/yiyiwang/Workspace/Yo`). **Never run two batteries at once** — 16 GB is
+not enough and the swapping manufactures failures that do not reproduce.
+
+```bash
+YO_STD=$PWD/std yo build                    # seed builds the tree
+cp yo-out/<target>/bin/yo /tmp/yo-fresh     # copy aside; do NOT let anything swap it mid-run
+YO_STD=$PWD/std /tmp/yo-fresh check ./std   # FRESH binary — a seed check cannot see new evaluator gates
+YO_STD=$PWD/std /tmp/yo-fresh check ./src
+YO_STD=$PWD/std /tmp/yo-fresh test ./tests --exclude tests/internal --exclude tests/cli-cases --bail --disable-sanitize
+YO_SELF_BIN=/tmp/yo-fresh bash scripts/cli-diff-test.sh          # expect PASS 52 GOLDEN-DIFF 0 SKIP 1
+S1=/tmp/yo-fresh P=x bash scripts/bootstrap/gates_fast.sh        # expect failures=0
+S1=/tmp/yo-fresh P=x bash scripts/bootstrap/fixpoint_only.sh     # expect FIXPOINT_HOLDS
+BIN=/tmp/yo-fresh OUT=/tmp/hsweep bash scripts/bootstrap/hollow_sweep69.sh   # expect SWEEP_GATE_OK
+grep -c "incompatible pointer" <suite log>                       # must be 0
+```
+
+Note `YO_SELF_BIN=`, not `BIN=`, for the golden harness — a whole battery was
+wasted on that once.
+
+### 5.2 The per-file WASI sweep — add this to your battery
+
+**This found the two worst bugs of the day.** The `--bail` suite stops at the
+first failure and cannot report a HANG at all; a per-file loop with a timeout
+reports every one:
+
+```bash
+for f in $(find tests -name '*.test.yo' -not -path 'tests/internal/*' -not -path 'tests/cli-cases/*' | sort); do
+  YO_STD=$PWD/std timeout 240 /tmp/yo-fresh test "./$f" --parallel 1 --target wasm-wasi \
+    &> "logs/$(echo $f | tr / _).log"
+  echo -e "$?\t$f"
+done
+```
+
+~4 s a file, ~15 min for the corpus. rc=124 is a hang. It caught:
+
+- the **3 h 31 min CI hang**: `tests/control_fn_as_regular_call.test.yo` hands a
+  task to a `ThreadPool` and drains it, but standalone WASI has no pthreads, so
+  `join_all`'s sentinel never ran and `drained.recv()` blocked forever (C32);
+- a regression **I** introduced: a hardcoded `>> usize(32)` in the collections
+  capacity rounding, correct on 64-bit and undefined on wasm32 where `usize` is
+  **32 bits**. `with_capacity` rounded wrong there while the whole native suite
+  stayed green at 3240/3240.
+
+**`usize` is 32 bits on wasm32 and nowhere else.** Never write a bit position or
+a `1 << k` boundary; derive it (`sizeof(usize) * usize(8)`). Written up in
+`.github/instructions/testing.instructions.md`.
+
+### 5.3 Things that cost me time
+
+- **`gh pr view --json statusCheckRollup` reports a PENDING check as
+  `conclusion: ""`, not `null`.** A `!= null` filter calls every running leg a
+  failure — it made a healthy PR look like it had 14 broken legs. Filter on
+  non-empty, or use `gh api .../actions/runs/<id>/jobs`, whose `conclusion` really
+  is null while running. And a run still `in_progress` cannot have failing legs.
+- **A backtick inside a backtick template string ends the string** — including
+  inside a comment in emitted C, which every `src/codegen/` emitter writes through
+  templates. `yo fmt` then reformats the "code" that follows and the parse error
+  lands on the comment line, complaining about paren-less calls. Documented in
+  `.github/skills/yo-syntax/syntax-cheatsheet.md`.
+- **A vacuity probe must target the branch the host actually takes.** My first
+  probe edited the `x86_64-apple-darwin` arm on an aarch64 machine, passed, and
+  proved nothing. Probe the live arm and confirm it FAILS.
+- **A local named `short` (or any in-scope type name) fails with "Cannot unify
+  incompatible types: String and Type."** Known:
+  `issues/builtin-name-shadows-user-definition.md`.
+- **Golden renumbering drift is normal and must be re-recorded, not reverted** —
+  but prove it first: normalize `(struct|enum)_yo_id_\d+` and diff. Every
+  `std/` declaration added shifts the anonymous ids after it (I saw uniform +2,
+  then 0/2/4/6). `YO_SELF_BIN=<bin> bash scripts/cli-diff-test.sh lsp-completion --record`.
+- **Releases require develop's OWN run to be green**, not the PR's — the release
+  workflow has a guard that queries
+  `test.yml/runs?head_sha=<develop HEAD>&status=completed` and refuses anything
+  but `success`. It caught me dispatching while develop's run was still in
+  flight. Also: develop moves under you, so the gate applies to whatever HEAD is
+  at dispatch time.
+- **A timing assertion whose two branches differ by less than platform jitter is
+  a coin flip** that fails on the slow correct machine, not the wrong
+  implementation (PR #324 is exactly this). Where a concurrency property can be
+  observed through shared state, observe it there and keep wall clock for "did
+  not hang".
+
+### 5.4 Release naming change in flight (PR #323)
+
+Assets move to canonical Rust-style triples
+(`yo-v0.2.19-aarch64-apple-darwin.tar.gz`,
+`…-x86_64-pc-windows-msvc`, `…-x86_64-unknown-linux-musl`), decided by the
+maintainer. `plans/RELEASE_ASSET_TRIPLES.md` has the mapping table and the four
+places the name is produced/consumed. Two things to carry forward:
+
+- The maintainer said **no backward-compatibility machinery** — no duplicate
+  uploads. The triple-then-short probe that remains exists only to keep the
+  CURRENT release (v0.2.18, short names, and today's `SEED_VERSION`) working;
+  each of the four arms is marked removable.
+- **The compiler's own `--target` vocabulary is deliberately NOT changed.**
+  `src/target.yo`'s `parse_target` takes two or three dash components with no
+  vendor field, so `aarch64-apple-darwin` parses as os=`apple`/abi=`darwin` and
+  `x86_64-pc-windows-msvc` fails the arity check. Aligning them touches that
+  parser, `std/build.yo`'s ten exported `CompilationTarget` constants, every
+  `--target` string in docs/tests/cli-cases and every user's `build.yo`. If it is
+  ever wanted, do it **additively as aliases**.
+
+---
+
+## 6. Suggested order
+
+1. Merge #323–#326 as they go green (rebase on develop first; expect golden
+   drift from #325/#326).
+2. **C33** (§4.1) — the design is done; the timeout is the risky part, so try
+   that first and find out early whether C22 forces the `_fetch_inner` split to
+   be uglier than expected.
+3. **C18's cheap first step** (§4.2) — one measurement decides a small, safe
+   change that ends a whole class of silent failure.
+4. `Command.current_dir` generation A (§3) — small, unblocks the next seed.
+5. Then S5, working from the two measurements already recorded.

--- a/plans/backlog/SEED_VERSION_AUTOMATION.md
+++ b/plans/backlog/SEED_VERSION_AUTOMATION.md
@@ -54,7 +54,10 @@ paren-less prefix calls inside `src/`/`std/`
 release CONTAINING those features becomes the seed, i.e. typically the
 bump after next.
 
-**Added 2026-08-25:** collapse `std/time/sleep.yo`'s `sleep_blocking` to its
+**Added 2026-08-25, DONE 2026-08-28** (collapsed once v0.2.18 became the seed;
+verified by compiling a probe AND building the whole tree with the real v0.2.18
+bundle, both rc=0, and `tests/time/sleep.test.yo` 4/4): collapse
+`std/time/sleep.yo`'s `sleep_blocking` to its
 natural one-expression body,
 `__yo_ms_sleep(usize(duration.as_millis()))`. It is written as a two-statement
 body only because the seed predates the codegen fix in

--- a/std/time/sleep.yo
+++ b/std/time/sleep.yo
@@ -41,20 +41,9 @@ sleep :: (fn(duration : Duration, io : Io) -> Impl(Future(unit)))({
 /// Block the current thread for `duration`. Nothing else runs on this thread
 /// until it returns — inside async code use `sleep` instead.
 ///
-/// SEED-GATED, not style: the `ms` binding must stay until a released seed
-/// carries the codegen fix in
-/// `issues/fixed/inline-builtin-alias-drops-body-arguments.md`. A function body
-/// that is a SINGLE inline-builtin call is elided by codegen and re-emitted
-/// with the CALLER's arguments, so the one-expression form hands the raw
-/// `Duration` to `usleep`. The compiler in this tree rejects that form loudly
-/// — `error: invalid operands to binary expression ('__yo_t1035' (aka Duration)
-/// and 'int')` at `usleep((...) * 1000)` — but `yo build` compiles this tree
-/// with the SEED, which predates the fix, so collapsing this body breaks the
-/// bootstrap. Collapse it at the next seed bump.
-sleep_blocking :: (fn(duration : Duration) -> unit)({
-  ms := usize(duration.as_millis());
-  __yo_ms_sleep(ms)
-});
+sleep_blocking :: (fn(duration : Duration) -> unit)(
+  __yo_ms_sleep(usize(duration.as_millis()))
+);
 export(
   sleep,
   sleep_blocking


### PR DESCRIPTION
`std/time/sleep.yo`'s `sleep_blocking` kept a two-statement body purely because
`yo build` compiles this tree with the SEED, and seeds before the
inline-builtin-alias fix (`issues/fixed/inline-builtin-alias-drops-body-arguments.md`)
elided a single-inline-builtin body and re-emitted it with the CALLER's
arguments — handing the raw `Duration` to `usleep`.
`plans/backlog/SEED_VERSION_AUTOMATION.md` said to simply retry it at each seed
bump, since it fails loudly: clang rejects `invalid operands to binary expression
('Duration' and 'int')`.

Retried against the real v0.2.18 bundle (not an assumption — the bundle was
downloaded and used):

- a probe calling `sleep_blocking(Duration.from_millis(60))` compiles with that
  seed and sleeps 64 ms
- `YO_STD=$PWD/std <v0.2.18 seed>/bin/yo build` — **rc=0**
- `tests/time/sleep.test.yo` 4/4

Backlog item struck.