### PR TITLE
plans: handover — 2026-08-28 evening update

### DIFF
--- a/plans/HANDOVER_2026_08_28.md
+++ b/plans/HANDOVER_2026_08_28.md
@@ -9,6 +9,62 @@ workarounds.**
 
 ---
 
+## 0. Update — 2026-08-28 evening (second session)
+
+Everything below this section is the morning hand-off and is still accurate as
+history; this is what changed since.
+
+**Merged to develop:** #324 (sleep-overlap test), #326 (`sleep_blocking`),
+#325 (D5 done, `std/sys/bufio` deleted), **#328 — the compiler's `--target`
+vocabulary is the canonical Rust triple** (user decision: follow Rust, no
+compatibility; `plans/TARGET_TRIPLES.md` supersedes §5.4's "what does NOT
+change"), #323 (assets named by triple). A peer session working in the main
+checkout landed #327 (C18), #329 (C19), #330 and #332 (its own C33). Then
+**#333 — C33 reworked on top of #332**: `_read_http_response` is an `io.async`
+future, the deadline is a `yield`-driven race in `_fetch_with_deadline`
+(NOT `std/async.timeout` inside a task), six loopback-server tests, plus three
+compiler/runtime fixes the loopback tests exposed:
+
+| row | what | status |
+| --- | --- | --- |
+| C36 | dispatch-mode cond: a sibling arm's SECOND await was never awaited/extracted (chained layer with no binding; `=` re-assignment targets not recorded) — plain `http://` fetch crashed since #322 | FIXED, issues/fixed/async-cond-dispatch-skips-chained-sibling-arm.md |
+| C37 | `io.await` in a plain fn = nested blocking event loop; from inside a task it deadlocks (also `JoinHandle.await`, `join_all`/`race`/`any`/`timeout`) | OPEN — wants a runtime re-entrancy panic as its own PR, issues/sync-await-in-plain-fn-nests-the-event-loop.md |
+| C38 | while-with-await inside one match arm whose sibling awaits → struct lacks `while_loop_N_active` | OPEN, issues/while-await-inside-match-arm-missing-loop-field.md |
+| C39 | `Exception(throw: …)` handler assigning a captured `Box` fails inference | OPEN, issues/exception-handler-closure-with-box-capture-fails-inference.md |
+| C40 | `__yo_async_run_ready_tasks` drained until empty → a `yield` loop starved `__yo_io_poll` | FIXED (drain bounded to queue length at entry) |
+| C41 | Linux: `__yo_io_poll` never entered the kernel under `IORING_SETUP_DEFER_TASKRUN` → busy loops never saw timers/sockets complete (the Timeout tests hung ONLY on Linux legs) | FIXED (zero-timeout `io_uring_wait_cqe_timeout` per poll), issues/fixed/io-uring-defer-taskrun-poll-never-enters-kernel.md |
+
+**Release:** v0.2.19 dispatched from develop `5ecee4350` (run 33162545026)
+after develop's own run went green. Breaking items for its notes: Rust
+triples for `--target`/`CompilationTarget`, triple-named assets, `std/sys/bufio`
+deleted, 64 MiB default HTTP response ceiling. **Parked until the release is
+out: #335** removes `yo compile --release` (a pure `--optimize 2` alias; user
+decision) — merge it right after, then update the memory/instructions that say
+"always `--release`".
+
+**Things learned the hard way today**
+
+- **The main checkout is shared with a peer Claude session.** Never
+  `checkout -b` there; take a `/private/tmp` worktree, init submodules, copy
+  the binary out of the repo before gating. Check `gh pr list` before starting
+  an item — #332 landed a parallel C33 while mine was in the battery.
+- **A `--target`-style rename sweep must include KEY names**, not just strings
+  (the repo-root `build.yo` compares `CompilationTarget.X86_64_Linux_Gnu`).
+- **Test net code against a SPAWNED loopback server task.** The live-HTTPS
+  test alone hid a crash on the plain-http path for a full release.
+- **A test process that hangs loses its stdout AND stderr** (the runner
+  captures per test and prints on completion) — markers cannot locate a hang.
+  Use `--debug-async-await` on a standalone driver, `sample <pid>` for a
+  stack, and the CI `hollow-sweep-results` artifact for the Linux verdicts.
+- **macOS `/bin/bash` is 3.2: `&>>` is a syntax error** — a battery script
+  died silently after its second stage; use `>> f 2>&1`.
+- **GNU `sed` is on PATH** (nix); `sed -i ''` is BSD syntax and misbehaves —
+  edit with Python.
+- **Never edit the tree while a battery's fixpoint stage runs** — S1 must be
+  built from the tree the gate compiles.
+
+---
+
 ## 1. State right now
 
 **v0.2.18 is published** (2026-08-28 00:28Z, all 13 assets, marked Latest, notes


### PR DESCRIPTION
Docs only. Records what changed since the morning hand-off: triples landed (#328/#323), the C33 rework (#333) and the six compiler/runtime rows it surfaced (C36–C41), v0.2.19 dispatch, #335 parked until after the release, and the operational traps hit today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)