### PR TITLE
fix: sleep(0) on Linux — clamp the timerfd arm to 1 ns (zero it_value disarms)

### DIFF
--- a/issues/fixed/sleep-zero-disarms-linux-timerfd.md
+++ b/issues/fixed/sleep-zero-disarms-linux-timerfd.md
@@ -1,7 +1,10 @@
 # `sleep(0)` never completes on Linux — timerfd_settime(0) DISARMS the timer
 
-**Status: OPEN.** Found 2026-09-01 reviewing #373's `yield` park while
-evaluating `sleep(u64(0))` as a granularity-free park.
+**Status: FIXED 2026-09-01.** Found reviewing #373's `yield` park while
+evaluating `sleep(u64(0))` as a granularity-free park. Fixed by clamping the
+timerfd arm value to 1 ns (`__yo_async_sleep_start`,
+`src/codegen/async/runtime_io_common.yo`); pinned by "Test zero-length sleep
+completes" in `tests/sys/timer.test.yo` (plain-context await + in-task await).
 
 ## What
 

--- a/src/codegen/async/runtime_io_common.yo
+++ b/src/codegen/async/runtime_io_common.yo
@@ -704,7 +704,13 @@ ${timer_dispose_init}
   struct itimerspec its = {0};
   its.it_value.tv_sec = (time_t)(milliseconds / 1000);
   its.it_value.tv_nsec = (long)((milliseconds % 1000) * 1000000);
-  
+  if (milliseconds == 0) {
+    // POSIX defines a zero it_value as DISARMING the timer, so sleep(0)
+    // would never fire. Arm for 1 ns instead — completes on the next loop
+    // turn like the kqueue/Windows/wasm runtimes.
+    its.it_value.tv_nsec = 1;
+  }
+
   if (timerfd_settime(tfd, 0, &its, NULL) < 0) {
     int err = errno;
     future->result = -err;

--- a/tests/sys/timer.test.yo
+++ b/tests/sys/timer.test.yo
@@ -37,3 +37,20 @@ test("Test Io timer", {
   io.await(task1, io);
   io.await(task2, io);
 });
+test("Test zero-length sleep completes", {
+  // sleep(0) must complete on the next loop turn on every runtime. Linux's
+  // timerfd variant regressed this: POSIX defines a zero it_value as
+  // DISARMING the timer, so the io_uring read never completed and the awaiter
+  // parked forever (issues/fixed/sleep-zero-disarms-linux-timerfd.md).
+  r0 := io.await(sleep(u64(0)), io);
+  assert(r0 >= i32(0), "sleep(0) awaited from a plain context should complete without error");
+  inner := Box(bool)(false);
+  t := io.async((io : Io) => {
+    r1 := io.await(sleep(u64(0)), io);
+    assert(r1 >= i32(0), "sleep(0) awaited inside a task should complete without error");
+    inner.* = true;
+  });
+  io.spawn(t, io);
+  io.await(t, io);
+  assert(inner.*, "the zero-sleep task body should have run to completion");
+});


### PR DESCRIPTION
POSIX defines `timerfd_settime` with a zero `it_value` as **disarming** the timer, so `sleep(u64(0))` (and `std/time` sleeps with a zero duration) parked its awaiter forever on the io_uring runtime. The kqueue, Windows, and wasm runtimes all complete a zero-length sleep on the next loop turn; the timerfd variant now matches by arming for 1 ns.

Found evaluating `sleep(0)` as a granularity-free `yield` park during the #373 review (`issues/fixed/sleep-zero-disarms-linux-timerfd.md`) — this defect is what blocks that park; the eventual timer-free yield (enqueue own completion) remains seed-gated on a new runtime extern.

Pinned by **"Test zero-length sleep completes"** in `tests/sys/timer.test.yo`: a plain-context await and an in-task await, both asserting non-negative completion.

Verified locally: `check ./src` 262/262; stage-1 built from the tree runs `tests/sys/timer.test.yo` 2/2 on macOS (kqueue regression guard); the `x86_64-unknown-linux-gnu` cross-emit carries the clamp. The Linux runtime path itself is exercised by this PR's ubuntu CI legs (stage-2 templates) — a regression would hang the new test into the runner deadline, so green ubuntu legs are the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)