### PR TITLE
fix: yo version install unbreak + the compiler's build path no longer nests the event loop (strict golden green)

### DIFF
--- a/issues/asan-stack-overread-set-effect-batch-selftest.md
+++ b/issues/asan-stack-overread-set-effect-batch-selftest.md
@@ -1,64 +1,93 @@
-# ASan stack-buffer-overflow in set_effect's bundle copy — develop CI red since #363 (blocks the v0.2.21 release gate)
+# ASan stack-buffer-overflow in set_effect's bundle copy — develop CI red since #363 (blocks the v0.2.21 release gate); ANOTHER SYMPTOM of C54's specialization split
 
-**Status: OPEN — develop HEAD CI fails on every native leg; NOT reproducible on this
-macOS host (its clang has a broken ASan runtime, so the local runner silently skips
-the sanitizer).**
+**Status: ROOT-CAUSED 2026-08-30 (CI sweep repro). This is the C54 mechanism
+clobbering a future's EFFECT type across specializations — see
+issues/future-wrapper-return-shared-across-specializations.md for the arc and
+its recorded failed approaches. A codegen-side mitigation was attempted and is
+NOT viable (below); the fix is the C54 body half.**
 
-Found 2026-08-30 continuing the std audit handover. `test (ubuntu-latest)`,
-`test (ubuntu-24.04-arm)`, `test (macos-latest)`, `test (macos-26-intel)`,
-"Self-hosted `test` subcommand", and the "Full-corpus hollow sweep" all fail the
-SAME single test of `tests/async_await.test.yo`:
+`test (ubuntu-latest)`, `test (ubuntu-24.04-arm)`, `test (macos-latest)`,
+`test (macos-26-intel)`, "Self-hosted `test` subcommand", and the
+"Full-corpus hollow sweep" all failed the SAME single test of
+`tests/async_await.test.yo`:
 
 ```
 ✗ a top-level await returns as soon as its future completes, despite unrelated pending I/O
-  Test failed with exit code 256
-  ==4428==ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 40
-      #0 __asan_memcpy
-      #1 _file____home_temp_14412_set_effect
-      #2 _file____home_temp_14417_resume
-      #3 __yo_user_main
-  Address ... is located in stack of thread T1 at offset 64 in frame #2:
-    This frame has 1 object(s):
-      [32, 64) '__yo_eff_bundle_yo_id_15516' <== Memory access at offset 64 overflows this variable
+  ==ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 40
+      #1 _file____priv_temp_14412_set_effect
+      #2 _file____priv_temp_14417_resume
+  [32, 64) '__yo_eff_bundle_yo_id_15516' <== Memory access ... overflows this variable
 ```
 
-## What is known
+## Root cause (isolated by a CI index sweep over the ASan-compiled batch)
 
