### PR TITLE
issues: point the remaining references at issues/fixed/

### DIFF
--- a/issues/builtin-name-shadows-user-definition.md
+++ b/issues/builtin-name-shadows-user-definition.md
@@ -6,7 +6,7 @@ integer type inside a template interpolation; the def-eval failure was
 swallowed, the WHOLE async body shipped hollow, and **`yo version install`
 was silently broken in the released v0.2.19 and v0.2.20** (rc=0 no-op /
 bare-SIGABRT rc=134 —
-issues/wrong-arity-call-silently-accepted-version-install-broken.md). This
+issues/fixed/wrong-arity-call-silently-accepted-version-install-broken.md). This
 issue is no longer theoretical: pick option 1 (reserve) or 2 (prefer user
 bindings), or at minimum land option 3's shadowing diagnostic, before the
 next release.

--- a/src/evaluator/context.yo
+++ b/src/evaluator/context.yo
@@ -969,7 +969,7 @@ forward_ref_diagnostic :: (fn(msg : String) -> Option(String))({
 /// that shipped broken `yo version install` in v0.2.19/v0.2.20: check stayed
 /// green, the swallow ate "Argument count mismatch", and the async state
 /// machine emitted a too-few-arguments C call (UB — garbage values, not an
-/// error). issues/wrong-arity-call-silently-accepted-version-install-broken.md.
+/// error). issues/fixed/wrong-arity-call-silently-accepted-version-install-broken.md.
 hard_swallow_diagnostic :: (fn(msg : String) -> Option(String))(
   match(
     forward_ref_diagnostic(msg),

--- a/src/version_cache.yo
+++ b/src/version_cache.yo
@@ -654,7 +654,7 @@ download_version :: (
       // BUILTIN — the def-eval swallow then hollowed this whole async body,
       // which is what broke `yo version install` in v0.2.19/v0.2.20
       // (issues/builtin-name-shadows-user-definition.md, third face;
-      // issues/wrong-arity-call-silently-accepted-version-install-broken.md).
+      // issues/fixed/wrong-arity-call-silently-accepted-version-install-broken.md).
       short_name := host_bundle_name(version, e.exn);
       println(`No ${bundle_name}.tar.gz on v${version} — retrying the pre-triple bundle name (${short_name})...`);
       bundle_name = short_name;
@@ -755,7 +755,7 @@ ensure_cached_version :: (
     // stack garbage at runtime: truthy garbage silently no-opped the install
     // (rc=0, nothing cached), falsy garbage continued into corrupted state
     // (rc=134) — `yo version install` was broken in every release
-    // (issues/wrong-arity-call-silently-accepted-version-install-broken.md).
+    // (issues/fixed/wrong-arity-call-silently-accepted-version-install-broken.md).
     cached := e.io.await(is_version_cached(version, e.io, e.exn), e);
     if(cached, {
       return(get_version_cache_dir(version));


### PR DESCRIPTION
Follow-up to #388's move: three citations (builtin-name-shadows doc, two version_cache comments, the new hard_swallow_diagnostic doc comment) still named the old path.