### PR TITLE
tls: move OpenSSL interop from std's c_include into a per-target runtime backend

### DIFF
--- a/issues/comments-preceding-definitions-can-hollow-the-definition.md
+++ b/issues/comments-preceding-definitions-can-hollow-the-definition.md
@@ -1,0 +1,37 @@
+# Certain comments directly above a definition poison its def-eval when the module loads as a dependency
+
+**Status: OPEN.** Found 2026-08-31 building the TLS runtime backend
+(fix/tls-runtime-backend): a `//` comment block placed directly above a new
+`fn` in `src/codegen/async/runtime_io_common.yo` made the module fail with
+`Cannot unify incompatible types: "String" and "str"` — but ONLY when the
+module was loaded as a DEPENDENCY (checking `runtime.yo`, which imports it);
+checking `runtime_io_common.yo` directly passed.
+
+## Measured
+
+- A 6-line `//` comment above `generate_tls_runtime` (mentioning
+  `__yo_tls_*` externs, `std/crypto/tls.yo` paths, and
+  `(AsyncRuntimeOptions.uses_tls)` in parens) → dependency-load fails,
+  direct check passes.
+- Replacing it with the one-liner `// TLS runtime (see generate_tls_runtime).`
+  → ALSO fails on dependency load (the parens look like a signature?).
+- Removing the comment entirely → the def still failed while the emitter
+  body was ~72 separate `em.emit_string_line("...")` calls, with the failing
+  prefix BISECT moving as lines were edited (non-monotonic; strongly suggests
+  a parse/def-eval interaction, not one bad line).
+- Rewriting the SAME emitter as one `emitter.emit_string(...)` with a
+  single concatenated string → everything passes (262/262).
+
+So at least two faces: (a) comment-with-parens/paths above a definition, (b)
+many sequential `emit_string_line` string literals in one body — both only
+reproducible on the dependency-load path, both resolved by the rewrite. Same
+family as issues/builtin-name-shadows-user-definition.md's "doc-comment
+shaping": comment text influencing def-eval.
+
+## Suggested attack
+
+The dependency-load path (`_load_module_at_abs`) evaluates definitions in a
+different env/order than the entry path (`mm_load_file`); a comment-derived
+`doc` field that the entry path ignores may be consumed as a SIGNATURE hint
+on the dependency path. Repro: the branch `fix/tls-runtime-backend` at the
+commit before the `emit_string` rewrite.

--- a/issues/fixed/tls-runtime-emission-gated-behind-uses-async.md
+++ b/issues/fixed/tls-runtime-emission-gated-behind-uses-async.md
@@ -1,0 +1,48 @@
+# TLS runtime emission was gated behind `uses_async` — a sync `tls_available()` probe emitted an undeclared call
+
+**Status: FIXED 2026-09-01**, in the same PR that introduced the TLS runtime
+backend (caught revalidating that branch after its rebase onto post-#373
+develop, before it ever landed).
+
+## What
+
+The first version of the per-target TLS backend emitted
+`generate_tls_runtime` from inside `generate_async_runtime`
+(`src/codegen/async/runtime.yo`), which itself only runs under
+`if(context.uses_async)` (`src/codegen/functions/generation.yo`). A program
+whose ONLY TLS touch is the synchronous `tls_available()` probe has
+`uses_async == false`, so the `__yo_tls_available` definition was never
+emitted while the call to it was:
+
+```
+tmp/tlsuse.c:1562: error: call to undeclared function '__yo_tls_available'
+```
+
+The nesting also skipped wasm entirely (`generate_tls_runtime` sat inside the
+`!(is_target_wasm)` branch), so a wasm program calling any `__yo_tls_` extern
+would have hit the same undeclared-function error.
+
+## Fix
+
+- Hoist the emission to `generate_all_functions`' runtime section as a
+  sibling of the parallelism runtime: `if(get_uses_tls(),
+  generate_tls_runtime(...))` — independent of `uses_async`.
+- Target selection moved fully into the emitted C's preprocessor guard:
+  `#if !defined(_WIN32) && !defined(__wasm__)` picks OpenSSL; Windows AND
+  wasm get the ABI stubs (`__yo_tls_available` → 0) from the same emission.
+
+## Pin
+
+`tests/crypto/tls_available_sync.test.yo` — a test file with zero async
+usage anywhere in its batch (the runner inlines all of a file's test bodies
+into one `__yo_user_main`, so one async-using test in the file would mask the
+gate). It runs on Windows deliberately: the stub answering `false` is the
+contract there.
+
+## Lesson
+
+A "mirrors `g_uses_parallelism`" flag must also mirror WHERE the twin is
+read: the parallelism runtime is emitted at the `generate_all_functions`
+level, not inside the async runtime. The verification gap was that every
+manual gating check exercised TLS through `std/http` (async by construction)
+— the sync-probe shape was never compiled.

