### PR TITLE
async runtime: `__yo_async_spawn_start_cwd` — Command.current_dir generation A

### DIFF
--- a/plans/backlog/SEED_VERSION_AUTOMATION.md
+++ b/plans/backlog/SEED_VERSION_AUTOMATION.md
@@ -99,7 +99,13 @@ consumers shed their `.Ok/.Err` arms — and `BufWriter(W)` regained
 
 ## Seed-gated follow-up (2026-08-27): `Command.current_dir`
 
-Needs `posix_spawn_file_actions_addchdir_np` (macOS) / `addchdir` (glibc
-2.29+) wired into `__yo_async_spawn_start` as a new cwd parameter — a
-runtime-shim extern signature change the seed cannot compile against.
-Add at the next seed bump alongside the other generation-gated items.
+**Generation A DONE 2026-08-28:** the runtime emits
+`__yo_async_spawn_start_cwd(file, argv, envp, stdin, stdout, stderr, cwd)` on
+all platforms (posix `posix_spawn_file_actions_addchdir_np`, weak-linked so an
+older libc reports ENOSYS; Windows `CreateProcessW` lpCurrentDirectory; wasm
+stub) and the 6-argument `__yo_async_spawn_start` std declares is a wrapper
+passing NULL. Proven by tests/process/command.test.yo under the fresh binary.
+**Generation B (once `SEED_VERSION` ≥ the release carrying this):** declare
+`__yo_async_spawn_start_cwd` in std/sys/externs.yo, make `std/sys/process.spawn`
+take `cwd : ?(*(u8))`, add `Command.current_dir(path)` + a test through the
+public API; then delete the 6-argument wrapper in a later generation.

