### PR TITLE
fix: dedup on-demand type-body emission without touching emission order (dyn batch redefinition)

### DIFF
--- a/issues/build-smoke-hangs-registry-perturbation.md
+++ b/issues/build-smoke-hangs-registry-perturbation.md
@@ -130,7 +130,7 @@ against a `--debug-async-await` build of #369:
    site + evaluator-side registration of concrete params/results, and making
    the type intern table's insertion order unobservable.
 4. Also fixed in a worktree (unmerged): the dyn double-emission
-   (issues/dyn-async-future-trait-body-emitted-twice.md) — its shared-set
+   (issues/fixed/dyn-async-future-trait-body-emitted-twice.md) — its shared-set
    fix reorders the intern table and must be reworked order-stably.
 * Optionally: make `yield` park on the loop (enqueue itself) so a sync-await
   of it drives `poll_step` once; that would have turned this whole hang into

--- a/issues/fixed/dyn-async-future-trait-body-emitted-twice.md
+++ b/issues/fixed/dyn-async-future-trait-body-emitted-twice.md
@@ -1,14 +1,19 @@
 # A dyn method's async Future-trait return type emitted its struct TWICE — "redefinition of '__yo_t60_struct'"
 
-**Status: OPEN — the shared-set fix was implemented, verified on the dyn batch,
-and then RETRACTED: keying suppression on the C name renumbers the whole type
-table (the early on-demand render changes interning order; ~1.7k lines of the
-compiler's own C change) and that perturbation flipped the CI tier-1
-async_await and the platform smoke legs — the same fragility class this
-campaign keeps hitting. The correct fix must dedup WITHOUT changing emission
-order (e.g. emit-once keyed on type_key with the name assigned at first
-collection, or defer the on-demand body to the pass that owns the name).
-Found 2026-08-31; mechanism below stands.** Found
+**Status: FIXED 2026-09-01.** The retracted shared-set fix (see history below)
+was replaced by an ASYMMETRIC set that cannot perturb emission order:
+`CodeGenContext.on_demand_body_cnames` is populated ONLY by the on-demand
+hook (`_on_demand_collect_and_declare`, codegen_c.yo) with the C names whose
+bodies IT emits — the name is already rendered there, so no new interning —
+and the declaration passes (types/generation.yo: simple-enum, topological
+struct/enum/tuple, nullable-pointer-enum, and the union/future-trait arms of
+the fifth pass) skip exactly those names. On a tree where the hook never
+fires before/during the passes the set is empty at pass time and the emitted
+C is byte-identical — PROVEN: the pre-fix and post-fix compilers emit
+hash-identical stage-2 C (sha256 b94924bd…) for the same input tree.
+`tests/dyn.test.yo` 9/9. (This redefinition went live on develop when #374
+re-landed the prelude shrink; every full-suite CI leg was red on batch 60.)
+Found
 2026-08-31 diagnosing why the `tests/dyn.test.yo` batch went RED under the
 self-hosted compiler the moment #370's prelude shrink landed (the develop-HEAD
 hollow sweep reported `tests/dyn.test.yo RED`, and every native suite leg died

--- a/src/codegen/codegen_c.yo
+++ b/src/codegen/codegen_c.yo
@@ -130,6 +130,12 @@ _on_demand_collect_and_declare :: (fn(t : TypeValue, context : CodeGenContext) -
         od_l.push_str("; // Forward declaration (on-demand)");
         context.emitter.emit_declaration_string_line(od_l);
       });
