### PR TITLE
cli: remove `yo compile --release` — it was exactly `--optimize 2`

### DIFF
--- a/.github/actions/build-stage1/action.yml
+++ b/.github/actions/build-stage1/action.yml
@@ -96,7 +96,7 @@ runs:
         set +e
         sudo systemd-run --scope -p MemoryHigh=11G -p MemoryMax=14G \
           env YO_MAIN_STACK_MB=4096 nice -n 10 "$YO_BIN" compile src/main.yo \
-            --release --allocator ${{ inputs.allocator }} --std-path ./std \
+            --optimize 2 --allocator ${{ inputs.allocator }} --std-path ./std \
             --emit-c --skip-c-compiler -o /tmp/stage1 > /dev/null
         EMIT_RC=$?
         set -e

--- a/.github/instructions/c-codegen.instructions.md
+++ b/.github/instructions/c-codegen.instructions.md
@@ -55,11 +55,11 @@ versions in the job logs first.
 
 ## Compilation commands
 
-- Emit C only: `yo compile tmp/fixme.yo --emit-c --skip-c-compiler --release`
+- Emit C only: `yo compile tmp/fixme.yo --emit-c --skip-c-compiler --optimize 2`
 - Compile with clang: `clang -std=c11 -Wall -Wextra a.out.c vendor/mimalloc/src/static.c -Ivendor/mimalloc/include -o ./a.out`
 - Add `-luring` on Linux for async Io features.
 - On Windows, use `zig` instead of `clang`.
-- Full pipeline: `yo compile tmp/fixme.yo --release -o a.out && ./a.out`
+- Full pipeline: `yo compile tmp/fixme.yo --optimize 2 -o a.out && ./a.out`
 
 `yo` is the self-hosted compiler binary from a release bundle, on `PATH`. The old
 `./yo-cli` bash shim and the TypeScript compiler it drove are gone; `tmp/fixme.yo`
@@ -74,7 +74,7 @@ versions in the job logs first.
 
 - `--sanitize address` — AddressSanitizer for memory error and leak detection
 - `--sanitize leak` — LeakSanitizer for leak detection only
-- Example: `yo compile tmp/fixme.yo --release --sanitize address --allocator system -o test && ./test`
+- Example: `yo compile tmp/fixme.yo --optimize 2 --sanitize address --allocator system -o test && ./test`
 
 ## Debug flags
 

--- a/.github/instructions/debugging.instructions.md
+++ b/.github/instructions/debugging.instructions.md
@@ -40,7 +40,7 @@ swallow handlers are capture-free `->` effect handlers, so they cannot print the
 owner themselves). Output is large — redirect stderr and grep:
 
 ```bash
-YO_DEBUG_SWALLOW=1 yo compile tmp/fixme.yo --emit-c --skip-c-compiler --release 2>swallow.txt
+YO_DEBUG_SWALLOW=1 yo compile tmp/fixme.yo --emit-c --skip-c-compiler --optimize 2 2>swallow.txt
 grep -n 'swallow' swallow.txt | tail
 ```
 
@@ -56,7 +56,7 @@ failures), `YO_DEBUG_DISPATCH` (method dispatch), `YO_DEBUG_BIND=<name>`
 ## Output debugging
 
 - Always use `| head` or `| tail` to limit command output.
-- If a command produces no output for a long time, redirect: `yo compile tmp/fixme.yo --release &> compile_output.txt`
+- If a command produces no output for a long time, redirect: `yo compile tmp/fixme.yo --optimize 2 &> compile_output.txt`
 
 ## Evaluator-only checking
 
@@ -69,7 +69,7 @@ CI's ubuntu job with `Direct leak of N byte(s)` is invisible in a local macOS
 ASan run. Reproduce locally with the macOS `leaks` tool instead:
 
 ```bash
-yo compile repro.yo --release -o repro_bin
+yo compile repro.yo --optimize 2 -o repro_bin
 leaks --atExit -- ./repro_bin   # "0 leaks for 0 total leaked bytes" = clean
 ```
 

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -51,7 +51,7 @@ bash scripts/count-transpile-failures.sh tests/sync/.yo_selftest_batch_1_0.bin.c
 ## Scratch experiments
 
 - `tmp/fixme.yo` is the scratch file for one-off experiments (`tmp*` is gitignored). It replaces the old `src/tests/fixme.yo`.
-- Type-check it with `yo check tmp/fixme.yo`; compile and run it with `yo compile tmp/fixme.yo --release -o a.out && ./a.out`.
+- Type-check it with `yo check tmp/fixme.yo`; compile and run it with `yo compile tmp/fixme.yo --optimize 2 -o a.out && ./a.out`.
 - Its contents are disposable — there is no need to restore them after modifying it.
 
 ## C codegen tests
@@ -172,7 +172,7 @@ change". The gate that has teeth:
 #    corpus that includes the inputs the refactor is ABOUT (multibyte, empty,
 #    boundary). Print every result AND its length, so a silent truncation
 #    shows up.
-yo compile tmp/probe.yo --std-path "$PWD/std" --release -o tmp/probe.bin
+yo compile tmp/probe.yo --std-path "$PWD/std" --optimize 2 -o tmp/probe.bin
 ./tmp/probe.bin > before.txt; shasum -a 256 before.txt
 # 2. AFTER: same binary rebuilt, same corpus.
 ./tmp/probe.bin > after.txt; diff before.txt after.txt     # must be EMPTY

--- a/.github/skills/yo-project-workflow/workflow-cheatsheet.md
+++ b/.github/skills/yo-project-workflow/workflow-cheatsheet.md
@@ -14,7 +14,7 @@ These commands and patterns are aimed at normal Yo projects that use the public 
 | Build and run             | `yo build run`                                            |
 | Run project test step     | `yo build test`                                           |
 | List build steps          | `yo build --list-steps`                                   |
-| Compile one file          | `yo compile main.yo --release -o app`                     |
+| Compile one file          | `yo compile main.yo --optimize 2 -o app`                     |
 | Inspect generated C       | `yo compile main.yo --emit-c --skip-c-compiler`           |
 | Run tests in one file     | `yo test ./tests/main.test.yo --parallel 1`               |
 | Filter tests by name      | `yo test ./tests/main.test.yo --test-name-pattern "Name"` |
