### PR TITLE
ci: apostrophes broke the single-quoted Alpine docker scripts (musl syntax error)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1009,9 +1009,11 @@ jobs:
             # std/http in the compiler closure (D6 PR-3) puts OpenSSL into the
             # emitted C. Alpine splits the archives out of openssl-dev (headers +
             # .so) into openssl-libs-static — without it the assert below fires
-            # (PR #364's first run). Static here means the artifact needs NO
-            # openssl on the user's machine. Same assert-the-.a stance as
-            # liburing above.
+            # (the PR 364 first run hit this). Static here means the artifact
+            # needs NO openssl on the machine of whoever runs it. Same
+            # assert-the-.a stance as liburing above. No apostrophes in here:
+            # the whole script is single-quoted for docker sh -euc, and one
+            # broke the quoting on the test.yml twin of this block.
             test -f /usr/lib/libssl.a || {
               echo "::error::openssl-libs-static did not provide /usr/lib/libssl.a; -static -lssl cannot work"
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1482,8 +1482,12 @@ jobs:
             # std/http in the compiler closure (D6 PR-3) puts OpenSSL into the
             # emitted C. Alpine splits the archives out of openssl-dev (headers +
             # .so) into openssl-libs-static — without it the assert below fires
-            # (PR #364's first run). Static here means the artifact needs NO
-            # openssl on the host. Same assert-the-.a stance as liburing.
+            # (the PR 364 first run hit this). Static here means the artifact
+            # needs NO openssl on the host. Same assert-the-.a stance as
+            # liburing. NOTE: no apostrophes in here — the whole script is
+            # single-quoted for docker sh -euc, and one in the PR 364 comment
+            # broke the quoting (the musl leg died on "syntax error near
+            # unexpected token )" before reaching apk).
             test -f /usr/lib/libssl.a || {
               echo "::error::openssl-libs-static did not provide /usr/lib/libssl.a; -static -lssl cannot work"
               exit 1


### PR DESCRIPTION
Fixes the develop-red musl leg (run 33581883390): the openssl-libs-static comments carried apostrophes inside the single-quoted `sh -euc '...'` docker blocks, terminating the quoting — the wrapper script died with `syntax error near unexpected token )` before apk ran. Same comments sat in release.yml's Alpine blocks and would have failed the next release run. Rephrased apostrophe-free; verified no apostrophe remains inside any quoted docker script in either workflow. The failing job never reached the package step, so the package fix itself is still unexercised — this PR's CI is its first real run.