### PR TITLE
issues: C27 sharper diagnosis (materialization inference, not a swallow-reraise)

### DIFF
--- a/issues/generic-impl-async-method-closure-param-return-type-collapse.md
+++ b/issues/generic-impl-async-method-closure-param-return-type-collapse.md
@@ -52,3 +52,57 @@ SomeT-cell territory as C21 (`issues/fixed/async-trait-default-shares-one-impl-
 future-concrete-type.md`): the `Impl(Future(...))` SomeT of the method's return
 appears to lose its `FutureTraitT` resolution when the closure param
 participates in the capture analysis.
+
+## SHARPER DIAGNOSIS 2026-08-28 (measured after C18/C19 fixes)
+
+`YO_DEBUG_SWALLOW=1 yo check` over the repro shows the collapse IS a def-eval
+swallow, the same wall as C18/C19 — but un-swallowing it does NOT fix it, so
+it stays OPEN and is NOT a candidate for the C18/C19 flow-violation-reraise
+treatment:
+
+```
+[anon-swallow] Error: Expected expression value for "__yo_expr_to_string" argument
+[swallow] Error: Type mismatch for type member "value":    (×2)
+[swallow] Error: Cannot unify incompatible types:
+```
+
+- The io.async closure body (`r := body(self._value); return(r)`) is NOT
+  evaluated at `yo check` time (the async-closure def-eval blind spot), so
+  `print_info(r)` never fires — the type of `r` cannot be observed via check.
+- Inside the closure, `body`'s Fn-trait RETURN type is not resolved in the
+  generic-impl materialization context, so `body(self._value)` types as unit
+  and the future's output SomeT unifies to unit → `io.await(f, io)` yields
+  unit → the caller's `r == i64(10)` is the `Cannot unify: bool vs unit` the
+  user actually sees.
+- This is **generic-impl-materialization territory**, the same family as C21
+  (fixed) and C24 (fixed): the enclosing method's `T` binding and the `body`
+  closure-param type are not correctly threaded into the async closure's
+  capture/type context. C24 fixed the CAPTURE (runtime values dropped from
+  the frame); C27 is the TYPE face (the closure-param's Fn-trait return type
+  collapses), which C24's fix does not reach.
+
+### Why NOT a C18/C19-style flag fix
+
+C18/C19 are cases where a HARD, CORRECT rejection was merely swallowed —
+re-raising it via the flow-violation channel surfaces the right diagnostic.
+C27 is different: the closure body's inference produces a WRONG type (unit),
+not a rejectable error. Re-raising the swallowed "Cannot unify" would turn
+C27 into a loud error, but `with_lock` would still not WORK — the fix must
+make the closure-param return type RESOLVE correctly inside the generic-impl
+io.async body, which is genuine type-inference work in the materialization
+path.
+
+### Blast-radius note (why hasty fixes are rejected)
+
+Two attempts on 2026-08-27 both broke std and were reverted:
+1. **Uniquing the reserved "Impl" SomeT name** (`Impl$<id>`) — broke the Io
+   struct's `async` field type-member checks and `Pragma` resolution.
+2. **Skipping env-binding for "Impl"-named SomeTs in `_bind_some_type`** —
+   dropped std from 167→130 checking files.
+
+So the fix must thread the closure-param return type WITHOUT disturbing the
+shared "Impl" sugar name's resolution. This needs dedicated inference work in
+the generic-impl body-materialization path (impl.yo `_freshen_return_only_
+somes` neighborhood — the same code C21 touched), and must run the full
+battery to prove no std regression. `Mutex.with_lock` stays removed (a
+deferral, not a paper-over) until it lands.


### PR DESCRIPTION
Docs-only: refines the C27 diagnosis after the C18/C19 fixes — the generic-impl closure-param return-type collapse is a materialization inference bug (the closure body infers the WRONG type, unit), not a C18/C19-style swallow-reraise. Records why the two 2026-08-27 fix attempts broke std, so the next attempt threads the type without disturbing the shared Impl-sugar name resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)