### PR TITLE
issues: the async-body vacuous-compile hole is fixed (#390) — move to fixed/

### DIFF
--- a/issues/fixed/async-body-type-error-compiles-vacuously.md
+++ b/issues/fixed/async-body-type-error-compiles-vacuously.md
@@ -1,6 +1,6 @@
 # A type error inside an `io.async` closure body compiles vacuously (runs nothing, exits 0)
 
-- **Status**: OPEN (fix in flight)
+- **Status**: FIXED 2026-09-02 (#390 — poison gates at both io.async emitters)
 - **Found**: 2026-09-02 (STD API audit, handover §0c scoping)
 - **Family**: def-eval trial swallow → silent codegen hollowing. Siblings:
   `issues/fixed/trait-default-awaiting-self-async-method-emits-hollow-fn.md`

--- a/tests/cli-cases/compile-async-body-type-error/opts
+++ b/tests/cli-cases/compile-async-body-type-error/opts
@@ -3,7 +3,7 @@
 # binary ran to completion having executed none of the closure body (the
 # def-time anon-body trial swallowed the error, no await analysis was stamped,
 # and the sync-future fallback emitted a runs-nothing future — the C22
-# _sync_fut_t class; issues/async-body-type-error-compiles-vacuously.md).
+# _sync_fut_t class; issues/fixed/async-body-type-error-compiles-vacuously.md).
 # The gate is in codegen (src/codegen/exprs/async.yo), so the case compiles
 # rather than checks, and keeps the diagnostic substring.
 stdout_keep_match=was never fully evaluated


### PR DESCRIPTION
Bookkeeping for #390: `issues/async-body-type-error-compiles-vacuously.md` → `issues/fixed/` (status updated), and the golden case's opts comment repointed. The bare-`e` class the gate exposed stays open as `issues/io-async-bare-e-closure-body-never-evaluates.md`.