### PR TITLE
fix: .io on a bare Io receiver is the identity projection — bare-(e) io.async bodies evaluate and run

### DIFF
--- a/issues/fixed/io-async-bare-e-closure-body-never-evaluates.md
+++ b/issues/fixed/io-async-bare-e-closure-body-never-evaluates.md
@@ -1,7 +1,10 @@
 # A bare `(e) =>` io.async closure body never evaluates — it compiled to a runs-nothing future, silently
 
-- **Status**: OPEN (the silent form is now a hard compile error via the async
-  poison gate, #390; making the body actually evaluate is the open work)
+- **Status**: FIXED 2026-09-03 — the `.io` projection is now total: on a
+  bare `Io` receiver it is the IDENTITY (evaluator +
+  codegen `property_access.yo` twins), so the bundle-style body evaluates at
+  def time and the future runs it. Pinned by the "bare-e closure with
+  e.io.await body runs" test in tests/async_unit_tail_await.test.yo.
 - **Found**: 2026-09-02, validating #390's poison gate against the test suite
   (`tests/async_unit_tail_await.test.yo`'s `outer_unit`, wasm + macOS legs).
 

--- a/issues/module-global-referenced-inside-async-closure-undeclared.md
+++ b/issues/module-global-referenced-inside-async-closure-undeclared.md
@@ -1,0 +1,47 @@
+# A module-level global referenced inside an io.async closure body emits undeclared-identifier C
+
+- **Status**: OPEN
+- **Found**: 2026-09-03, building the bare-`e` repro for
+  `issues/fixed/io-async-bare-e-closure-body-never-evaluates.md` (PR #394).
+
+## Reproducer
+
+```rust
+{ AtomicI32, MemoryOrder } :: import("std/sync/atomic");
+
+counter := AtomicI32(i32(0));
+
+annotated_unit :: (fn(io : Io) -> Impl(Future(unit)))(
+  io.async((io2 : Io) => { counter.fetch_add(i32(1), MemoryOrder.Relaxed); () })
+);
+
+main :: (fn(io : Io) -> unit)({
+  io.await(annotated_unit(io), io);
+});
+export(main);
+```
+
+`yo compile` fails at the C level — the async closure's emission references
+the module global TWO incompatible ways at once:
+
+```
+error: use of undeclared identifier 'counter'
+error: no member named 'counter_m8791753955306202863' in 'struct __yo_t14_struct'
+```
+
+The capture machinery routes the module-level binding into the closure's
+capture struct (the `counter_m<hash>` member — the module-global C-name
+mangling from `issues/fixed/module-global-c-names-are-not-namespaced.md`)
+while at least one use site emits the RAW name `counter`. Note the ANNOTATED
+closure form fails identically — this is not the bare-`e` class.
+
+Workaround used by every existing async test: reference only fn-locals and
+params inside async closure bodies (the `Box`-local pattern of
+`tests/async_await.test.yo`).
+
+## Where to look
+
+The async state-machine / sync-future closure capture collection: a binding
+that is MODULE-level should not be captured at all (it is process-global in
+C) — the capture filter probably tests "not in the closure's local frames"
+and misses the module-global registry.

--- a/src/codegen/exprs/property_access.yo
+++ b/src/codegen/exprs/property_access.yo
@@ -28,6 +28,7 @@ open(import("std/string"));
 { _call_generate_expr } :: import("./_expr.yo");
 { sanitize_for_c_identifier, get_variable_name_for_codegen, get_enum_variant_c_name, can_optimize_as_nullable_pointer, type_key } :: import("../utils/index.yo");
 { generate_comptime_value } :: import("./comptime_value.yo");
+{ lookup_io_builtin_struct_field } :: import("../../expr_info.yo");
 /// True if `s` is all ASCII digits (non-empty).
 _all_digits :: (fn(s : String) -> bool)({
   // BYTE count — the loop reads byte_at; String.len() counts RUNES
@@ -316,6 +317,18 @@ generate_field_access :: (fn(expr : AstExpr, indent : String, context : Function
       .None => ()
     );
     return(get_variable_name_for_codegen(field_name.clone(), Option(Environment).Some(ei.env)));
+  });
+  // The bare `Io` effect struct's `.io` member is the IDENTITY projection
+  // (evaluator twin in evaluator/exprs/property_access.yo): a bundle-style
+  // body (`e.io.await(f, e.io)`) whose effect bound to the bare Io emits
+  // `e`, not a nonexistent `e.io` field. Keyed on the io-builtin side
+  // table, so a user struct with an `io` field is untouched.
+  if((field_name == "io") && is_struct_type(object_type) && match(
+    object_type,
+    .Struct({ id : oid }) => lookup_io_builtin_struct_field(oid.clone(), String.from("await")).is_some(),
+    _ => false
+  ), {
+    return(object_code.clone());
   });
   // Newtype: accessing the single field returns the value itself (zero-cost).
   // A by-`ref` receiver is already dereferenced by generate_atom (`(*self)`), so

--- a/src/evaluator/exprs/property_access.yo
+++ b/src/evaluator/exprs/property_access.yo
@@ -36,6 +36,7 @@ _(env : pa_dbg_env) :: import("std/env");
   expr_info_table_set,
   expr_info_origin_type,
   expr_info_set_origin_type,
+  lookup_io_builtin_struct_field,
   ComptimeRef
 } :: import("../../expr_info.yo");
 { Environment, Variable, get_variables_from_env } :: import("../../env.yo");
@@ -1435,6 +1436,36 @@ Raw pointer operations may dereference invalid memory.`,
     });
   });
   obj_val_main := match(obj_info_opt, .Some(oi) => oi.value, .None => Option(EvalValue).None);
+  // -------------------------------------------------------------------------
+  // `.io` on the bare `Io` effect struct is the IDENTITY projection.
+  // The bundle-style body form (`e.io.await(f, e.io)`) is written against an
+  // effect BUNDLE ({io, exn}), but when an io.async closure's effect binds
+  // `E` to the bare `Io` (Step 6b-nested derives it from the receiver), `e`
+  // IS the Io and the projection must total — identity — or the body fails
+  // its def-time trial ("No matching call found" on `(e.io).await`), was
+  // historically swallowed into a runs-nothing future, and is now rejected
+  // by the async poison gate
+  // (issues/io-async-bare-e-closure-body-never-evaluates.md). Only `io` is
+  // total: `.exn` on a bare Io stays a field-miss (there is no exception
+  // capability to project). Identity is keyed on the io-builtin side table,
+  // so a user struct that merely has an `io` field is untouched.
+  if(is_struct_type(base_ty) && ast_expr_is_atom(property_expr) && (ast_expr_token(property_expr).value == "io"), {
+    io_proj_sid := match(base_ty, .Struct({ id : ips }) => ips, _ => String.from(""));
+    if((io_proj_sid.len() > usize(0)) && lookup_io_builtin_struct_field(io_proj_sid.clone(), String.from("await")).is_some(), {
+      out_io := new_expr_info(env, base_ty);
+      out_io.value = obj_val_main;
+      out_io.variable_name = match(obj_info_opt, .Some(oi_io) => oi_io.variable_name, .None => Option(String).None);
+      out_io.path_collection = match(
+        obj_info_opt,
+        .Some(oi_pc) => oi_pc.path_collection,
+        .None => ArrayList(ArrayList(String)).new()
+      );
+      out_io.is_accessing_property = Option(bool).Some(true);
+      expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_io);
+      expr_info_table_set(ctx.expr_info_table, ast_expr_id(property_expr), out_io);
+      return(expr);
+    });
+  });
   // -------------------------------------------------------------------------
   // Struct / Tuple / Union field access
   // -------------------------------------------------------------------------

--- a/tests/async_unit_tail_await.test.yo
+++ b/tests/async_unit_tail_await.test.yo
@@ -83,3 +83,20 @@ test("concrete unit tail await control still works", {
   io.await(outer_unit(io), t_e);
   assert(true, "completed");
 });
+// The bare-(e) form (issues/io-async-bare-e-closure-body-never-evaluates.md):
+// an UNANNOTATED closure param with a bundle-style `e.io.await(...)` body.
+// The `.io` projection on a bare `Io` receiver is identity, so the body
+// evaluates at def time and the future actually RUNS it — before the root
+// fix this shape compiled to a runs-nothing future (silently, pre-#390) or
+// was rejected by the poison gate (post-#390). The awaited VALUE proves the
+// body executed end to end.
+test("bare-e closure with e.io.await body runs", {
+  inner7 :: (fn(io : Io) -> Impl(Future(i32)))(
+    io.async((io2 : Io) => i32(7))
+  );
+  outer7 :: (fn(io : Io) -> Impl(Future(i32)))(
+    io.async(e => e.io.await(inner7(io), e.io))
+  );
+  v := io.await(outer7(io), io);
+  assert(v == i32(7), "the bare-e closure body must actually run");
+});


### PR DESCRIPTION
## What

Closes `issues/fixed/io-async-bare-e-closure-body-never-evaluates.md` (the class #390's poison gate exposed).

An `io.async` closure with an **unannotated** param and a **bundle-style** body — `io.async((e) => e.io.await(f, e.io))` — whose effect binds to the bare `Io` (Step 6b-nested derives `E := Io` from the receiver) could never evaluate at def time: `e.io` is a *bundle* projection and the `Io` struct has no `io` field. Pre-#390 the swallow was silent (the future compiled to a **runs-nothing** stub — the test's `assert(true)` could not tell); post-#390 the gate rejected it.

## Fix

The `.io` projection is now **total**: on a receiver whose type is the `Io` effect struct, `X.io` is the **identity** —
- evaluator twin (`src/evaluator/exprs/property_access.yo`): the access records the object's info (type/value/name/path) instead of a field-miss,
- codegen twin (`src/codegen/exprs/property_access.yo`): returns the object's C text (same shape as the newtype zero-cost field).

Only `.io` is total — `.exn` on a bare `Io` stays a field-miss (there is no exception capability to project). Identity is keyed on the **io-builtin side table** (`lookup_io_builtin_struct_field`), so a user struct with an `io` field is untouched, and bundle receivers (`{io, exn}`) keep their real field projection.

## Acceptance (fixed-binary)

- the repro compiles **and its body runs**: the awaited inner value `7` flows out and the assert holds
- `.exn` on a bare Io still errors; a user struct's `io` field projects normally (prints its value)
- #390's repro still fails (gate intact); good/dead/nested twins still pass
- `check ./std` **172/172**; self-compile green; **full fast suite green (rc=0)**; CLI battery **PASS 57 / GOLDEN-DIFF 0 / NO-GOLDEN 0**; fmt gate clean
- new regression test: *bare-e closure with e.io.await body runs* (`tests/async_unit_tail_await.test.yo`, 3/3)

Note: an orthogonal pre-existing bug surfaced while building the repro (a **module-level global** referenced inside an async closure body emits `use of undeclared identifier` + a mangled capture member — repro available); not addressed here, happy to file it separately if it's not already tracked.