+      // Record the body emission so the declaration passes skip this C name
+      // (they may not have reached it yet — the hook can fire DURING a pass).
+      // Mark before emitting, matching type_id_static_names' stance.
+      if(od_is_struct || od_is_enum || od_is_tuple || od_is_union || od_is_future, {
+        _od_m := context.on_demand_body_cnames.insert(od_cn.clone());
+      });
       cond(
         od_is_struct => generate_struct_declaration(od_ty, od_cn.clone(), context),
         od_is_enum => generate_enum_declaration(od_ty, od_cn.clone(), context),

--- a/src/codegen/types/generation.yo
+++ b/src/codegen/types/generation.yo
@@ -1479,7 +1479,7 @@ generate_type_declarations :: (fn(context : CodeGenContext) -> unit)({
           ty := entry.ty;
           skip := (type_contains_some_type(ty) || entry.c_include.is_some());
           if(!(skip) && (is_enum_type(ty) && can_optimize_as_simple_enum(ty)), {
-            if(!(emitted_decl_cnames.contains(entry.c_name.clone())), {
+            if(!(emitted_decl_cnames.contains(entry.c_name.clone())) && !(context.on_demand_body_cnames.contains(entry.c_name.clone())), {
               _dn := emitted_decl_cnames.insert(entry.c_name.clone());
               generate_enum_declaration(ty, entry.c_name.clone(), context);
             });
@@ -1703,11 +1703,14 @@ generate_type_declarations :: (fn(context : CodeGenContext) -> unit)({
         entries.get(yi),
         .Some(e) => if(e.type_id == sid, {
           found = true;
-          cond(
-            (e.kind == "struct") => generate_struct_declaration(e.ty, e.c_name.clone(), context),
-            (e.kind == "enum") => generate_enum_declaration(e.ty, e.c_name.clone(), context),
-            (e.kind == "tuple") => generate_tuple_declaration(e.ty, e.c_name.clone(), context),
-            true => ()
+          if(
+            !(context.on_demand_body_cnames.contains(e.c_name.clone())),
+            cond(
+              (e.kind == "struct") => generate_struct_declaration(e.ty, e.c_name.clone(), context),
+              (e.kind == "enum") => generate_enum_declaration(e.ty, e.c_name.clone(), context),
+              (e.kind == "tuple") => generate_tuple_declaration(e.ty, e.c_name.clone(), context),
+              true => ()
+            )
           );
         }),
         .None => ()
@@ -1728,7 +1731,9 @@ generate_type_declarations :: (fn(context : CodeGenContext) -> unit)({
           ty := entry.ty;
           skip := (_walk_skip_some(ty) || entry.c_include.is_some());
           if(!(skip) && (is_enum_type(ty) && can_optimize_as_nullable_pointer(ty).is_some()), {
-            generate_enum_declaration(ty, entry.c_name.clone(), context);
+            if(!(context.on_demand_body_cnames.contains(entry.c_name.clone())), {
+              generate_enum_declaration(ty, entry.c_name.clone(), context);
+            });
           });
         },
         .None => ()
@@ -1749,12 +1754,13 @@ generate_type_declarations :: (fn(context : CodeGenContext) -> unit)({
         .Some(entry) => {
           ty := entry.ty;
           skip := (type_contains_some_type(ty) || entry.c_include.is_some());
+          od_done := context.on_demand_body_cnames.contains(entry.c_name.clone());
           if(
             !(skip),
             cond(
               is_dyn_type(ty) => generate_dyn_declaration(ty, entry.c_name.clone(), context),
-              is_union_type(ty) => generate_union_declaration(ty, entry.c_name.clone(), context),
-              is_future_trait_type(ty) => generate_future_trait_declaration(ty, entry.c_name.clone(), context),
+              (is_union_type(ty) && !(od_done)) => generate_union_declaration(ty, entry.c_name.clone(), context),
+              (is_future_trait_type(ty) && !(od_done)) => generate_future_trait_declaration(ty, entry.c_name.clone(), context),
               true => ()
             )
           );

--- a/src/codegen/utils/index.yo
+++ b/src/codegen/utils/index.yo
@@ -212,6 +212,19 @@ CodeGenContext :: ref(
     /// ("redefinition of __yo_typeid___yo_tN" — the lexer batch). Shared by
     /// the typeid/downcast expression emitters and the Dyn vtable pass.
     type_id_static_names : HashSet(String),
+    /// C names of type BODIES the on-demand declare hook already emitted
+    /// (_on_demand_collect_and_declare, codegen_c.yo). The declaration passes
+    /// (types/generation.yo) SKIP these — one C name must have exactly one
+    /// definition, and a type first resolved lazily DURING a pass (e.g. a dyn
+    /// method's Future-trait return type minted while its vtable renders) is
+    /// emitted by the hook and would be re-emitted when the pass iteration
+    /// reaches it ("redefinition of __yo_tN_struct", the dyn batch). Populated
+    /// ONLY by the hook — the passes never mark — so on a tree where the hook
+    /// never fires before/during the passes the emitted C is byte-identical
+    /// (dedup must NOT change emission or interning order: a prior fix that
+    /// re-keyed emissions was retracted for renumbering the type table — see
+    /// issues/fixed/dyn-async-future-trait-body-emitted-twice.md).
+    on_demand_body_cnames : HashSet(String),
     /// __yo_dyn_box_* typedefs already emitted. Shared between the type-decl
     /// phase's box pass and the function phase's ctor pass: dyn impls register
     /// LAZILY (at use sites during body generation), so a box first seen by
@@ -318,6 +331,7 @@ impl(
       inside_match : false,
       type_id_statics : HashMap(String, String).new(),
       type_id_static_names : HashSet(String).new(),
+      on_demand_body_cnames : HashSet(String).new(),
       dyn_box_typedefs : HashSet(String).new(),
       dyn_impls : HashMap(String, DynImplEntry).new(),
       current_module_id : Option(String).None,


### PR DESCRIPTION
**Un-reds develop**: every full-suite CI leg has been failing since #374 on `tests/dyn.test.yo`'s batch — `error: redefinition of '__yo_t60_struct'` (#375's and #376's runs both show it).

## Mechanism (issues/fixed/dyn-async-future-trait-body-emitted-twice.md)
A dyn method's async Future-trait return type is minted lazily WHILE the fifth declaration pass renders the dyn vtable; the on-demand hook emits its forward typedef + body, and the pass iteration then reaches the same entry and emits the body again — one C name, two definitions. The defect predates #370/#374 (the on-demand path and the declaration passes never shared an already-emitted set); #374's prelude shrink merely re-shifted collection order enough to make a Future-trait arrive lazily at pass time.

## Why this fix can't perturb emission order
A prior shared-set fix was retracted for renumbering the type table and flipping other CI legs. This one is **asymmetric**: `CodeGenContext.on_demand_body_cnames` is populated ONLY by the on-demand hook with the C names whose bodies IT emits (the name is already rendered there — no new interning), and the declaration passes skip exactly those names. On a tree where the hook never fires before/during the passes the set is empty at pass time and the emitted C is untouched.

**Proven byte-identical on a healthy corpus**: the pre-fix and post-fix compilers emit hash-identical stage-2 C for the same input tree (`sha256 b94924bd…`).

## Validation (local, this tree)
- `check ./src` 262/262
- `tests/dyn.test.yo` **9/9** (was: batch C compile error, the develop redness)
- `tests/async_await.test.yo` **188/188** (the leg the retracted fix flipped)
- `gates_fast`: failures=0, CLI scorecard 54 PASS / 0 DIFF / 1 SKIP
- `fixpoint_only`: **FIXPOINT_HOLDS**, CLANG_RC=0

Admin-merging to restore develop; #375 and #376 then merge develop in and re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)