### PR TITLE
std: seed-gated sweep — delete the dead KeyNotFound/ElementNotFound variants + the prelude if-macro; Command.current_dir generation B

### DIFF
--- a/.github/instructions/yo-syntax.instructions.md
+++ b/.github/instructions/yo-syntax.instructions.md
@@ -103,7 +103,7 @@ Same-operator chains never need parens: `a + b + c`, `a && b && c`.
 
 ## `if` is sugar for `cond`
 
-`if(...)` calls are desugared to `cond(...)` at parse time (`desugar_if_calls` in `src/expr.yo`), so every pass after parsing sees a real `cond` node. The equivalent macro definition is kept in `prelude.yo` as the spec and as a fallback for dynamically built ASTs (plans/MACRO_POLICY.md Part 3.2):
+`if(...)` calls are desugared to `cond(...)` at parse time (`desugar_if_calls` in `src/expr.yo`), so every pass after parsing sees a real `cond` node. The prelude macro that used to back this was DELETED 2026-08-30 once the v0.2.20 seed shipped the desugar (plans/MACRO_POLICY.md Part 3.2) — an `if` call the desugar leaves alone (odd arity, mismatched labels, a dynamically built AST) is now an error:
 
 ```rust
 if(condition, then_body)        // → cond(condition => then_body, true => ())

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -10,7 +10,7 @@ D4 PR 9 closed BY EVENTS 2026-08-28: the vendor migrated upstream
 (markdown_yo ff51f91 — zero substring sites remain, and its byte-based
 decoders are CORRECT by construction under the byte-indexed String), the
 pointer is at the migrated commit, and the docs pipeline runs it green end
-to end. D5 closed except the SEED-GATED bufio consumer migration (recorded
+to end. D5 closed — the bufio consumer migration landed 2026-08-28 with the v0.2.18 seed (recorded
 in the backlog doc).
 
 > **Condensed 2026-08-26.** The execution narratives for landed work were
@@ -505,7 +505,7 @@ Open D7 items:
 
 | Module | Verdict | Notes |
 |---|---|---|
-| prelude | FIX + EXTEND | D3 traits DONE; C6 impl removals DONE; `if` macro deletion is seed-gated (next seed bump) |
+| prelude | FIX + EXTEND | D3 traits DONE; C6 impl removals DONE; `if` macro DELETED 2026-08-30 (the v0.2.20 seed ships the parse-time desugar) |
 | error/assert | EXTEND | downcast, derive(Error), context; narrow `error.yo`'s blanket `open(import(./string|./fmt))` re-export |
 | fmt | FIX + EXTEND | `display.yo` deleted (§6); format specs DONE (D3.10); still: collapse 4 print bodies; dedupe 15 snprintf helpers |
 | spec/ | FREEZE AS DOC | identity stubs; mark experimental, exclude from stability promise |
@@ -655,7 +655,7 @@ declarations at runtime.
 2. ~~`std/encoding/utf8.yo` (D8)~~ **DONE 2026-08-25**; ~~`html_encode`~~ **DONE 2026-08-27** (the five XSS-critical characters; `html_decode(html_encode(s)) == s` pinned) — the D2 rename `decode_html` → `html_decode` landed with it
 3. `std/io` redesign with stdio handles (D5) — slices 1–2 DONE; generic wrappers + bufio move remain
 4. ~~`fs.copy`, `fs.remove_dir_all`, `read_link`, `set_permissions`, `try_exists`~~ **DONE 2026-08-27** — `copy` (contents + permission bits + byte count), `try_exists` (throws instead of lying `false` on a denied parent), `set_permissions` in `std/fs/file`; `read_link` in `std/fs/dir`; `remove_dir_all` in **`std/fs/walker`** (its implementation IS the walker, and `fs/walker` imports `fs/dir` — the reverse would cycle); `src/fetch` + `src/version_cache` dropped their private copies. En route: the libc `chmod`/`fchmod` bindings declared their mode as the OPAQUE `mode_t : Type`, which no Yo caller can construct (`mode_t(384)` is a SomeT-callee error — silently swallowed in async bodies); rebound as `u32`
-5. ~~`process.Child`/`spawn`/`Stdio`~~ **DONE 2026-08-27** (`Stdio` Inherit/Piped/Null; chainable builders returning `Self` incl. `env`/`env_clear` over a real envp built from `environ` + overrides; `spawn() -> Child` with `pid`/`write_stdin`/`close_stdin`/`read_std{out,err}_to_end`/`kill`/`wait`; parent pipe ends CLOEXEC — without it a child held the parent's stdin write end and never saw EOF; `ExitStatus.code()` is now `Option(i32)` — a signal death is `.None`, 13 consumers swept). `current_dir` DEFERRED: needs `posix_spawn_file_actions_addchdir` in the runtime shim — a new extern, i.e. SEED-GATED (plans/backlog/SEED_VERSION_AUTOMATION.md). **POSIX-only for now**: the Child/spawn plumbing and the item-4 fs wrappers have no Windows story (fs_convenience's S3 section hard-crashed the Windows CI child; sections skip on Windows) — issues/s3-fs-wrappers-windows-semantics-audit.md
+5. ~~`process.Child`/`spawn`/`Stdio`~~ **DONE 2026-08-27** (`Stdio` Inherit/Piped/Null; chainable builders returning `Self` incl. `env`/`env_clear` over a real envp built from `environ` + overrides; `spawn() -> Child` with `pid`/`write_stdin`/`close_stdin`/`read_std{out,err}_to_end`/`kill`/`wait`; parent pipe ends CLOEXEC — without it a child held the parent's stdin write end and never saw EOF; `ExitStatus.code()` is now `Option(i32)` — a signal death is `.None`, 13 consumers swept). `current_dir` DONE 2026-08-30: generation A (runtime `__yo_async_spawn_start_cwd`, all three runtimes) shipped in v0.2.20; generation B (std/sys `spawn_cwd`, `Command.current_dir`, end-to-end test) landed once that seed was live. **POSIX-only for now**: the Child/spawn plumbing and the item-4 fs wrappers have no Windows story (fs_convenience's S3 section hard-crashed the Windows CI child; sections skip on Windows) — issues/s3-fs-wrappers-windows-semantics-audit.md
 6. ~~async combinators + async channel/mutex + `timeout` (D7)~~ **DONE
    2026-08-27** (branch `s3/async-combinators`, merge pending the CI-red
    triage). Delivered: **JoinHandle `state()`/`is_finished()`/`abort()`**
@@ -802,12 +802,14 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
      (**C35** — same, the check was missing, now FIXED), and
      `HashMapError.KeyNotFound` / `HashSetError.ElementNotFound`, which are dead
      BY DESIGN (lookups return `Option`) and want DELETING here, in §6, since
-     removing a public variant is breaking. **SEED-GATED (measured 2026-08-29):**
+     removing a public variant is breaking. **DELETED 2026-08-30** (seed gate lifted by
+     v0.2.20, which carries C46's nominal-enum exact compare): both variants
+     are gone, and `check ./std` under the v0.2.20 seed passes with the two
+     enums' now-identical shapes. (The gate, for the record: 
      with both variants gone the two enums have identical shapes and the
      v0.2.19 seed — which predates C46's nominal-enum exact compare (#343) —
      conflates them across the std module graph (`check ./std` fails in
-     `hash_set.yo` under the seed, passes under develop's compiler). Delete
-     them in the first PR after SEED_VERSION advances past #343. `std/allocator`'s `Layout` /
+     `hash_set.yo` under the seed, passes under develop's compiler). They were slated for the first PR after SEED_VERSION advanced past #343 — this is that PR.) `std/allocator`'s `Layout` /
      `layout_of` are unconsumed by std but tested and useful on their own
      (a type's size + alignment as a value) — **DECIDED KEEP 2026-08-29** as
      the reflection helper they are; an `alloc(Layout)` entry point can be

--- a/std/collections/hash_map.yo
+++ b/std/collections/hash_map.yo
@@ -8,8 +8,6 @@ pragma(Pragma.AllowUnsafe);
 HashMapError :: enum(
   /// Memory allocation failed.
   AllocError(error : AllocError),
-  /// The requested key was not found.
-  KeyNotFound,
   /// Capacity calculation overflowed.
   CapacityOverflow
 );

--- a/std/collections/hash_set.yo
+++ b/std/collections/hash_set.yo
@@ -7,8 +7,6 @@ pragma(Pragma.AllowUnsafe);
 HashSetError :: enum(
   /// Memory allocation failed.
   AllocError(error : AllocError),
-  /// The element was not found in the set.
-  ElementNotFound,
   /// Capacity calculation overflowed.
   CapacityOverflow
 );

--- a/std/prelude.yo
+++ b/std/prelude.yo
@@ -8268,36 +8268,13 @@ TryInto :: (fn(comptime(To) : Type) -> comptime(Trait))(
   )
 );
 export(TryInto);
-/// `if` macro — expands to `cond(condition => then, true => else)`.
-///
-/// ## Example
-/// ```rust
-/// if(x > 0, println("positive"), println("non-positive"));
-/// ```
-///
-/// NOTE (plans/MACRO_POLICY.md Part 3.2): current compilers desugar
-/// `if(...)` calls to `cond(...)` at parse time (`desugar_if_calls` in
-/// src/expr.yo), so this macro is normally never dispatched. It is KEPT
-/// for (a) seed-generation bootstrap compatibility — the seed binary has
-/// no desugar pass and needs this definition to compile the tree — and
-/// (b) as the fallback for `if` calls the desugar leaves alone (odd
-/// arity, mismatched labels, dynamically built ASTs). Do not delete until
-/// the seed release ships the desugar pass.
-if :: (
-  fn(
-    quote(condition) : Expr,
-    quote(then) : Expr,
-    (quote(else) : Expr) ?= quote(())
-  ) -> unquote(Expr)
-)(
-  quote(
-    cond(
-      unquote(condition) => unquote(then),
-      true => unquote(else)
-    )
-  )
-);
-export(if);
+// The `if` macro was DELETED 2026-08-30 (plans/MACRO_POLICY.md Part 3.2):
+// `if(...)` desugars to `cond(...)` at parse time (`desugar_if_calls`,
+// src/expr.yo) in every compiler since the desugar landed, and the v0.2.20
+// seed ships it — the bootstrap-compatibility reason to keep the macro is
+// gone. An `if` call the desugar leaves alone (odd arity, mismatched
+// labels, a dynamically built AST) is now an error instead of silently
+// dispatching a macro.
 // The `try` macro (unwrap a `Result`, returning early on `Err`) was
 // REMOVED 2026-08-21 (plans/MACRO_POLICY.md Part 3.1): it had zero call
 // sites outside its own test file, it was the only std macro that

