### PR TITLE
doc: accept # <well-known section> headings (fenced code ignored); normalise std to ##

### DIFF
--- a/issues/fixed/doc-sections-require-double-hash-but-std-writes-single-hash.md
+++ b/issues/fixed/doc-sections-require-double-hash-but-std-writes-single-hash.md
@@ -1,6 +1,10 @@
 # `yo doc` recognizes only `## Section` headings, but std writes `# Examples` (70 sites) — those sections are never extracted
 
-**Status: OPEN.** Found 2026-08-29 adding the `## Stability` module marker
+**Status: FIXED** (2026-08-29): both options — `src/doc/sections.yo`
+accepts `# <name>` for the well-known section names (arbitrary `#` headings
+stay description content) and ignores `#` lines inside fenced code blocks;
+std's 62 single-`#` known headings were normalised to `## `. Tests:
+`tests/internal/doc_sections.test.yo` (3 new cases). Found 2026-08-29 adding the `## Stability` module marker
 (plans/STD_API_AUDIT.md §9 S5). **Severity:** LOW (rendering only): the text
 still appears inside the description, but `# Examples` / `# Returns` /
 `# Deprecated` written with a single `#` are not parsed as the well-known

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -775,9 +775,10 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
    are in `.github/instructions/yo-design.instructions.md` ("API stability").
    `std/encoding/csv` is the first module carrying the marker (new in this
    release); `std/http/server` and `std/fs/watch` get it in their own PRs.
-   Found en route: `yo doc` only recognises `## ` section headings while std
-   writes `# Examples` at 70 sites
-   (issues/doc-sections-require-double-hash-but-std-writes-single-hash.md).
+   Found en route: `yo doc` only recognised `## ` section headings while std
+   wrote `# Examples` at 70 sites — **FIXED 2026-08-29**: `# <well-known name>`
+   is accepted (fenced code ignored) and std normalised to `## `
+   (issues/fixed/doc-sections-require-double-hash-but-std-writes-single-hash.md).
 
    **Two inputs measured 2026-08-27, to be worked before the freeze:**
 

--- a/src/doc/sections.yo
+++ b/src/doc/sections.yo
@@ -16,17 +16,40 @@ ParsedDocComment :: struct(
   /// Named sections keyed by lowercase heading (e.g., "returns", "examples").
   sections : HashMap(String, String)
 );
-// Returns true if `line` matches /^##\s+(.+)$/ — a ## section heading.
+/// Check if a section name is a well-known section heading.
+is_known_section :: (fn(name : String) -> bool)({
+  lower := name.to_lowercase();
+  cond(
+    (lower == `returns`) => true,
+    (lower == `errors`) => true,
+    (lower == `panics`) => true,
+    (lower == `examples`) => true,
+    (lower == `safety`) => true,
+    (lower == `deprecated`) => true,
+    (lower == `stability`) => true,
+    true => false
+  )
+});
+// Returns true if `line` is a section heading: `## <anything>`, or `# <name>`
+// where <name> is a well-known section (`# Examples`, `# Returns`, ...).
+// Authors write either level — std alone had 70 single-`#` headings against 5
+// double ones, and the single-`#` sections were silently folded into the
+// description (issues/fixed/doc-sections-require-double-hash-but-std-writes-single-hash.md).
+// An arbitrary `# heading` stays description content.
 is_section_heading_ :: (fn(line : String) -> bool)(
   cond(
-    (line.len() < usize(4)) => false,
-    (!(line.starts_with(`## `))) => false,
-    true => true
+    (line.len() < usize(3)) => false,
+    line.starts_with(`## `) => (line.len() >= usize(4)),
+    line.starts_with(`# `) => is_known_section(line.substring(usize(2), line.len()).trim()),
+    true => false
   )
 );