@@ -157,7 +157,7 @@ test("Async test", {
 ```bash
 yo compile main.yo --cc clang -o app
 yo compile main.yo --cc zig -o app
-yo compile main.yo --cc emcc --release -o app
+yo compile main.yo --cc emcc --optimize 2 -o app
 yo test ./tests/main.test.yo --target wasm32-wasip1
 ```
 

--- a/.github/skills/yo-wasm-integration/wasm-integration-cheatsheet.md
+++ b/.github/skills/yo-wasm-integration/wasm-integration-cheatsheet.md
@@ -6,9 +6,9 @@ Patterns for building Yo libraries as WebAssembly modules and consuming them fro
 
 | Target               | Command                                            | Output                        |
 | -------------------- | -------------------------------------------------- | ----------------------------- |
-| Emscripten (browser) | `yo compile src/api.yo --cc emcc --release -o api` | `.js` + `.wasm`               |
+| Emscripten (browser) | `yo compile src/api.yo --cc emcc --optimize 2 -o api` | `.js` + `.wasm`               |
 | WASI (standalone)    | `yo compile src/api.yo --target wasm32-wasip1 -o api`  | `.wasm` (runs via `wasmtime`) |
-| Native (testing)     | `yo compile src/api.yo --release -o api`           | Native binary                 |
+| Native (testing)     | `yo compile src/api.yo --optimize 2 -o api`           | Native binary                 |
 
 ## WASM API design pattern
 
@@ -225,10 +225,10 @@ function readStringWithStoredLength(mod, ptr, lenPtr) {
 
 ```bash
 # Test native first (fast iteration, AddressSanitizer)
-yo compile src/wasm_api.yo --release --sanitize address -o test && ./test
+yo compile src/wasm_api.yo --optimize 2 --sanitize address -o test && ./test
 
 # Test Emscripten WASM
-yo compile src/wasm_api.yo --cc emcc --release -o npm/my_lib_wasm_api
+yo compile src/wasm_api.yo --cc emcc --optimize 2 -o npm/my_lib_wasm_api
 
 # Test WASI
 yo compile src/wasm_api.yo --target wasm32-wasip1 -o test.wasm && wasmtime test.wasm

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -74,7 +74,7 @@ jobs:
           # the site-builder compile and the `yo doc` runs the site binary
           # spawns must resolve std from the checkout, exactly like the
           # `yo build` bootstrap does.
-          yo compile scripts/build_site.yo --release -o /tmp/build-site
+          yo compile scripts/build_site.yo --optimize 2 -o /tmp/build-site
           /tmp/build-site --output yo-out/site --version "${{ inputs.version }}" --yo yo
 
       - name: Upload Pages artifact

--- a/.github/workflows/fixpoint-arm64.yml
+++ b/.github/workflows/fixpoint-arm64.yml
@@ -101,7 +101,7 @@ jobs:
           echo Y | sudo tee /sys/module/zswap/parameters/enabled || true
           sudo systemd-run --scope -p MemoryHigh=11G -p MemoryMax=14G \
             env YO_MAIN_STACK_MB=4096 nice -n 10 /usr/bin/time -v \
-            /tmp/yo-stage1 compile src/main.yo --release --allocator mimalloc \
+            /tmp/yo-stage1 compile src/main.yo --optimize 2 --allocator mimalloc \
               --std-path ./std --emit-c-to /tmp/yo-stage2.c --skip-c-compiler
           ls -la /tmp/yo-stage2.c
 
@@ -118,7 +118,7 @@ jobs:
           echo Y | sudo tee /sys/module/zswap/parameters/enabled || true
           sudo systemd-run --scope -p MemoryHigh=11G -p MemoryMax=14G \
             env YO_MAIN_STACK_MB=4096 nice -n 10 /usr/bin/time -v \
-            /tmp/yo-stage2 compile src/main.yo --release --allocator mimalloc \
+            /tmp/yo-stage2 compile src/main.yo --optimize 2 --allocator mimalloc \
               --std-path ./std --emit-c-to /tmp/yo-stage3.c --skip-c-compiler
           ls -la /tmp/yo-stage3.c
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,7 +393,7 @@ jobs:
           # the site-builder compile and the `yo doc` runs the site binary
           # spawns must resolve std from the checkout, exactly like the
           # `yo build` bootstrap does.
-          yo compile scripts/build_site.yo --release -o /tmp/build-site
+          yo compile scripts/build_site.yo --optimize 2 -o /tmp/build-site
           /tmp/build-site --output yo-out/site --version "v${{ steps.version.outputs.version }}" --yo yo
 
       # Uploaded here, DEPLOYED by the deploy-site job at the bottom of this
@@ -568,7 +568,7 @@ jobs:
         shell: bash
         env:
           YO_MAIN_STACK_MB: "4096"
-        run: yo compile src/main.yo --release --allocator mimalloc --std-path ./std -o yo-candidate
+        run: yo compile src/main.yo --optimize 2 --allocator mimalloc --std-path ./std -o yo-candidate
 
       # Two emits by the candidate: the mimalloc-flavored C for the bundle
       # binary, and the libc-flavored portable arm (published as
@@ -585,10 +585,10 @@ jobs:
           # (369.8s vs 418-429s wall on equal input) and needs no vendored
           # mimalloc in the assemble job's clang line. Linux/CI stay mimalloc
           # (glibc malloc inflates the emit's RSS ~72%).
-          ./yo-candidate compile src/main.yo --release --allocator ${{ matrix.bundle_allocator }} \
+          ./yo-candidate compile src/main.yo --optimize 2 --allocator ${{ matrix.bundle_allocator }} \
             --std-path ./std --target ${{ matrix.yo_target }} \
             --emit-c --skip-c-compiler -o "cross/yo-${{ matrix.target }}" > /dev/null
-          ./yo-candidate compile src/main.yo --release --allocator system \
+          ./yo-candidate compile src/main.yo --optimize 2 --allocator system \
             --std-path ./std --target ${{ matrix.yo_target }} \
             --emit-c --skip-c-compiler -o "portable-arm/${{ matrix.target }}" > /dev/null
           # Travel the allocator WITH the C rather than repeating it in the
@@ -815,7 +815,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/seed-smoke" && cd "$RUNNER_TEMP/seed-smoke"
           printf '%s\n' 'open(import("std/fmt"));' 'main :: (fn() -> unit)(println("hello from the yo seed"));' 'export(main);' > hello.yo
           if [ -f "$BUNDLE_DIR/bin/yo.exe" ]; then YO="$BUNDLE_DIR/bin/yo.exe"; else YO="$BUNDLE_DIR/bin/yo"; fi
-          YO_STD="$BUNDLE_DIR/std" "$YO" compile hello.yo --release -o hello 2>compile.err || { cat compile.err; exit 1; }
+          YO_STD="$BUNDLE_DIR/std" "$YO" compile hello.yo --optimize 2 -o hello 2>compile.err || { cat compile.err; exit 1; }
           cat compile.err
           if grep -q "mimalloc: error" compile.err; then
             echo "::error::The bundled compiler reported allocator errors on its own stderr — refusing to ship this bundle."
@@ -881,7 +881,7 @@ jobs:
       # The one seed-driven self-emit in this file that had NO swapfile, while
       # seed-cross-emit and test.yml's musl leg all provision
       # one. That asymmetry killed the v0.2.10 release: this job ran the same
-      # `yo compile src/main.yo --release --allocator mimalloc` its test.yml
+      # `yo compile src/main.yo --optimize 2 --allocator mimalloc` its test.yml
       # twin runs, on a bare 16 GB runner, and the runner DIED at 50 min —
       # "The hosted runner lost communication with the server ... starves it
       # for CPU/Memory", the documented starvation signature. The identical
@@ -950,7 +950,7 @@ jobs:
         env:
           YO_MAIN_STACK_MB: "4096"
         run: |
-          yo compile src/main.yo --release --allocator mimalloc \
+          yo compile src/main.yo --optimize 2 --allocator mimalloc \
             --std-path ./std --emit-c --skip-c-compiler -o yo-musl > /dev/null
           ls -la yo-musl.c
 
@@ -987,7 +987,7 @@ jobs:
         env:
           YO_MAIN_STACK_MB: "4096"
         run: |
-          ./yo-musl compile src/main.yo --release --allocator mimalloc \
+          ./yo-musl compile src/main.yo --optimize 2 --allocator mimalloc \
             --std-path ./std --emit-c --skip-c-compiler -o gate-stage2 > /dev/null
           test -s gate-stage2.c
           SIZE=$(wc -c < gate-stage2.c)
@@ -1036,7 +1036,7 @@ jobs:
             -v "$PWD:/w" -w /w/smoke -e BUNDLE="$BUNDLE" alpine:3.20 sh -euc '
               apk add --no-cache build-base liburing-dev
               YO=/w/$BUNDLE/bin/yo
-              YO_STD=/w/$BUNDLE/std $YO compile hello.yo --release -o hello 2>compile.err || { cat compile.err; exit 1; }
+              YO_STD=/w/$BUNDLE/std $YO compile hello.yo --optimize 2 -o hello 2>compile.err || { cat compile.err; exit 1; }
               cat compile.err
               # The bundled binary is built with mimalloc, whose diagnostics are
               # a correctness gate: a cross-allocator free prints
@@ -1063,7 +1063,7 @@ jobs:
           BUNDLE_DIR="$PWD/$BUNDLE"
           mkdir -p "$RUNNER_TEMP/musl-smoke" && cd "$RUNNER_TEMP/musl-smoke"
           printf '%s\n' 'open(import("std/fmt"));' 'main :: (fn() -> unit)(println("hello from the yo seed"));' 'export(main);' > hello.yo
-          YO_STD="$BUNDLE_DIR/std" "$BUNDLE_DIR/bin/yo" compile hello.yo --release -o hello 2>compile.err || { cat compile.err; exit 1; }
+          YO_STD="$BUNDLE_DIR/std" "$BUNDLE_DIR/bin/yo" compile hello.yo --optimize 2 -o hello 2>compile.err || { cat compile.err; exit 1; }
           cat compile.err
           if grep -q "mimalloc: error" compile.err; then
             echo "::error::the bundled compiler reported allocator errors on its own stderr — refusing to ship this bundle"
@@ -1090,7 +1090,7 @@ jobs:
           YO_MAIN_STACK_MB: "4096"
         run: |
           mkdir -p portable-arm
-          yo compile src/main.yo --release --allocator system \
+          yo compile src/main.yo --optimize 2 --allocator system \
             --std-path ./std --emit-c --skip-c-compiler \
             -o "portable-arm/${{ matrix.portable_target }}" > /dev/null
           ls -la "portable-arm/${{ matrix.portable_target }}.c"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -312,7 +312,7 @@ jobs:
           # `yo build` bootstrap does.
           VERSION=$(perl -ne 'print $1 if /^CURRENT_YO_VERSION :: "([^"]+)";/' src/version.yo)
           [ -n "$VERSION" ] || { echo "::error::could not read CURRENT_YO_VERSION from src/version.yo"; exit 1; }
-          yo compile scripts/build_site.yo --release -o /tmp/build-site
+          yo compile scripts/build_site.yo --optimize 2 -o /tmp/build-site
           /tmp/build-site --output yo-out/site --version "v$VERSION" --yo yo
 
       # A site build that emits nothing exits 0 exactly as happily as one that
@@ -409,7 +409,7 @@ jobs:
       # release target, which is what caught the Windows POSIX-isms at v0.2.0
       # (issues/fixed/windows-native-selfhosted-build-fails.md).
       # P2.5 step 24b (user directive): `yo build` is the canonical yo-self
-      # builder. VERIFIED equivalent to the raw `compile --release --allocator
+      # builder. VERIFIED equivalent to the raw `compile --optimize 2 --allocator
       # mimalloc` it replaces — build.yo carries the same flags (ReleaseSmall +
       # Mimalloc) and the two routes land 16 bytes apart on an 8.8 MB binary;
       # the residual ~0.77% byte delta also appears between two SAME-route
@@ -525,7 +525,7 @@ jobs:
           set +e
           sudo systemd-run --scope -p MemoryHigh=11G -p MemoryMax=14G \
             env YO_MAIN_STACK_MB=4096 nice -n 10 "$YO_BIN" compile src/main.yo \
-              --release --allocator mimalloc --std-path ./std \
+              --optimize 2 --allocator mimalloc --std-path ./std \
               --emit-c --skip-c-compiler -o /tmp/stage1 > /dev/null
           EMIT_RC=$?
           set -e
@@ -675,7 +675,7 @@ jobs:
       - name: Build the candidate compiler (previous seed, native)
         env:
           YO_MAIN_STACK_MB: "4096"
-        run: yo compile src/main.yo --release --allocator mimalloc --std-path ./std -o yo-candidate
+        run: yo compile src/main.yo --optimize 2 --allocator mimalloc --std-path ./std -o yo-candidate
 
       # Built ONCE and shared: the retired weekly workflow rebuilt the
       # candidate inside each of its four cross-emit legs — at per-PR
@@ -745,7 +745,7 @@ jobs:
         run: |
           chmod +x yo-candidate
           mkdir -p cross
-          ./yo-candidate compile src/main.yo --release --allocator system \
+          ./yo-candidate compile src/main.yo --optimize 2 --allocator system \
             --std-path ./std --target ${{ matrix.yo_target }} \
             --emit-c --skip-c-compiler -o "cross/yo-${{ matrix.target }}" > /dev/null
           ls -la "cross/yo-${{ matrix.target }}.c"
@@ -961,7 +961,7 @@ jobs:
           SAMPLER=$!
           sudo systemd-run --scope -p MemoryHigh=11G -p MemoryMax=14G \
             env YO_MAIN_STACK_MB=4096 nice -n 10 /usr/bin/time -v \
-            /tmp/yo-stage1 compile src/main.yo --release --emit-c --skip-c-compiler --allocator mimalloc -o /tmp/yo-stage2
+            /tmp/yo-stage1 compile src/main.yo --optimize 2 --emit-c --skip-c-compiler --allocator mimalloc -o /tmp/yo-stage2
           kill $SAMPLER || true
           markers=$(grep -cE '^\s*// (Failed to transpile|Unknown type:)' /tmp/yo-stage2.c || true)
           echo "stage-2 markers: $markers"
@@ -1053,7 +1053,7 @@ jobs:
           SAMPLER=$!
           sudo systemd-run --scope -p MemoryHigh=11G -p MemoryMax=14G \
             env YO_MAIN_STACK_MB=4096 nice -n 10 /usr/bin/time -v \
-            /tmp/stage2/yo-stage2-bin compile src/main.yo --release --emit-c --skip-c-compiler --allocator mimalloc -o /tmp/yo-stage3
+            /tmp/stage2/yo-stage2-bin compile src/main.yo --optimize 2 --emit-c --skip-c-compiler --allocator mimalloc -o /tmp/yo-stage3
           kill $SAMPLER || true
           if cmp -s /tmp/stage2/yo-stage2.c /tmp/yo-stage3.c; then
             echo "FIXPOINT_HOLDS: stage-2 and stage-3 C are byte-identical"
@@ -1395,7 +1395,7 @@ jobs:
         env:
           YO_MAIN_STACK_MB: "4096"
         run: |
-          yo compile src/main.yo --release --allocator mimalloc --std-path ./std \
+          yo compile src/main.yo --optimize 2 --allocator mimalloc --std-path ./std \
             --emit-c --skip-c-compiler -o yo-musl
           ls -la yo-musl.c
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,20 +233,20 @@ yo check ./std
 yo check ./tmp/fixme.yo
 
 # Emit C only (inspect generated code)
-yo compile tmp/fixme.yo --emit-c --skip-c-compiler --release
+yo compile tmp/fixme.yo --emit-c --skip-c-compiler --optimize 2
 
 # Full compile + run
-yo compile tmp/fixme.yo --release -o a.out && ./a.out
+yo compile tmp/fixme.yo --optimize 2 -o a.out && ./a.out
 
 # Compile with AddressSanitizer
-yo compile tmp/fixme.yo --release --sanitize address --allocator system -o test && ./test
+yo compile tmp/fixme.yo --optimize 2 --sanitize address --allocator system -o test && ./test
 ```
 
 Always save verbose output to a file to avoid terminal truncation:
 
 ```bash
 yo test file.yo --bail -v &> output.txt
-yo compile tmp/fixme.yo --release &> compile_output.txt
+yo compile tmp/fixme.yo --optimize 2 &> compile_output.txt
 ```
 
 ### Build system commands
@@ -325,7 +325,7 @@ yo version clean      # Remove all cached versions
 - **`yo fetch` auto-prunes stale lock entries.** When a dep is removed from `build.yo`, running `yo fetch` removes it from `yo.lock`. Global cache is not auto-cleaned.
 - **`GIT_TERMINAL_PROMPT=0`** must be set when running `git ls-remote` on potentially non-existent repos to prevent interactive credential prompts.
 - **A "move" of a named local into a struct/enum field is NOT a consumption in the evaluator.** `set_expr_as_consumed` (`src/evaluator/utils.yo`) only fires for owning temps and `own` parameters; a named local passed to a struct literal gets a deferred `___dup` (copy semantics), and the move you see in the emitted C is manufactured by the **dup/drop pair optimizer** (`_optimize_dup_drop_pairs` in `src/evaluator/exprs/begin.yo`) cancelling that dup against the scope-end drop. So a missing drop in the C is an optimizer bug, not a consumption-marking bug — and any tree walk in that optimizer family must follow `ExprInfo.macro_expansion` for macro calls (`for`, collection literals, user macros — their calls keep the macro head in the AST; the expansion is where branch structure is visible). `if(...)` no longer needs this: since 2026-08-21 it is desugared to `cond(...)` at parse time (`desugar_if_calls`, plans/MACRO_POLICY.md), so passes see the real `cond` node. See `issues/fixed/where-constraints-arraylist-96b-leak.md`.
-- **A `-O0` binary that SIGSEGVs (rc=139) on deep recursion is stack exhaustion, NOT heap corruption — don't chase ASan/malloc.** Compiled Yo programs run `main` on a worker thread whose stack defaults to 1 GiB (`__yo_main_stack` in `src/codegen/functions/generation.yo`) and is overridable at runtime via the `YO_MAIN_STACK_MB` env var. At `-O0` (the default, non-`--release` build) clang gives every temporary its own stack slot, so the big evaluator functions (`evaluate_match` ~9 MB, `evaluate_function_call` ~8 MB) have multi-MB frames; deep compile-time recursion — e.g. `derive(Eq)` over a ~46-variant enum unrolling `__yo_comptime_fold_range` once per variant — then exhausts a 1 GiB stack at ~45 levels (≈22 MB/level). This is why `check ./src` crashed under `is_executing`. **`--release` (-O2, `src/main.yo`) shrinks frames ~100× via LLVM stack coloring (only runs at `-O1`+), needing <1 MB/level — it handles 1000+ levels on 1 GiB and never hits this.** So: validate the self-hosted compiler under deep recursion either with `--release`, or keep the fast `-O0` loop and bump the stack: `YO_MAIN_STACK_MB=4096 <binary> check ./src`. Diagnose this class of crash by rc=139 with no ASan output + a sharp deterministic depth threshold (it scales linearly with the stack size). The default is kept at 1 GiB (reserved lazily) so CI runners are not asked to reserve gigabytes.
+- **A `-O0` binary that SIGSEGVs (rc=139) on deep recursion is stack exhaustion, NOT heap corruption — don't chase ASan/malloc.** Compiled Yo programs run `main` on a worker thread whose stack defaults to 1 GiB (`__yo_main_stack` in `src/codegen/functions/generation.yo`) and is overridable at runtime via the `YO_MAIN_STACK_MB` env var. At `-O0` (the default, non-`--optimize 2` build) clang gives every temporary its own stack slot, so the big evaluator functions (`evaluate_match` ~9 MB, `evaluate_function_call` ~8 MB) have multi-MB frames; deep compile-time recursion — e.g. `derive(Eq)` over a ~46-variant enum unrolling `__yo_comptime_fold_range` once per variant — then exhausts a 1 GiB stack at ~45 levels (≈22 MB/level). This is why `check ./src` crashed under `is_executing`. **`--optimize 2` (-O2, `src/main.yo`) shrinks frames ~100× via LLVM stack coloring (only runs at `-O1`+), needing <1 MB/level — it handles 1000+ levels on 1 GiB and never hits this.** So: validate the self-hosted compiler under deep recursion either with `--optimize 2`, or keep the fast `-O0` loop and bump the stack: `YO_MAIN_STACK_MB=4096 <binary> check ./src`. Diagnose this class of crash by rc=139 with no ASan output + a sharp deterministic depth threshold (it scales linearly with the stack size). The default is kept at 1 GiB (reserved lazily) so CI runners are not asked to reserve gigabytes.
 
 ## Debugging codegen / C compilation issues
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ main :: (fn() -> unit)({
 
 export(main);
 
-// $ yo compile main.yo --release -o main
+// $ yo compile main.yo --optimize 2 -o main
 // $ ./main
 ```
 

--- a/build.yo
+++ b/build.yo
@@ -3,7 +3,7 @@
 //! P2.2 of `plans/SELF_HOSTING_COMPLETION.md`: this file makes `yo build` the
 //! canonical way to build the compiler — it replaced both `bun run build` (the
 //! retired TypeScript reference) and the raw `yo compile src/main.yo
-//! --release` invocation — and doubles as the P1 build-system parity
+//! --optimize 2` invocation — and doubles as the P1 build-system parity
 //! acceptance test.
 //!
 //! Steps:
@@ -17,7 +17,7 @@
 build :: import("std/build");
 
 // ReleaseSmall maps to plain `-O2` — byte-for-byte the flags of today's
-// canonical `yo compile src/main.yo --release` build (release mode +
+// canonical `yo compile src/main.yo --optimize 2` build (release mode +
 // -O2; see the `optimize_num` mapping in src/build_runner.yo —
 // release-small → "2", and release-safe would instead drop the release flag).
 // NOT Debug: a -O0 compiler binary hits the 1 GiB main-stack ceiling on deep

--- a/docs/en-US/INSTALL_WASM.md
+++ b/docs/en-US/INSTALL_WASM.md
@@ -19,7 +19,7 @@ $ ./emsdk activate latest
 $ source ./emsdk_env.sh
 
 # Compile a Yo program to WASM
-$ yo compile main.yo --cc emcc --release -o app
+$ yo compile main.yo --cc emcc --optimize 2 -o app
 
 # This produces: app.html + app.js + app.wasm
 # Run with Node.js:

--- a/docs/en-US/INSTALL_WINDOWS.md
+++ b/docs/en-US/INSTALL_WINDOWS.md
@@ -30,7 +30,7 @@ Alternatively, you can use `zig` as the C compiler (no Visual Studio needed):
 
 ```bash
 $ choco install zig
-$ yo compile main.yo --cc zig --release -o main
+$ yo compile main.yo --cc zig --optimize 2 -o main
 ```
 
 For system library discovery, install **vcpkg**:

--- a/docs/zh-CN/CONTRIBUTING.md
+++ b/docs/zh-CN/CONTRIBUTING.md
@@ -30,11 +30,11 @@ $ git submodule update --init --recursive
 $ yo check ./src
 ```
 
-从源码构建编译器。务必加上 `--release`：在 `-O0` 下，求值器中那些大函数的栈帧有好几
+从源码构建编译器。务必加上 `--optimize 2`：在 `-O0` 下，求值器中那些大函数的栈帧有好几
 兆字节，编译期的深度递归会耗尽栈空间。
 
 ```bash
-$ yo compile src/main.yo --release -o /tmp/yo-self-bin
+$ yo compile src/main.yo --optimize 2 -o /tmp/yo-self-bin
 ```
 
 > 没有监视重建的循环 —— 改动之后重新运行上面的 `yo compile`。
@@ -43,7 +43,7 @@ $ yo compile src/main.yo --release -o /tmp/yo-self-bin
 文件放在那里）：
 
 ```bash
-$ /tmp/yo-self-bin compile ./tmp/fixme.yo --release -o /tmp/fixme && /tmp/fixme
+$ /tmp/yo-self-bin compile ./tmp/fixme.yo --optimize 2 -o /tmp/fixme && /tmp/fixme
 ```
 
 用 `yo test` 运行测试套件：

--- a/docs/zh-CN/INSTALL_WASM.md
+++ b/docs/zh-CN/INSTALL_WASM.md
@@ -18,7 +18,7 @@ $ ./emsdk activate latest
 $ source ./emsdk_env.sh
 
 # 将 Yo 程序编译为 WASM
-$ yo compile main.yo --cc emcc --release -o app
+$ yo compile main.yo --cc emcc --optimize 2 -o app
 
 # 生成：app.html + app.js + app.wasm
 # 使用 Node.js 运行：

--- a/docs/zh-CN/INSTALL_WINDOWS.md
+++ b/docs/zh-CN/INSTALL_WINDOWS.md
@@ -28,7 +28,7 @@ $ scoop install llvm
 
 ```bash
 $ choco install zig
-$ yo compile main.yo --cc zig --release -o main
+$ yo compile main.yo --cc zig --optimize 2 -o main
 ```
 
 对于系统库发现，安装 **vcpkg**：

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -206,7 +206,7 @@ main :: (fn() -> unit)({
 
 export(main);
 
-// $ yo compile main.yo --release -o main
+// $ yo compile main.yo --optimize 2 -o main
 // $ ./main
 ```
 

--- a/scripts/bootstrap/chunked_gate.sh
+++ b/scripts/bootstrap/chunked_gate.sh
@@ -27,11 +27,11 @@ N=${N:-4}
 P=${P:-chgate}
 
 echo "== building the compiler normally =="
-"$S1" compile src/main.yo --release -o "/tmp/${P}_single" --std-path ./std > "/tmp/${P}_single_build.log" 2>&1
+"$S1" compile src/main.yo --optimize 2 -o "/tmp/${P}_single" --std-path ./std > "/tmp/${P}_single_build.log" 2>&1
 echo "SINGLE_BUILD_RC=$?"
 
 echo "== building the compiler with --emit-chunks $N =="
-"$S1" compile src/main.yo --release --emit-chunks "$N" -o "/tmp/${P}_chunked" --std-path ./std > "/tmp/${P}_chunked_build.log" 2>&1
+"$S1" compile src/main.yo --optimize 2 --emit-chunks "$N" -o "/tmp/${P}_chunked" --std-path ./std > "/tmp/${P}_chunked_build.log" 2>&1
 echo "CHUNKED_BUILD_RC=$?"
 grep -E '^chunks: ' "/tmp/${P}_chunked_build.log" || true
 
@@ -40,10 +40,10 @@ for b in "/tmp/${P}_single" "/tmp/${P}_chunked"; do
 done
 
 echo "== both binaries emit the compiler's own C =="
-"/tmp/${P}_single" compile src/main.yo --release --skip-c-compiler \
+"/tmp/${P}_single" compile src/main.yo --optimize 2 --skip-c-compiler \
   --emit-c-to "/tmp/${P}_emit_single.c" --std-path ./std > "/tmp/${P}_emit_single.log" 2>&1
 echo "SINGLE_EMIT_RC=$?"
-"/tmp/${P}_chunked" compile src/main.yo --release --skip-c-compiler \
+"/tmp/${P}_chunked" compile src/main.yo --optimize 2 --skip-c-compiler \
   --emit-c-to "/tmp/${P}_emit_chunked.c" --std-path ./std > "/tmp/${P}_emit_chunked.log" 2>&1
 echo "CHUNKED_EMIT_RC=$?"
 

--- a/scripts/bootstrap/fixpoint_only.sh
+++ b/scripts/bootstrap/fixpoint_only.sh
@@ -4,7 +4,7 @@
 set -u
 cd "$(dirname "$0")/../.." || exit 2
 S1=${S1:?}; P=${P:?}
-YO_MAIN_STACK_MB=4096 "$S1" compile src/main.yo --release --emit-c --skip-c-compiler -o /tmp/${P}_stage2 &> /tmp/${P}_stage2_emit.log
+YO_MAIN_STACK_MB=4096 "$S1" compile src/main.yo --optimize 2 --emit-c --skip-c-compiler -o /tmp/${P}_stage2 &> /tmp/${P}_stage2_emit.log
 echo "STAGE2_RC=$?"
 # GATE, not a readout: a stage-2 C carrying an untranspiled body is a broken
 # compiler even when stage2 == stage3 byte-for-byte (both stages would emit the
@@ -19,6 +19,6 @@ else
 fi
 clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 /tmp/${P}_stage2.c -o /tmp/${P}_s2 2> /tmp/${P}_clang.log
 echo "CLANG_RC=$?"
-YO_MAIN_STACK_MB=4096 /tmp/${P}_s2 compile src/main.yo --release --emit-c --skip-c-compiler -o /tmp/${P}_stage3 &> /tmp/${P}_stage3_emit.log
+YO_MAIN_STACK_MB=4096 /tmp/${P}_s2 compile src/main.yo --optimize 2 --emit-c --skip-c-compiler -o /tmp/${P}_stage3 &> /tmp/${P}_stage3_emit.log
 echo "STAGE3_RC=$?"
 if cmp -s /tmp/${P}_stage2.c /tmp/${P}_stage3.c; then echo "FIXPOINT_HOLDS"; else echo "FIXPOINT_BROKEN"; cmp /tmp/${P}_stage2.c /tmp/${P}_stage3.c | head -2; fi

--- a/scripts/bootstrap/gates_fast.sh
+++ b/scripts/bootstrap/gates_fast.sh
@@ -41,7 +41,7 @@ dump_log() {
 echo "=== T1 GATE 0: repros ==="
 for r in issues/repros/box-eq-comptime-int-forall-leak.yo issues/repros/arc-spawn-capture-split.yo; do
   n=$(basename "$r" .yo)
-  timeout 900 "$S1" compile "$r" --release -o "/tmp/${P}_${n}" &> "/tmp/${P}_${n}.log"
+  timeout 900 "$S1" compile "$r" --optimize 2 -o "/tmp/${P}_${n}" &> "/tmp/${P}_${n}.log"
   rc=$?
   echo "$n compile_rc=$rc"
   if [ "$rc" != "0" ]; then
@@ -96,7 +96,7 @@ echo "=== T1 GATE 2: corpus golden scoring ==="
 # with src/ (P2.5 step 13); diff-test.sh is golden-only now, so this gate
 # ABSORBED the former GATE 2b, which ran the identical command with --golden.
 #
-# The goldens were recorded with THIS GATE'S OWN FLAGS (--release) — they are
+# The goldens were recorded with THIS GATE'S OWN FLAGS (--optimize 2; diff-test.sh's --release option emits exactly that) — they are
 # behavior-affecting, so score with the same ones. An intended behavior change
 # re-records in the same commit:
 #   scripts/diff-test.sh tests/codegen-bootstrap --release --parallel 4 --record

--- a/scripts/bootstrap/instrument_calls.py
+++ b/scripts/bootstrap/instrument_calls.py
@@ -16,7 +16,7 @@ Usage:
         --ctor 'ArrayList(u8)' --ctor Variable --fn add_variable_to_env
 
     clang -std=c11 -fno-strict-aliasing -fwrapv -w -O2 /tmp/re/s1prof.c -o /tmp/re/s1prof
-    <binary> compile src/main.yo --release --emit-c --skip-c-compiler -o /tmp/x
+    <binary> compile src/main.yo --optimize 2 --emit-c --skip-c-compiler -o /tmp/x
     python3 scripts/bootstrap/report_calls.py            # joins counts + map
 
 `--ctor NAME` matches the Yo type name in the struct's trailing comment, so it

--- a/scripts/bootstrap/probe-stack-sizing.sh
+++ b/scripts/bootstrap/probe-stack-sizing.sh
@@ -61,7 +61,7 @@ main :: (fn() -> unit)({
 export(main);
 YO
 
-"$YO" compile "$WORK/probe.yo" --release -o "$WORK/probe" > "$WORK/compile.log" 2>&1 || {
+"$YO" compile "$WORK/probe.yo" --optimize 2 -o "$WORK/probe" > "$WORK/compile.log" 2>&1 || {
   echo "::error::probe failed to compile"; tail -20 "$WORK/compile.log"; exit 1; }
 
 # Subshells with stderr closed: the SMALL run is EXPECTED to die on a signal,

--- a/scripts/diff-test.sh
+++ b/scripts/diff-test.sh
@@ -72,7 +72,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --parallel) PARALLEL="$2"; shift 2 ;;
     --cc)       CC="$2"; shift 2 ;;
-    --release)  RELEASE="--release"; shift ;;
+    --release)  RELEASE="--optimize 2"; shift ;;  # yo compile has no --release any more
     --filter)   FILTER="$2"; shift 2 ;;
     -v|--verbose) VERBOSE=1; shift ;;
     --golden)   shift ;;   # no-op: golden scoring is the only mode