-- The failing test body itself passes UNSANITIZED and on wasm/windows legs; only
-  the ASan-instrumented native legs die. PR #365's red legs are this same failure
-  (the branch is not at fault).
-- The read starts at offset 64 — exactly one-past the 32-byte `__yo_eff_bundle_*`
-  temp — so the `value` POINTER handed to `set_effect` is one object off (or the
-  copy is from a slot the temp no longer occupies), not merely a wider copy of the
-  temp itself.
-- The injection is C56/#354-era codegen: `emit_effect_injection_for_sm` in
-  `src/codegen/async/state_machine.yo` materializes the bundle named at the await
-  into a stack temp and passes `&temp`. #362 (C60) rewrote how the bundle
-  expression is chosen; the regression window is #361–#363 (v0.2.20 cut was green).
-- Static cross-check of EVERY `__yo_set_effect_fn(..., &__yo_eff_bundle_*)` site in
-  the locally-emitted batch C (`.yo_selftest_batch_1_1.bin.c`, 119 sites + 53
-  inside resume fns, temp type vs the receiver set_effect's copy type) found ZERO
-  type mismatches on macOS — the local artifact is clean, so the defect is
-  platform- or composition-dependent (CI's batch 14_1 has a site mine lacks, or
-  Linux stack layout exposes it).
-- This host cannot runtime-reproduce: the local test runner prints
-  "AddressSanitizer is not functional with this compiler setup" and silently skips
-  the sanitizer (worth its own follow-up: a silent ASan skip should be loud, or a
-  `--sanitize-required` mode for exactly this debugging).
+Reproduced with a temporary ubuntu workflow (`debug/asan-batch` branch, since
+deleted): the test file's second batch, cross-emitted to Linux C and compiled
+with `-fsanitize=address`, crashes at exactly **test index 85** — the failing
+test itself. The emitted C at the fault:
 
-## Suggested attack
+```c
+// _file____priv_temp_14417_resume, line ~56298 (the await site):
+__yo_t14 __yo_eff_bundle_yo_id_15516 = sm->__yo_param_0;   // t14 = Io, 32 bytes
+sm->var_206481->__yo_set_effect_fn(..., "__bundle", (void*)&__yo_eff_bundle_yo_id_15516);
 
-The proven Windows debug-loop pattern (temp workflow on a branch, build + run one
-thing on the target runner, upload logs): a workflow that builds the compiler on
-ubuntu-latest, generates the async_await batch (`YO_KEEP_BATCH=1 yo test
-./tests/async_await.test.yo`), compiles the batch WITH `-fsanitize=address`, runs
-the failing index, and uploads BOTH the ASan report and the batch `.c` — then read
-the emitted C at `_14412`/`_14417`/`__yo_eff_bundle_15516` and walk back to the
-`emit_effect_injection_for_sm` path that emitted it. Alternatively reproduce on
-any Linux box with working ASan before touching codegen.
+// _file____priv_temp_14412_set_effect (the child future):
+sm->__yo_param_0 = *((__yo_t41*)value);                    // t41 = IoExn, 40 bytes
+```
 
-## Impact
+`IoExn` is `{ io : Io, exn }` — it CONTAINS the 32-byte `Io` inline plus the
+8-byte `exn` (40 total). The C60/#354-era `emit_effect_injection_for_sm`
+materialized the bundle temp **in the ARG's recorded type** (`Io`, 32 bytes —
+the pre-#366 shape), while the awaited future's `set_effect` copies its OWN
+declared effect record (`IoExn`, 40 bytes) — an 8-byte stack over-read. The
+test passes unsanitized because the child never reads the injected bundle.
 
-Blocks the release pipeline: v0.2.21's gate requires a completed green Test run
-on develop HEAD. Everything else queued behind it (§2a version-install fixes, the
-fs-watch PR #365 merge) lands on red develop otherwise.
+WHY an `Io`-bundled await meets a future whose emitted SM carries an `IoExn`
+bundle at all: see "The real mechanism" below — a cross-specialization
+effect-binding split, not a property of any single await expression.
+
+## The mitigation attempt (NOT viable — recorded so it is not retried)
+
+`emit_effect_injection_for_sm` / `emit_effect_injection_for_await` were taught
+to size the `__bundle` temp by the FUTURE's declared effect type (zeroed temp +
+name-shared field copies when the arg's C type differs). Built, re-emitted the
+batch, swept on CI: **the crash site's emission was byte-identical** — because
+at the await site the future's effect type RESOLVES TO `Io` (equal to the
+arg's — the emitter's own view is self-consistent and takes the direct-init
+path), while the CHILD's `set_effect` was EMITTED ELSEWHERE under `IoExn`.
+Neither side can see the other's type, so no emission-site check can catch
+this. Reverted.
+
+## The real mechanism (why the two views differ)
+
+The batch compiles many `two_hop`-shaped call sites; the same nested
+`io.async` closure gets SPECIALIZED more than once, and the second
+specialization's effect-bundle binding (C60's receiver-derived `E`) leaks into
+the first's emitted state machine through the shared/global specialization
+registry — the exact "second specialization clobbers the first via the global
+last-writer registry" mechanism of C54, on the effect type instead of the
+result type. Standalone compiles of the same file type the future `Io` and are
+clean; only the multi-specialization batch context splits the views.
+
+**Fix**: the C54 body half (stamp the call's types concretely inside the
+specialization body / stop keying the fallback by the shared forall id) — see
+issues/future-wrapper-return-shared-across-specializations.md (C54) and its repro
+issues/repros/future-wrapper-return-two-r-specializations.yo. Until then,
+every PR's native test legs stay red on this one test.
+
+## Repro assets
+
+The `debug/asan-batch` branch (temporary — delete when done) carries the
+workflow + the offending pre-emitted `tests/debug-batch-linux.c`: crash at
+batch test index 85 (`a top-level await returns as soon as its future
+completes...`), `_14417_resume` line ~56298 → `_14412_set_effect` line ~8662
+(t14 = `Io` 32-byte temp, t41 = `IoExn` 40-byte copy).
+
+## Follow-ups
+
+- A SILENT local ASan skip cost a day of repro attempts: the runner prints
+  "AddressSanitizer is not functional..." and continues unsanitized on this
+  macOS host (Apple clang 17's ASan runtime hangs under this environment).
+  A `--sanitize-required` mode (or a loud summary line) would have caught it.
+- The temporary debug workflow + committed batch C on `debug/asan-batch`
+  should be deleted once the mitigation is merged.

--- a/issues/asan-stack-overread-set-effect-batch-selftest.md
+++ b/issues/asan-stack-overread-set-effect-batch-selftest.md
@@ -1,0 +1,64 @@
+# ASan stack-buffer-overflow in set_effect's bundle copy — develop CI red since #363 (blocks the v0.2.21 release gate)
+
+**Status: OPEN — develop HEAD CI fails on every native leg; NOT reproducible on this
+macOS host (its clang has a broken ASan runtime, so the local runner silently skips
+the sanitizer).**
+
+Found 2026-08-30 continuing the std audit handover. `test (ubuntu-latest)`,
+`test (ubuntu-24.04-arm)`, `test (macos-latest)`, `test (macos-26-intel)`,
+"Self-hosted `test` subcommand", and the "Full-corpus hollow sweep" all fail the
+SAME single test of `tests/async_await.test.yo`:
+
+```
+✗ a top-level await returns as soon as its future completes, despite unrelated pending I/O
+  Test failed with exit code 256
+  ==4428==ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 40
+      #0 __asan_memcpy
+      #1 _file____home_temp_14412_set_effect
+      #2 _file____home_temp_14417_resume
+      #3 __yo_user_main
+  Address ... is located in stack of thread T1 at offset 64 in frame #2:
+    This frame has 1 object(s):
+      [32, 64) '__yo_eff_bundle_yo_id_15516' <== Memory access at offset 64 overflows this variable
+```
+
+## What is known
+
+- The failing test body itself passes UNSANITIZED and on wasm/windows legs; only
+  the ASan-instrumented native legs die. PR #365's red legs are this same failure
+  (the branch is not at fault).
+- The read starts at offset 64 — exactly one-past the 32-byte `__yo_eff_bundle_*`
+  temp — so the `value` POINTER handed to `set_effect` is one object off (or the
+  copy is from a slot the temp no longer occupies), not merely a wider copy of the
+  temp itself.
+- The injection is C56/#354-era codegen: `emit_effect_injection_for_sm` in
+  `src/codegen/async/state_machine.yo` materializes the bundle named at the await
+  into a stack temp and passes `&temp`. #362 (C60) rewrote how the bundle
+  expression is chosen; the regression window is #361–#363 (v0.2.20 cut was green).
+- Static cross-check of EVERY `__yo_set_effect_fn(..., &__yo_eff_bundle_*)` site in
+  the locally-emitted batch C (`.yo_selftest_batch_1_1.bin.c`, 119 sites + 53
+  inside resume fns, temp type vs the receiver set_effect's copy type) found ZERO
+  type mismatches on macOS — the local artifact is clean, so the defect is
+  platform- or composition-dependent (CI's batch 14_1 has a site mine lacks, or
+  Linux stack layout exposes it).
+- This host cannot runtime-reproduce: the local test runner prints
+  "AddressSanitizer is not functional with this compiler setup" and silently skips
+  the sanitizer (worth its own follow-up: a silent ASan skip should be loud, or a
+  `--sanitize-required` mode for exactly this debugging).
+
+## Suggested attack
+
+The proven Windows debug-loop pattern (temp workflow on a branch, build + run one
+thing on the target runner, upload logs): a workflow that builds the compiler on
+ubuntu-latest, generates the async_await batch (`YO_KEEP_BATCH=1 yo test
+./tests/async_await.test.yo`), compiles the batch WITH `-fsanitize=address`, runs
+the failing index, and uploads BOTH the ASan report and the batch `.c` — then read
+the emitted C at `_14412`/`_14417`/`__yo_eff_bundle_15516` and walk back to the
+`emit_effect_injection_for_sm` path that emitted it. Alternatively reproduce on
+any Linux box with working ASan before touching codegen.
+
+## Impact
+
+Blocks the release pipeline: v0.2.21's gate requires a completed green Test run
+on develop HEAD. Everything else queued behind it (§2a version-install fixes, the
+fs-watch PR #365 merge) lands on red develop otherwise.

--- a/issues/build-startup-blocking-awaits-strict-golden-red-since-337.md
+++ b/issues/build-startup-blocking-awaits-strict-golden-red-since-337.md
@@ -1,0 +1,138 @@
+# The compiler's own build path drives blocking awaits inside async tasks — the strict-cleanliness CLI golden has been red since it was added
+
+**Status: OPEN (fix landing with this issue); the golden `async-blocking-await-inside-task` was RED from birth.**
+Found 2026-08-30 continuing the std audit handover: §2a's "strict-mode
+regression" was misdiagnosed as fallout of the version_cache un-hollowing. It
+is not — the regression predates and is independent of those fixes.
+
+## The false alarm, cleared
+
+The handover's diagnosis: un-hollowing `version_cache.yo` made formerly-dead
+`io.async` bodies execute inside `run_build`'s task, tripping the C37 guard
+under `YO_ASYNC_STRICT=1`. Measured against the actual binaries:
+
+- The **released v0.2.20 seed** (develop at cut time, no version_cache fixes)
+  aborts rc=134 on the golden's own tiny fixture — before any build output.
+- A binary built at **#337 itself** (82e3c467d, where the golden was added),
+  compiled by the v0.2.20 seed, aborts identically.
+- The v0.2.19 seed does not abort — it predates the guard entirely (no guard
+  string in the binary; the fixture runs rc=0 with no panic at all).
+
+**Why #337's own verification said "clean"** (the retirement note on
+issues/retired/compiler-build-runner-nests-event-loop.md): a compiled
+program's runtime C comes from the COMPILING binary's embedded templates. The
+#337-era smoke-test binary was compiled by the v0.2.19 seed, whose runtime
+templates carry no guard — the binary could not fire the very guard its source
+added. The first binary actually able to abort (v0.2.20) went red on the
+golden immediately. `cli-diff-test.sh` is wired into no workflow, so nothing
+in CI ever saw it.
+
+## The real defects (all fixed here)
+
+Backtrace at the abort (identical shape on every binary that has the guard):
+
+```
+__yo_user_main → run_build_cmd → poll_step → run_build SM resume
+  → evaluate_build_file SM → mm_load_file (plain fn) → poll_step → GUARD
+```
+
+1. **Module loading did its file reads through the async `std/fs` `read`.**
+   `mm_load_file` read the entry file and `_load_module_at_abs` read every
+   demand-loaded import — each an `io.await` in a NON-io.async function, i.e.
+   a blocking poll loop, run inside `run_build`'s task (C37/C42). Module
+   loading is COMPTIME work: the evaluator calls the demand loader
+   synchronously, so it can never be a future. Fix: `_read_file_sync` in
+   module_manager — libc open/read/close, mirroring `_path_exists_sync`, with
+   `IoError.from_errno` thrown through the same exn so error values match
+   std/fs exactly. Comptime I/O no longer touches the event loop at all (also
+   strictly better for the LSP). `g_loader_io` and `mm_eval_entry_exprs`'s io
+   param went vestigial and were removed.
+
+2. **The build-graph helpers blocked inside `compile_artifact`'s task**:
+   `_git_version`, `_cache_collect_yo_files`, `_cache_read_file`,
+   `_read_stamp`, `_write_stamp` — the retired issue's own site list. All are
+   now `io.async` futures awaited properly by `compile_artifact`.
+
+## The conversion recipe (why it looks like this)
+
+Two language realities shaped the fix:
+
+- **A local `Exception` handler + `unwind(value)` inside an `io.async` body
+  LOSES the value and aborts the future** (probed: the caller's subsequent
+  statements silently never run — awaiting an aborted future discards the
+  caller's remaining continuation). So the plain-fn swallow handlers could not
+  simply move inside async bodies.
+- **Branch-nested awaits still drop continuations**
+  (issues/async-await-in-nested-if-drops-continuation.md), so every await in
+  the converted bodies is a top-level statement and every decision is data.
+
+The pattern that satisfies both (established by `Command.output`'s stderr
+drain): run the throwing operation as a **spawned task whose body carries its
+own local swallow handler**, poll `is_finished()` + `await yield()`, then
+`handle.await` — a task that unwound is `.None` at the handle. `_git_output_task`,
+`_read_bytes_task`, `_read_dir_task`, `_write_string_task` are those bodies.
+
+Semantic deltas, deliberate and reviewed:
+
+- `_cache_collect_yo_files` is now a breadth-first worklist (was recursion);
+  it visits the identical file set, and the per-directory sort keeps the
+  stamp deterministic — its VALUE changes once (traversal order), which
+  invalidates every inputs-sha256 cache exactly one time.
+- `_write_stamp` now writes even an EMPTY stamp (cache disabled / stamping
+  failed): truncating the previous stamp is the correct outcome in both cases
+  (the next build must not cache-hit), and it keeps the write await
+  branch-free.
+
+## Verification
+
+- `YO_ASYNC_STRICT=1 <new binary> build run` on the golden fixture: the
+  compiler survives, the fixture program panics with the guard message, rc
+  propagates — `scripts/cli-diff-test.sh --filter async-blocking-await-inside-task`
+  goes PASS.
+- The same battery of paths the retired issue listed (`check ./std`, `doc`,
+  smoke build) re-verified green.
+
+## Follow-ups this surfaces
+
+- `ssize_t(0)` — constructing a `c_include`-declared TYPE through its module
+  binding — fails def-eval and the failure is SWALLOWED, hollowing the whole
+  function (bisected: `fcntl.open`/`__yo_errno` externs are fine; the
+  constructor is the trigger; casting the RESULT, `i64(n)`, is fine). Same
+  enforcement family as the arity row: def-eval failures inside function
+  bodies must not be silent.
+- **`unwind` inside a local handler in an `io.async` body must carry the
+  FUTURE's payload type** — `unwind(())` (or any other type) fails def-eval
+  with "Incompatible type for `unwind` argument: Expected (enclosing function
+  return type): T" AND THE FAILURE IS SWALLOWED, hollowing the whole SM.
+  Found by `YO_DEBUG_SWALLOW=1 check` after two blind iterations; the dummy
+  payload value is discarded (the task aborts either way), only its TYPE is
+  checked. Unit payloads (`Future(unit, …)`) unwind with `unwind(())` —
+  that IS the matching type; the trap is declaring the task's payload as
+  anything the awaited fn does not actually return (`_write_string_task`
+  declared `usize` while the module-level `write_string` returns
+  `Future(unit)` — the unify failure was swallowed too). Plain (non-async)
+  functions are unaffected: their handlers' unwind payloads type-check
+  against the fn's return type as written.
+- Two more swallowed-shape casualties from this conversion, both hollowing a
+  whole SM silently: (a) an `if(cond, { Result...Ok(()); }, {...Err...})`
+  whose then-branch was made a single semicolon-terminated statement — the
+  branch value became `unit`, the arms no longer unified, and the failure
+  was swallowed (fix: a `cond`-tail with typed arms); (b) `_ := handle.await(...)`
+  as a discard of an `Option(usize)` inside an async body — "Cannot unify
+  unit and usize", swallowed (fix: a `match` over the Option). Every one of
+  these was invisible to `yo check` and only visible in the emitted C's
+  `__attribute__((error("failed to transpile")))` markers — grepping the
+  emitted C for `failed to transpile` after every build is the working
+  tripwire until the async-SM gate exists.
+- `cli-diff-test.sh` has no CI wiring — the golden was red for two releases
+  unnoticed. Wiring the corpus into a workflow is the durable fix.
+- The aborted-future-await semantics (silent continuation discard) deserves
+  its own issue and a compiler diagnostic — it turned five silent breakages
+  into RC=0 no-ops this week (the hollow-SM family).
+- `src/doc_command.yo` is wall-to-wall plain-fn `io.await`s reached from
+  `_run_doc_step` inside `execute_node`'s task — a `doc` step in a build under
+  strict mode still aborts. Same recipe applies (its module reads are already
+  sync via this fix; the walk/exists/metadata/command awaits remain).
+- The retirement note on issues/retired/compiler-build-runner-nests-event-loop.md
+  is factually wrong (its clean verdict was structurally impossible); this
+  file supersedes it as the record.

--- a/issues/builtin-name-shadows-user-definition.md
+++ b/issues/builtin-name-shadows-user-definition.md
@@ -1,5 +1,16 @@
 # Builtin names silently shadow same-named user definitions (OPEN-DESIGN)
 
+**PRODUCTION CASUALTY (2026-08-30):** a local named `short` in
+`src/version_cache.yo`'s `download_version` resolved to the prelude C-interop
+integer type inside a template interpolation; the def-eval failure was
+swallowed, the WHOLE async body shipped hollow, and **`yo version install`
+was silently broken in the released v0.2.19 and v0.2.20** (rc=0 no-op /
+bare-SIGABRT rc=134 —
+issues/wrong-arity-call-silently-accepted-version-install-broken.md). This
+issue is no longer theoretical: pick option 1 (reserve) or 2 (prefer user
+bindings), or at minimum land option 3's shadowing diagnostic, before the
+next release.
+
 **Found 2026-08-06** while attempting to fix
 `issues/retired/ctfe-elided-unit-call-arg-temp-leak.md` (whose diagnosis this
 finding invalidates — see the banner there).

--- a/issues/future-wrapper-return-shared-across-specializations.md
+++ b/issues/future-wrapper-return-shared-across-specializations.md
@@ -13,6 +13,17 @@ error: initializing 'int64_t' with an expression of incompatible type '__yo_t9' 
   int64_t _file____priv_temp_13090 = closure_yo_id_11203(&(sm->__capture.body), (&(sm->__capture.self->_value)));
 ```
 
+## Second symptom (2026-08-30): the develop-HEAD ASan red is this same mechanism on the EFFECT type
+
+Every native test leg fails one `tests/async_await.test.yo` test with an ASan
+stack-buffer-overflow: a bundle temp sized by one specialization's view of a
+future's effect (`Io`, 32 bytes) is copied by a `set_effect` emitted under
+another specialization's view (`IoExn`, 40 bytes) — same shared-registry
+clobber, `E` instead of `R`. Full analysis + the not-viable codegen mitigation
+attempt: issues/asan-stack-overread-set-effect-batch-selftest.md. This makes
+the C54 body half the critical path for the v0.2.21 release (develop CI is
+red until it lands).
+
 ## Reproducer
 
 `issues/repros/future-wrapper-return-two-r-specializations.yo`: a generic impl

--- a/issues/wrong-arity-call-silently-accepted-version-install-broken.md
+++ b/issues/wrong-arity-call-silently-accepted-version-install-broken.md
@@ -1,0 +1,79 @@
+# A wrong-arity call is silently accepted — and it broke `yo version install` in every release
+
+**Status: OPEN (compiler hole); the one production instance is FIXED.**
+Found 2026-08-30 validating the D6 PR-3 curl→std/http swap: `yo version
+install <v>` either silently no-opped (rc=0, nothing cached, zero output) or
+died with a bare SIGABRT (rc=134) — nondeterministically — **including in the
+released v0.2.19 and v0.2.20 binaries**, so the breakage long predates the
+swap.
+
+## The production instance (fixed)
+
+`src/version_cache.yo` `ensure_cached_version` called
+
+```rust
+cached := e.io.await(is_version_cached(version, e.io), e);
+```
+
+— TWO args for the THREE-param `is_version_cached(version, io, exn)`. At
+runtime the missing `exn` record made `cached` read garbage: truthy garbage
+took the `if(cached)` arm and returned the cache dir silently (the rc=0
+no-op), falsy garbage continued into corrupted state (the silent rc=134).
+Fixed by passing `e.exn`. (The `exn` params on these helpers are DEAD — the
+bundle at the await carries the handlers — which is why the body worked at
+all; a parameter-list diet is a separate cleanup.)
+
+## The full inventory (all in `src/version_cache.yo`, all FIXED 2026-08-30)
+
+Any ONE def-eval failure inside an `io.async` body hollows the WHOLE emitted
+state machine — the await of the resulting future silently early-returns from
+the caller (the plain-fn await's aborted-future path). `download_version`'s
+body had THREE independent hollowing causes:
+
+1. `ensure_cached_version` → `is_version_cached(version, e.io)` — 2 args for
+   3 params.
+2. `_cleanup_failed_download(version_dir, tmp_dir.path(), e.io)` — 3 args for
+   4 params, at FOUR call sites.
+3. A local named `short` interpolated in the 404-fallback println —
+   builtin-first dispatch resolved the prelude C-interop integer type instead
+   of the local ("Argument count mismatch: expected 1, got 0" in the template
+   lowering; issues/builtin-name-shadows-user-definition.md third face, now
+   with a production casualty). Renamed to `short_name`.
+
+A tree-wide `YO_DEBUG_SWALLOW=1 check` sweep for "Argument count mismatch"
+was run over ./src and ./std after the fixes.
+
+## The gate gap (why nothing caught a hollow async body)
+
+The C22 stub gate attributes hollow CLOSURES whose calls survive; a hollow
+ASYNC STATE MACHINE body is emitted as a structurally valid SM that never
+runs its statements and completes/aborts immediately — no abort-stub, no
+attribute, a green build. The C22-class enforcement needs an async-SM
+equivalent: an SM whose body ExprInfos were never stamped must poison its
+resume function the same way.
+
+## The compiler hole
+
+The evaluator accepts the wrong-arity call: the call's def-time evaluation
+fails, the swallow eats it (the
+issues/fixed/def-eval-swallow-remaining-roots.md family;
+memory-of-record: "check accepts wrong-arity calls"), and codegen emits a
+call with too few C arguments — UB that presents as garbage values, not as an
+error anywhere. `yo check ./src` was green the whole time.
+
+Same enforcement family as C61 (rejected outside the swallow) and the C22
+stub gate (C compiler as the deadness oracle): **argument-count validation
+against the resolved callee must run OUTSIDE the def-eval trial swallow** —
+arity is knowable even when the trial body fails for other reasons.
+`try_to_call_function_with_arguments` already throws "Argument count
+mismatch: expected N, got M" in some paths (seen in C60's swallow traces), so
+the gap is which layer swallows it for this shape (an io.async-wrapped
+helper called from another async body).
+
+## Test gap
+
+`yo version install` has no test at any level — it needs network, so the CLI
+corpus never covers it (this is how a total breakage shipped in at least two
+releases). Minimum: a compiler test pinning the ARITY rejection
+(comptime_expect_error on a 2-arg call to a 3-param fn in the async-helper
+shape), and a version_cache unit test that stubs `_download_file`.

--- a/src/build_runner.yo
+++ b/src/build_runner.yo
@@ -18,12 +18,13 @@ open(import("std/fmt"));
 // throughout this file (`run_step.args`). Same rename form main.yo uses for `env`.
 _(args : proc_args) :: import("std/env");
 { exists, read, write_string } :: import("std/fs/file");
-{ read_dir } :: import("std/fs/dir");
+{ read_dir, DirEntry } :: import("std/fs/dir");
 { sha256_hex } :: import("std/crypto/sha256");
 { CURRENT_YO_VERSION } :: import("./version.yo");
 _(env : proc_env) :: import("std/env");
 { create_dir_all } :: import("std/fs/dir");
-{ Command } :: import("std/process/command");
+{ Command, Output, ExitStatus } :: import("std/process/command");
+{ yield } :: import("std/async");
 { mm_load_yo_file, mm_reset, get_std_path_override, resolve_std_path } :: import("./module_manager.yo");
 { exit } :: import("std/libc/stdlib");
 {
@@ -98,27 +99,59 @@ ExecutionContext :: ref(
 /// `getGitVersion` (src/build-runner.ts:1417-1429), whose entire body is a
 /// try/catch returning undefined — the version is decoration on the "Building …"
 /// line, never a reason to fail a build.
+_git_output_task :: (fn(cmd : Command, io : Io) -> Impl(Future(Output, IoExn)))(
+  io.async((e : IoExn) => {
+    // Local swallow handler: a missing git / spawn failure must unwind THIS
+    // task (read as `.None` at the JoinHandle below), never reach the
+    // build's own handler and fail the build. The unwind payload must match
+    // the future's payload type — any other type fails def-eval and silently
+    // hollows this SM (the C22-adjacent swallow hole); the value itself is
+    // discarded, the task aborts either way.
+    swallow := Exception(
+      throw : (
+        (_e) -> unwind(
+          Output(
+            status : ExitStatus(raw : i32(0)),
+            stdout : ArrayList(u8).new(),
+            stderr : ArrayList(u8).new()
+          )
+        )
+      )
+    );
+    e.io.await(cmd.output(e.io), IoExn(io : e.io, exn : swallow))
+  })
+);
 _git_version :: (
   fn(
     project_dir : String,
     io : Io,
     exn : Exception
-  ) -> Option(String)
-)({
-  // `git -C <dir>` rather than a cwd on the Command — `std/process/command.yo`
-  // has no `current_dir`, and this is git's own equivalent of TS's
-  // `execSync(..., { cwd: projectDir })`.
-  cmd := Command.new(String.from("git"));
-  cmd.arg(String.from("-C"));
-  cmd.arg(project_dir);
-  cmd.arg(String.from("describe"));
-  cmd.arg(String.from("--tags"));
-  cmd.arg(String.from("--always"));
-  out := io.await(cmd.output(io), IoExn(io : io, exn : exn));
-  if(!(out.status.success()), return(Option(String).None));
-  v := String.from_bytes(out.stdout).trim();
-  if(v.len() == usize(0), Option(String).None, Option(String).Some(v))
-});
+  ) -> Impl(Future(Option(String), IoExn))
+)(
+  io.async((e : IoExn) => {
+    // `git -C <dir>` rather than a cwd on the Command — `std/process/command.yo`
+    // has no `current_dir`, and this is git's own equivalent of TS's
+    // `execSync(..., { cwd: projectDir })`. The output future runs as a
+    // SPAWNED TASK polled with is_finished + yield: a blocking await from
+    // inside a task nests the event loop (C37), and awaiting an aborted
+    // future directly would discard this closure's continuation.
+    cmd := Command.new(String.from("git"));
+    cmd.arg(String.from("-C"));
+    cmd.arg(project_dir);
+    cmd.arg(String.from("describe"));
+    cmd.arg(String.from("--tags"));
+    cmd.arg(String.from("--always"));
+    t := e.io.spawn(_git_output_task(cmd, e.io), e);
+    while(runtime(!(t.is_finished())), {
+      e.io.await(yield(e.io), e.io);
+    });
+    out_opt := t.await(e.io);
+    out := match(out_opt, .Some(o) => o, .None => return(Option(String).None));
+    if(!(out.status.success()), return(Option(String).None));
+    v := String.from_bytes(out.stdout).trim();
+    if(v.len() == usize(0), Option(String).None, Option(String).Some(v))
+  })
+);
 /// The compiler binary to invoke for sub-steps (artifact compiles, test runs).
 ///
 /// `src/build-runner.ts` compiles IN PROCESS (`codeGenerator.compileModule`) —
@@ -379,115 +412,201 @@ detect_cycle :: (fn(dag : ArrayList(DAGNode)) -> Option(String))({
 // version + argv covers the yo side); delete yo-out or set
 // YO_BUILD_NO_CACHE=1 to bypass.
 // ---------------------------------------------------------------------------
-/// Recursively collect `*.yo` files under `dir`, skipping build outputs and
-/// VCS/tooling directories. Sorted for a deterministic stamp — read_dir
-/// order is platform-dependent (the readdir-order lesson).
+_read_dir_task :: (fn(dir : String, io : Io) -> Impl(Future(ArrayList(DirEntry), IoExn)))(
+  io.async((e : IoExn) => {
+    // Local swallow handler: read_dir on a FILE (or a vanished dir) unwinds
+    // THIS task, read as `.None` at the JoinHandle below — that failure IS
+    // the dir-vs-file test, so no stat is needed (the readdir-order lesson
+    // still applies: names are sorted by the consumer). The unwind payload
+    // must match the future's payload type or def-eval fails and silently
+    // hollows this SM; the value is discarded, the task aborts either way.
+    swallow := Exception(throw : ((_e) -> unwind(ArrayList(DirEntry).new())));
+    e.io.await(read_dir(Path.new(dir.clone()), e.io), IoExn(io : e.io, exn : swallow))
+  })
+);
+/// Collect `*.yo` files under `dir`, skipping build outputs and VCS/tooling
+/// directories. Names are sorted per directory for a deterministic stamp —
+/// read_dir order is platform-dependent (the readdir-order lesson). Each
+/// directory's read_dir runs as a spawned task polled with is_finished +
+/// yield (a blocking await from inside a task nests the event loop, C37);
+/// breadth-first over a worklist, which visits exactly the recursion's set.
 _cache_collect_yo_files :: (
-  fn(dir : String, out : ArrayList(String), io : Io) -> unit
-)({
-  walk_exn := Exception(throw : ((_e) -> unwind(())));
-  entries := io.await(read_dir(Path.new(dir.clone()), io), IoExn(io : io, exn : walk_exn));
-  names := ArrayList(String).new();
-  (i : usize) = usize(0);
-  while(i < entries.len(), {
-    match(
-      entries.get(i),
-      .Some(en) => {
-        names.push(en.name.clone());
-      },
-      .None => ()
-    );
-    i = (i + usize(1));
-  });
-  names.sort();
-  (j : usize) = usize(0);
-  while(j < names.len(), {
-    name := names(j);
-    skip := (
-      (name == "yo-out") ||
-        ((name == ".git") || ((name == "node_modules") || (name.starts_with(String.from("tmp")))))
-    );
-    if(!(skip), {
-      full := Path.new(dir.clone()).join(Path.new(name.clone())).to_string();
-      cond(
-        name.ends_with(String.from(".yo")) => {
-          out.push(full);
-        },
-        true => {
-          // Directories recurse; read_dir on a FILE throws and the walker's
-          // handler swallows it, so no stat is needed here.
-          if(!(name.contains(String.from("."))), {
-            recur(full, out, io);
-          });
-        }
-      );
+  fn(dir : String, out : ArrayList(String), io : Io) -> Impl(Future(unit, IoExn))
+)(
+  io.async((e : IoExn) => {
+    work := ArrayList(String).new();
+    work.push(dir.clone());
+    (wi : usize) = usize(0);
+    while(wi < work.len(), {
+      d := work(wi).clone();
+      wi = (wi + usize(1));
+      t := e.io.spawn(_read_dir_task(d.clone(), e.io), e);
+      while(runtime(!(t.is_finished())), {
+        e.io.await(yield(e.io), e.io);
+      });
+      entries := match(t.await(e.io), .Some(es) => es, .None => ArrayList(DirEntry).new());
+      names := ArrayList(String).new();
+      (i : usize) = usize(0);
+      while(i < entries.len(), {
+        match(
+          entries.get(i),
+          .Some(en) => {
+            names.push(en.name.clone());
+          },
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+      names.sort();
+      (j : usize) = usize(0);
+      while(j < names.len(), {
+        name := names(j);
+        skip := (
+          (name == "yo-out") ||
+            ((name == ".git") || ((name == "node_modules") || (name.starts_with(String.from("tmp")))))
+        );
+        if(!(skip), {
+          full := Path.new(d.clone()).join(Path.new(name.clone())).to_string();
+          cond(
+            name.ends_with(String.from(".yo")) => {
+              out.push(full);
+            },
+            true => {
+              // Directories are queued; the next round's read_dir on a FILE
+              // unwinds its task (skipped above), so no stat is needed here.
+              if(!(name.contains(String.from("."))), {
+                work.push(full);
+              });
+            }
+          );
+        });
+        j = (j + usize(1));
+      });
     });
-    j = (j + usize(1));
-  });
-});
+  })
+);
+_read_bytes_task :: (fn(path : String, io : Io) -> Impl(Future(ArrayList(u8), IoExn)))(
+  io.async((e : IoExn) => {
+    // Local swallow handler: an unreadable file unwinds THIS task, read as
+    // `.None` at the JoinHandle below. The unwind payload must match the
+    // future's payload type or def-eval fails and silently hollows this SM;
+    // the value is discarded, the task aborts either way.
+    swallow := Exception(throw : ((_e) -> unwind(ArrayList(u8).new())));
+    e.io.await(read(Path.new(path.clone()), e.io), IoExn(io : e.io, exn : swallow))
+  })
+);
 /// Read a file into the stamp accumulator; `.None` (file vanished mid-walk)
 /// disables the cache for this artifact rather than mis-stamping it.
-_cache_read_file :: (fn(path : String, io : Io) -> Option(ArrayList(u8)))({
-  rd_exn := Exception(throw : ((_e) -> unwind(Option(ArrayList(u8)).None)));
-  bytes := io.await(read(Path.new(path.clone()), io), IoExn(io : io, exn : rd_exn));
-  Option(ArrayList(u8)).Some(bytes)
+_cache_read_file :: (
+  fn(path : String, io : Io) -> Impl(Future(Option(ArrayList(u8)), IoExn))
+)(
+  io.async((e : IoExn) => {
+    t := e.io.spawn(_read_bytes_task(path.clone(), e.io), e);
+    while(runtime(!(t.is_finished())), {
+      e.io.await(yield(e.io), e.io);
+    });
+    match(
+      t.await(e.io),
+      .Some(bytes) => Option(ArrayList(u8)).Some(bytes),
+      .None => Option(ArrayList(u8)).None
+    )
+  })
+);
+/// Append `s2` and a newline to the stamp accumulator. A module-level fn
+/// rather than a local closure, so the io.async body using it stays a plain
+/// statement sequence.
+_stamp_push_str :: (fn(dst : ArrayList(u8), s2 : String) -> unit)({
+  b := s2.as_bytes();
+  (bi : usize) = usize(0);
+  while(bi < b.len(), {
+    dst.push(b(bi));
+    bi = (bi + usize(1));
+  });
+  dst.push(u8(10));
 });
 /// The artifact's input stamp, or "" when stamping failed (cache disabled).
 _artifact_input_stamp :: (
-  fn(argv : ArrayList(String), project_dir : String, io : Io) -> String
-)({
-  acc := ArrayList(u8).new();
-  push_str := (fn(dst : ArrayList(u8), s2 : String) -> unit)({
-    b := s2.as_bytes();
-    (bi : usize) = usize(0);
-    while(bi < b.len(), {
-      dst.push(b(bi));
-      bi = (bi + usize(1));
+  fn(argv : ArrayList(String), project_dir : String, io : Io) -> Impl(Future(String, IoExn))
+)(
+  io.async((e : IoExn) => {
+    acc := ArrayList(u8).new();
+    _stamp_push_str(acc, `yo-version ${CURRENT_YO_VERSION}`);
+    sep := String.from(" ");
+    _stamp_push_str(acc, `argv ${sep.join(argv)}`);
+    files := ArrayList(String).new();
+    e.io.await(_cache_collect_yo_files(project_dir.clone(), files, e.io), e);
+    std_root := resolve_std_path();
+    if(std_root.len() > usize(0), {
+      e.io.await(
+        _cache_collect_yo_files(std_root.replace(String.from("file://"), String.new()), files, e.io),
+        e
+      );
     });
-    dst.push(u8(10));
-  });
-  push_str(acc, `yo-version ${CURRENT_YO_VERSION}`);
-  sep := String.from(" ");
-  push_str(acc, `argv ${sep.join(argv)}`);
-  files := ArrayList(String).new();
-  _cache_collect_yo_files(project_dir.clone(), files, io);
-  std_root := resolve_std_path();
-  if(std_root.len() > usize(0), {
-    _cache_collect_yo_files(std_root.replace(String.from("file://"), String.new()), files, io);
-  });
-  lock_path := Path.new(project_dir.clone()).join(Path.new(String.from("yo.lock"))).to_string();
-  files.push(lock_path);
-  (fi : usize) = usize(0);
-  while(fi < files.len(), {
-    fpath := files(fi);
-    match(
-      _cache_read_file(fpath.clone(), io),
-      .Some(bytes) => {
-        push_str(acc, `${fpath} ${sha256_hex(bytes)}`);
-      },
-      .None => {
-        // yo.lock legitimately may not exist; any OTHER unreadable input
-        // disables the cache.
-        if(!(fpath.ends_with(String.from("yo.lock"))), {
-          return(String.new());
-        });
-      }
-    );
-    fi = (fi + usize(1));
-  });
-  sha256_hex(acc)
-});
+    lock_path := Path.new(project_dir.clone()).join(Path.new(String.from("yo.lock"))).to_string();
+    files.push(lock_path);
+    (fi : usize) = usize(0);
+    while(fi < files.len(), {
+      fpath := files(fi);
+      bytes_opt := e.io.await(_cache_read_file(fpath.clone(), e.io), e);
+      match(
+        bytes_opt,
+        .Some(bytes) => {
+          _stamp_push_str(acc, `${fpath} ${sha256_hex(bytes)}`);
+        },
+        .None => {
+          // yo.lock legitimately may not exist; any OTHER unreadable input
+          // disables the cache.
+          if(!(fpath.ends_with(String.from("yo.lock"))), {
+            return(String.new());
+          });
+        }
+      );
+      fi = (fi + usize(1));
+    });
+    sha256_hex(acc)
+  })
+);
 /// Read the recorded stamp next to an output, `.None` when absent.
-_read_stamp :: (fn(path : String, io : Io) -> Option(String))({
-  st_exn := Exception(throw : ((_e) -> unwind(Option(String).None)));
-  bytes := io.await(read(Path.new(path.clone()), io), IoExn(io : io, exn : st_exn));
-  Option(String).Some(String.from_bytes(bytes))
-});
+_read_stamp :: (fn(path : String, io : Io) -> Impl(Future(Option(String), IoExn)))(
+  io.async((e : IoExn) => {
+    t := e.io.spawn(_read_bytes_task(path.clone(), e.io), e);
+    while(runtime(!(t.is_finished())), {
+      e.io.await(yield(e.io), e.io);
+    });
+    match(
+      t.await(e.io),
+      .Some(bytes) => Option(String).Some(String.from_bytes(bytes)),
+      .None => Option(String).None
+    )
+  })
+);
+_write_string_task :: (fn(path : String, data : String, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async((e : IoExn) => {
+    // Local swallow handler: stamp write failures unwind THIS task, read as
+    // `.None` at the JoinHandle below (the cache is an optimization). The
+    // unwind payload matches the future's payload — write_string's own
+    // unit — or def-eval fails and silently hollows this SM.
+    swallow := Exception(throw : ((_e) -> unwind(())));
+    e.io.await(write_string(Path.new(path.clone()), data.clone(), e.io), IoExn(io : e.io, exn : swallow))
+  })
+);
 /// Record the stamp; failures are silent (the cache is an optimization).
-_write_stamp :: (fn(path : String, stamp : String, io : Io) -> unit)({
-  wr_exn := Exception(throw : ((_e) -> unwind(())));
-  io.await(write_string(Path.new(path.clone()), stamp.clone(), io), IoExn(io : io, exn : wr_exn));
-});
+/// An EMPTY stamp (cache disabled or stamping failed) is still written: it
+/// truncates the previous stamp, making the next build a guaranteed cache
+/// miss — which is the correct outcome in both of those cases anyway.
+_write_stamp :: (fn(path : String, stamp : String, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async((e : IoExn) => {
+    t := e.io.spawn(_write_string_task(path.clone(), stamp.clone(), e.io), e);
+    while(runtime(!(t.is_finished())), {
+      e.io.await(yield(e.io), e.io);
+    });
+    match(
+      t.await(e.io),
+      .Some(_u) => (),
+      .None => ()
+    )
+  })
+);
 compile_artifact :: (
   fn(
     artifact : BuildArtifact,
@@ -535,8 +654,9 @@ compile_artifact :: (
       ctx.registry.modules(usize(0)).name,
       artifact.name.clone()
     );
+    git_v := e.io.await(_git_version(ctx.project_dir.clone(), e.io, e.exn), e);
     version_suffix := match(
-      _git_version(ctx.project_dir.clone(), e.io, e.exn),
+      git_v,
       .Some(v) => ` ${v}`,
       .None => String.new()
     );
@@ -716,8 +836,13 @@ compile_artifact :: (
     // ran) — issues/async-await-in-nested-if-drops-continuation.md. The
     // unconditional exists()/read are harmless when the cache is disabled.
     cache_enabled := match(proc_env.get(`YO_BUILD_NO_CACHE`), .Some(v) => (v != "1"), .None => true);
+    // The stamp is computed unconditionally (a top-level await on purpose —
+    // see the comment above) and only USED when the cache is enabled; the
+    // walk is exactly the work a cached build needs, and YO_BUILD_NO_CACHE
+    // remains the escape hatch for it.
+    stamp_raw := e.io.await(_artifact_input_stamp(cmd._args, ctx.project_dir.clone(), e.io), e);
     stamp := cond(
-      cache_enabled => _artifact_input_stamp(cmd._args, ctx.project_dir.clone(), e.io),
+      cache_enabled => stamp_raw,
       true => String.new()
     );
     stamp_path := `${output_path.to_string()}.inputs-sha256`;
@@ -725,7 +850,7 @@ compile_artifact :: (
     // Building line shows), so the existence probe must too — without it a
     // static-library artifact could never cache-hit.
     out_exists := e.io.await(exists(Path.new(`${output_path.to_string()}${lib_suffix}`), e.io), e.io);
-    prev_stamp := _read_stamp(stamp_path.clone(), e.io);
+    prev_stamp := e.io.await(_read_stamp(stamp_path.clone(), e.io), e);
     stamp_matches := match(prev_stamp, .Some(prev) => (prev == stamp), .None => false);
     use_cache := (((cache_enabled && (stamp.len() > usize(0))) && out_exists) && stamp_matches);
     if(use_cache, {
@@ -733,15 +858,20 @@ compile_artifact :: (
       return(Result(unit, String).Ok(()));
     });
     st := e.io.await(cmd.status(e.io), e);
-    if(st.success(), {
-      if(cache_enabled && (stamp.len() > usize(0)), {
-        _write_stamp(stamp_path.clone(), stamp.clone(), e.io);
-      });
-      Result(unit, String).Ok(())
-    }, {
-      code := st.code().unwrap_or(i32(-1));
-      Result(unit, String).Err(`Compilation failed (exit ${code})`)
-    })
+    // The write decision is DATA, not a branch: an empty stamp (cache off or
+    // stamping failed) is written as-is and truncates — see _write_stamp.
+    stamp_to_write := cond(
+      ((st.success() && cache_enabled) && (stamp.len() > usize(0))) => stamp.clone(),
+      true => String.new()
+    );
+    _ := e.io.await(_write_stamp(stamp_path.clone(), stamp_to_write, e.io), e);
+    cond(
+      st.success() => Result(unit, String).Ok(()),
+      true => {
+        code := st.code().unwrap_or(i32(-1));
+        Result(unit, String).Err(`Compilation failed (exit ${code})`)
+      }
+    )
   })
 );
 // ---------------------------------------------------------------------------

--- a/src/lsp/diagnostics.yo
+++ b/src/lsp/diagnostics.yo
@@ -273,7 +273,7 @@ _analyze_eval :: (
     )
   );
   exprs := parse(text, entry_abs.clone(), local_exn);
-  outcome := mm_eval_entry_exprs(entry_abs.clone(), std_path.clone(), exprs, io, local_exn);
+  outcome := mm_eval_entry_exprs(entry_abs.clone(), std_path.clone(), exprs, local_exn);
   AnalyzeOutcome(ok : outcome.ok, exprs : exprs, info_table : outcome.ctx.expr_info_table)
 });
 

--- a/src/main.yo
+++ b/src/main.yo
@@ -1767,7 +1767,7 @@ run_compile :: (
     // collected functions — the prelude's, every imported module's, and the entry
     // module's. `mm_eval_entry_exprs` applies it from the published slot.
     entry_abs := mm_resolve_entry_abs(input_path.clone(), std_path.clone());
-    outcome := mm_eval_entry_exprs(entry_abs, std_path.clone(), exprs, io, exn);
+    outcome := mm_eval_entry_exprs(entry_abs, std_path.clone(), exprs, exn);
     if(!(outcome.ok), {
       exn.throw(dyn(`compile: failed to evaluate module "${input_path}"`));
       return(());

--- a/src/module_manager.yo
+++ b/src/module_manager.yo
@@ -31,7 +31,6 @@ open(import("std/string"));
 open(import("std/error"));
 open(import("std/fmt"));
 { Path } :: import("std/path");
-{ read } :: import("std/fs/file");
 { ArrayList } :: import("std/collections/array_list");
 { getenv } :: import("std/libc/stdlib");
 { current_exe } :: import("std/env");
@@ -55,11 +54,10 @@ open(import("std/fmt"));
 (g_cached_prelude_env : Option(Environment)) = Option(Environment).None;
 // Demand-driven module loader state (set per load run). The import handler
 // `ctx.load_module` has a fixed `(path) -> LoadModuleResult` signature with no
-// `io`/`exn`, so the loading context is stashed here for the on-demand load
+// `exn`, so the loading context is stashed here for the on-demand load
 // path. This enables CIRCULAR imports: a module is registered as "loading"
 // (with its live env) before its body runs, so a cyclic import reads its
 // partial exports instead of failing "module not preloaded".
-(g_loader_io : Option(Io)) = Option(Io).None;
 (g_loader_std_path : Option(String)) = Option(String).None;
 (g_loader_exn : Option(Exception)) = Option(Exception).None;
 // Shared ExprInfoTable for codegen: when set (during `compile`), every
@@ -147,6 +145,63 @@ _path_exists_sync :: (fn(path : String) -> bool)({
   free(.Some(buf));
   return(rc == int(0));
 });
+extern(
+  "Yo",
+  // errno as a CALL — the C macro is an int LVALUE, not a pointer (same
+  // pattern as std/fs/file.yo).
+  __yo_errno : (fn() -> i32)
+);
+/// Read a whole file synchronously via libc open/read/close. Module loading is
+/// COMPTIME work: it runs inside the evaluator and, under `yo build`, inside
+/// run_build's async task — where the async `std/fs` `read` compiles to a
+/// blocking poll loop that drives the event loop from inside a task
+/// (C37/C42, issues/retired/compiler-build-runner-nests-event-loop.md; the
+/// runtime guard aborts under YO_ASYNC_STRICT=1, so the strict-cleanliness CLI
+/// golden could never pass). The demand loader cannot become a future — the
+/// evaluator calls it synchronously at comptime — so comptime file reads must
+/// not touch the event loop at all. Errors mirror std/fs exactly: an
+/// `IoError.from_errno(errno)` thrown through `exn`.
+_read_file_sync :: (fn(path : String, exn : Exception) -> ArrayList(u8))({
+  // Module-qualified: a bare `open(...)` would resolve to the module-open
+  // builtin, not libc's open (builtin-first dispatch,
+  // issues/builtin-name-shadows-user-definition.md).
+  fcntl :: import("std/libc/fcntl");
+  unistd :: import("std/libc/unistd");
+  { IoError } :: import("std/sys/errors");
+  { GlobalAllocator } :: import("std/allocator");
+  { malloc, free } :: GlobalAllocator;
+  cstr := path.to_cstr().ptr().unwrap();
+  fd := unsafe(fcntl.open(*(char)(cstr), int(fcntl.O_RDONLY)));
+  if(fd < int(0), {
+    exn.throw(dyn(IoError.from_errno(__yo_errno())));
+  });
+  result := ArrayList(u8).new();
+  buf := *(u8)(malloc(usize(4096)).unwrap());
+  while(runtime(true), {
+    // i64 immediately: the c_include `ssize_t` type has no constructor a
+    // body can name (`ssize_t(0)` fails def-eval, silently hollowing this
+    // fn — the C22-adjacent swallow), but casting its RESULT is fine.
+    n := i64(unsafe(unistd.read(fd, *(void)(buf), usize(4096))));
+    cond(
+      (n < i64(0)) => {
+        free(.Some(*(void)(buf)));
+        _ := unsafe(unistd.close(fd));
+        exn.throw(dyn(IoError.from_errno(__yo_errno())));
+      },
+      (n == i64(0)) => break,
+      true => {
+        (i : usize) = usize(0);
+        while(i < usize(n), {
+          result.push((buf.add(i)).*);
+          i = (i + usize(1));
+        });
+      }
+    );
+  });
+  free(.Some(*(void)(buf)));
+  _ := unsafe(unistd.close(fd));
+  result
+});
 /// Resolve the standard-library root. The proper evaluator needs this so
 /// `import("std/...")` can be satisfied — without it, the prelude cannot be
 /// loaded and the majority of user code references (`Option`, `Box`, `+`, …)
@@ -199,15 +254,13 @@ resolve_std_path :: (fn() -> String)({
 // ---------------------------------------------------------------------------
 // State accessors (main.yo's compile path drives these directly)
 // ---------------------------------------------------------------------------
-/// Stash the io / std-path / exn the demand loader will use for nested imports.
+/// Stash the std-path / exn the demand loader will use for nested imports.
 mm_set_loader_context :: (
   fn(
-    io : Io,
     std_path : String,
     exn : Exception
   ) -> unit
 )({
-  g_loader_io = Option(Io).Some(io);
   g_loader_std_path = Option(String).Some(std_path);
   g_loader_exn = Option(Exception).Some(exn);
 });
@@ -333,7 +386,6 @@ mm_reset :: (fn() -> unit)({
   clear_module_cache();
   g_cached_prelude_env = Option(Environment).None;
   g_shared_expr_info_table = Option(ExprInfoTable).None;
-  g_loader_io = Option(Io).None;
   g_loader_std_path = Option(String).None;
   g_loader_exn = Option(Exception).None;
   g_load_module_error = Option(String).None;
@@ -395,16 +447,18 @@ _load_module_at_abs :: (fn(abs : String) -> Option(String))({
   if(module_cache_has(abs.clone()), {
     return(Option(String).None);
   });
-  io := match(g_loader_io, .Some(i) => i, .None => return(Option(String).None));
   std_path := match(g_loader_std_path, .Some(s) => s, .None => String.from(""));
   exn := match(g_loader_exn, .Some(e) => e, .None => return(Option(String).None));
-  fs_path := abs.replace(String.from("file://"), String.from(""));
-  src_bytes := io.await(read(Path.new(fs_path.clone()), io), IoExn(io : io, exn : exn));
+  fs_path := abs.replace(String.from("file://"), String.new());
+  // COMPTIME read — synchronous on purpose (see _read_file_sync): the demand
+  // loader runs inside the evaluator's comptime import resolution, where the
+  // async read's blocking poll loop would nest the event loop (C37/C42).
+  src_bytes := _read_file_sync(fs_path.clone(), exn);
   (src : String) = String.from_bytes(src_bytes);
   // Open-buffer overlay (Phase B1): the editor's text wins over the disk
-  // read above. The read still ALWAYS runs — the await stays a top-level
-  // statement (the async-lowering rule), and import resolution requires the
-  // file to exist on disk anyway.
+  // read above. The read still ALWAYS runs — it is a plain synchronous
+  // statement (no async-lowering shape to respect), and import resolution
+  // requires the file to exist on disk anyway.
   match(
     _open_doc_text(fs_path.clone()),
     .Some(open_text) => {
@@ -564,11 +618,10 @@ mm_eval_entry_exprs :: (
     entry_abs : String,
     std_path : String,
     exprs : ArrayList(AstExpr),
-    io : Io,
     exn : Exception
   ) -> ModuleLoadOutcome
 )({
-  mm_set_loader_context(io, std_path.clone(), exn);
+  mm_set_loader_context(std_path.clone(), exn);
   env := mm_fresh_module_env(entry_abs.clone());
   ctx := eval_context_new(std_path.clone(), entry_abs.clone());
   ctx.is_executing = true;
@@ -678,7 +731,11 @@ mm_load_file :: (
   if(verbose, {
     println(`check: parsing ${input_path}`);
   });
-  src_bytes := io.await(read(Path.new(input_path.clone()), io), IoExn(io : io, exn : exn));
+  // COMPTIME read — synchronous on purpose (see _read_file_sync): evaluating
+  // a module runs inside the evaluator, and under `yo build` inside
+  // run_build's async task, where the async read's blocking poll loop would
+  // nest the event loop (C37/C42).
+  src_bytes := _read_file_sync(input_path.clone(), exn);
   src := String.from_bytes(src_bytes);
   exprs := parse(src, input_path.clone(), local_exn);
   if(verbose, {
@@ -712,7 +769,7 @@ mm_load_file :: (
   });
   // The demand loader must use the LOCAL exn: a nested import's failure has to
   // unwind this file's handler, not the driver's.
-  outcome := mm_eval_entry_exprs(entry_abs, std_path.clone(), exprs, io, local_exn);
+  outcome := mm_eval_entry_exprs(entry_abs, std_path.clone(), exprs, local_exn);
   if(outcome.ok && verbose, {
     println(`check: ${input_path} — evaluator OK`);
   });

--- a/src/version_cache.yo
+++ b/src/version_cache.yo
@@ -456,12 +456,12 @@ clean_version_cache :: (
 /// Follows redirects. Returns the response body as a String.
 /// Mirrors the TS httpGet: HTTP 403 throws the rate-limit message, any
 /// other status >= 400 throws `HTTP <code> fetching <url>`.
+// (The old signature declared an `exn` parameter no call site ever passed —
+// the arity mismatch was swallowed at def-eval time and HOLLOWED this whole
+// async body, silently breaking `yo version list --remote` in every release;
+// issues/wrong-arity-call-silently-accepted-version-install-broken.md.)
 _http_get :: (
-  fn(
-    url : String,
-    io : Io,
-    exn : Exception
-  ) -> Impl(Future(String, IoExn))
+  fn(url : String, io : Io) -> Impl(Future(String, IoExn))
 )(
   io.async((e : IoExn) => {
     cmd := Command.new(String.from("curl"));
@@ -517,12 +517,13 @@ _http_get :: (
 /// "404") so the caller can map statuses to messages (the TS downloadFile
 /// throws and the caller inspects the message; without catch, we return
 /// the status instead). Throws only when curl itself fails (network error).
+// (Same dead-`exn` arity hollow as _http_get — this one broke the download
+// half of `yo version install`.)
 _download_file :: (
   fn(
     url : String,
     dest_path : String,
-    io : Io,
-    exn : Exception
+    io : Io
   ) -> Impl(Future(String, IoExn))
 )(
   io.async((e : IoExn) => {
@@ -678,9 +679,15 @@ download_version :: (
     (code : i64) = match(code_str.parse_i64(), .None => i64(0), .Some(c) => c);
     // Pre-triple fallback: the short `yo-v<v>-<os>-<arch>[-musl]` name.
     if(code == i64(404), {
-      short := host_bundle_name(version, e.exn);
-      println(`No ${bundle_name}.tar.gz on v${version} — retrying the pre-triple bundle name (${short})...`);
-      bundle_name = short;
+      // NOT named `short`: that shadows the prelude C-interop integer type,
+      // and builtin-first dispatch makes the interpolation below resolve the
+      // BUILTIN — the def-eval swallow then hollowed this whole async body,
+      // which is what broke `yo version install` in v0.2.19/v0.2.20
+      // (issues/builtin-name-shadows-user-definition.md, third face;
+      // issues/wrong-arity-call-silently-accepted-version-install-broken.md).
+      short_name := host_bundle_name(version, e.exn);
+      println(`No ${bundle_name}.tar.gz on v${version} — retrying the pre-triple bundle name (${short_name})...`);
+      bundle_name = short_name;
       url = `${_releases_download_url()}/v${version}/${bundle_name}.tar.gz`;
       tarball_path = `${tmp_path_str}/${bundle_name}.tar.gz`;
       short_code_str := e.io.await(_download_file(url, tarball_path, e.io), e);
@@ -700,14 +707,14 @@ download_version :: (
       code = match(legacy_code_str.parse_i64(), .None => i64(0), .Some(c2) => c2);
     });
     if(code == i64(404), {
-      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io), e);
+      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
       msg := `Yo v${version} has no ${bundle_name}.tar.gz release asset.`;
       msg.push_string(String.from("\nRun `yo version list --remote` to see the published releases, or check "));
       msg.push_string(`https://github.com/${_github_repo()}/releases`);
       e.exn.throw(dyn(msg));
     });
     if(code >= i64(400), {
-      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io), e);
+      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
       e.exn.throw(dyn(`HTTP ${code.to_string()} downloading ${url}`));
     });
     // 2. Extract; the tarball root is a `<bundleName>/` directory holding