-// Returns the heading text after `## ` (trimmed).
+// Returns the heading text after `## ` / `# ` (trimmed).
 get_section_heading_ :: (fn(line : String) -> String)(
-  line.substring(usize(3), line.len()).trim()
+  cond(
+    line.starts_with(`## `) => line.substring(usize(3), line.len()).trim(),
+    true => line.substring(usize(2), line.len()).trim()
+  )
 );
 // Trim leading/trailing blank lines from section content; join with \n.
 trim_section_content_ :: (fn(lines : ArrayList(String)) -> String)({
@@ -127,6 +150,7 @@ parse_doc_comment :: (fn(text : String) -> ParsedDocComment)({
   current_section_lines := ArrayList(String).new();
   count := lines.len();
   i := usize(0);
+  in_fence := false;
   while(i < count, {
     line := match(
       lines.get(i),
@@ -135,7 +159,12 @@ parse_doc_comment :: (fn(text : String) -> ParsedDocComment)({
         break;
       }
     );
-    if(is_section_heading_(line), {
+    // A `#` line inside a fenced code block (a shell comment in a ```sh
+    // example, a Markdown heading in quoted output) is code, not a heading.
+    if(line.trim().starts_with(`\`\`\``), {
+      in_fence = !(in_fence);
+    });
+    if(!(in_fence) && is_section_heading_(line), {
       match(
         current_section_name,
         .Some(name) => {
@@ -168,19 +197,5 @@ parse_doc_comment :: (fn(text : String) -> ParsedDocComment)({
   description := trim_section_content_(description_lines);
   summary := extract_summary_(description);
   ParsedDocComment(summary : summary, description : description, sections : sections)
-});
-/// Check if a section name is a well-known section heading.
-is_known_section :: (fn(name : String) -> bool)({
-  lower := name.to_lowercase();
-  cond(
-    (lower == `returns`) => true,
-    (lower == `errors`) => true,
-    (lower == `panics`) => true,
-    (lower == `examples`) => true,
-    (lower == `safety`) => true,
-    (lower == `deprecated`) => true,
-    (lower == `stability`) => true,
-    true => false
-  )
 });
 export(parse_doc_comment, is_known_section);

--- a/std/build.yo
+++ b/std/build.yo
@@ -3,7 +3,7 @@
 //! All functions are compile-time only — they register build artifacts
 //! and steps that the build runner uses to orchestrate compilation.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! build :: import "std/build";
@@ -402,7 +402,7 @@ export(module : _module);
 /// Declare a user-configurable build option.
 /// Returns the option value (from CLI `-Dname=value`, or the default).
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// strip :: build.option({
 ///   name: "strip",
@@ -449,7 +449,7 @@ DocConfig :: struct(
 export(DocConfig);
 /// Register a documentation generation step. Returns a Step for dependency wiring.
 ///
-/// # Examples
+/// ## Examples
 ///
 /// ```rust
 /// build :: import "std/build";

--- a/std/cli/arg_parser.yo
+++ b/std/cli/arg_parser.yo
@@ -3,7 +3,7 @@
 //! Supports flags (`--verbose`), options (`--output file`), short aliases (`-v`),
 //! and positional arguments. Automatically generates help text.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { ArgParser } :: import "std/cli/arg_parser";

--- a/std/collections/array_list.yo
+++ b/std/collections/array_list.yo
@@ -966,7 +966,7 @@ __array_list_build_pushes :: (fn(comptime(tmp) : Expr, comptime(elems) : ExprLis
 /// The element type `T` is inferred from the first element via `typeof`, so
 /// at least one element is required.
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// xs := array_list(i32(1), i32(2), i32(3));
 /// names := array_list(`alice`, `bob`);

--- a/std/collections/btree_map.yo
+++ b/std/collections/btree_map.yo
@@ -1,6 +1,6 @@
 //! Sorted map backed by a sorted array with O(log n) lookup via binary search.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { BTreeMap } :: import "std/collections/btree_map";

--- a/std/collections/deque.yo
+++ b/std/collections/deque.yo
@@ -1,6 +1,6 @@
 //! Double-ended queue (ring buffer) with O(1) push/pop at both ends.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Deque } :: import "std/collections/deque";

--- a/std/collections/entry.yo
+++ b/std/collections/entry.yo
@@ -11,7 +11,7 @@
 //! `struct(_0, _1)` — a POSITIONAL pair produced by `zip`. A map entry is
 //! named: it has a `key` and a `value`.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { MapEntry } :: import("std/collections/entry");

--- a/std/collections/hash_map.yo
+++ b/std/collections/hash_map.yo
@@ -902,7 +902,7 @@ __hash_map_build_sets :: (fn(comptime(tmp) : Expr, comptime(entries) : ExprList)
 /// `K` and `V` are inferred from the first entry's key and value via `typeof`,
 /// so at least one entry is required.
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// m := hash_map(`a` => i32(1), `b` => i32(2));
 /// ```

--- a/std/collections/hash_set.yo
+++ b/std/collections/hash_set.yo
@@ -889,7 +889,7 @@ __hash_set_build_adds :: (fn(comptime(tmp) : Expr, comptime(elems) : ExprList) -
 /// `T` is inferred from the first element via `typeof`, so at least one
 /// element is required.
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// s := hash_set(i32(1), i32(2), i32(3));
 /// ```

--- a/std/collections/ordered_map.yo
+++ b/std/collections/ordered_map.yo
@@ -13,7 +13,7 @@
 //! - `remove`: O(n) — must rebuild the key order list to skip the removed key
 //! - `iter` / `keys` / `values`: O(n), in insertion order
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { OrderedMap } :: import "std/collections/ordered_map";

--- a/std/collections/priority_queue.yo
+++ b/std/collections/priority_queue.yo
@@ -1,6 +1,6 @@
 //! Binary min-heap priority queue.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { PriorityQueue } :: import "std/collections/priority_queue";

--- a/std/crypto/md5.yo
+++ b/std/crypto/md5.yo
@@ -1,7 +1,7 @@
 //! MD5 hash function (RFC 1321), pure Yo implementation.
 //! MD5 is considered cryptographically broken — use SHA-256 for security.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { md5_hex } :: import "std/crypto/md5";

--- a/std/crypto/random.yo
+++ b/std/crypto/random.yo
@@ -2,7 +2,7 @@
 //! Uses OS entropy sources (getrandom on Linux, arc4random_buf on macOS,
 //! BCryptGenRandom on Windows, getentropy on WASI).
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { random_u64, uuid_v4 } :: import "std/crypto/random";

--- a/std/crypto/sha256.yo
+++ b/std/crypto/sha256.yo
@@ -1,6 +1,6 @@
 //! SHA-256 hash function (FIPS 180-4), pure Yo implementation.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { sha256_hex } :: import "std/crypto/sha256";

--- a/std/encoding/base64.yo
+++ b/std/encoding/base64.yo
@@ -1,6 +1,6 @@
 //! Base64 encoding and decoding (RFC 4648) with standard and URL-safe variants.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { base64_encode, base64_decode } :: import "std/encoding/base64";

--- a/std/encoding/error.yo
+++ b/std/encoding/error.yo
@@ -2,7 +2,7 @@
 //!
 //! `hex`, `base64` and `utf16` all report decoding failures with this type.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { EncodingError } :: import "std/encoding/error";

--- a/std/encoding/hex.yo
+++ b/std/encoding/hex.yo
@@ -2,7 +2,7 @@
 //!
 //! Converts between raw bytes (`ArrayList(u8)`) and hex strings.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { hex_encode, hex_decode } :: import "std/encoding/hex";

--- a/std/encoding/html.yo
+++ b/std/encoding/html.yo
@@ -3,7 +3,7 @@
 //! Decodes named (&amp;), decimal (&#38;), and hex (&#x26;) HTML character references.
 //! Uses Legacy mode — entities without trailing semicolon are also decoded.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { html_decode } :: import "std/encoding/html";

--- a/std/encoding/html_char_utils.yo
+++ b/std/encoding/html_char_utils.yo
@@ -2,7 +2,7 @@
 //!
 //! Provides Unicode codepoint validation and conversion for HTML entity processing.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { is_valid_entity_code, from_code_point } :: import "std/encoding/html_char_utils";

--- a/std/encoding/json.yo
+++ b/std/encoding/json.yo
@@ -2,7 +2,7 @@
 //!
 //! Provides a dynamically-typed JSON value tree.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { json_parse, json_stringify, JsonValue } :: import "std/encoding/json";

--- a/std/encoding/toml.yo
+++ b/std/encoding/toml.yo
@@ -3,7 +3,7 @@
 //! Parses a subset of TOML into a `TomlValue` tree.
 //! Supports: strings, integers, booleans, table sections, comments.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { toml_parse, TomlValue } :: import "std/encoding/toml";

--- a/std/encoding/utf16.yo
+++ b/std/encoding/utf16.yo
@@ -2,7 +2,7 @@
 //!
 //! Converts between Yo's UTF-8 `str` and UTF-16 code units (`ArrayList(u16)`).
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { utf8_to_utf16, utf16_to_utf8 } :: import "std/encoding/utf16";

--- a/std/encoding/utf8.yo
+++ b/std/encoding/utf8.yo
@@ -15,7 +15,7 @@
 //! above this layer. Callers that need a throwable error wrap it in their own
 //! module's error enum (`StringError.InvalidUtf8` does exactly that).
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { decode, encode_into, validate } :: import "std/encoding/utf8";

--- a/std/fmt/format.yo
+++ b/std/fmt/format.yo
@@ -6,7 +6,7 @@
 //! blanket impl — Rust's model, where fill/align/width are post-processing over
 //! whatever the value rendered as.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! open(import("std/fmt/format"));

--- a/std/fmt/spec.yo
+++ b/std/fmt/spec.yo
@@ -8,7 +8,7 @@
 //! kind  := "x" | "X" | "b" | "o"
 //! ```
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { FormatSpec } :: import "std/fmt/spec";

--- a/std/fmt/writer.yo
+++ b/std/fmt/writer.yo
@@ -1,6 +1,6 @@
 //! Chainable string builder for composing formatted output.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Writer, Alignment } :: import "std/fmt/writer";

--- a/std/fs/dir.yo
+++ b/std/fs/dir.yo
@@ -2,7 +2,7 @@
 //!
 //! Wraps low-level `std/sys/dir` with typed APIs using the `Exception` effect.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { create_dir, remove_dir, read_dir } :: import "std/fs/dir";

--- a/std/fs/file.yo
+++ b/std/fs/file.yo
@@ -3,7 +3,7 @@
 //! Wraps a file descriptor with typed async I/O operations.
 //! Uses the `Exception` effect for error handling.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { File, read_to_string, write_string, OpenMode } :: import "std/fs/file";

--- a/std/fs/metadata.yo
+++ b/std/fs/metadata.yo
@@ -1,7 +1,7 @@
 //! File metadata via `statx` with ergonomic accessors.
 //! Uses the Exception effect for error handling.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { metadata } :: import "std/fs/metadata";

--- a/std/fs/temp.yo
+++ b/std/fs/temp.yo
@@ -5,7 +5,7 @@
 //! only when the directory is empty). Call `remove(io)` explicitly when you
 //! need to observe removal errors.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { TempDir } :: import "std/fs/temp";

--- a/std/fs/walker.yo
+++ b/std/fs/walker.yo
@@ -1,6 +1,6 @@
 //! Recursive directory traversal.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { walk, WalkEntry } :: import "std/fs/walker";

--- a/std/http/client.yo
+++ b/std/http/client.yo
@@ -303,7 +303,7 @@ _fetch_follow :: (
 /// and — when `opts.timeout` is set — races the whole exchange against the
 /// deadline, throwing `HttpError.Timeout` if the deadline wins.
 ///
-/// # Example
+/// ## Example
 ///
 /// ```rust
 /// opts := FetchOptions.new().with_method(.POST).with_body(`{"key": "value"}`).with_timeout(Duration.from_secs(i64(10)));
@@ -369,7 +369,7 @@ export(fetch_with);
 /// Perform an HTTP GET request to the given URL string.
 /// Returns the `HttpResponse` on success.
 ///
-/// # Example
+/// ## Example
 ///
 /// ```rust
 /// resp := io.await(fetch(`http://example.com`, io), { io, exn });

--- a/std/imm/list.yo
+++ b/std/imm/list.yo
@@ -5,7 +5,7 @@
 //!
 //! All elements must implement `Send` to guarantee thread safety.
 //!
-//! # Examples
+//! ## Examples
 //!
 //! ```rust
 //! { List } :: import "std/imm/list";

--- a/std/imm/map.yo
+++ b/std/imm/map.yo
@@ -14,7 +14,7 @@
 //! Structurally-acyclic types satisfy the bound automatically; a
 //! self-referential type is rejected at instantiation.
 //!
-//! # Examples
+//! ## Examples
 //!
 //! ```rust
 //! { Map } :: import "std/imm/map";

--- a/std/imm/set.yo
+++ b/std/imm/set.yo
@@ -6,7 +6,7 @@
 //!
 //! Elements must implement `Eq`, `Hash`, and `Send`.
 //!
-//! # Examples
+//! ## Examples
 //!
 //! ```rust
 //! { Set } :: import "std/imm/set";

--- a/std/imm/sorted_map.yo
+++ b/std/imm/sorted_map.yo
@@ -6,7 +6,7 @@
 //!
 //! Keys must implement `Eq`, `Ord`, and `Send`. Values must implement `Send`.
 //!
-//! # Examples
+//! ## Examples
 //!
 //! ```rust
 //! { SortedMap } :: import "std/imm/sorted_map";

--- a/std/imm/sorted_set.yo
+++ b/std/imm/sorted_set.yo
@@ -6,7 +6,7 @@
 //!
 //! Elements must implement `Eq`, `Ord`, and `Send`.
 //!
-//! # Examples
+//! ## Examples
 //!
 //! ```rust
 //! { SortedSet } :: import "std/imm/sorted_set";

--- a/std/imm/vec.yo
+++ b/std/imm/vec.yo
@@ -14,7 +14,7 @@
 //! Structurally-acyclic types satisfy the bound automatically; a
 //! self-referential type is rejected at instantiation.
 //!
-//! # Examples
+//! ## Examples
 //!
 //! ```rust
 //! { Vec } :: import "std/imm/vec";

--- a/std/prelude.yo
+++ b/std/prelude.yo
@@ -6450,7 +6450,7 @@ export(Var);
 /// - `.Some(value)` — contains a value of type `T`
 /// - `.None` — contains no value
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// (x : Option(i32)) = .Some(i32(42));
 /// assert(x.is_some(), "expected Some");
@@ -7311,7 +7311,7 @@ derive_rule(Default, __derive_default);
 /// - `.Ok(value)` — contains a success value of type `OkType`
 /// - `.Err(error)` — contains an error value of type `ErrorType`
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// (r : Result(i32, str)) = .Ok(i32(42));
 /// assert(r.is_ok(), "expected Ok");
@@ -7870,7 +7870,7 @@ export(Result);
 ///
 /// Use `box(value)` to allocate. Access the inner value with `b.*`.
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// b := box(i32(42));
 /// assert((b.* == i32(42)), "inner value is 42");
@@ -7999,7 +7999,7 @@ export(^);
 ///
 /// Use `arc(value)` to allocate. Access the inner value with `a.*`.
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// a := arc(i32(42));
 /// assert((a.* == i32(42)), "inner value is 42");
@@ -8035,7 +8035,7 @@ extern(
 /// Useful for FFI or low-level patterns where a value must be
 /// allocated first and initialized later (e.g., by a C function).
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// extern "C",
 ///   time_t : Type,
@@ -8270,7 +8270,7 @@ TryInto :: (fn(comptime(To) : Type) -> comptime(Trait))(
 export(TryInto);
 /// `if` macro — expands to `cond(condition => then, true => else)`.
 ///
-/// # Example
+/// ## Example
 /// ```rust
 /// if(x > 0, println("positive"), println("non-positive"));
 /// ```
@@ -8321,7 +8321,7 @@ export(if);
 /// transparently: a blanket `into_iter` impl on `Iterator` (below)
 /// makes every iterator its own `IntoIterator`.
 ///
-/// # Examples
+/// ## Examples
 /// ```rust
 /// // Object elements — mutate in place through the handle.
 /// for(names, (s) => {

--- a/std/process/command.yo
+++ b/std/process/command.yo
@@ -3,7 +3,7 @@
 //! Wraps `std/sys/process` with a fluent API for constructing argv, capturing
 //! stdout/stderr through pipes, and waiting for the child to exit.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Command } :: import "std/process/command";

--- a/std/regex/error.yo
+++ b/std/regex/error.yo
@@ -9,7 +9,7 @@
 //! Positions are **byte offsets into the pattern**, recording where the parser
 //! stopped — not necessarily where the construct began.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Regex, RegexError } :: import("std/regex");

--- a/std/regex/index.yo
+++ b/std/regex/index.yo
@@ -6,7 +6,7 @@
 //! they export only what their siblings consume, and nothing in them is
 //! covered by the stability promise.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Regex } :: import("std/regex");

--- a/std/signal.yo
+++ b/std/signal.yo
@@ -2,7 +2,7 @@
 //!
 //! Wraps `std/sys/signal` with a typed `Signal` enum.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { on_signal, off_signal, Signal, SignalHandler } :: import "std/signal";

--- a/std/string/unicode.yo
+++ b/std/string/unicode.yo
@@ -12,7 +12,7 @@
 //! i) are NOT applied; the mapping is per code point, like Go's
 //! `unicode.ToUpper` and `strings.ToUpper`.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { unicode_to_lowercase, unicode_to_uppercase } :: import "std/string/unicode";

--- a/std/sync/channel.yo
+++ b/std/sync/channel.yo
@@ -4,7 +4,7 @@
 //! Channel uses `atomic object` with atomic reference counting, so it can be
 //! safely shared across threads without `Arc` wrapping.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Channel } :: import "std/sync/channel";

--- a/std/sync/once.yo
+++ b/std/sync/once.yo
@@ -3,7 +3,7 @@
 //! `Once` runs a side-effecting closure exactly once; `OnceCell(T)` stores the
 //! value that closure produced and hands it back on every later call.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Once, OnceCell } :: import "std/sync/once";

--- a/std/sync/rwlock.yo
+++ b/std/sync/rwlock.yo
@@ -19,7 +19,7 @@
 //! release the lock from their `Dispose` impl, so the release happens on a
 //! normal return, on an early `return`, and on an `unwind` alike.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { RwLock } :: import "std/sync/rwlock";

--- a/std/sync/waitgroup.yo
+++ b/std/sync/waitgroup.yo
@@ -1,7 +1,7 @@
 //! Wait for a group of tasks to complete, similar to Go's `sync.WaitGroup`.
 pragma(Pragma.AllowUnsafe);
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { WaitGroup } :: import "std/sync/waitgroup";

--- a/std/testing/bench.yo
+++ b/std/testing/bench.yo
@@ -3,7 +3,7 @@
 //! Runs a function N times, measures elapsed nanoseconds, and returns statistics
 //! (average, min, max).
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { bench } :: import "std/testing/bench";

--- a/std/thread.yo
+++ b/std/thread.yo
@@ -81,7 +81,7 @@ impl(
 ///
 /// Uses atomic reference counting, so a pool may be shared across threads.
 ///
-/// # Example
+/// ## Example
 ///
 /// ```rust
 /// { ThreadPool, spawn } :: import "std/thread";

--- a/std/time/datetime.yo
+++ b/std/time/datetime.yo
@@ -1,6 +1,6 @@
 //! Wall-clock date and time in UTC.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { DateTime } :: import "std/time/datetime";

--- a/std/time/duration.yo
+++ b/std/time/duration.yo
@@ -1,6 +1,6 @@
 //! Duration type representing a span of time with nanosecond precision.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Duration } :: import "std/time/duration";

--- a/std/time/instant.yo
+++ b/std/time/instant.yo
@@ -1,6 +1,6 @@
 //! Monotonic clock instant for measuring elapsed time.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { Instant } :: import "std/time/instant";

--- a/std/time/sleep.yo
+++ b/std/time/sleep.yo
@@ -8,7 +8,7 @@
 //! The underlying timers take whole milliseconds, so sub-millisecond
 //! precision in the `Duration` is truncated.
 //!
-//! # Example
+//! ## Example
 //!
 //! ```rust
 //! { sleep, sleep_blocking } :: import "std/time/sleep";

--- a/tests/internal/doc_sections.test.yo
+++ b/tests/internal/doc_sections.test.yo
@@ -155,3 +155,21 @@ test("parses a module-level ## Stability section", {
   st := match(parsed.sections.get(`stability`), .Some(v) => v, .None => ``);
   assert(st.starts_with(`unstable`), `stability section content: ${st}`);
 });
+test("parses single-# well-known sections (# Examples, # Returns) like ## ones", {
+  result := parse_doc_comment(`Adds two numbers.\n\n# Examples\n\n\`\`\`rust\nadd(1, 2)\n\`\`\`\n\n# Returns\n\nThe sum.`);
+  assert(result.sections.contains_key(`examples`), "# Examples is a section");
+  assert(result.sections.contains_key(`returns`), "# Returns is a section");
+  assert(result.sections.get(`returns`).unwrap() == `The sum.`, "returns content");
+  assert(result.description == `Adds two numbers.`, "description excludes the sections");
+});
+test("an arbitrary single-# heading stays description content", {
+  result := parse_doc_comment(`Intro.\n\n# Notes\n\nSome notes.`);
+  assert(result.sections.len() == usize(0), "# Notes is not a well-known section");
+  assert(result.description.contains(`# Notes`), "kept in the description");
+  assert(result.description.contains(`Some notes.`), "with its text");
+});
+test("a # line inside a fenced code block is not a heading", {
+  result := parse_doc_comment(`Run it.\n\n## Examples\n\n\`\`\`sh\n# Examples of flags\nyo build\n\`\`\`\n\nDone.`);
+  assert(result.sections.len() == usize(1), "only the real ## Examples section");
+  assert(result.sections.get(`examples`).unwrap().contains(`# Examples of flags`), "the shell comment stays inside the section");
+});


### PR DESCRIPTION
Closes the yo doc sections gap (plans/STD_API_AUDIT.md S5): the parser recognised only '## Section' headings while std wrote '# Examples' / '# Returns' / '# Deprecated' at 62 sites, so those sections were folded into the description and the Examples/Deprecated banners and JSON fields were missing for most of std. src/doc/sections.yo: '# <name>' is a heading when <name> is a well-known section (arbitrary # headings stay description content); # lines inside fenced code blocks are never headings. std: the 62 single-# known headings normalised to '## ' (comments only; check ./std 171/171, fmt --check clean). Tests: tests/internal/doc_sections.test.yo +3 (27 pass). The doc-* CLI goldens are re-recorded in a follow-up commit on this branch. issues/fixed/doc-sections-require-double-hash-but-std-writes-single-hash.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)