### PR TITLE
fmt: D2 flattens through prefix operands (a && !b chains)

### DIFF
--- a/plans/FMT_PAREN_ELISION.md
+++ b/plans/FMT_PAREN_ELISION.md
@@ -112,7 +112,10 @@ has no remaining caller, and the helper is deleted.
 ### D2 — E4: flatten left-nested same-operator groups
 
 `(a ⊕ b) ⊕ c` → `a ⊕ b ⊕ c` when the group is the LEFT operand of the same
-operator and the group's depth-0 operators all equal it. Includes inside a
+operator and the group's depth-0 INFIX operators all equal it. Prefix
+operators in operand position do not count as chain links — `((a) && !b) && !c`
+flattens all the way to `(a) && !b && !c` (refined 2026-09-03; the first cut
+counted the `!`s as operators and refused to flatten past them). Includes inside a
 retained R1 group: `y := ((1 + 2) + 3)` → `y := (1 + 2 + 3)`.
 Right operands NEVER flatten (R2); mixed operators NEVER (R3).
 

--- a/src/codegen/codegen_c.yo
+++ b/src/codegen/codegen_c.yo
@@ -197,10 +197,10 @@ compute_needs_cycle_gc :: (fn(context : CodeGenContext) -> unit)({
       vals.next(),
       .Some(entry) => {
         ty := entry.ty;
-        is_struct_root := ((is_reference_struct_type(ty) && !is_atomic_reference_struct_type(ty)) && !_struct_has_generic_field(ty));
+        is_struct_root := (is_reference_struct_type(ty) && !is_atomic_reference_struct_type(ty) && !_struct_has_generic_field(ty));
         // A reference-semantics enum can also form an RC cycle (recursive Self
         // variant field), so it is a cycle root too.
-        is_enum_root := ((is_reference_enum_type(ty) && !is_atomic_reference_enum_type(ty)) && !type_contains_some_type_deep(ty));
+        is_enum_root := (is_reference_enum_type(ty) && !is_atomic_reference_enum_type(ty) && !type_contains_some_type_deep(ty));
         if((is_struct_root || is_enum_root) && can_type_form_rc_cycle(ty), {
           context.needs_cycle_gc = true;
           go = false;

--- a/src/codegen/exprs/generation.yo
+++ b/src/codegen/exprs/generation.yo
@@ -707,7 +707,7 @@ generate_func_call :: (fn(expr : AstExpr, indent : String, context : FunctionGen
   match(
     ei.value,
     .Some(v) => {
-      is_plain_comptime := ((!is_unknown_val(v) && !is_unit_type(ei.ty)) && !has_any_control_flow(ei.control_flow));
+      is_plain_comptime := (!is_unknown_val(v) && !is_unit_type(ei.ty) && !has_any_control_flow(ei.control_flow));
       is_runtime_ctor := ((is_struct_val(v) || is_enum_val(v)) && ctor_has_runtime_args);
       if(is_plain_comptime && !is_runtime_ctor, {
         comptime_code := generate_comptime_value(v, ei.ty, context.base);

--- a/src/codegen/exprs/match.yo
+++ b/src/codegen/exprs/match.yo
@@ -406,7 +406,7 @@ _emit_case_body_and_break :: (fn(case_body : AstExpr, indent : String, body_inde
   body_code := generate_case_body(case_body, body_indent.clone(), context);
   assigned := match(
     temp_var_opt,
-    .Some(tv) => if((!is_unit && (body_code.len() > usize(0))) && !_is_control_flow_code(body_code), {
+    .Some(tv) => if(!is_unit && (body_code.len() > usize(0)) && !_is_control_flow_code(body_code), {
       line := body_indent.clone();
       line.push_string(tv.clone());
       line.push_str(" = ");
@@ -1030,7 +1030,7 @@ _emit_destructure_binds :: (fn(enum_type : TypeValue, variant_name : String, par
                 label := match(pargs.get(usize(0)), .Some(le) => if(ast_expr_is_atom(le), ast_expr_token(le).value, String.from("")), .None => String.from(""));
                 match(
                   pargs.get(usize(1)),
-                  .Some(var_expr) => if((ast_expr_is_atom(var_expr) && !(ast_expr_token(var_expr).value == "_")) && (label.len() > usize(0)), {
+                  .Some(var_expr) => if(ast_expr_is_atom(var_expr) && !(ast_expr_token(var_expr).value == "_") && (label.len() > usize(0)), {
                     // Find the field index for this label.
                     (fi : usize) = labels.len();
                     nl := labels.len();

--- a/src/codegen/exprs/return.yo
+++ b/src/codegen/exprs/return.yo
@@ -800,7 +800,7 @@ generate_return :: (fn(expr : AstExpr, indent : String, context : FunctionGenera
       return_temp_var := match(ei.variable_name, .Some(vn) => Option(String).Some(get_variable_name_for_codegen(vn, Option(Environment).Some(ei.env))), .None => Option(String).None);
       match(
         return_temp_var,
-        .Some(rtv) => if((!handled_deferred_dup && !is_unit) && !(rtv == arg_code), {
+        .Some(rtv) => if(!handled_deferred_dup && !is_unit && !(rtv == arg_code), {
           line := indent.clone();
           line.push_string(return_type.clone());
           line.push_str(" ");

--- a/src/codegen/functions/constructors.yo
+++ b/src/codegen/functions/constructors.yo
@@ -127,7 +127,7 @@ _generate_one_constructor :: (fn(type : TypeValue, c_name : String, context : Fu
   // Traversal function pointer (cyclic GC only; atomic never participates;
   // the small header has no traverse_fn — nothing ever reads it on
   // untracked objects).
-  if((context.base.needs_cycle_gc && !is_atomic) && !small_header, {
+  if(context.base.needs_cycle_gc && !is_atomic && !small_header, {
     line := String.from("  obj->header.traverse_fn = __yo_traverse_");
     line.push_string(c_name.clone());
     line.push_str(";");
@@ -152,7 +152,7 @@ _generate_one_constructor :: (fn(type : TypeValue, c_name : String, context : Fu
     fi = (fi + usize(1));
   });
   // Register with GC if this type might participate in cycles.
-  if((context.base.needs_cycle_gc && !is_atomic) && can_type_form_rc_cycle(type), {
+  if(context.base.needs_cycle_gc && !is_atomic && can_type_form_rc_cycle(type), {
     em.emit_string_line(String.from("  __yo_gc_register(obj);"));
   });
   em.emit_string_line(String.from("  return obj;"));
@@ -492,7 +492,7 @@ generate_ref_enum_traversal_functions :: (fn(context : FunctionGenerationContext
       .Some(entry) => {
         ty := entry.ty;
         // Atomic ref-enums never participate in cycle GC; generic enums skip.
-        if((is_reference_enum_type(ty) && !is_atomic_reference_enum_type(ty)) && !type_contains_some_type(ty), {
+        if(is_reference_enum_type(ty) && !is_atomic_reference_enum_type(ty) && !type_contains_some_type(ty), {
           _generate_one_ref_enum_traversal(ty, entry.c_name.clone(), context);
         });
       },
@@ -517,7 +517,7 @@ _generate_one_ref_enum_constructor_set :: (fn(type : TypeValue, c_name : String,
   // Dispose dispatch is shared across all variants (depends on the type).
   dispose_opt := get_dispose_function_for_type(type, context);
   is_atomic := is_atomic_reference_enum_type(type);
-  registers_with_gc := ((context.base.needs_cycle_gc && !is_atomic) && can_type_form_rc_cycle(type));
+  registers_with_gc := (context.base.needs_cycle_gc && !is_atomic && can_type_form_rc_cycle(type));
   enum_small_header := type_uses_small_rc_header(type, context.base.needs_cycle_gc, is_atomic);
   match(
     type,
@@ -603,7 +603,7 @@ _generate_one_ref_enum_constructor_set :: (fn(type : TypeValue, c_name : String,
         );
         // Traversal function pointer (cyclic GC only; atomic never
         // participates; small header has no traverse_fn).
-        if((context.base.needs_cycle_gc && !is_atomic) && !enum_small_header, {
+        if(context.base.needs_cycle_gc && !is_atomic && !enum_small_header, {
           em.emit_string_line(`  obj->header.traverse_fn = __yo_traverse_${c_name};`);
         });
         // Tag + active variant's non-unit field assignments.

--- a/src/codegen/functions/declarations.yo
+++ b/src/codegen/functions/declarations.yo
@@ -509,7 +509,7 @@ should_skip_function_codegen :: (fn(func_id : String, c_name : String, value : E
   // it where it can, but a module-namespace / registry path may still have
   // registered it; this gate is the single source of truth. Effect-record
   // members stay type-erased and emitted, as for the hard-generic skip.
-  if((!is_user_main && !is_erm) && (fn_has_specializations(func_id.clone()) && func_params_have_raw_some_type(function_type)), {
+  if(!is_user_main && !is_erm && (fn_has_specializations(func_id.clone()) && func_params_have_raw_some_type(function_type)), {
     return(true);
   });
   has_evidence := (get_evidence_parameters(function_type).len() > usize(0));
@@ -525,8 +525,8 @@ should_skip_function_codegen :: (fn(func_id : String, c_name : String, value : E
   // Only the hard-generic skip is ERM-exempt (an effect handler's generic params are
   // type-erased to void*; a macro's Expr param is not a runtime type at all).
   skip_unemittable := (!is_user_main && ((!is_erm && is_function_type_hard_generic(function_type)) || _func_has_expr_param(function_type)));
-  skip1 := ((!is_user_main && (!is_effectful && (!has_evidence && !is_erm))) && (is_function_type_hard_generic(function_type) || (_func_result_is_comptime_only(function_type) || is_function_value_with_only_builtin_yo_inline_function_call(value).is_some())));
-  has_generic_params := ((!is_user_main && (!is_effectful && !is_erm)) && _func_has_generic_params(function_type));
+  skip1 := (!is_user_main && (!is_effectful && (!has_evidence && !is_erm)) && (is_function_type_hard_generic(function_type) || (_func_result_is_comptime_only(function_type) || is_function_value_with_only_builtin_yo_inline_function_call(value).is_some())));
+  has_generic_params := (!is_user_main && (!is_effectful && !is_erm) && _func_has_generic_params(function_type));
   // Array with an UNRESOLVED length variable (`Array(i32, n)`) has no C
   // rendering (`// Unknown type:` ate the prototype line — array.test
   // batch clang errors); treat it as a generic return like a SomeT one.
@@ -544,7 +544,7 @@ should_skip_function_codegen :: (fn(func_id : String, c_name : String, value : E
   );
   has_generic_return := (type_contains_some_type_for_codegen_param(ret, ArrayList(String).new()) || _ret_has_len_var(ret));
   returns_plain_impl := _returns_plain_impl(ret);
-  skip2 := (has_generic_params || ((has_generic_return && !returns_plain_impl) && !is_erm));
+  skip2 := (has_generic_params || (has_generic_return && !returns_plain_impl && !is_erm));
   // A specialization whose RESULT type is a comptime-only type (comptime_int/
   // float/string) is a compile-time function that must NOT be emitted as runtime
   // C. TS folds comptime calls and never emits them; yo-self's create_specialized
@@ -557,7 +557,7 @@ should_skip_function_codegen :: (fn(func_id : String, c_name : String, value : E
   // func_id (yo_id_124) is shared across runtime AND comptime specializations
   // (no per-func_id comptime flag distinguishes them), but the per-call resolved
   // RETURN type does. See issues/fixed/yo-self-return-temp-void-someT.md.
-  skip_comptime_result := ((!is_user_main && !is_erm) && (is_comptime_int_type(ret) || is_comptime_float_type(ret) || is_comptime_string_type(ret)));
+  skip_comptime_result := (!is_user_main && !is_erm && (is_comptime_int_type(ret) || is_comptime_float_type(ret) || is_comptime_string_type(ret)));
   // A closure marked for codegen (io.async closure) must be EMITTED even when its
   // synthesized type still has SomeT params (its body + result are concrete; the
   // io.async sync-future resume calls it directly). Without this it is dropped as

--- a/src/codegen/utils/index.yo
+++ b/src/codegen/utils/index.yo
@@ -1530,7 +1530,7 @@ get_variable_name_for_codegen :: (fn(variable_name : String, env : Option(Enviro
               mg_i = (mg_i + usize(1));
             });
           };
-          if((!is_extern_c && !mg_any_param) && is_module_level_global(variable.token.module_path, variable.name), {
+          if(!is_extern_c && !mg_any_param && is_module_level_global(variable.token.module_path, variable.name), {
             return(`${var_name}${module_global_c_suffix(variable.token.module_path)}`);
           });
           var_name

--- a/src/env.yo
+++ b/src/env.yo
@@ -2704,7 +2704,7 @@ add_variable_to_frame :: (
       (j : usize) = usize(0);
       (replaced : bool) = false;
       (duplicate : bool) = false;
-      while(((j < m) && !duplicate) && !replaced, {
+      while((j < m) && !duplicate && !replaced, {
         match(
           frame.variables.get(j),
           .Some(existing) => cond(
@@ -3568,7 +3568,7 @@ get_receiver_methods_by_name_from_env :: (
   // resolve. SomeT receivers are excluded (they take the where-clause walk
   // below, mirroring TS's specialized handling), as are Dyn receivers
   // (TS skips DynType here too).
-  if(((methods.len() == usize(0)) && !is_some_type(dereferenced)) &&
+  if((methods.len() == usize(0)) && !is_some_type(dereferenced) &&
     !is_dyn_type(dereferenced), {
     match(
       _g_find_methods_from_generic_impls_fn,

--- a/src/evaluator/calls/index_trait.yo
+++ b/src/evaluator/calls/index_trait.yo
@@ -1541,7 +1541,7 @@ try_to_call_with_index_trait :: (
   //    `ComptimeIndex(usize)`. Mirrors TS index-trait.ts:255-274.
   match(
     self_value,
-    .Some(sv_ct) => if((!is_unknown_val(sv_ct) && array_val.is_none()) && string_raw_opt.is_none(), {
+    .Some(sv_ct) => if(!is_unknown_val(sv_ct) && array_val.is_none() && string_raw_opt.is_none(), {
       match(
         _try_comptime_custom_type_index(
           expr,

--- a/src/evaluator/exprs/begin.yo
+++ b/src/evaluator/exprs/begin.yo
@@ -1562,7 +1562,7 @@ evaluate_begin_expression :: (
                   rft,
                   .Func({ result : rfb, meta : __fm1 }) => {
                     rfco := __fm1.*.result_is_comptime_only;
-                    if((!rfco && type_representation_contains_raw_ptr(rfb))
+                    if(!rfco && type_representation_contains_raw_ptr(rfb)
                     && !is_implicitly_unsafe_capable_file(Option(String).Some(ast_expr_token(ret_arg).module_path.clone())), {
                       ret_slice_opts := FlowOptions(
                         allow_same_frame_local : false,

--- a/src/evaluator/exprs/binding.yo
+++ b/src/evaluator/exprs/binding.yo
@@ -351,7 +351,7 @@ evaluate_binding :: (
   // the check itself after the RHS is evaluated, relaxing it for ctl
   // handlers whose body ALWAYS unwinds (TS binding.ts:160
   // `deferGenericFnTypeCheckToAssignment` + assignment.ts:447-470).
-  if((!is_compile_time_only && !g_defer_generic_fn_type_check) && (is_function_type(user_defined_type) && is_function_type_generic(user_defined_type)), {
+  if(!is_compile_time_only && !g_defer_generic_fn_type_check && (is_function_type(user_defined_type) && is_function_type_generic(user_defined_type)), {
     ty_str := type_to_string(user_defined_type);
     exn.throw(
       dyn(

--- a/src/evaluator/types/struct.yo
+++ b/src/evaluator/types/struct.yo
@@ -178,7 +178,7 @@ evaluate_struct_type :: (
     // `!(field.is_comptime)`: a comptime field is ERASED from the C layout
     // (get_runtime_struct_fields drops it), so `ref(struct(header :: 1))`
     // cannot collide and must stay legal.
-    if((is_reference_semantics && !field.is_comptime) && (field.label == "header"), {
+    if(is_reference_semantics && !field.is_comptime && (field.label == "header"), {
       res_args := match(arg, .FnCall(_, _, a3, _, _) => a3, .Atom(_, _) => ArrayList(AstExpr).new());
       res_tok := if(
         ast_expr_is_fn_call(arg),

--- a/src/evaluator/utils.yo
+++ b/src/evaluator/utils.yo
@@ -1250,7 +1250,7 @@ merge_and_check_envs :: (
             // mismatch. (Mirrored in the per-column merge below.) See
             // issues/yo-self-p1-transpile-tail.md Candidate 3.
             case_var_k := match(case_frame.variables.get(kk), .Some(v) => v, .None => base_var);
-            if(((base_var.name != case_var_k.name) && !is_temp_variable_name(env.module_path, base_var.name)) && !is_temp_variable_name(env.module_path, case_var_k.name), {
+            if((base_var.name != case_var_k.name) && !is_temp_variable_name(env.module_path, base_var.name) && !is_temp_variable_name(env.module_path, case_var_k.name), {
               exn.throw(
                 dyn(
                   format_error_message(
@@ -1592,7 +1592,7 @@ Conflicting initialization: ${type_to_string(cb_cur_ty)}`
             base_var.is_owning_the_same_rc_value_as = Option(Box(Variable)).None;
           });
           // Partial ownership → error
-          if((any_owning && !all_owning) && !base_var.is_owning_the_rc_value, {
+          if(any_owning && !all_owning && !base_var.is_owning_the_rc_value, {
             err_list := ArrayList(TokenAndError).new();
             (oei : usize) = usize(0);
             while(oei < n_cases, {

--- a/src/evaluator/values/impl.yo
+++ b/src/evaluator/values/impl.yo
@@ -3137,7 +3137,7 @@ evaluate_module_value :: (
         // colon pairs are forward-declarable the same way (array_list's
         // Clone/Index/Iterator impls — root #3 of
         // issues/fixed/def-eval-swallow-remaining-roots.md).
-        if((ast_expr_is_fn_call(c2_pp_expr) && !ast_expr_is_fn_call_of(c2_pp_expr, BK_COLON, .Some(usize(2)))) && (!ast_expr_is_fn_call_of(c2_pp_expr, BK_WHERE, .None) && !ast_expr_is_fn_call_of(c2_pp_expr, "!", .Some(usize(1)))), {
+        if(ast_expr_is_fn_call(c2_pp_expr) && !ast_expr_is_fn_call_of(c2_pp_expr, BK_COLON, .Some(usize(2))) && (!ast_expr_is_fn_call_of(c2_pp_expr, BK_WHERE, .None) && !ast_expr_is_fn_call_of(c2_pp_expr, "!", .Some(usize(1)))), {
           c2_ta := match(
             c2_pp_expr,
             .FnCall(_, _, ta, _, _) => ta,
@@ -3329,7 +3329,7 @@ evaluate_module_value :: (
       if(ast_expr_is_fn_call_of(mf_expr, BK_WHERE, .None), {
         _collect_impl_where_constraints(mf_expr, forall_names, forall_some_types, forall_env, ctx, exn, impl_where_some_types, impl_where_traits);
       });
-      if((ast_expr_is_fn_call(mf_expr) && !ast_expr_is_fn_call_of(mf_expr, BK_COLON, .Some(usize(2)))) && !ast_expr_is_fn_call_of(mf_expr, BK_WHERE, .None), {
+      if(ast_expr_is_fn_call(mf_expr) && !ast_expr_is_fn_call_of(mf_expr, BK_COLON, .Some(usize(2))) && !ast_expr_is_fn_call_of(mf_expr, BK_WHERE, .None), {
         trait_fn_expr2 := match(
           mf_expr,
           .FnCall(_, tfb, _, _, _) => tfb,
@@ -3809,7 +3809,7 @@ evaluate_module_value :: (
           // Direct colon pair: add it directly.
           method_exprs.push(field_expr);
         });
-        if((ast_expr_is_fn_call(field_expr) && !ast_expr_is_fn_call_of(field_expr, BK_COLON, .Some(usize(2)))) && !ast_expr_is_fn_call_of(field_expr, BK_WHERE, .None), {
+        if(ast_expr_is_fn_call(field_expr) && !ast_expr_is_fn_call_of(field_expr, BK_COLON, .Some(usize(2))) && !ast_expr_is_fn_call_of(field_expr, BK_WHERE, .None), {
           // Non-colon FnCall: treat as trait constructor, extract its colon-pair args.
           // (`where(...)` args are skipped — see the generic loop above.)
           trait_inner_args := match(

--- a/src/formatter.yo
+++ b/src/formatter.yo
@@ -1080,6 +1080,7 @@ is_left_same_operator_flatten_group :: (
                 (paren_depth : usize) = usize(0);
                 (bracket_depth : usize) = usize(0);
                 (curly_depth : usize) = usize(0);
+                (seen_primary : bool) = false;
                 (op_count : usize) = usize(0);
                 (mismatch : bool) = false;
                 (i : usize) = (left_index + usize(1));
@@ -1096,16 +1097,31 @@ is_left_same_operator_flatten_group :: (
                         );
                         if(at_top_level, {
                           cond(
-                            (t.kind == TokenKind.Operator) => {
-                              op_count = (op_count + usize(1));
-                              if(!(t.value == n.value), {
-                                mismatch = true;
-                              });
-                            },
+                            (t.kind == TokenKind.Operator) => cond(
+                              // A prefix-capable operator in OPERAND
+                              // position (no primary since the last chain
+                              // operator) is an operand, not a chain link —
+                              // `a && !b && !c` is ONE && chain; the `!`s do
+                              // not split it.
+                              !seen_primary => {
+                                if(!is_prefix_capable_operator(t), {
+                                  mismatch = true;
+                                });
+                              },
+                              true => {
+                                op_count = (op_count + usize(1));
+                                if(!(t.value == n.value), {
+                                  mismatch = true;
+                                });
+                                seen_primary = false;
+                              }
+                            ),
                             ((t.kind == TokenKind.Comma) || (t.kind == TokenKind.Semicolon)) => {
                               mismatch = true;
                             },
-                            true => ()
+                            true => {
+                              seen_primary = true;
+                            }
                           );
                         });
                         cond(

--- a/std/http/client.yo
+++ b/std/http/client.yo
@@ -270,7 +270,7 @@ _fetch_follow :: (
       // `max_redirects == 0` means "do not follow": the first 3xx comes back
       // verbatim (reqwest's `Policy::none`). Otherwise the cap counts hops
       // FOLLOWED, so the (max+1)th 3xx throws.
-      follow := ((resp.is_redirect() && !location.is_empty()) && (opts.max_redirects > usize(0)));
+      follow := (resp.is_redirect() && !location.is_empty() && (opts.max_redirects > usize(0)));
       cond(
         follow => {
           cond(

--- a/tests/internal/formatter.test.yo
+++ b/tests/internal/formatter.test.yo
@@ -245,3 +245,16 @@ test("fmt elision: quote argument with macro splices keeps its group (gate-conse
   );
   assert(_fmt(out.clone()) == out, "and that is a fixed point");
 });
+test("fmt elision D2: prefix operands are not chain operators", {
+  src := String.from(
+    "main :: (fn() -> unit)({\n  if(((exp_enum_id != giv_enum_id) && !(same_enum_ctor)) && !(same_variants), {\n    return(1);\n  });\n});\nexport(main);\n"
+  );
+  out := _fmt(src.clone());
+  assert(
+    out.contains(
+      String.from("if((exp_enum_id != giv_enum_id) && !same_enum_ctor && !same_variants, {")
+    ),
+    "((A) && !b) && !c flattens fully — the ! operands do not split the && chain"
+  );
+  assert(_fmt(out.clone()) == out, "idempotent");
+});


### PR DESCRIPTION
Follow-up to #386, found by review:

\`\`\`rust
if(((exp_enum_id != giv_enum_id) && !(same_enum_ctor)) && !(same_variants), {
\`\`\`
flattened only to
\`\`\`rust
if(((exp_enum_id != giv_enum_id) && !same_enum_ctor) && !same_variants, {
\`\`\`
instead of
\`\`\`rust
if((exp_enum_id != giv_enum_id) && !same_enum_ctor && !same_variants, {
\`\`\`

Root cause: D2's content scan counted every depth-0 Operator token as a chain link, so the prefix \`!\` in operand position flagged an operator mismatch and the group was refused. The scan now tracks the operand boundary (a primary seen since the last chain operator): a prefix-capable operator in operand position is an operand, not a link — the same distinction \`classify_group_content\` already makes for leading prefix runs.

- Regression test added first (fails on the old code, passes now); 30/30 formatter tests.
- 17-file resweep of the same shape across \`src/\`+\`std/\`+\`tests/\`; second pass a no-op.
- No cli-case fixture affected → no golden changes.
- \`plans/FMT_PAREN_ELISION.md\` D2 section records the refinement.