--- a/src/codegen/async/runtime_io_common.yo
+++ b/src/codegen/async/runtime_io_common.yo
@@ -1124,8 +1124,21 @@ static uint8_t* __yo_addrinfo_next(uint8_t* ai) {
 
 extern char** environ;
 
-static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** argv, uint8_t** envp,
-                                              int32_t stdin_fd, int32_t stdout_fd, int32_t stderr_fd) {
+// posix_spawn_file_actions_addchdir_np: macOS 10.15+, glibc 2.29+, musl 1.2.5+.
+// Declared weak so a libc without it still links; the call site checks the
+// address and reports ENOSYS instead of silently spawning in the wrong cwd.
+#if !defined(__APPLE__)
+extern int posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t*, const char*) __attribute__((weak));
+#endif
+
+// The spawn shim with a working directory (NULL = inherit the parent's).
+//  Command.current_dir  (std/process) is the consumer; it is generation-gated
+// on this symbol existing in the SEED's emitted runtime, so std keeps calling
+// the 6-argument  __yo_async_spawn_start  wrapper below until the seed carries
+// this (plans/backlog/SEED_VERSION_AUTOMATION.md).
+static __yo_io_future_t* __yo_async_spawn_start_cwd(const uint8_t* file, uint8_t** argv, uint8_t** envp,
+                                                  int32_t stdin_fd, int32_t stdout_fd, int32_t stderr_fd,
+                                                  const uint8_t* cwd) {
   __yo_io_future_t* future = (__yo_io_future_t*)__yo_malloc(sizeof(__yo_io_future_t));
   memset(future, 0, sizeof(__yo_io_future_t));
 
@@ -1135,6 +1148,24 @@ static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** a
 
   posix_spawn_file_actions_t actions;
   posix_spawn_file_actions_init(&actions);
+
+  if (cwd) {
+#if !defined(__APPLE__)
+    if (!posix_spawn_file_actions_addchdir_np) {
+      posix_spawn_file_actions_destroy(&actions);
+      future->result = -ENOSYS;
+      atomic_init(&future->state, -1);
+      return future;
+    }
+#endif
+    int cd = posix_spawn_file_actions_addchdir_np(&actions, (const char*)cwd);
+    if (cd != 0) {
+      posix_spawn_file_actions_destroy(&actions);
+      future->result = -cd;
+      atomic_init(&future->state, -1);
+      return future;
+    }
+  }
 
   if (stdin_fd >= 0) {
     posix_spawn_file_actions_adddup2(&actions, stdin_fd, 0);
@@ -1162,6 +1193,13 @@ static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** a
   atomic_init(&future->state, -1);
 
   return future;
+}
+
+// Inherit the parent's working directory. This is the symbol std declares
+// today; keep it until the seed emits __yo_async_spawn_start_cwd.
+static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** argv, uint8_t** envp,
+                                              int32_t stdin_fd, int32_t stdout_fd, int32_t stderr_fd) {
+  return __yo_async_spawn_start_cwd(file, argv, envp, stdin_fd, stdout_fd, stderr_fd, NULL);
 }
 
 static __yo_io_future_t* __yo_async_waitpid_start(int32_t pid, int32_t options) {

--- a/src/codegen/async/runtime_io_wasm.yo
+++ b/src/codegen/async/runtime_io_wasm.yo
@@ -811,10 +811,15 @@ static __yo_io_future_t* __yo_async_getdents_start(int32_t fd, void* buf, uint32
 }
 
 // --- Process spawn/wait (stub — no process model on WASM) ---
+static __yo_io_future_t* __yo_async_spawn_start_cwd(const uint8_t* file, uint8_t** argv, uint8_t** envp,
+                                                  int32_t stdin_fd, int32_t stdout_fd, int32_t stderr_fd,
+                                                  const uint8_t* cwd) {
+  (void)file; (void)argv; (void)envp; (void)stdin_fd; (void)stdout_fd; (void)stderr_fd; (void)cwd;
+  return __yo_wasm_io_completed(-ENOSYS);
+}
 static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** argv, uint8_t** envp,
                                               int32_t stdin_fd, int32_t stdout_fd, int32_t stderr_fd) {
-  (void)file; (void)argv; (void)envp; (void)stdin_fd; (void)stdout_fd; (void)stderr_fd;
-  return __yo_wasm_io_completed(-ENOSYS);
+  return __yo_async_spawn_start_cwd(file, argv, envp, stdin_fd, stdout_fd, stderr_fd, NULL);
 }
 static __yo_io_future_t* __yo_async_waitpid_start(int32_t pid, int32_t options) {
   (void)pid; (void)options; return __yo_wasm_io_completed(-ENOSYS);

--- a/src/codegen/async/runtime_io_windows.yo
+++ b/src/codegen/async/runtime_io_windows.yo
@@ -3681,8 +3681,11 @@ static HANDLE __yo_win_dup_inheritable_handle(HANDLE handle) {
   return dup;
 }
 
-static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** argv, uint8_t** envp,
-                                              int32_t stdin_fd, int32_t stdout_fd, int32_t stderr_fd) {
+// See runtime_io_common.yo: the cwd-taking shim, with the 6-argument name as
+// an inherit-cwd wrapper for the seed-gated std side.
+static __yo_io_future_t* __yo_async_spawn_start_cwd(const uint8_t* file, uint8_t** argv, uint8_t** envp,
+                                                  int32_t stdin_fd, int32_t stdout_fd, int32_t stderr_fd,
+                                                  const uint8_t* cwd) {
   __yo_io_future_t* future = (__yo_io_future_t*)__yo_malloc(sizeof(__yo_io_future_t));
   memset(future, 0, sizeof(__yo_io_future_t));
 
@@ -3763,7 +3766,9 @@ static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** a
   DWORD flags = 0;
   if (env_block) flags |= CREATE_UNICODE_ENVIRONMENT;
 
-  BOOL ok = CreateProcessW(NULL, cmdline, NULL, NULL, TRUE, flags, env_block, NULL, &si, &pi);
+  wchar_t* wcwd = cwd ? __yo_win_utf8_to_wide((const char*)cwd) : NULL;
+  BOOL ok = CreateProcessW(NULL, cmdline, NULL, NULL, TRUE, flags, env_block, wcwd, &si, &pi);
+  if (wcwd) __yo_free(wcwd);
 
   CloseHandle(hStdInInherit);
   CloseHandle(hStdOutInherit);
@@ -3783,6 +3788,11 @@ static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** a
   future->result = (int32_t)pi.dwProcessId;
   atomic_init(&future->state, -1);
   return future;
+}
+
+static __yo_io_future_t* __yo_async_spawn_start(const uint8_t* file, uint8_t** argv, uint8_t** envp,
+                                              int32_t stdin_fd, int32_t stdout_fd, int32_t stderr_fd) {
+  return __yo_async_spawn_start_cwd(file, argv, envp, stdin_fd, stdout_fd, stderr_fd, NULL);
 }
 
 static __yo_io_future_t* __yo_async_waitpid_start(int32_t pid, int32_t options) {

--- a/tests/process/command.test.yo
+++ b/tests/process/command.test.yo
@@ -203,3 +203,83 @@ test("Stdio.Null discards child stdout", {
   st := io.await(child.wait(io), e);
   assert(st.success(), "echo to /dev/null exits 0");
 });
+
+// ============================================================================
+// Command.current_dir — GENERATION A (runtime symbol only)
+// ============================================================================
+// `__yo_async_spawn_start_cwd` is the spawn shim with a working directory.
+// std cannot declare it yet: `yo build` compiles std with the SEED's emitted
+// runtime, which predates the symbol (plans/backlog/SEED_VERSION_AUTOMATION.md).
+// Tests run under the FRESH binary, so this file declares the extern itself
+// and proves the symbol spawns in the requested directory on every platform.
+// Generation B (after the seed bump) switches std/sys/process to it and adds
+// `Command.current_dir`.
+{ IoFuture } :: import("std/sys/future");
+IO_process :: import("std/sys/process");
+{ GlobalAllocator } :: import("std/allocator");
+{ malloc, free } :: GlobalAllocator;
+{ create_dir_all_str, remove_dir, remove_file } :: import("std/fs/dir");
+{ exists } :: import("std/fs/file");
+{ Path } :: import("std/path");
+extern(
+  "Yo",
+  __yo_async_spawn_start_cwd : (
+    fn(
+      file : *(u8),
+      argv : *(?(*(u8))),
+      envp : ?(*(?(*(u8)))),
+      stdin_fd : i32,
+      stdout_fd : i32,
+      stderr_fd : i32,
+      cwd : ?(*(u8))
+    ) -> IoFuture
+  )
+);
+test("__yo_async_spawn_start_cwd runs the child in the requested directory (current_dir generation A)", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  dir := `yo_cwd_probe_dir`;
+  io.await(create_dir_all_str("yo_cwd_probe_dir", io), e);
+  // The child creates `marker.txt` in ITS cwd; the assertion is path-free.
+  storage := ArrayList(ArrayList(u8)).new();
+  cond(
+    (platform == Platform.Windows) => {
+      storage.push(`cmd.exe`.to_cstr());
+      storage.push(`/C`.to_cstr());
+      storage.push(`type nul > marker.txt`.to_cstr());
+    },
+    true => {
+      storage.push(`/bin/sh`.to_cstr());
+      storage.push(`-c`.to_cstr());
+      storage.push(`touch marker.txt`.to_cstr());
+    }
+  );
+  argc := storage.len();
+  argv_raw := malloc(sizeof(?(*(u8))) * (argc + usize(1))).unwrap();
+  argv_buf := *(?(*(u8)))(argv_raw);
+  j := usize(0);
+  while(runtime(j < argc), {
+    (argv_buf.add(j)).* = storage(j).ptr();
+    j = (j + usize(1));
+  });
+  (argv_buf.add(argc)).* = .None;
+  program_cstr := (argv_buf.add(usize(0))).*.unwrap();
+  cwd_c := dir.to_cstr();
+  pid := io.await(__yo_async_spawn_start_cwd(program_cstr, argv_buf, .None, i32(-1), i32(-1), i32(-1), cwd_c.ptr()), io);
+  assert(pid > i32(0), `spawn with cwd should return a pid, got ${pid}`);
+  status := io.await(IO_process.waitpid(pid, i32(0)), io);
+  assert(IO_process.exit_status(status) == i32(0), `child should exit 0, status ${status}`);
+  marker := Path.new(`yo_cwd_probe_dir/marker.txt`);
+  made := io.await(exists(marker, io), io);
+  assert(made, "the child must have run inside yo_cwd_probe_dir");
+  free(.Some(argv_raw));
+  io.await(remove_file(marker, io), e);
+  io.await(remove_dir(Path.new(dir), io), e);
+});


### PR DESCRIPTION
Generation A of the seed-gated `Command.current_dir` item (`plans/backlog/SEED_VERSION_AUTOMATION.md`).

The spawn shim gains a working-directory variant on every platform — `__yo_async_spawn_start_cwd(file, argv, envp, stdin, stdout, stderr, cwd)`: POSIX via `posix_spawn_file_actions_addchdir_np` (declared weak so a libc without it reports `ENOSYS` rather than spawning in the wrong directory), Windows via `CreateProcessW`'s `lpCurrentDirectory`, wasm a stub. The 6-argument `__yo_async_spawn_start` that std declares today becomes a wrapper passing `NULL`, so std keeps compiling against the seed's runtime.

**Generation B** (once `SEED_VERSION` ≥ the release carrying this): declare the new extern in `std/sys/externs.yo`, give `std/sys/process.spawn` a `cwd`, add `Command.current_dir(path)` + a public-API test, and later drop the wrapper.

Test: `tests/process/command.test.yo` declares the extern itself (tests run under the fresh binary, not the seed) and checks that a child spawned with `cwd` creates its marker file inside that directory — 8/8 pass. Gates (gates_fast, fixpoint) running; results in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
