### PR TITLE
docs: point the installer one-liners at the published site copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ Installs a native prebuilt compiler.
 
 ```bash
 # macOS / Linux
-$ curl -sSL https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.sh | sh
+$ curl -sSL https://shd101wyy.github.io/Yo/install.sh | sh
 ```
 
 ```powershell
 # Windows (PowerShell)
-> irm https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.ps1 | iex
+> irm https://shd101wyy.github.io/Yo/install.ps1 | iex
 ```
 
 This installs to `<prefix>/lib/yo/<tag>` and links `<prefix>/bin/yo`, with the
@@ -92,10 +92,10 @@ prefix defaulting to `$HOME/.local`. Useful options:
 
 ```bash
 # a specific release, system-wide
-$ curl -sSL https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.sh | sh -s -- --version=v0.2.4 --prefix=/usr/local
+$ curl -sSL https://shd101wyy.github.io/Yo/install.sh | sh -s -- --version=v0.2.4 --prefix=/usr/local
 
 # build from source with your own toolchain
-$ curl -sSL https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.sh | sh -s -- -cc=gcc -cflags='-march=native'
+$ curl -sSL https://shd101wyy.github.io/Yo/install.sh | sh -s -- -cc=gcc -cflags='-march=native'
 ```
 
 **Platforms without a prebuilt bundle** — pass `--from-source`. The installer

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -69,12 +69,12 @@ Yo 的目标是 **简单** 和 **快速**（比 C 语言慢约 0% - 15%）。
 
 ```bash
 # macOS / Linux
-$ curl -sSL https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.sh | sh
+$ curl -sSL https://shd101wyy.github.io/Yo/install.sh | sh
 ```
 
 ```powershell
 # Windows（PowerShell）
-> irm https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.ps1 | iex
+> irm https://shd101wyy.github.io/Yo/install.ps1 | iex
 ```
 
 安装到 `<prefix>/lib/yo/<tag>`，并在 `<prefix>/bin/yo` 创建链接，`prefix` 默认为
@@ -92,10 +92,10 @@ $ curl -sSL https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/insta
 
 ```bash
 # 安装指定版本，系统级安装
-$ curl -sSL https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.sh | sh -s -- --version=v0.2.4 --prefix=/usr/local
+$ curl -sSL https://shd101wyy.github.io/Yo/install.sh | sh -s -- --version=v0.2.4 --prefix=/usr/local
 
 # 使用自己的工具链从源码构建
-$ curl -sSL https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.sh | sh -s -- -cc=gcc -cflags='-march=native'
+$ curl -sSL https://shd101wyy.github.io/Yo/install.sh | sh -s -- -cc=gcc -cflags='-march=native'
 ```
 
 **没有预编译包的平台** —— 使用 `--from-source`。安装脚本会下载该版本的单文件

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,6 +1,6 @@
 # Installation script for Yo on Windows (PowerShell); use -Help to see options.
 #
-#   irm https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.ps1 | iex
+#   irm https://shd101wyy.github.io/Yo/install.ps1 | iex
 #
 # Installs a prebuilt release bundle. Yo is self-hosted: the bundle carries the
 # native compiler plus the standard library and the vendored mimalloc sources,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------
 # Installation script for Yo on Linux and macOS; use -h to see options.
 #
-#   curl -fsSL https://raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/install.sh | sh
+#   curl -fsSL https://shd101wyy.github.io/Yo/install.sh | sh
 #
 # Installs a prebuilt release bundle. Yo is self-hosted: the bundle carries the
 # native compiler plus the standard library and the vendored mimalloc sources,


### PR DESCRIPTION
README (en + zh-CN) and the usage headers of `scripts/install.sh` / `install.ps1` named the branch-pinned `raw.githubusercontent.com/shd101wyy/Yo/develop/scripts/...` path. The site build (`scripts/build_site.yo`, "installer contract") publishes both scripts at the site root, so the documented one-liners are now

```
curl -sSL https://shd101wyy.github.io/Yo/install.sh | sh
irm https://shd101wyy.github.io/Yo/install.ps1 | iex
```

Companion: vendor/markdown_yo's workflows (PR #339) switch to the same URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)