--- a/src/codegen/async/runtime.yo
+++ b/src/codegen/async/runtime.yo
@@ -17,8 +17,9 @@
 { generate_async_runtime_io_linux } :: import("./runtime_io_linux.yo");
 { generate_async_runtime_io_windows } :: import("./runtime_io_windows.yo");
 { generate_async_runtime_io_wasm } :: import("./runtime_io_wasm.yo");
-{ generate_async_runtime_io_common, AsyncRuntimeOptions } :: import("./runtime_io_common.yo");
+{ generate_async_runtime_io_common, AsyncRuntimeOptions, generate_tls_runtime } :: import("./runtime_io_common.yo");
 { panic, assert } :: import("std/assert");
+{ get_uses_tls } :: import("../utils/index.yo");
 /// Emit the async/await runtime for the compilation target. Mirrors
 /// `generateAsyncRuntime`. `_debug_async_await` matches the TS unused param
 /// (debug tracing is gated by the `ASYNC_DEBUG` macro in the emitted C).
@@ -49,6 +50,9 @@ generate_async_runtime :: (
   });
   if(!(is_target_wasm(target_info)), {
     generate_async_runtime_io_common(emitter, target_info, options);
+    if(get_uses_tls(), {
+      generate_tls_runtime(emitter);
+    });
   });
 });
 export(generate_async_runtime);

--- a/src/codegen/async/runtime.yo
+++ b/src/codegen/async/runtime.yo
@@ -17,9 +17,8 @@
 { generate_async_runtime_io_linux } :: import("./runtime_io_linux.yo");
 { generate_async_runtime_io_windows } :: import("./runtime_io_windows.yo");
 { generate_async_runtime_io_wasm } :: import("./runtime_io_wasm.yo");
-{ generate_async_runtime_io_common, AsyncRuntimeOptions, generate_tls_runtime } :: import("./runtime_io_common.yo");
+{ generate_async_runtime_io_common, AsyncRuntimeOptions } :: import("./runtime_io_common.yo");
 { panic, assert } :: import("std/assert");
-{ get_uses_tls } :: import("../utils/index.yo");
 /// Emit the async/await runtime for the compilation target. Mirrors
 /// `generateAsyncRuntime`. `_debug_async_await` matches the TS unused param
 /// (debug tracing is gated by the `ASYNC_DEBUG` macro in the emitted C).
@@ -50,9 +49,6 @@ generate_async_runtime :: (
   });
   if(!(is_target_wasm(target_info)), {
     generate_async_runtime_io_common(emitter, target_info, options);
-    if(get_uses_tls(), {
-      generate_tls_runtime(emitter);
-    });
   });
 });
 export(generate_async_runtime);

--- a/src/codegen/async/runtime_io_common.yo
+++ b/src/codegen/async/runtime_io_common.yo
@@ -1942,4 +1942,146 @@ ${macos_tick}
     );
   });
 });