@@ -720,7 +727,7 @@ download_version :: (
     tar_cmd.arg(tmp_path_str);
     tar_out := e.io.await(tar_cmd.output(e.io), e);
     if(!(tar_out.status.success()), {
-      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io), e);
+      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
       e.exn.throw(dyn(`Failed to extract ${bundle_name}.tar.gz for Yo v${version}`));
     });
     // The tarball root is conventionally named after the asset, but do not
@@ -745,7 +752,7 @@ download_version :: (
       ei = (ei + usize(1));
     });
     if(found_root == false, {
-      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io), e);
+      e.io.await(_cleanup_failed_download(version_dir, tmp_dir.path(), e.io, e.exn), e);
       e.exn.throw(dyn(`Unexpected bundle layout in ${bundle_name}.tar.gz (no directory with bin/ and std/).`));
     });
     // 3. Remove any existing partial extraction (or a dead npm-shaped
@@ -772,7 +779,14 @@ ensure_cached_version :: (
   ) -> Impl(Future(String, IoExn))
 )(
   io.async((e : IoExn) => {
-    cached := e.io.await(is_version_cached(version, e.io), e);
+    // Arity fix (2026-08-30): this call passed TWO args to the THREE-param
+    // is_version_cached for its entire life — the def-eval swallow accepts
+    // wrong-arity calls, and the missing `exn` record made `cached` read
+    // stack garbage at runtime: truthy garbage silently no-opped the install
+    // (rc=0, nothing cached), falsy garbage continued into corrupted state
+    // (rc=134) — `yo version install` was broken in every release
+    // (issues/wrong-arity-call-silently-accepted-version-install-broken.md).
+    cached := e.io.await(is_version_cached(version, e.io, e.exn), e);
     if(cached, {
       return(get_version_cache_dir(version));
     });


### PR DESCRIPTION
Two commits, one release-critical theme: `yo version install` was silently broken in every release, and fixing it surfaced that the compiler itself violates the C37 strict-mode contract on every `yo build`.

## 1. version_cache un-hollowing (b42b7a5f3)

`yo version install <v>` either silently no-opped (rc=0) or died with a bare SIGABRT — in the released v0.2.19 AND v0.2.20. Five independent def-eval failures inside `io.async` bodies, each hollowing the whole emitted state machine (any one failure hollows the SM; the caller's await then silently early-returns). Verified live end-to-end: install, remote list, cached path, 404 fallback. Issue: issues/wrong-arity-call-silently-accepted-version-install-broken.md.

## 2. the compiler's build path nests the event loop (b783c4077)

Under `YO_ASYNC_STRICT=1` every guard-carrying compiler binary — including released v0.2.20 and a binary built at #337 itself — aborts at `yo build` startup. The `async-blocking-await-inside-task` CLI golden has been red since it was added: #337's verifying binary was compiled by the guard-less v0.2.19 seed, whose runtime templates could not fire the guard. Fixes:

- **Comptime module loading is now synchronous libc I/O** (`_read_file_sync`): the evaluator calls the demand loader synchronously at comptime — it can never be a future — so comptime reads must not touch the event loop at all. `g_loader_io` / `mm_eval_entry_exprs`'s io param went vestigial and are removed. Strictly better for the LSP too.
- **The build-graph helpers are proper `io.async` futures** (`_git_version`, `_cache_collect_yo_files` — now a breadth-first worklist over the identical file set, stamp value changes once — `_cache_read_file`, `_read_stamp`, `_write_stamp`), using the `Command.output` spawned-task recipe: the throwing operation runs as a spawned task whose body carries its own swallow handler (an `unwind` inside an `io.async` body must carry the FUTURE's payload type or def-eval fails and silently hollows the SM — four such swallowed shapes are documented in the issue), polled with `is_finished` + `await yield`, consumed via `handle.await` (`.None` = it unwound). Every await is a top-level statement (branch-nested awaits still drop continuations); every decision is data.

Issue: issues/build-startup-blocking-awaits-strict-golden-red-since-337.md (supersedes the retired issue's incorrect clean verdict).

## Verification

- The strict-cleanliness CLI golden (async-blocking-await-inside-task): **PASS** (was rc=134 on every prior binary).
- gates_fast GATEs 0/1/3/4/5/6 green; its three reported FAILs are the macOS bash-3.2 associative-array harness bug (the same harness scripts pass under a bash 5 — full corpus: 45 PASS vs the develop seed's 44, the identical pre-existing 9 diffs, zero new).
- Corpus golden scoring + fixpoint battery: finishing locally, results will be noted here.

## Note for reviewers

develop HEAD's CI is red from a SEPARATE regression (ASan stack-buffer-overflow in a `set_effect` bundle copy on one async_await test, every native leg — issues/asan-stack-overread-set-effect-batch-selftest.md on this branch; not caused by these commits — the develop seed shows it too). The test legs of THIS PR will show that failure; the bootstrap-fixpoint legs should be green.