--- a/src/README.md
+++ b/src/README.md
@@ -93,7 +93,7 @@ The strongest evaluator gate is not the unit suite but the self-hosted
 binary itself:
 
 ```bash
-yo compile src/main.yo --release -o /tmp/yo-self-bin         # ~6 min (always --release; -O0 hits stack ceilings)
+yo compile src/main.yo --optimize 2 -o /tmp/yo-self-bin         # ~6 min (always --optimize 2; -O0 hits stack ceilings)
 /tmp/yo-self-bin check ./std                                     # 153/153
 /tmp/yo-self-bin test ./tests --exclude tests/internal --parallel 1   # fast language suite
 # Stage-2 self-compile + fixpoint (the strongest gate of all):
@@ -104,10 +104,10 @@ bash scripts/bootstrap/fixpoint_only.sh                          # emit + clang 
 
 Compiled Yo programs run `main` on a worker thread with a 1 GiB default
 stack, overridable via `YO_MAIN_STACK_MB`. Always build the self-hosted
-binary with `--release`: at `-O0` the big evaluator functions have
+binary with `--optimize 2`: at `-O0` the big evaluator functions have
 multi-MB frames and deep compile-time recursion exhausts the stack
 (rc=139) — see the pitfall entry in `AGENTS.md`. If a deep input still
-crashes a `--release` binary, raise the stack:
+crashes a `--optimize 2` binary, raise the stack:
 
 ```bash
 YO_MAIN_STACK_MB=4096 /tmp/yo-self-bin check ./src