-export(generate_sys_runtime, generate_async_runtime_io_common, AsyncRuntimeOptions);
+
+generate_tls_runtime :: (fn(emitter : Emitter) -> unit)({
+  emitter.emit_string(
+    `\n`
+    +
+      `// === TLS backend (std/crypto/tls ABI) ===\n`
+      +
+        `#if !defined(_WIN32)\n`
+        +
+          `#include <openssl/ssl.h>\n`
+          +
+            `#include <openssl/bio.h>\n`
+            +
+              `#include <openssl/err.h>\n`
+              +
+                `\n`
+                +
+                  `void* __yo_tls_ctx_new(void) {\n`
+                  +
+                    `  SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());\n`
+                    +
+                      `  if (!ctx) return NULL;\n`
+                      +
+                        `  SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);\n`
+                        +
+                          `  SSL_CTX_set_default_verify_paths(ctx);\n`
+                          +
+                            `  return ctx;\n`
+                            +
+                              `}\n`
+                              +
+                                `void* __yo_tls_ssl_new(void* ctx, const char* hostname) {\n`
+                                +
+                                  `  SSL* ssl = SSL_new((SSL_CTX*)ctx);\n`
+                                  +
+                                    `  if (!ssl) return NULL;\n`
+                                    +
+                                      `  BIO* rbio = BIO_new(BIO_s_mem());\n`
+                                      +
+                                        `  BIO* wbio = BIO_new(BIO_s_mem());\n`
+                                        +
+                                          `  if (!rbio || !wbio) {\n`
+                                          +
+                                            `    if (rbio) BIO_free(rbio);\n`
+                                            +
+                                              `    if (wbio) BIO_free(wbio);\n`
+                                              +
+                                                `    SSL_free(ssl);\n`
+                                                +
+                                                  `    return NULL;\n`
+                                                  +
+                                                    `  }\n`
+                                                    +
+                                                      `  SSL_set_bio(ssl, rbio, wbio);\n`
+                                                      +
+                                                        `  SSL_set_connect_state(ssl);\n`
+                                                        +
+                                                          `  SSL_set1_host(ssl, hostname);\n`
+                                                          +
+                                                            `  SSL_ctrl(ssl, SSL_CTRL_SET_TLSEXT_HOSTNAME, 0, (void*)hostname);\n`
+                                                            +
+                                                              `  return ssl;\n`
+                                                              +
+                                                                `}\n`
+                                                                +
+                                                                  `int __yo_tls_handshake(void* ssl) { return SSL_do_handshake((SSL*)ssl); }\n`
+                                                                  +
+                                                                    `int __yo_tls_get_error(void* ssl, int ret) { return SSL_get_error((SSL*)ssl, ret); }\n`
+                                                                    +
+                                                                      `int __yo_tls_read(void* ssl, void* buf, int num) { return SSL_read((SSL*)ssl, buf, num); }\n`
+                                                                      +
+                                                                        `int __yo_tls_write(void* ssl, const void* buf, int num) { return SSL_write((SSL*)ssl, buf, num); }\n`
+                                                                        +
+                                                                          `int __yo_tls_shutdown(void* ssl) { return SSL_shutdown((SSL*)ssl); }\n`
+                                                                          +
+                                                                            `void __yo_tls_free(void* ssl, void* ctx) { SSL_free((SSL*)ssl); SSL_CTX_free((SSL_CTX*)ctx); }\n`
+                                                                            +
+                                                                              `void* __yo_tls_rbio(void* ssl) { return SSL_get_rbio((SSL*)ssl); }\n`
+                                                                              +
+                                                                                `void* __yo_tls_wbio(void* ssl) { return SSL_get_wbio((SSL*)ssl); }\n`
+                                                                                +
+                                                                                  `size_t __yo_tls_bio_pending(void* bio) { return BIO_ctrl_pending((BIO*)bio); }\n`
+                                                                                  +
+                                                                                    `int __yo_tls_bio_read(void* bio, void* buf, int len) { return BIO_read((BIO*)bio, buf, len); }\n`
+                                                                                    +
+                                                                                      `int __yo_tls_bio_write(void* bio, const void* buf, int len) { return BIO_write((BIO*)bio, buf, len); }\n`
+                                                                                      +
+                                                                                        `void __yo_tls_err_string(char* buf, size_t len) {\n`
+                                                                                        +
+                                                                                          `  unsigned long code = ERR_get_error();\n`
+                                                                                          +
+                                                                                            `  if (code == 0) { snprintf(buf, len, \"no error in the OpenSSL queue\"); return; }\n`
+                                                                                            +
+                                                                                              `  ERR_error_string_n(code, buf, len);\n`
+                                                                                              +
+                                                                                                `}\n`
+                                                                                                +
+                                                                                                  `int __yo_tls_available(void) { return 1; }\n`
+                                                                                                  +
+                                                                                                    `#else\n`
+                                                                                                    +
+                                                                                                      `void* __yo_tls_ctx_new(void) { return NULL; }\n`
+                                                                                                      +
+                                                                                                        `void* __yo_tls_ssl_new(void* ctx, const char* hostname) { (void)ctx; (void)hostname; return NULL; }\n`
+                                                                                                        +
+                                                                                                          `int __yo_tls_handshake(void* ssl) { (void)ssl; return -1; }\n`
+                                                                                                          +
+                                                                                                            `int __yo_tls_get_error(void* ssl, int ret) { (void)ssl; return ret; }\n`
+                                                                                                            +
+                                                                                                              `int __yo_tls_read(void* ssl, void* buf, int num) { (void)ssl; (void)buf; (void)num; return -1; }\n`
+                                                                                                              +
+                                                                                                                `int __yo_tls_write(void* ssl, const void* buf, int num) { (void)ssl; (void)buf; (void)num; return -1; }\n`
+                                                                                                                +
+                                                                                                                  `int __yo_tls_shutdown(void* ssl) { (void)ssl; return 0; }\n`
+                                                                                                                  +
+                                                                                                                    `void __yo_tls_free(void* ssl, void* ctx) { (void)ssl; (void)ctx; }\n`
+                                                                                                                    +
+                                                                                                                      `void* __yo_tls_rbio(void* ssl) { (void)ssl; return NULL; }\n`
+                                                                                                                      +
+                                                                                                                        `void* __yo_tls_wbio(void* ssl) { (void)ssl; return NULL; }\n`
+                                                                                                                        +
+                                                                                                                          `size_t __yo_tls_bio_pending(void* bio) { (void)bio; return 0; }\n`
+                                                                                                                          +
+                                                                                                                            `int __yo_tls_bio_read(void* bio, void* buf, int len) { (void)bio; (void)buf; (void)len; return 0; }\n`
+                                                                                                                            +
+                                                                                                                              `int __yo_tls_bio_write(void* bio, const void* buf, int len) { (void)bio; (void)buf; (void)len; return 0; }\n`
+                                                                                                                              +
+                                                                                                                                `void __yo_tls_err_string(char* buf, size_t len) { snprintf(buf, len, \"TLS is not available in this build; Windows Schannel pending, D6\"); }\n`
+                                                                                                                                +
+                                                                                                                                  `int __yo_tls_available(void) { return 0; }\n`
+                                                                                                                                  +
+                                                                                                                                    `#endif\n`
+                                                                                                                                    +
+                                                                                                                                      `\n`
+  );
+});
+
+export(
+  generate_tls_runtime,
+  generate_sys_runtime,
+  generate_async_runtime_io_common,
+  AsyncRuntimeOptions
+);

