### PR TITLE
S5 freeze: yo doc stability marker + std API stability policy

### DIFF
--- a/.github/instructions/yo-design.instructions.md
+++ b/.github/instructions/yo-design.instructions.md
@@ -141,9 +141,18 @@ AF_INET6 :: cond(
 
 Current goal: make Yo work on Linux, macOS, and Windows.
 
-## Breaking changes are acceptable
+## API stability: the language may still break, `std` may not
 
-Yo is a new, evolving language. Don't worry about breaking changes when making design decisions.
+Yo the LANGUAGE is still evolving — language-level breaking changes are acceptable when the design calls for them. The STANDARD LIBRARY closed its breaking window with the S2 sweep (`plans/STD_API_AUDIT.md` §1, §5–§6): every `std` module is **stable** unless its module doc carries a `## Stability` section, and stable modules change **additively only**:
+
+- Additive = new modules, new exported functions/types/constants, new trait impls, new enum variants only where the enum is documented as non-exhaustive, new optional builder methods, wider accepted inputs, bug fixes that make behaviour match the documentation. Renames, signature changes, removed exports, changed error variants, changed defaults and changed wire/serialization formats are NOT additive — they need a documented deprecation (`# Deprecated` doc section on the old name, kept working) and land only with a new module or as a parallel API.
+- A NEW module enters as `unstable` for one release: its inner doc ends with
+  ```
+  //! ## Stability
+  //! unstable — new in vX.Y.Z; the API may still change until the next release.
+  ```
+  `yo doc` renders the marker (HTML badge, `"stability"` in JSON, a note in Markdown); the audit's §7 table records when a module was frozen. Drop the section to freeze it.
+- Dead surface is not "stable": an export with no consumer and no test is deleted BEFORE it is frozen (the §6 rule), never marked stable by default. Freezing an export no test exercises is how a broken API becomes permanent (C34).
 
 ## Compile-time only functions must use `comptime` return types
 

--- a/issues/doc-sections-require-double-hash-but-std-writes-single-hash.md
+++ b/issues/doc-sections-require-double-hash-but-std-writes-single-hash.md
@@ -1,0 +1,20 @@
+# `yo doc` recognizes only `## Section` headings, but std writes `# Examples` (70 sites) — those sections are never extracted
+
+**Status: OPEN.** Found 2026-08-29 adding the `## Stability` module marker
+(plans/STD_API_AUDIT.md §9 S5). **Severity:** LOW (rendering only): the text
+still appears inside the description, but `# Examples` / `# Returns` /
+`# Deprecated` written with a single `#` are not parsed as the well-known
+sections (`src/doc/sections.yo` `is_section_heading_` requires `## `), so the
+Examples/Deprecated banners and JSON fields are missing for most of std.
+
+Counts (2026-08-29): 70 `//! # …` / `/// # …` headings vs 5 `## …` in `std/`.
+
+## Fix options
+
+1. Accept both `# ` and `## ` as section headings when the heading text is a
+   well-known section name (`is_known_section`), keeping arbitrary `#`
+   headings as description content.
+2. Normalise std to `## `.
+
+Option 1 is the robust one (users will write either); do 2 as well for
+consistency. Regression test: `tests/internal/doc_sections.test.yo`.

--- a/plans/D6_TLS_PLAN.md
+++ b/plans/D6_TLS_PLAN.md
@@ -93,5 +93,13 @@ throwing `UnsupportedScheme` — std stays honest.
    response loop, default port 443, live https fetch pinned. (The
    build-without-OpenSSL error message polish is deferred; the linker names
    the missing library, which suffices.)
-3. P0+ curl swap in `src/fetch.yo`/`version_cache.yo` (measure first — the
+3. **BLOCKED 2026-08-29 on Windows TLS (Schannel).** `version_cache.yo`'s two
+   curl calls are `https://api.github.com` + release-asset downloads; swapping
+   them onto `std/http` makes the COMPILER BINARY depend on `TlsStream`, which
+   today is OpenSSL-only — `yo version install` / `yo version list --remote`
+   would lose TLS on Windows (no OpenSSL on the runners or on user machines),
+   and every from-source build of the compiler (`yo.c`, `install.sh`) would
+   need libssl headers. Re-open once Schannel lands with the Windows platform
+   audit; until then curl stays (it is present on every supported OS).
+   Original item: P0+ curl swap in `src/fetch.yo`/`version_cache.yo` (measure first — the
    row notes it is blocked on this).

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -512,7 +512,7 @@ Open D7 items:
 | process | EXTEND | Child/spawn/Stdio + env + builders-return-Self + `code() -> Option(i32)` DONE 2026-08-27; still: `current_dir` (seed-gated runtime shim), hide `raw` (needs module-private visibility) |
 | cli | EXTEND or DROP-TO-PACKAGE | typed values, required enforcement, `--`, repeated opts, help-not-an-error; needs tty/color access (D8 wrappers). Recommendation: keep minimal-but-correct in std |
 | net | FIX + EXTEND | C2/C3 DONE; `Shutdown` enum DONE; usize counts DONE; UnixStream/UnixListener DONE 2026-08-27 (incl. their Reader/Writer impls); still: `incoming()`, UDP `connect` + typed `recv_from`, `parse_v6`, `SocketAddr.parse`, `Eq`/`Hash` on addr types, RFC 5952 V6 formatting |
-| http | FIX + EXTEND | C1 DONE; ~~https over TLS~~ **DONE 2026-08-28** (D6 PR-2: scheme branch, shared generic Reader response loop, TcpStream|TlsStream transport, default port 443); still: timeouts (dead `Timeout` variant becomes real), redirects (needs `Url.join`), chunked decoding, binary bodies, keep-alive; **server (P1)**: `parse_request`, `HttpServer` on `TcpListener`; collapse `FetchOptions` into `HttpRequest` |
+| http | FIX + EXTEND | C1 DONE; ~~https over TLS~~ **DONE 2026-08-28** (D6 PR-2: scheme branch, shared generic Reader response loop, TcpStream|TlsStream transport, default port 443); still: timeouts (dead `Timeout` variant becomes real), redirects (needs `Url.join`), chunked decoding, binary bodies, keep-alive; **server (P1)**: `parse_request`, `HttpServer` on `TcpListener`; collapse `FetchOptions` into `HttpRequest`; the compiler's own curl→`std/http` swap (D6 PR-3) is **BLOCKED on Windows TLS** (plans/D6_TLS_PLAN.md item 3) |
 | async | PROMOTE | combinator home: `join_all`, `race`, `any`, `timeout`, interval, cancellation for `JoinHandle` (`abort()`), async channel/mutex (D7). `sleep(Duration, io)` lives in `std/time/sleep.yo` — do NOT add a second one; re-export if wanted |
 | thread/worker/sync | REDESIGN (D7) | ThreadPool DONE; `join() -> T` + panic propagation blocked below std — see D7 |
 | time | EXTEND | ~~`Duration`: `Add/Sub` operators, `Eq/Ord/Hash`, `from_secs_f64`, `subsec_*`, consts~~ + ~~`Instant` `add/sub`, `Eq/Ord`~~ **DONE 2026-08-28** (PR #312: operators mirror add/sub incl. zero-saturation, total-nanos Hash, from_secs_f64 clamps negatives, SECOND…HOUR consts, Instant.sub clamps at clock zero); **make std USE it** (timeouts, sleeps); ~~`DateTime`: RFC3339 `parse`/`format`, component ctor, arithmetic, `Eq/Ord`~~ **DONE 2026-08-28** (leap-aware `parse` incl. lowercase t/z + space separator + nano fractions + numeric offsets, typed `DateTimeError`, validating `new`, `add`/`sub(Duration)` offset-preserving, INSTANT-basis `Eq`/`Ord` + `to_unix_utc`; `to_string` was already RFC3339 — round-trip pinned); sleep unification DONE (§5) |
@@ -742,8 +742,20 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
    change.)
 4. **S3 — P0 additions.** ← next after D5 slice 2
 5. **S4 — P1 additions.**
-6. **S5 — stability freeze:** stable/unstable markers in `yo doc` output,
-   additive-only policy documented in `yo-design.instructions.md`.
+6. **S5 — stability freeze:** ~~stable/unstable markers in `yo doc` output,
+   additive-only policy documented in `yo-design.instructions.md`~~ **DONE
+   2026-08-29**: a module's inner doc may end with a `## Stability` section
+   (`unstable — new in vX.Y.Z; …`); `yo doc` carries it as
+   `DocModule.stability` (HTML badge, `"stability"` in JSON, a note on the
+   Markdown module page + an index badge). Every std module without the
+   section is stable and additive-only — the policy, what counts as
+   additive, the one-release `unstable` entry rule and the deprecation path
+   are in `.github/instructions/yo-design.instructions.md` ("API stability").
+   `std/encoding/csv` is the first module carrying the marker (new in this
+   release); `std/http/server` and `std/fs/watch` get it in their own PRs.
+   Found en route: `yo doc` only recognises `## ` section headings while std
+   writes `# Examples` at 70 sites
+   (issues/doc-sections-require-double-hash-but-std-writes-single-hash.md).
 
    **Two inputs measured 2026-08-27, to be worked before the freeze:**
 
@@ -758,7 +770,12 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
      (**C35** — same, the check was missing, now FIXED), and
      `HashMapError.KeyNotFound` / `HashSetError.ElementNotFound`, which are dead
      BY DESIGN (lookups return `Option`) and want DELETING here, in §6, since
-     removing a public variant is breaking. `std/allocator`'s `Layout` /
+     removing a public variant is breaking. **SEED-GATED (measured 2026-08-29):**
+     with both variants gone the two enums have identical shapes and the
+     v0.2.19 seed — which predates C46's nominal-enum exact compare (#343) —
+     conflates them across the std module graph (`check ./std` fails in
+     `hash_set.yo` under the seed, passes under develop's compiler). Delete
+     them in the first PR after SEED_VERSION advances past #343. `std/allocator`'s `Layout` /
      `layout_of` are unconsumed too — no `alloc(Layout)` entry point exists —
      which needs the same delete-or-implement decision. The struct-field face of
      the sweep came back clean apart from reflection metadata and

--- a/src/doc/builder.yo
+++ b/src/doc/builder.yo
@@ -86,6 +86,23 @@ extract_doc_sections :: (fn(doc : Option(String)) -> DocSections)(
     }
   )
 );
+/// The module's stability marker: the first line of its `## Stability` doc
+/// section verbatim (`unstable — new in v0.2.20; …`), or `.None` when the
+/// module has none. Renderers key the badge on its first word.
+module_stability :: (fn(doc : Option(String)) -> Option(String))(
+  match(
+    doc,
+    .None => Option(String).None,
+    .Some(text) => match(
+      parse_doc_comment(text).sections.get(String.from("stability")),
+      .None => Option(String).None,
+      .Some(sec) => {
+        first := match(sec.split(`\n`).get(usize(0)), .Some(l) => l, .None => sec);
+        Option(String).Some(first.trim())
+      }
+    )
+  )
+);
 /// Build a lookup map from declaration name → doc comment content.
 /// Mirrors `buildDocLookup` (builder.ts:110).
 build_doc_lookup :: (fn(extraction : DocExtractionResult) -> HashMap(String, String))({
@@ -1630,6 +1647,7 @@ build_doc_module_from_tokens :: (
     name : name,
     path : path,
     doc : module_doc,
+    stability : module_stability(module_doc),
     functions : ArrayList(DocFunction).new(),
     types : types,
     traits : ArrayList(DocTrait).new(),
@@ -2299,6 +2317,7 @@ build_doc_module :: (
     name : name.clone(),
     path : path.clone(),
     doc : module_doc,
+    stability : module_stability(module_doc),
     functions : functions,
     types : types,
     traits : traits,

--- a/src/doc/model.yo
+++ b/src/doc/model.yo
@@ -172,6 +172,11 @@ DocModule :: struct(
   name : String,
   path : String,
   doc : Option(String),
+  /// Stability marker from the module's `## Stability` doc section — `unstable`
+  /// while a new module settles (plans/STD_API_AUDIT.md §1: additive-only
+  /// changes once stable; new modules enter with this marker for one release).
+  /// `.None` = stable (the default for every std module).
+  stability : Option(String),
   functions : ArrayList(DocFunction),
   types : ArrayList(DocType),
   traits : ArrayList(DocTrait),

--- a/src/doc/render_html.yo
+++ b/src/doc/render_html.yo
@@ -1473,6 +1473,14 @@ _render_module_content :: (
   html := `<div class="breadcrumb"><a href="../index.html">Home</a> &rsaquo; ${_escape_html(m.name)}</div>`;
   html.push_string(`<h1>Module <code>${_escape_html(m.name)}</code></h1>`);
   html.push_string(`<div class="module-path">${_escape_html(m.path)}</div>`);
+  match(
+    m.stability,
+    .None => (),
+    .Some(st) => {
+      level := match(st.split(` `).get(usize(0)), .Some(w) => w.to_lowercase(), .None => st.to_lowercase());
+      html.push_string(`<div class="stability stability-${_escape_html(level)}"><strong>Stability: ${_escape_html(st)}</strong> — stable modules only change additively; this one may still change.</div>`);
+    }
+  );
   html.push_string(_render_doc(m.doc));
   if(m.types.len() > usize(0), {
     html.push_str("<h2>Types</h2>\n<div class=\"item-list\">");

--- a/src/doc/render_html_assets.yo
+++ b/src/doc/render_html_assets.yo
@@ -237,6 +237,11 @@ generate_css :: (fn() -> String)({
   s.push_str("  font-family: var(--font-mono);\n");
   s.push_str("  margin-bottom: 16px;\n");
   s.push_str("}\n");
+  s.push_str(".stability {\n");
+  s.push_str("  margin: 0.5rem 0 1rem 0; padding: 0.5rem 0.75rem; border-radius: 6px;\n");
+  s.push_str("  border: 1px solid #d8a200; background: #fff7d6; color: #5a4300;\n");
+  s.push_str("}\n");
+  s.push_str(".stability-unstable strong { color: #a36b00; }\n");
   s.push_str("\n");
   s.push_str(".doc-content {\n");
   s.push_str("  margin: 12px 0 24px;\n");

--- a/src/doc/render_json.yo
+++ b/src/doc/render_json.yo
@@ -372,6 +372,7 @@ _module_to_json :: (fn(m : DocModule) -> JsonValue)({
   _obj_add_str(keys, vals, String.from("name"), m.name.clone());
   _obj_add_str(keys, vals, String.from("path"), m.path.clone());
   _obj_add_opt_str(keys, vals, String.from("doc"), m.doc);
+  _obj_add_opt_str(keys, vals, String.from("stability"), m.stability);
   _obj_add(keys, vals, String.from("functions"), _functions_to_json(m.functions));
   t_vals := ArrayList(JsonValue).new();
   (ti : usize) = usize(0);

--- a/src/doc/render_markdown.yo
+++ b/src/doc/render_markdown.yo
@@ -600,6 +600,14 @@ render_module_md :: (fn(mod : DocModule) -> String)({
   lines.push(`> Module path: \`${mod.path}\``);
   lines.push(``);
   match(
+    mod.stability,
+    .None => (),
+    .Some(st) => {
+      lines.push(`> **Stability: ${st}** — stable modules only change additively; this one may still change.`);
+      lines.push(``);
+    }
+  );
+  match(
     mod.doc,
     .None => (),
     .Some(d) => {
@@ -784,7 +792,13 @@ render_index_md :: (fn(model : DocModel) -> String)({
         ` — ${first_line}`
       }
     );
-    lines.push(`- [\`${mod.path}\`](module/${mod.name}.md) (${item_count.to_string()} items)${summary}`);
+    badge_word := match(
+      mod.stability,
+      .None => ``,
+      .Some(st) => match(st.split(` `).get(usize(0)), .Some(w) => w.to_lowercase(), .None => st)
+    );
+    badge := if(badge_word.is_empty(), ``, ` _(${badge_word})_`);
+    lines.push(`- [\`${mod.path}\`](module/${mod.name}.md)${badge} (${item_count.to_string()} items)${summary}`);
     i = (i + usize(1));
   });
   lines.push(``);

--- a/src/doc/sections.yo
+++ b/src/doc/sections.yo
@@ -179,6 +179,7 @@ is_known_section :: (fn(name : String) -> bool)({
     (lower == `examples`) => true,
     (lower == `safety`) => true,
     (lower == `deprecated`) => true,
+    (lower == `stability`) => true,
     true => false
   )
 });

--- a/std/encoding/csv.yo
+++ b/std/encoding/csv.yo
@@ -16,6 +16,9 @@
 //! rows := csv_parse(String.from("a,b\n1,\"x,y\"\n"));   // Result(ArrayList(ArrayList(String)), CsvError)
 //! text := csv_write(rows.unwrap());                      // `a,b\n1,"x,y"\n`
 //! ```
+//!
+//! ## Stability
+//! unstable — new in v0.2.20; the API may still change until the next release.
 open(import("../string"));
 { ArrayList } :: import("../collections/array_list");
 { Error } :: import("../error");

--- a/tests/cli-cases/doc-html/expected_tree
+++ b/tests/cli-cases/doc-html/expected_tree
@@ -1,6 +1,6 @@
-./docs-out/index.html	6ac8bd8c7d31e73f589595910af9887cb4ecfe96ec73874c53a6eb4712be82e3
-./docs-out/module/point.html	2b52aa2fefbc87efadeaeaccd2a98826d55d56b6c66eba3e538ccebadb8d71d6
-./docs-out/module/shapes.html	32610626839bd6d91dd4b9a77efee90a023453bde264fcf41ba960b85a86468f
+./docs-out/index.html	b726c64e60058714ec2244173eb68b74bf5365ad858c30694f8cf573cb1c82b2
+./docs-out/module/point.html	299c39204a36a318ea86e1b750d0c6127e43daa916faa4cc0f5d1b841eff35f2
+./docs-out/module/shapes.html	6edd90c03de603032af6c51605eb804b3e8e3e07f2d3939bf429eba67b409f43
 ./package.json	d6fac2e5150817020bb2e539eb133ed4d41ed46af982482f4d46feb699f0cb54
 ./point.yo	0d86ca29b7301a6148a1cf1f7f0587046504b6198b5dcdc1b1b6e31c773ee954
 ./shapes.yo	901694877051083dcc2e8df1cb25278e3c6b079bea8aadcf39540f0046ccc286

--- a/tests/internal/doc_render_markdown.test.yo
+++ b/tests/internal/doc_render_markdown.test.yo
@@ -139,6 +139,7 @@ make_module_ :: (fn() -> DocModule)({
     name : `math`,
     path : `std/math`,
     doc : Option(String).Some(`Math utilities.`),
+    stability : Option(String).None,
     functions : fns,
     types : types,
     traits : traits,
@@ -570,6 +571,7 @@ test("renderModuleMd: renders empty module without content sections", {
     name : `empty`,
     path : `std/empty`,
     doc : Option(String).None,
+    stability : Option(String).None,
     functions : ArrayList(DocFunction).new(),
     types : ArrayList(DocType).new(),
     traits : ArrayList(DocTrait).new(),
@@ -596,6 +598,7 @@ test("renderIndexMd: uses first line of module doc as summary", {
     name : m.name,
     path : m.path,
     doc : Option(String).Some(`First line summary.\nMore details here.`),
+    stability : Option(String).None,
     functions : m.functions,
     types : m.types,
     traits : m.traits,
@@ -606,4 +609,27 @@ test("renderIndexMd: uses first line of module doc as summary", {
   model := DocModel(name : `proj`, modules : modules, version : Option(String).None);
   md := render_index_md(model);
   assert(md.contains(`First line summary.`), "summary from first line");
+});
+// ── stability marker (plans/STD_API_AUDIT.md §1: new modules enter `unstable`) ──
+test("renderModuleMd: renders the stability note and the index badge", {
+  m := make_module_();
+  um := DocModule(
+    name : m.name,
+    path : m.path,
+    doc : m.doc,
+    stability : Option(String).Some(`unstable`),
+    functions : m.functions,
+    types : m.types,
+    traits : m.traits,
+    constants : m.constants,
+    submodules : m.submodules
+  );
+  md := render_module_md(um);
+  assert(md.contains(`**Stability: unstable**`), "module page carries the stability note");
+  stable_md := render_module_md(m);
+  assert(!(stable_md.contains(`Stability:`)), "a stable module has no note");
+  modules := ArrayList(DocModule).new();
+  modules.push(um);
+  idx := render_index_md(DocModel(name : `proj`, modules : modules, version : Option(String).None));
+  assert(idx.contains(`(module/math.md) _(unstable)_`), "index badge");
 });

--- a/tests/internal/doc_sections.test.yo
+++ b/tests/internal/doc_sections.test.yo
@@ -134,6 +134,7 @@ test("recognizes known sections", {
   assert(is_known_section(`returns`), "returns is known");
   assert(is_known_section(`errors`), "errors is known");
   assert(is_known_section(`panics`), "panics is known");
+  assert(is_known_section(`stability`), "stability is known (module freeze marker)");
   assert(is_known_section(`examples`), "examples is known");
   assert(is_known_section(`safety`), "safety is known");
   assert(is_known_section(`deprecated`), "deprecated is known");
@@ -147,4 +148,10 @@ test("rejects unknown sections", {
   assert(!(is_known_section(`notes`)), "notes is not known");
   assert(!(is_known_section(`see also`)), "see also is not known");
   assert(!(is_known_section(`todo`)), "todo is not known");
+});
+test("parses a module-level ## Stability section", {
+  parsed := parse_doc_comment(`CSV reader and writer.\n\n## Stability\nunstable — new in v0.2.20; the API may still change.`);
+  assert(parsed.summary == `CSV reader and writer.`, "summary unaffected");
+  st := match(parsed.sections.get(`stability`), .Some(v) => v, .None => ``);
+  assert(st.starts_with(`unstable`), `stability section content: ${st}`);
 });


### PR DESCRIPTION
plans/STD_API_AUDIT.md §9 S5 — "stable/unstable markers in yo doc output, additive-only policy documented in yo-design.instructions.md".

## What
- **`yo doc` stability marker.** A module's inner doc may end with a `## Stability` section (`unstable — new in vX.Y.Z; …`). `sections.yo` knows the heading; the builder carries the first line verbatim as `DocModule.stability`; renderers show it — HTML badge (new `.stability` CSS), `"stability"` in JSON, a note on the Markdown module page and an `_(unstable)_` index badge. Tests: `tests/internal/doc_sections.test.yo` (+1), `doc_render_markdown.test.yo` (+1). The `doc-html` golden was re-recorded: the only diff is the added CSS rule (verified by diffing old vs new output for the fixture, 15 lines = 5 × 3 pages).
- **Policy.** `yo-design.instructions.md`'s "Breaking changes are acceptable" is replaced by "API stability: the language may still break, `std` may not" — what counts as additive, the one-release `unstable` entry for new modules, the deprecation path, and the dead-surface rule.
- `std/encoding/csv` carries the first marker (new this release). `std/http/server` and `std/fs/watch` get theirs in #351 / #348.
- **D6 PR-3** (the compiler's own curl→`std/http` swap) recorded as **blocked on Windows TLS** (Schannel): `yo version install` would lose TLS on Windows and every from-source compiler build would need libssl headers.
- **Dead variants** `HashMapError.KeyNotFound` / `HashSetError.ElementNotFound`: deletion measured and found **seed-gated** — the v0.2.19 seed (pre-C46) conflates the then-identical enums across the std module graph (`check ./std` fails under the seed, passes under develop's compiler). Recorded for the next seed bump.
- Filed `issues/doc-sections-require-double-hash-but-std-writes-single-hash.md`: `yo doc` only parses `## ` section headings while std writes `# Examples` at 70 sites.

## Verification (tree binary)
doc CLI cases 3/3 (after re-record), doc tests 24/26/39, `check ./std` 168/168, `check ./src` 262/262, full CLI scorecard 54 pass / 0 diff, **FIXPOINT_HOLDS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)