--- a/src/build_runner.yo
+++ b/src/build_runner.yo
@@ -635,10 +635,8 @@ compile_artifact :: (
     // every level except debug/release-safe, `mapOptimize` sends
     // release-safe/-small to -O2 and release-fast to -O3, allocator is passed
     // unconditionally, sanitize only when not "none".
-    // NOTE: no `--release` is emitted. Every level that would have set it
-    // (release-fast, release-small) also emits an explicit `--optimize` below,
-    // which supersedes it — so the flag never changed a single argv. `yo compile`
-    // now collapses `--release` into `--optimize` anyway.
+    // Only `--optimize <level>` is emitted: `yo compile` has no `--release`
+    // flag any more (it was a pure alias of `--optimize 2`, removed 2026-08-28).
     optimize_num := cond(
       (artifact.optimize == "release-safe") => String.from("2"),
       (artifact.optimize == "release-fast") => String.from("3"),

--- a/src/main.yo
+++ b/src/main.yo
@@ -1352,7 +1352,6 @@ run_compile :: (
   (compile_timeout_ms : String) = String.new();
   (skip_cc : bool) = false;
   (skip_codegen : bool) = false;
-  (release : bool) = false;
   (debug_gc : bool) = false;
   (debug_parallelism : bool) = false;
   (debug_async_await : bool) = false;
@@ -1518,8 +1517,10 @@ run_compile :: (
         ai = (ai + usize(1));
       },
       (a == "--release") => {
-        release = true;
-        ai = (ai + usize(1));
+        // Removed 2026-08-28: it was a pure alias of `--optimize 2` (no
+        // profile, no NDEBUG, no warning difference). Say so instead of
+        // failing as an unknown flag.
+        exn.throw(dyn(String.from("compile: --release was removed; use --optimize 2 (it was exactly that)")));
       },
       (a == "--debug-gc") => {
         debug_gc = true;
@@ -1590,16 +1591,6 @@ run_compile :: (
   });
   if((optimize != "") && (((optimize != "0") && (optimize != "1")) && ((optimize != "2") && (optimize != "3"))), {
     exn.throw(dyn(`compile: invalid --optimize "${optimize}". Choices: 0, 1, 2, 3`));
-  });
-  // `--release` is an ALIAS for `--optimize 2` — it selects no profile, gates
-  // nothing semantic, and never reaches `compile_module`, so the emitted C is
-  // identical with or without it. Collapse it into `optimize` HERE, so exactly
-  // ONE mechanism reaches the flag emission and the LTO gate below and the
-  // "explicit --optimize wins" precedence rule stops being a special case that
-  // every reader has to reconstruct. An explicit `--optimize` still wins simply
-  // by already being set.
-  if(release && (optimize == ""), {
-    optimize = String.from("2");
   });
   if((sanitize != "") && (((sanitize != "address") && (sanitize != "leak")) && (sanitize != "thread")), {
     exn.throw(dyn(`compile: invalid --sanitize "${sanitize}". Choices: address, leak, thread`));
@@ -1897,9 +1888,8 @@ run_compile :: (
   if(get_needs_intel_asm_syntax() && !(is_target_wasm(target)), {
     cmd.arg(String.from("-masm=intel"));
   });
-  // Optimization + warnings. `--release` was already collapsed into `optimize`
-  // above, so there is ONE mechanism here: an empty or "0" level means the -O0
-  // default, anything else is an optimized build.
+  // Optimization + warnings. `--optimize` is the ONE mechanism here: an empty
+  // or "0" level means the -O0 default, anything else is an optimized build.
   //
   // WARNINGS ARE NOT PURELY A FUNCTION OF THE OPTIMIZATION LEVEL. Generated C is
   // full of harmless noise (unused temporaries, redundant parens, pointer-sign
@@ -3779,10 +3769,10 @@ Examples:
   $ yo compile main.yo --target x86_64-unknown-linux-gnu -o app
   $ yo compile main.yo -l m -o app
   $ yo compile main.yo -I./include -L./lib -l mylib -o app
-  $ yo compile main.yo --release -D NDEBUG -o app
+  $ yo compile main.yo --optimize 2 -D NDEBUG -o app
   $ yo compile main.yo -g -o app_debug
-  $ yo compile main.yo --release -s --cflags='-march=native' -o app
-  $ yo compile main.yo --release --emit-chunks 16 -o app
+  $ yo compile main.yo --optimize 2 -s --cflags='-march=native' -o app
+  $ yo compile main.yo --optimize 2 --emit-chunks 16 -o app
                                  Split the emitted C into 16 translation units
                                  (opt-in; implies -flto=thin, --no-chunk-lto opts out)
 
@@ -3858,12 +3848,10 @@ Compile a '.yo' source file to a native executable (via C11).
 
 Options:
   -o <path>                 Output binary path
-  --release                 Optimized build (-O2; default is -O0). The usual
-                            way to build for real use.
-  --optimize <level>        Explicit C optimization level (0|1|2|3). --release
-                            is exactly --optimize 2; an explicit --optimize
-                            wins. Any level above 0 also enables the ThinLTO
-                            pairing that --emit-chunks requires.
+  --optimize <level>        C optimization level (0|1|2|3); default is -O0.
+                            Use 2 for real builds. Any level above 0 also
+                            enables the ThinLTO pairing that --emit-chunks
+                            requires.
   -g, --debug-symbols       Emit debug symbols
   -s, --strip               Strip the output binary
   --cc, --c-compiler <cc>   C compiler to use (clang|gcc|zig|emcc)
@@ -3894,8 +3882,8 @@ Options:
 
 Examples:
   $ yo compile main.yo -o app
-  $ yo compile main.yo --release --target x86_64-unknown-linux-gnu -o app
-  $ yo compile main.yo --emit-c --skip-c-compiler --release`
+  $ yo compile main.yo --optimize 2 --target x86_64-unknown-linux-gnu -o app
+  $ yo compile main.yo --emit-c --skip-c-compiler --optimize 2`
     ),
     (subcmd == "build") => Option(String).Some(
       `Usage: yo build [steps...] [options]

--- a/tests/cli-cases/addr-of-safe-code/cmd
+++ b/tests/cli-cases/addr-of-safe-code/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/await-in-later-cond-branch/cmd
+++ b/tests/cli-cases/await-in-later-cond-branch/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/await-nested-in-if-condition/cmd
+++ b/tests/cli-cases/await-nested-in-if-condition/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/compile-emit-chunks/cmd
+++ b/tests/cli-cases/compile-emit-chunks/cmd
@@ -1,2 +1,2 @@
-compile main.yo --release --emit-chunks 3 -o app
-compile main.yo --release --emit-chunks 3 -o app
+compile main.yo --optimize 2 --emit-chunks 3 -o app
+compile main.yo --optimize 2 --emit-chunks 3 -o app

--- a/tests/cli-cases/compile-undefined-call-unreferenced/cmd
+++ b/tests/cli-cases/compile-undefined-call-unreferenced/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/compile-undefined-call/cmd
+++ b/tests/cli-cases/compile-undefined-call/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/compile-undefined-method/cmd
+++ b/tests/cli-cases/compile-undefined-method/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/help-compile/expected_stdout
+++ b/tests/cli-cases/help-compile/expected_stdout
@@ -5,12 +5,10 @@ Compile a '.yo' source file to a native executable (via C11).
 
 Options:
   -o <path>                 Output binary path
-  --release                 Optimized build (-O2; default is -O0). The usual
-                            way to build for real use.
-  --optimize <level>        Explicit C optimization level (0|1|2|3). --release
-                            is exactly --optimize 2; an explicit --optimize
-                            wins. Any level above 0 also enables the ThinLTO
-                            pairing that --emit-chunks requires.
+  --optimize <level>        C optimization level (0|1|2|3); default is -O0.
+                            Use 2 for real builds. Any level above 0 also
+                            enables the ThinLTO pairing that --emit-chunks
+                            requires.
   -g, --debug-symbols       Emit debug symbols
   -s, --strip               Strip the output binary
   --cc, --c-compiler <cc>   C compiler to use (clang|gcc|zig|emcc)
@@ -41,6 +39,6 @@ Options:
 
 Examples:
   $ yo compile main.yo -o app
-  $ yo compile main.yo --release --target <TARGET> -o app
-  $ yo compile main.yo --emit-c --skip-c-compiler --release
+  $ yo compile main.yo --optimize 2 --target <TARGET> -o app
+  $ yo compile main.yo --emit-c --skip-c-compiler --optimize 2
 rc=0

--- a/tests/cli-cases/pragma-non-enum/cmd
+++ b/tests/cli-cases/pragma-non-enum/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/pragma-non-pragma-enum/cmd
+++ b/tests/cli-cases/pragma-non-pragma-enum/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/pragma-typo/cmd
+++ b/tests/cli-cases/pragma-typo/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/ptr-type-safe-code/cmd
+++ b/tests/cli-cases/ptr-type-safe-code/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/cli-cases/unsafe-call-safe-code/cmd
+++ b/tests/cli-cases/unsafe-call-safe-code/cmd
@@ -1,1 +1,1 @@
-compile main.yo --emit-c --skip-c-compiler --release
+compile main.yo --emit-c --skip-c-compiler --optimize 2

--- a/tests/specialized_inout_comptime_arg.test.yo
+++ b/tests/specialized_inout_comptime_arg.test.yo
@@ -12,7 +12,7 @@ open(import("std/fmt"));
 ///     (invalid C — hard clang error);
 ///   - a body that FORWARDS the param to another `inout` callee emitted
 ///     `f((&(x)))`, a `T**` where `T*` is expected — silently wrong under
-///     `--release` (which passes `-w`).
+///     `--optimize 2` (which passes `-w`).
 /// Root cause: the folded-const re-bind in `create_specialized_function_inline`
 /// (src/evaluator/calls/helper.yo) used `add_variable_to_env`, which hardcodes
 /// `is_ref : false`; the same defect was fixed once before in


### PR DESCRIPTION
**Do not merge before the next patch release is cut** (this touches `release.yml`); merge right after.

`--release` selected no profile, no `NDEBUG`, no warning difference — since #275 it collapsed to `if(release && optimize == "") optimize = "2"` (`src/main.yo`). Now `--optimize <level>` is the one mechanism; `--release` errors with `compile: --release was removed; use --optimize 2 (it was exactly that)`.

Swept every invocation to `--optimize 2`: `test.yml`, `release.yml`, `fixpoint-arm64.yml`, `deploy-site.yml`, `actions/build-stage1`, `scripts/bootstrap/*` (gates_fast, fixpoint_only, chunked_gate, probe-stack-sizing, instrument_calls), docs en/zh, instructions, skills, README/AGENTS/src README, twelve `tests/cli-cases/*/cmd`, and the `help-compile` golden. `scripts/diff-test.sh` keeps its own `--release` *harness* option name but emits `--optimize 2`. Seed-safe in one PR: v0.2.18 already accepts `--optimize`.

Gates (fresh binary from this tree): cli-diff **PASS 52 / GOLDEN-DIFF 0**, gates_fast **failures=0**, **FIXPOINT_HOLDS**.

Release-notes item (breaking): `yo compile --release` → `yo compile --optimize 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