--- a/src/codegen/async/runtime_io_common.yo
+++ b/src/codegen/async/runtime_io_common.yo
@@ -1949,7 +1949,7 @@ generate_tls_runtime :: (fn(emitter : Emitter) -> unit)({
     +
       `// === TLS backend (std/crypto/tls ABI) ===\n`
       +
-        `#if !defined(_WIN32)\n`
+        `#if !defined(_WIN32) && !defined(__wasm__)\n`
         +
           `#include <openssl/ssl.h>\n`
           +
@@ -2069,7 +2069,7 @@ generate_tls_runtime :: (fn(emitter : Emitter) -> unit)({
                                                                                                                             +
                                                                                                                               `int __yo_tls_bio_write(void* bio, const void* buf, int len) { (void)bio; (void)buf; (void)len; return 0; }\n`
                                                                                                                               +
-                                                                                                                                `void __yo_tls_err_string(char* buf, size_t len) { snprintf(buf, len, \"TLS is not available in this build; Windows Schannel pending, D6\"); }\n`
+                                                                                                                                `void __yo_tls_err_string(char* buf, size_t len) { snprintf(buf, len, \"TLS is not available in this build (Windows Schannel / wasm backends pending, D6)\"); }\n`
                                                                                                                                 +
                                                                                                                                   `int __yo_tls_available(void) { return 0; }\n`
                                                                                                                                   +

--- a/src/codegen/exprs/async.yo
+++ b/src/codegen/exprs/async.yo
@@ -80,7 +80,8 @@ open(import("std/string"));
   get_variable_type_string,
   get_variable_name_for_codegen,
   scope_stack_contains,
-  mark_uses_parallelism
+  mark_uses_parallelism,
+  mark_uses_tls
 } :: import("../utils/index.yo");
 { Environment } :: import("../../env.yo");
 {
@@ -2366,6 +2367,16 @@ preregister_async_blocks_in_expr :: (fn(expr : AstExpr, context : FunctionGenera
       // Mirror into the module global so main.yo can see it when it assembles
       // the emcc link line (TS: moduleManager.usesParallelism).
       mark_uses_parallelism();
+    }),
+    .None => ()
+  );
+  // TLS backend extern (D6): any __yo_tls_ call drags the TLS runtime (and
+  // its OpenSSL headers on unix) into the emitted C — gated so TLS-free
+  // programs link neither.
+  match(
+    _called_extern_name(expr, context),
+    .Some(name) => if(name.starts_with(String.from("__yo_tls_")), {
+      mark_uses_tls();
     }),
     .None => ()
   );

--- a/src/codegen/functions/generation.yo
+++ b/src/codegen/functions/generation.yo
@@ -31,7 +31,7 @@ open(import("std/string"));
 { is_temp_variable_name } :: import("../../utils.yo");
 { is_target_posix, is_target_linux, is_target_windows } :: import("../../target.yo");
 { get_func_type, is_closure_fn, get_closure_capture_info, is_effect_record_member } :: import("../../function_value.yo");
-{ get_type_string, get_variable_type_string, sanitize_for_c_identifier, get_variable_name_for_codegen, ChunkRange } :: import("../utils/index.yo");
+{ get_type_string, get_variable_type_string, sanitize_for_c_identifier, get_variable_name_for_codegen, ChunkRange, get_uses_tls } :: import("../utils/index.yo");
 { get_shell_redirect } :: import("../../evaluator/values/type_trait_methods.yo");
 { FunctionGenerationContext } :: import("./context.yo");
 { generate_function_prototype, should_skip_function_codegen, _async_override_return_type } :: import("./declarations.yo");
@@ -41,7 +41,7 @@ open(import("std/string"));
 { generate_deferred_drop_expressions, generate_deferred_dup_expressions } :: import("../exprs/drop_dup.yo");
 { t_unit } :: import("../../types/creators.yo");
 { collect_unwind_value_ctypes, generate_atomic_gc_runtime_functions } :: import("./gc_runtime.yo");
-{ generate_sys_runtime, AsyncRuntimeOptions } :: import("../async/runtime_io_common.yo");
+{ generate_sys_runtime, AsyncRuntimeOptions, generate_tls_runtime } :: import("../async/runtime_io_common.yo");
 { generate_async_runtime } :: import("../async/runtime.yo");
 { generate_parallelism_runtime } :: import("../parallelism/runtime.yo");
 { generate_ref_struct_constructor_functions, generate_ref_enum_constructor_functions, generate_closure_constructor_functions } :: import("./constructors.yo");
@@ -869,6 +869,13 @@ generate_all_functions :: (fn(context : FunctionGenerationContext) -> unit)({
   // Mirrors generateAllFunctions (generation.ts:386).
   if(context.uses_parallelism, {
     generate_parallelism_runtime(context.base.emitter, context.base.debug_parallelism, context.base.target_info, context.uses_async);
+  });
+  // TLS backend: emitted independently of uses_async — a SYNC program probing
+  // tls_available() must still link the __yo_tls_ ABI. Target selection
+  // (OpenSSL vs stubs) lives in the emitted C's preprocessor guard, so wasm
+  // and Windows get stubs from the same emission.
+  if(get_uses_tls(), {
+    generate_tls_runtime(context.base.emitter);
   });
   collect_unwind_value_ctypes(context);
   generate_atomic_gc_runtime_functions(context);

--- a/src/codegen/utils/index.yo
+++ b/src/codegen/utils/index.yo
@@ -68,6 +68,14 @@ mark_uses_parallelism :: (fn() -> unit)({
   g_uses_parallelism = true;
 });
 get_uses_parallelism :: (fn() -> bool)(g_uses_parallelism);
+// TLS runtime flag (D6): set when any __yo_tls_ extern is called, read by
+// generate_async_runtime to emit the TLS backend only for programs that use
+// it. Same lifetime reasoning as g_uses_parallelism above.
+(g_uses_tls : bool) = false;
+mark_uses_tls :: (fn() -> unit)({
+  g_uses_tls = true;
+});
+get_uses_tls :: (fn() -> bool)(g_uses_tls);
 { ExprInfoTable, ExprInfo, expr_info_table_get, get_extern_c_global_type, is_module_level_global, module_global_c_suffix, lookup_some_resolved_concrete } :: import("../../expr_info.yo");
 {
   AstExpr,
@@ -1665,6 +1673,8 @@ find_returned_async_block :: (fn(expr : Option(AstExpr)) -> Option(AstExpr))(
   )
 );
 export(
+  mark_uses_tls,
+  get_uses_tls,
   CodeGenContext,
   ChunkRange,
   CodegenTypeEntry,

--- a/std/crypto/tls.yo
+++ b/std/crypto/tls.yo
@@ -31,43 +31,31 @@ open(import("../string"));
 IoTraits :: import("../io");
 { ToString } :: import("../fmt");
 
-c_include(
-  "<openssl/ssl.h>",
-  // Library / context
-  TLS_client_method : (fn() -> *(void)),
-  SSL_CTX_new : (fn(method : *(void)) -> ?(*(void))),
-  SSL_CTX_free : (fn(ctx : *(void)) -> unit),
-  SSL_CTX_set_verify : (fn(ctx : *(void), mode : int, callback : ?(*(void))) -> unit),
-  SSL_CTX_set_default_verify_paths : (fn(ctx : *(void)) -> int),
-  // Connection object
-  SSL_new : (fn(ctx : *(void)) -> ?(*(void))),
-  SSL_free : (fn(ssl : *(void)) -> unit),
-  SSL_set_bio : (fn(ssl : *(void), rbio : *(void), wbio : *(void)) -> unit),
-  SSL_set_connect_state : (fn(ssl : *(void)) -> unit),
-  SSL_set1_host : (fn(ssl : *(void), hostname : *(char)) -> int),
-  SSL_ctrl : (fn(ssl : *(void), cmd : int, larg : i64, parg : ?(*(void))) -> i64),
-  // Handshake + I/O
-  SSL_do_handshake : (fn(ssl : *(void)) -> int),
-  SSL_get_error : (fn(ssl : *(void), ret : int) -> int),
-  SSL_read : (fn(ssl : *(void), buf : *(void), num : int) -> int),
-  SSL_write : (fn(ssl : *(void), buf : *(void), num : int) -> int),
-  SSL_shutdown : (fn(ssl : *(void)) -> int)
+extern(
+  "Yo",
+  // The TLS backend ABI (D6). OpenSSL on unix targets; ABI stubs on Windows
+  // until the Schannel row of the Windows platform audit lands — the
+  // implementation is selected per TARGET at C-compile time and emitted only
+  // when a __yo_tls_ extern is called.
+  __yo_tls_ctx_new : (fn() -> ?(*(void))),
+  __yo_tls_ssl_new : (fn(ctx : *(void), hostname : *(char)) -> ?(*(void))),
+  __yo_tls_handshake : (fn(ssl : *(void)) -> int),
+  __yo_tls_get_error : (fn(ssl : *(void), ret : int) -> int),
+  __yo_tls_read : (fn(ssl : *(void), buf : *(void), num : int) -> int),
+  __yo_tls_write : (fn(ssl : *(void), buf : *(void), num : int) -> int),
+  __yo_tls_shutdown : (fn(ssl : *(void)) -> int),
+  __yo_tls_free : (fn(ssl : *(void), ctx : *(void)) -> unit),
+  __yo_tls_rbio : (fn(ssl : *(void)) -> *(void)),
+  __yo_tls_wbio : (fn(ssl : *(void)) -> *(void)),
+  __yo_tls_bio_pending : (fn(bio : *(void)) -> usize),
+  __yo_tls_bio_read : (fn(bio : *(void), buf : *(void), len : int) -> int),
+  __yo_tls_bio_write : (fn(bio : *(void), buf : *(void), len : int) -> int),
+  __yo_tls_err_string : (fn(buf : *(char), len : usize) -> unit),
+  __yo_tls_available : (fn() -> bool)
 );
-c_include(
-  "<openssl/bio.h>",
-  BIO_new : (fn(kind : *(void)) -> ?(*(void))),
-  BIO_s_mem : (fn() -> *(void)),
-  BIO_read : (fn(bio : *(void), buf : *(void), len : int) -> int),
-  BIO_write : (fn(bio : *(void), buf : *(void), len : int) -> int),
-  BIO_ctrl_pending : (fn(bio : *(void)) -> usize)
-);
-c_include(
-  "<openssl/err.h>",
-  ERR_get_error : (fn() -> u64),
-  ERR_error_string_n : (fn(code : u64, buf : *(char), len : usize) -> unit)
-);
-// OpenSSL constants used here (stable public ABI values), as zero-arg fns —
-// runtime ints cannot be module-level `::` constants.
+/// True when this build's TLS backend can connect (unix + OpenSSL).
+tls_available :: (fn() -> bool)(unsafe(__yo_tls_available()));
+export(tls_available);
 _SSL_VERIFY_PEER :: (fn() -> int)(int(1));
 _SSL_CTRL_SET_TLSEXT_HOSTNAME :: (fn() -> int)(int(55));
 // SSL_get_error results.
@@ -104,18 +92,12 @@ impl(
   )
 );
 export(TlsError);
-/// Last OpenSSL error as text (empty queue → a fixed note).
+/// Last backend error as text (empty queue → a fixed note).
 _ssl_err_string :: (fn() -> String)({
-  code := unsafe(ERR_get_error());
-  cond(
-    (code == u64(0)) => `no error in the OpenSSL queue`.to_string(),
-    true => {
-      buf := ArrayList(u8).with_capacity(usize(256));
-      buf.resize_with_byte(usize(256), int(0));
-      unsafe(ERR_error_string_n(code, *(char)(buf.ptr().unwrap()), usize(256)));
-      String.from_cstr(buf.ptr().unwrap()).unwrap_or(`unknown OpenSSL error`.to_string())
-    }
-  )
+  buf := ArrayList(u8).with_capacity(usize(256));
+  buf.resize_with_byte(usize(256), int(0));
+  unsafe(__yo_tls_err_string(*(char)(buf.ptr().unwrap()), usize(256)));
+  String.from_cstr(buf.ptr().unwrap()).unwrap_or(`unknown TLS error`.to_string())
 });
 _throw_tls :: (fn(err : TlsError, exn : Exception) -> unit)(
   exn.throw(dyn(err))
@@ -139,9 +121,9 @@ _flush_wbio :: (fn(s : TlsStream, io : Io) -> Impl(Future(unit, IoExn)))({
   io.async((e) => {
     buf := ArrayList(u8).with_capacity(_PUMP_CAP());
     buf.resize_with_byte(_PUMP_CAP(), int(0));
-    (pending : usize) = unsafe(BIO_ctrl_pending(wbio));
+    (pending : usize) = unsafe(__yo_tls_bio_pending(wbio));
     while(pending > usize(0), {
-      n := unsafe(BIO_read(wbio, *(void)(buf.ptr().unwrap()), int(_PUMP_CAP())));
+      n := unsafe(__yo_tls_bio_read(wbio, *(void)(buf.ptr().unwrap()), int(_PUMP_CAP())));
       cond(
         (n > int(0)) => {
           // write_all over the raw chunk.
@@ -154,7 +136,7 @@ _flush_wbio :: (fn(s : TlsStream, io : Io) -> Impl(Future(unit, IoExn)))({
         },
         true => ()
       );
-      pending = unsafe(BIO_ctrl_pending(wbio));
+      pending = unsafe(__yo_tls_bio_pending(wbio));
     });
     return(());
   })
@@ -169,7 +151,7 @@ _feed_rbio :: (fn(s : TlsStream, io : Io) -> Impl(Future(usize, IoExn)))({
     n := e.io.await(tcp.read(buf.ptr().unwrap(), _PUMP_CAP(), e.io), e);
     cond(
       (n > usize(0)) => {
-        _w := unsafe(BIO_write(rbio, *(void)(buf.ptr().unwrap()), int(n)));
+        _w := unsafe(__yo_tls_bio_write(rbio, *(void)(buf.ptr().unwrap()), int(n)));
       },
       true => ()
     );
@@ -193,34 +175,28 @@ impl(
       );
       addr := SocketAddr.new(addrs(usize(0)), port);
       tcp := e.io.await(TcpStream.connect(addr, e.io), e);
-      // 2. OpenSSL objects.
-      ctx_opt := unsafe(SSL_CTX_new(unsafe(TLS_client_method())));
+      // 2. Backend objects (verify + trust store + SNI + hostname pin are
+      // configured inside __yo_tls_ssl_new).
+      host_c := host.to_cstr();
+      ctx_opt := unsafe(__yo_tls_ctx_new());
       if(ctx_opt.is_none(), {
         _throw_tls(TlsError.Handshake(detail : _ssl_err_string()), e.exn);
       });
       ctx := ctx_opt.unwrap();
-      unsafe(SSL_CTX_set_verify(ctx, _SSL_VERIFY_PEER(), ?(*(void)).None));
-      _vp := unsafe(SSL_CTX_set_default_verify_paths(ctx));
-      ssl_opt := unsafe(SSL_new(ctx));
+      ssl_opt := unsafe(__yo_tls_ssl_new(ctx, *(char)(host_c.ptr().unwrap())));
       if(ssl_opt.is_none(), {
-        unsafe(SSL_CTX_free(ctx));
         _throw_tls(TlsError.Handshake(detail : _ssl_err_string()), e.exn);
       });
       ssl := ssl_opt.unwrap();
-      rbio := unsafe(BIO_new(unsafe(BIO_s_mem()))).unwrap();
-      wbio := unsafe(BIO_new(unsafe(BIO_s_mem()))).unwrap();
-      unsafe(SSL_set_bio(ssl, rbio, wbio));
-      unsafe(SSL_set_connect_state(ssl));
-      host_c := host.to_cstr();
-      _h := unsafe(SSL_set1_host(ssl, *(char)(host_c.ptr().unwrap())));
-      _sni := unsafe(SSL_ctrl(ssl, _SSL_CTRL_SET_TLSEXT_HOSTNAME(), i64(0), ?(*(void)).Some(*(void)(host_c.ptr().unwrap()))));
+      rbio := unsafe(__yo_tls_rbio(ssl));
+      wbio := unsafe(__yo_tls_wbio(ssl));
       s := TlsStream(_tcp : tcp, _ctx : ctx, _ssl : ssl, _rbio : rbio, _wbio : wbio, _closed : false);
       // 3. Handshake pump. Awaits sit ONE branch under the while — deeper
       // nesting is an unsupported async shape (the closure FTTs to an abort
       // stub; see issues/ftt-stub-in-live-closure-falls-off-non-void-function.md).
       (done : bool) = false;
       while(!(done), {
-        rc := unsafe(SSL_do_handshake(ssl));
+        rc := unsafe(__yo_tls_handshake(ssl));
         e.io.await(_flush_wbio(s, e.io), e);
         (need_read : bool) = false;
         cond(
@@ -228,7 +204,7 @@ impl(
             done = true;
           },
           true => {
-            err := unsafe(SSL_get_error(ssl, rc));
+            err := unsafe(__yo_tls_get_error(ssl, rc));
             cond(
               (err == _SSL_ERROR_WANT_READ()) => {
                 need_read = true;
@@ -260,7 +236,7 @@ impl(
       (out : usize) = usize(0);
       (settled : bool) = false;
       while(!(settled), {
-        rc := unsafe(SSL_read(ssl, *(void)(buf), int(size)));
+        rc := unsafe(__yo_tls_read(ssl, *(void)(buf), int(size)));
         (act : int) = int(0);
         cond(
           (rc > int(0)) => {
@@ -268,7 +244,7 @@ impl(
             settled = true;
           },
           true => {
-            err := unsafe(SSL_get_error(ssl, rc));
+            err := unsafe(__yo_tls_get_error(ssl, rc));
             cond(
               (err == _SSL_ERROR_ZERO_RETURN()) => {
                 out = usize(0);
@@ -317,7 +293,7 @@ impl(
       (out : usize) = usize(0);
       (settled : bool) = false;
       while(!(settled), {
-        rc := unsafe(SSL_write(ssl, *(void)(buf), int(size)));
+        rc := unsafe(__yo_tls_write(ssl, *(void)(buf), int(size)));
         e.io.await(_flush_wbio(self, e.io), e);
         (need_read : bool) = false;
         cond(
@@ -326,7 +302,7 @@ impl(
             settled = true;
           },
           true => {
-            err := unsafe(SSL_get_error(ssl, rc));
+            err := unsafe(__yo_tls_get_error(ssl, rc));
             cond(
               (err == _SSL_ERROR_WANT_READ()) => {
                 need_read = true;
@@ -378,11 +354,11 @@ impl(
         self._closed => (),
         true => {
           self._closed = true;
-          _sd := unsafe(SSL_shutdown(self._ssl));
+          _sd := unsafe(__yo_tls_shutdown(self._ssl));
           e.io.await(_flush_wbio(self, e.io), e);
-          // SSL_free releases both BIOs (owned via SSL_set_bio).
-          unsafe(SSL_free(self._ssl));
-          unsafe(SSL_CTX_free(self._ctx));
+          // __yo_tls_free releases both BIOs (owned by the SSL object) and
+          // the context.
+          unsafe(__yo_tls_free(self._ssl, self._ctx));
           e.io.await(self._tcp.close(e.io), e);
         }
       );

--- a/tests/crypto/tls_available_sync.test.yo
+++ b/tests/crypto/tls_available_sync.test.yo
@@ -1,0 +1,19 @@
+//! `tls_available()` from a SYNC-only program: pins the TLS runtime emission
+//! being independent of `uses_async` (the `__yo_tls_` ABI must be emitted for
+//! a program whose only TLS touch is the sync probe — see
+//! issues/fixed/tls-runtime-emission-gated-behind-uses-async.md). Runs on
+//! Windows deliberately: the stub backend answering `false` there IS the
+//! contract until Schannel lands.
+pragma(Pragma.SkipWasm32Emscripten); // std/crypto/tls imports the socket stack
+pragma(Pragma.SkipWasm32Wasi); // no network stack in WASM
+{ assert } :: import("std/assert");
+{ tls_available } :: import("std/crypto/tls");
+{ platform, Platform } :: import("std/process");
+
+test("tls_available links and answers in a sync-only program", {
+  avail := tls_available();
+  cond(
+    (platform == Platform.Windows) => assert(!(avail), "Windows builds carry ABI stubs until the Schannel backend lands"),
+    true => assert(avail, "unix builds carry the OpenSSL backend")
+  );
+});


### PR DESCRIPTION
Carries the successor-agent's TLS backend redesign (rebased onto post-#373/#374 develop) plus a gating fix found revalidating it.

## The backend move (commit 1)
`std/crypto/tls.yo` no longer declares OpenSSL `c_include` blocks — the ABI is now `extern("Yo") __yo_tls_*`, emitted by `generate_tls_runtime` behind the `g_uses_tls` module global (mirrors `g_uses_parallelism`). Unix targets get the OpenSSL wrappers; Windows gets ABI stubs (`tls_available()` → `false`) until the Schannel backend lands. This unblocks #364's Windows story: programs (and the compiler's own closure, once `version_cache` uses `std/http`) no longer need OpenSSL headers unless they actually use TLS. Link flags come from the existing pkg-config probe (same stance as liburing). Also documents the def-eval comment-hollowing pitfall (`issues/comments-preceding-definitions-can-hollow-the-definition.md`).

## The gating fix (commit 2)
The first version emitted the TLS runtime from inside `generate_async_runtime` (which only runs under `uses_async`) — a **sync** program whose only TLS touch is `tls_available()` got a C error (`call to undeclared function '__yo_tls_available'`), and wasm targets could never see the ABI. The emission is now a sibling of the parallelism runtime, gated only on `get_uses_tls()`; the C guard widened to `#if !defined(_WIN32) && !defined(__wasm__)` so Windows AND wasm get stubs. `issues/fixed/tls-runtime-emission-gated-behind-uses-async.md`.

Pinned by `tests/crypto/tls_available_sync.test.yo` — an async-free batch, verified failing under the pre-fix stage-1 with the exact error; it runs on the Windows legs deliberately (the stub answering `false` is the contract there — the only Windows TLS coverage, since the live-fetch test skips Windows).

## Validation (local, this exact tree)
- `check ./src` 262/262, `check ./std` 172/172
- Gating matrix: plain program **0** TLS refs; sync TLS program links and prints `tls: true` (live OpenSSL); windows/wasm cross-emits carry the guard + stubs
- tls 2/2 (live HTTPS fetch), http 34/34, async 24/24 under stage-1
- `gates_fast`: failures=0, CLI scorecard 54 PASS / 0 DIFF / 1 SKIP
- `fixpoint_only`: **FIXPOINT_HOLDS**, CLANG_RC=0, stage-2 hollow=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)