--- a/std/process/command.yo
+++ b/std/process/command.yo
@@ -109,7 +109,8 @@ Command :: ref(
     _env_clear : bool,
     _stdin : Stdio,
     _stdout : Stdio,
-    _stderr : Stdio
+    _stderr : Stdio,
+    _cwd : Option(String)
   )
 );
 impl(
@@ -125,7 +126,8 @@ impl(
       _env_clear : false,
       _stdin : Stdio.Inherit,
       _stdout : Stdio.Inherit,
-      _stderr : Stdio.Inherit
+      _stderr : Stdio.Inherit,
+      _cwd : Option(String).None
     )
   ),
   /// Append a single argument to the argv list.
@@ -158,6 +160,14 @@ impl(
     self
   }),
   /// Start the child from an EMPTY environment (only `env()` entries).
+  /// Run the child with `dir` as its working directory. POSIX uses
+  /// posix_spawn_file_actions_addchdir_np (spawn reports ENOSYS on a libc
+  /// without it — macOS 10.15+/glibc 2.29+/musl 1.2.5+ all have it);
+  /// Windows passes lpCurrentDirectory.
+  current_dir : (fn(self : Self, dir : String) -> Self)({
+    self._cwd = Option(String).Some(dir);
+    self
+  }),
   env_clear : (fn(self : Self) -> Self)({
     self._env_clear = true;
     self
@@ -286,6 +296,14 @@ _spawn_with_fds :: (
   storage := _build_cstr_storage(self);
   env_storage := _build_env_storage(self);
   use_envp := (self._env_clear || (self._env_overrides.len() > usize(0)));
+  // The cwd C string is built OUTSIDE the async closure for the same reason
+  // as `storage`: it must be an Rc value the capture struct can own, and it
+  // must stay alive until the spawn call reads it.
+  cwd_cstr := match(
+    self._cwd,
+    .Some(cd) => Option(ArrayList(u8)).Some(cd.to_cstr()),
+    .None => Option(ArrayList(u8)).None
+  );
   // Flush our own stdout BEFORE creating the child. `print`/`println` go through
   // C `fwrite(..., stdout)` (std/fmt/index.yo), which is BLOCK-buffered when
   // stdout is a pipe — while the child inherits the raw fd and writes straight
@@ -363,7 +381,15 @@ _spawn_with_fds :: (
       (envp_buf.add(envc)).* = .None;
       envp_arg = .Some(envp_buf);
     });
-    pid := e.io.await(IO_process.spawn(program_cstr, argv_buf, envp_arg, stdin_fd, stdout_fd, stderr_fd), e.io);
+    (cwd_ptr : ?(*(u8))) = .None;
+    match(
+      cwd_cstr,
+      .Some(cc) => {
+        cwd_ptr = cc.ptr();
+      },
+      .None => ()
+    );
+    pid := e.io.await(IO_process.spawn_cwd(program_cstr, argv_buf, envp_arg, stdin_fd, stdout_fd, stderr_fd, cwd_ptr), e.io);
     // Free argv/envp buffers (storage lists drop naturally at scope end).
     free(.Some(argv_raw));
     match(

--- a/std/sys/externs.yo
+++ b/std/sys/externs.yo
@@ -70,6 +70,10 @@ extern(
   // Process Operations
   // ========================================================================
   __yo_async_spawn_start : (fn(file : *(u8), argv : *(?(*(u8))), envp : ?(*(?(*(u8)))), stdin_fd : i32, stdout_fd : i32, stderr_fd : i32) -> IoFuture),
+  /// Spawn with a working directory (`.None` = inherit the parent's). POSIX:
+  /// posix_spawn_file_actions_addchdir_np (ENOSYS on a libc without it);
+  /// Windows: lpCurrentDirectory. In the v0.2.20 seed's runtime and later.
+  __yo_async_spawn_start_cwd : (fn(file : *(u8), argv : *(?(*(u8))), envp : ?(*(?(*(u8)))), stdin_fd : i32, stdout_fd : i32, stderr_fd : i32, cwd : ?(*(u8))) -> IoFuture),
   __yo_async_waitpid_start : (fn(pid : i32, options : i32) -> IoFuture),
   __yo_process_exit_status : (fn(status : i32) -> i32),
   __yo_process_term_signal : (fn(status : i32) -> i32),
@@ -282,6 +286,7 @@ export(
   __yo_sync_umask,
   // Process operations
   __yo_async_spawn_start,
+  __yo_async_spawn_start_cwd,
   __yo_async_waitpid_start,
   __yo_process_exit_status,
   __yo_process_term_signal,

--- a/std/sys/process.yo
+++ b/std/sys/process.yo
@@ -9,7 +9,7 @@
 // Use `?(*(u8))` for entries so .None can be used as the terminator.
 pragma(Pragma.AllowUnsafe);
 { IoFuture } :: import("./future.yo");
-{ __yo_async_spawn_start, __yo_async_waitpid_start, __yo_process_exit_status, __yo_process_term_signal, __yo_kill } :: import("./externs.yo");
+{ __yo_async_spawn_start, __yo_async_spawn_start_cwd, __yo_async_waitpid_start, __yo_process_exit_status, __yo_process_term_signal, __yo_kill } :: import("./externs.yo");
 // Spawn a child process.
 // Returns the child pid on success, -errno on failure.
 // `argv` is a NULL-terminated array of argument strings.
@@ -26,6 +26,20 @@ spawn :: (
   ) -> IoFuture
 )(
   __yo_async_spawn_start(file, argv, envp, stdin_fd, stdout_fd, stderr_fd)
+);
+// Spawn with a working directory (`.None` = inherit the parent's).
+spawn_cwd :: (
+  fn(
+    file : *(u8),
+    argv : *(?(*(u8))),
+    envp : ?(*(?(*(u8)))),
+    stdin_fd : i32,
+    stdout_fd : i32,
+    stderr_fd : i32,
+    cwd : ?(*(u8))
+  ) -> IoFuture
+)(
+  __yo_async_spawn_start_cwd(file, argv, envp, stdin_fd, stdout_fd, stderr_fd, cwd)
 );
 // Wait for a child process to exit.
 // Returns the exit status (encoded; use exit_status/term_signal helpers).
@@ -47,6 +61,7 @@ term_signal :: (fn(status : i32) -> i32)(
 );
 export(
   spawn,
+  spawn_cwd,
   waitpid,
   kill,
   exit_status,

--- a/tests/process/command.test.yo
+++ b/tests/process/command.test.yo
@@ -322,6 +322,42 @@ test("__yo_async_spawn_start_cwd runs the child in the requested directory (curr
   io.await(remove_file(marker, io), e);
   io.await(remove_dir(Path.new(dir), io), e);
 });
+// Generation B (the v0.2.20 seed carries the runtime symbol): the std surface.
+test("Command.current_dir runs the child in the requested directory (generation B)", {
+  exn := Exception(
+    throw : (
+      (err) -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  dir := `yo_cwd_probe_dir_b`;
+  io.await(create_dir_all_str("yo_cwd_probe_dir_b", io), e);
+  cmd := cond(
+    (platform == Platform.Windows) => {
+      c := Command.new(`cmd.exe`);
+      c.arg(`/C`);
+      c.arg(`type nul > marker.txt`);
+      c
+    },
+    true => {
+      c := Command.new(`/bin/sh`);
+      c.arg(`-c`);
+      c.arg(`touch marker.txt`);
+      c
+    }
+  );
+  cmd.current_dir(dir.to_string());
+  st := io.await(cmd.status(io), e);
+  assert(st.success(), "child exited 0");
+  marker := Path.new(`yo_cwd_probe_dir_b/marker.txt`);
+  made := io.await(exists(marker, io), io);
+  assert(made, "the child must have run inside yo_cwd_probe_dir_b");
+  io.await(remove_file(marker, io), e);
+  io.await(remove_dir(Path.new(dir), io), e);
+});
 // Regression (issues/fixed/command-output-drains-stdout-then-stderr-sequentially.md):
 // `output` used to drain stdout to EOF and only then stderr, so a child that
 // writes more than the pipe buffer (64 KiB) to stderr while stdout is still


### PR DESCRIPTION
The three seed-gated std-audit items, unblocked by the v0.2.20 seed (per plans/STD_API_AUDIT.md §9 phasing):

1. **`HashMapError.KeyNotFound` / `HashSetError.ElementNotFound` DELETED** — dead variants whose shapes are identical to surviving ones since #343's nominal enums (the gate that held them is satisfied). Audit §9 dead-variant rows close.
2. **The prelude `if` macro DELETED** — the parse-time `if`→`cond` desugar (`desugar_if_calls`, plans/MACRO_POLICY.md) shipped in the v0.2.20 seed, so the prelude fallback is dead. A dynamically built `if` AST is now an error, as intended. `.github/instructions/yo-syntax.instructions.md` updated.
3. **`Command.current_dir` generation B** — `std/sys/externs.yo` + `std/sys/process.yo` gain `__yo_async_spawn_start_cwd`/`spawn_cwd` (the runtime symbol shipped in v0.2.20, generation A in #338); `std/process/command.yo` gains `_cwd : Option(String)`, the `current_dir` builder, and `_spawn_with_fds` now calls `spawn_cwd` (`.None` = inherit); generation-B end-to-end test in `tests/process/command.test.yo`.

## Verification (v0.2.20 seed, develop merged in)

- `check ./std` 172/172, `check ./src` 262/262.
- Affected tests: `tests/process/command.test.yo` 11/11, `tests/hash.test.yo` 14/14, `tests/internal/{quote_macro_eval,macro_expansion,macro_helpers,macro_registry}` 3+2+3+5 all pass.
- gates_fast real gates green (the three reported FAILs are the macOS bash-3.2 associative-array harness bug — the same scripts pass under a bash 5: CLI corpus 45 PASS with the identical pre-existing 9 diffs, zero new).
- **FIXPOINT_HOLDS**, CLANG_RC=0, stage2 hollow=0.

The native test legs will show the documented develop-inherited ASan failure (the E-class; see issues/asan-stack-overread-set-effect-batch-selftest.md) — the fixpoint legs should be green.
