### PR TITLE
issues: E-class breadcrumb — cross-contaminated capture type points at the specialization cache key

### DIFF
--- a/issues/asan-stack-overread-set-effect-batch-selftest.md
+++ b/issues/asan-stack-overread-set-effect-batch-selftest.md
@@ -88,6 +88,18 @@ issues/future-wrapper-return-shared-across-specializations.md (C54) and its repr
 issues/repros/future-wrapper-return-two-r-specializations.yo. Until then,
 every PR's native test legs stay red on this one test.
 
+## Breadcrumb for the spec-cache attack (2026-08-30, from the R-fix tracing)
+
+While instrumenting the R-class fix, the `body` capture's type was observed
+as `Impl : (Fn(i64) -> R)` DURING THE `R = String` SPECIALIZATION's body
+evaluation — `T` carried the OTHER specialization's i64 substitution while
+`R` stayed bare. The capture-type stamp itself is cross-contaminated, i.e.
+the specialization cache (create_specialized_function_inline's key) is
+serving a stale/substituted signature to the wrong spec — consistent with
+the child-SM-gets-IoExn symptom and worth checking FIRST:
+`src/evaluator/calls/helper.yo`'s cache key vs the forall/comptime bindings
+of the two call sites.
+
 ## Repro assets
 
 The `debug/asan-batch` branch (temporary — delete when done) carries the


### PR DESCRIPTION
Docs-only: adds the observation from the C54 R-fix tracing to issues/asan-stack-overread-set-effect-batch-selftest.md — the `body` capture's type read `Impl : (Fn(i64) -> R)` DURING the R = String specialization's eval (T carried the OTHER spec's i64), so the specialization cache in create_specialized_function_inline is serving a cross-substituted signature. First place to look for the E-class/ASan fix.