### PR TITLE
Error diagnostics P1: structured Diagnostic value, one renderer, single-print edges

### DIFF
--- a/issues/parser-multibyte-spec-tests-leak-under-linux-asan.md
+++ b/issues/parser-multibyte-spec-tests-leak-under-linux-asan.md
@@ -1,0 +1,59 @@
+# The two multibyte spec-peel parser tests leak under Linux ASan (clang 21) — pre-existing, CI-invisible
+
+**Status: OPEN** (documented 2026-09-03 during the P1 error-diagnostics work —
+**not a regression of it**: reproduced on pristine `origin/develop`
+`060acdc26` with the stock seed `v0.2.23`, before any of that work's edits).
+
+## Reproducer
+
+```bash
+git worktree add /tmp/yo-pristine origin/develop
+nix-shell shell.nix --run 'cd /tmp/yo-pristine && ~/.local/bin/yo test ./tests/internal/parser.test.yo --parallel 1 --test-name-pattern "multibyte" -v'
+```
+
+## What happens
+
+Two tests fail:
+
+- `Peel a format spec off a MULTIBYTE template expression`
+- `A spaced colon-pair stays a colon-pair with multibyte content`
+
+Under the nix `clang` 21.1.2 toolchain (Linux x86_64, Steam Deck), the test
+binary's AddressSanitizer/LeakSanitizer run reports at exit:
+
+```
+SUMMARY: AddressSanitizer: 1881 byte(s) leaked in 32 allocation(s).
+```
+
+The leak stacks are symbol-less (batch-binary offsets), mostly 104-byte
+"direct leak" objects — the shape of leaked RC `String`/`ArrayList` temps
+(32 allocations ≈ a handful of objects per test iteration).
+
+Under a system `zig` cc (no ASan linked), the same two tests fail with
+SIGABRT (rc=134) instead — same two tests, different mechanism.
+
+## Why this is not the error-diagnostics work's regression
+
+1. Reproduced on a pristine worktree of `origin/develop` (`060acdc26`) with
+   the unmodified stock seed — none of the P1 edits present.
+2. The sibling test `Peeling survives multibyte literal text around the
+   interpolation` passes, and every other parser test (52 total) passes,
+   including the new `make_parse_error renders via the shared renderer`.
+3. develop's CI is green on the same commit (`gh run list --branch develop`
+   — "Build and Test" success, 2026-09-03), so CI's clang/runner does not
+   surface it.
+
+## Analysis / next steps
+
+- The two failing tests share the MULTIBYTE path of the format-spec peeling
+  (`_SpecSplit` / `peel_spec` in `src/parser.yo`) — the leak is plausibly a
+  missing drop on a temp in the multibyte scanning loop (byte-indexed walks
+  building per-rune strings).
+- CI-invisibility suggests an allocator/LSan-version difference, not absence
+  of the leak — worth symbolizing locally: rebuild the kept batch
+  (`YO_KEEP_BATCH=1`) with `-g` and `ASAN_SYMBOLIZER_PATH` pointed at
+  llvm-symbolizer from the nix shell, then map the frames to parser
+  functions.
+- If confirmed as a missing drop in the peel path, the fix belongs with the
+  dup/drop optimizer family (`_optimize_dup_drop_pairs`,
+  `src/evaluator/exprs/begin.yo`) or a `consume` at the peel site.

--- a/plans/ERROR_DIAGNOSTICS_OVERHAUL.md
+++ b/plans/ERROR_DIAGNOSTICS_OVERHAUL.md
@@ -13,6 +13,19 @@
 > **§11 decisions recorded 2026-09-03**: `yo explain` (no alias), numeric
 > `E0308`-style codes, a bilingual English + 简体中文 registry from day one,
 > exit codes stay 0/1, runtime-panic locations stay in P3 (details §11).
+>
+> **P1 LANDED 2026-09-03** (this branch): structured `Diagnostic` + shared
+> renderer in `src/diagnostics.yo`; `YoError` rebased, dead `ErrorKind`/
+> `is_assertion_error`/`YoLexerError`/`ParseError`/`LexerError` deleted,
+> 1028 call sites trimmed; lexer/parser/evaluator all throw the one
+> structured error; single-print edges (D1–D6 dead). Verified:
+> `check ./src` 264/264, `compile --skip-c-compiler` rc=0, stage-1 built at
+> CI's flag set, internal error 17/17 + lexer 47/47 + parser 50/52 (the 2
+> are pre-existing on pristine develop —
+> `issues/parser-multibyte-spec-tests-leak-under-linux-asan.md`), CLI corpus
+> 54 PASS (3 doc-* diffs are local git-version text only; 1 network skip),
+> lsp-handshake golden re-recorded (leak + doubled location gone, LSP frames
+> byte-identical).
 
 Yo's positioning is "designed for the LLM era" — and the error channel is the
 highest-bandwidth feedback an iterating agent receives. Today that channel is

--- a/plans/ERROR_DIAGNOSTICS_OVERHAUL.md
+++ b/plans/ERROR_DIAGNOSTICS_OVERHAUL.md
@@ -1,0 +1,627 @@
+# Error diagnostics overhaul — structured, coded, LLM-first
+
+> **Status: PROPOSED 2026-09-03 — awaiting maintainer review. Nothing here is
+> implemented.** This doc is the detailed design for ROADMAP items
+> [Phase 2.3](ROADMAP.md) ("Error-message overhaul"), [Phase 4.2](ROADMAP.md)
+> ("Errors as few-shot repairs") and [Phase 4.5](ROADMAP.md)
+> ("`yo explain <error-id>` / machine-consumable diagnostics"), and it closes
+> the "structured-diagnostics return channel" remaining-quality item in
+> [P4_LSP.md](P4_LSP.md) header. Sections 1–4 are a verified audit of the
+> current `src/` (all numbers re-runnable, commands given); sections 5+ are
+> the design and phasing proposed for approval.
+
+Yo's positioning is "designed for the LLM era" — and the error channel is the
+highest-bandwidth feedback an iterating agent receives. Today that channel is
+pre-formatted prose with the location baked into the string, no codes, no
+machine format, and several printing bugs (location printed twice per entry,
+`check:` prefixes leaking into `compile`/`lsp`/`test`, lexer errors with no
+file at all). This plan makes the diagnostic **data** first-class, gives every
+error family a stable Rust-style code with an offline explanation (`yo
+explain E0308`), and adds `--error-format=human|short|json` so an agent can
+consume diagnostics without ever parsing human text.
+
+---
+
+## 1. Audit — the error pipeline as it stands
+
+### 1.1 The core model (`src/error.yo`, 182 lines)
+
+The entire compiler's error model is four small types:
+
+- `ErrorKind` — an enum with **exactly one variant**, `Overflow`. It is set at
+  2 sites (`src/evaluator/builtins/comptime_numeric_fns.yo:223,250`) and
+  **never read anywhere** — write-only.
+- `TokenAndError { token, error_message }` — a `Token` plus a pre-rendered
+  string.
+- `YoError { token_and_error_list, is_assertion_error, kind }` — thrown as
+  `dyn(...)` through `exn.throw`; `to_string` joins entries with `Error: `
+  prefixes. `is_assertion_error` is `true` at exactly 5 sites (all
+  `comptime_assert.yo`) and is **never read** — also write-only.
+- `YoLexerError` — **dead code**: defined and exported but never constructed;
+  the live lexer error is a *different* struct (§1.2).
+
+The critical structural defect: `format_error_message`
+(`src/error.yo:125-136`) **bakes the location block into the message string**
+— `` `${trimmed}\n\n${line}` `` where `line` is `path:row:col:\n<source>\n^` —
+and then `YoError.to_string` (`src/error.yo:109-110`) appends
+`get_line_at_token` **again**. The rendered string is the only representation
+of a diagnostic anywhere in the pipeline; every consumer downstream of the
+throw sees only text.
+
+Emission census (rerun with `grep -rn 'format_error_message(' --include='*.yo'
+src/ | grep -v format_error_messages`):
+
+| Metric | Count |
+| --- | --- |
+| `format_error_message(` call sites | **1012 in 111 files** |
+| `format_error_messages(` batch sites | 17 (10 in `evaluator/utils.yo`) |
+| Delivered via `exn.throw` | ~1024 evaluator sites — fail-fast, single error |
+
+Top files: `evaluator/types/function.yo` 94, `evaluator/exprs/match.yo` 58,
+`evaluator/builtins/type_fns.yo` 44, `comptime_list_fns.yo` 33,
+`types/trait.yo` 30, `calls/function.yo` 26, `builtins/asm.yo` 26.
+
+Message text quality is actually decent — messages embed rendered types
+(`type_to_string`, 192 uses) and expression source (`ast_expr_to_string`, 215
+uses), and several carry multi-line guidance (the overloading policy message
+even cites `plans/FUNCTION_OVERLOADING_POLICY.md`). What's missing is
+everything *around* the text.
+
+### 1.2 Per-stage matrix
+
+| Stage | Type | File path | Row:col | Source line + caret | Multi-error |
+| --- | --- | --- | --- | --- | --- |
+| Lexer (`src/lexer.yo:48` `LexerError`) | local struct | **no** | raw **0-based** | **no** | fail-fast (6 sites) |
+| Parser (`src/parser.yo:44` `ParseError`) | local struct | yes | 1-based | **rustc-style** `-->`, gutter, `^` | fail-fast (33 sites) |
+| Evaluator (`YoError`) | token list | yes | 1-based | plain `path:row:col:` + line + `^` at token **middle** | multi-entry (ownership flows) |
+| Codegen fatal (`codegen/constants.yo:197`) | thrown string | rare | rare | no | fail-fast (95 `codegen_fatal_expr` + 30 `codegen_fatal`) |
+| Codegen hollow (`codegen/exprs/generation.yo:592`) | `// Failed to transpile` C comment | no | no | no | silent; fatal only for `__yo_user_main` |
+| C compiler (`main.yo:2279-2307`) | raw inherited stderr | `.c` file only | `.c` lines | raw clang text | n/a |
+| Runtime panic (`codegen/exprs/panic.yo`) | `fprintf(stderr, msg); abort()` | **no** | **no** | n/a | n/a |
+
+Notes:
+
+- The parser already renders the way we want everything to render. This plan
+  generalizes *it*, not the other way around.
+- Lexer `LexerError` prints `lexer error at 4:12: unexpected character` — no
+  file (the struct has no `module_path`), no source line, and the row:col is
+  **un-incremented 0-based** while every other stage prints +1.
+- No `#line` directives are emitted (`grep -c '#line'` on the 1.5M-line
+  emitted `yo.c` → 0), so C-compiler diagnostics are untraceable to Yo
+  source. That gap is ROADMAP Phase 2.4's own item — cross-referenced in
+  §9, not absorbed here.
+- Runtime panics carry no location; string-literal panic messages print with
+  literal embedded quotes (`"ArrayList: index out of bounds"` — quotes and
+  all, verified in emitted `yo.c:53530`); abort is a bare SIGABRT with no
+  exit-code distinction.
+
+### 1.3 Output channels
+
+**CLI.** One top-level handler (`src/main.yo:4106-4115`) prints
+`yo: error: ${err.to_string()}` and `exit(1)`. That's the only common path;
+everything else is per-subcommand special-casing:
+
+- `run_fmt` installs its own handler printing the bare message (no prefix).
+- The module loader's handlers (`src/module_manager.yo:420-427, 677-681`)
+  print `check: error in: ${err.to_string()}` **and** stash the error. The
+  stash is what `run_check` reports per failed file — but the *print* fires on
+  every path that loads modules, so a broken `yo compile` emits the full
+  evaluator dump under a `check:` prefix, followed by a wrapper line that
+  **omits the underlying text** (`compile: failed to evaluate module "<path>"`,
+  `main.yo:1771-1773`).
+- Parse errors get a doubled prefix: `yo: error: error: expected )` (main
+  prepends, `ParseError.to_string` starts with `error: `).
+- No ANSI color anywhere in compiler output (`grep -rn $'\x1b' src/ scripts/`
+  → 0; the harness even strips it defensively, `scripts/cli-diff-test.sh:169`).
+- Exit codes: 0/1 everywhere except version pass-through, `--watch-once`
+  (failed-file count), watch prelude-edit (2), and LSP sentinels.
+
+**LSP.** `src/lsp/diagnostics.yo` re-evaluates the buffer, stashes
+`err.to_string()` text, and **parses the human string back** — anchor lines
+ending in `:` are split from the right (`diagnostics.yo:128-152`), the
+`Error:` prefix is stripped, the underline length is *guessed* by scanning
+identifier bytes (`_ident_len_at`, `diagnostics.yo:83-103`), the
+printed-twice location is deduped (`:163-183`), and unanchorable errors
+(lexer) collapse to a 0:0 whole-message diagnostic. The file's own header
+says a structured channel is the cleaner design. This is the P4 remaining
+item.
+
+**Test runner.** Per-test `✓`/`✗` lines (unicode, not color); on failure the
+runner prints `Test failed with exit code N` plus the captured child
+stdout+stderr — first line only unless `-v` (`main.yo:2941-2959`). No
+expected/actual diff, no test-file line. `--json-summary` is **accepted and
+ignored** (`main.yo:2432-2434`). A test file that fails to *compile* streams
+the child compiler's raw dump (unfiltered) and then throws
+`test: batch compile failed (exit N)`.
+
+**Warnings.** `format_warning_messages` (`error.yo:151-173`) has **zero
+production callers** — the compiler emits no evaluator/parser warnings today.
+There is no warnings channel in practice, and no `-W` flags.
+
+### 1.4 Defect list
+
+Everything below is verified; the phases in §7 fix them.
+
+| # | Defect | Evidence |
+| --- | --- | --- |
+| D1 | Location block printed **twice per error entry** | `error.yo:125-136` bakes it; `error.yo:109-110` appends it again; LSP dedups (`diagnostics.yo:163-183`) |
+| D2 | `check: error in:` print leaks into `compile`/`lsp`/`test`; wrapper line drops the error text | `module_manager.yo:420-427,677-681`; `main.yo:1771-1773` |
+| D3 | Lexer errors: no file, no source line, 0-based row:col | `lexer.yo:48-64,59-61` |
+| D4 | `yo: error: error:` doubled prefix on parse errors | `main.yo:4110` + `parser.yo:56-81` |
+| D5 | No span: caret is one char at token *middle* (`col + len/2`) | `error.yo:47` |
+| D6 | Secondary locations render as `Error: value moved here` — no note severity | `error.yo:110`; e.g. `evaluator/utils.yo:451-457` |
+| D7 | `ErrorKind`/`is_assertion_error` are write-only dead weight | §1.1 |
+| D8 | No did-you-mean machinery (3 hardcoded hints; `target.yo` is the only good citizen) | `target.yo:338-430` |
+| D9 | Four inconsistent layouts for the same expected/actual concept | `assignment.yo` vs `match.yo` vs `trait.yo` (§1.1) |
+| D10 | No machine-readable output; LSP parses text back; `--json-summary` ignored | §1.3 |
+| D11 | ~125 codegen fatal sites are position-less internal preconditions; 14 `__yo_panic` sites SIGABRT with **no ICE wrapper or bug-report request** | `codegen/constants.yo:197-230` |
+| D12 | C-compiler diagnostics unmappable (no `#line`) — ROADMAP 2.4 | §1.2 |
+| D13 | Runtime panics: no location; StrLit quotes artifact; no rc distinction | §1.2 |
+| D14 | No color, ever | §1.3 |
+| D15 | Warnings are dead code; no `-W` flags | §1.3 |
+| D16 | Import-chain errors cascade (ROADMAP 2.3: "15-deep"); leaf not isolated | §8.4 |
+
+### 1.5 What is already good (keep)
+
+- The parser's rustc-style renderer — promoted to THE renderer.
+- Message text: specific, type-rendered, sometimes multi-line with guidance.
+  **The plan deliberately freezes existing message strings verbatim** — only
+  the structure around them changes (see §6 for why that keeps 28 CLI goldens
+  green).
+- `target.yo`'s errors (did-you-mean + supported-list) — the pattern to
+  generalize.
+- Multi-entry errors for ownership flows ("value moved here" etc.) — the raw
+  material for labeled secondary spans.
+- Fail-fast single-error evaluation: for an LLM repair loop, one precise error
+  per iteration is a feature (§10 keeps it a non-goal to change).
+
+### 1.6 Test-coupling census (what a format change costs)
+
+| Coupling | Count | Breaks if… | Verdict |
+| --- | --- | --- | --- |
+| `comptime_expect_error(...)` in `tests/*.test.yo` | 280 | — | **Safe**: occurrence-only — it checks the argument *threw* (`comptime_expect_error.yo:51-67`); the optional message string is only wording for the "did not throw" failure. Never matches error text. |
+| `tests/internal/error.test.yo` | ~13 tests pin exact/contains format | renderer changes | **Rewrite** in P1 (becomes the golden suite for the new renderer) |
+| `tests/internal/lexer.test.yo` | 4 exact `.message ==` + 1 behavioral | lexer message/render changes | **Adjust** in P1 (messages frozen; render assertions updated) |
+| `tests/internal/parser.test.yo` | 1 `ParseError.to_string` pin | renderer changes | **Adjust** in P1 |
+| `tests/cli-cases/*` `stdout_keep_match=` | 28 cases pin message *substrings* | message text changes | **Survive by design** (text frozen in P1–P2); each verified during P1 |
+| `tests/cli-cases/lsp-handshake/expected_stdout` | 1 full golden containing the doubled dump | any render change | **Re-record** in P1 |
+| Other `expected_stdout` with "Error" | 1 of 57 (the lsp-handshake one) | — | covered above |
+
+---
+
+## 2. Design principles (why these choices, for an LLM audience)
+
+1. **Data first, text second.** A diagnostic is a value
+   (`code, severity, message, path, row, col, span, labels, notes, help`);
+   human text and JSON are both *renderings of the value*. No consumer ever
+   parses a rendering (the LSP stops doing exactly that).
+2. **Stable identifiers.** Codes are `E` + 4 digits (rustc style, e.g.
+   `E0308`). Once published in a release, a code is **never renumbered or
+   repurposed** — rustc's compat rule. Message text may improve freely; the
+   code is the contract an agent's tooling, memories, and retry logic key on.
+3. **The corrected form rides in-band.** ROADMAP 2.3: "every error should
+   carry the corrected form the way the `unsafe(...)` gate hint does." Where
+   the compiler can synthesize a fix (did-you-mean, signature, expected type),
+   it goes in `help:` — the agent repairs in one hop instead of researching.
+4. **Bounded output.** One primary error (fail-fast is kept), cascade
+   collapsed to the leaf + a short chain note, no repetition (D1/D2/D16). An
+   agent's context is the scarce resource.
+5. **Depth on demand.** The terminal error stays short; the long explanation
+   with bad/good examples lives one command away (`yo explain E0308`) and the
+   tail line advertises it. This is also the few-shot-repair corpus of ROADMAP
+   4.2: `yo explain --format json` over the registry *is* the corpus export.
+6. **Determinism.** Same input → byte-identical output; JSON keys in a fixed
+   order; 0-based positions in JSON (matches `Token`'s internal basis and
+   LSP), 1-based in human text, stated in the schema.
+
+---
+
+## 3. The `Diagnostic` model
+
+New module `src/diagnostics.yo` (types + renderers + code table), new
+`src/diagnostics_registry.yo` (explanations data, §5). Flat files, matching
+repo style.
+
+```rust
+Severity :: enum(Error, Warning, Note, Help);
+
+Span :: struct(
+  path : String,       // module path as printed today
+  row : usize,         // 0-based (Token basis; +1 is display-only)
+  col : usize,         // 0-based, rune column
+  len : usize          // rune length of the span (token/expr source length)
+);
+
+Label :: struct(       // a secondary location attached to a diagnostic
+  severity : Severity, // Note today; Help reserved
+  message : String,    // "value moved here", "expected type comes from this parameter"
+  span : Span
+);
+
+Diagnostic :: struct(
+  code : Option(String),      // "E0308"; .None until P2 assigns it (renders without [E…])
+  severity : Severity,        // Error for the primary; entries never less than the thrower says
+  message : String,           // VERBATIM existing text (frozen in P1/P2)
+  span : Span,                // primary location
+  labels : ArrayList(Label),  // secondary locations (today's extra TokenAndError entries)
+  notes : ArrayList(String),  // plain "note:" prose lines, no location
+  help : Option(String)       // "help:" — did-you-mean, corrected form, signature
+);
+```
+
+Rules:
+
+- **Primary span** = today's `ast_expr_token(...)` choice, unchanged (the
+  audit confirms it already points at the erroring sub-expression for
+  semantic errors and the enclosing call for shape errors — sensible).
+- `len` comes from the token's own source length, fixing D5 (underline spans
+  the token instead of a lone caret at its middle).
+- In a batch (`format_error_messages`), entry 0 is the primary `Error`; the
+  remaining entries become `Note` labels. The ~12 batch push sites
+  (`utils.yo`, `assignment.yo`, `begin.yo`, …) all follow first-equals-primary
+  today ("use of moved value" + "value moved here"); P1 verifies each site as
+  it converts (acceptance item, §7.1).
+
+### One throwable, rendered at the edge
+
+`YoError` is re-based to carry the structure (same thrown type, so ~1024
+`exn.throw` sites and every existing catch keep working):
+
+```rust
+YoError :: ref(struct(
+  diagnostics : ArrayList(Diagnostic),  // replaces token_and_error_list
+  is_assertion_error : bool,            // deleted (D7)
+  kind : Option(ErrorKind)              // deleted; ErrorKind deleted (D7)
+));
+```
+
+- `format_error_message(token, message, …)` **keeps its signature** — 1012
+  call sites untouched — and internally builds a `Diagnostic` with the
+  verbatim message, **without baking any location into the string** (D1's
+  root cause removed).
+- `YoError.to_string()` renders via the shared human renderer (§4.1) — so
+  every existing catch/print site gets the new format for free.
+- `LexerError` and `ParseError` are converted to `Diagnostic`s at their
+  construction sites (lexer/parser keep their internal structs; what they
+  *throw* becomes a `YoError` carrying one diagnostic; lexer's gains
+  `module_path` and a source line — D3). Their internal types remain for
+  unit tests to inspect.
+- `codegen_fatal` / `codegen_fatal_expr` wrap their message in a diagnostic
+  of the internal family (`E13xx` once coded), prefixing
+  `internal compiler error:` and appending the file:line of the *compiler*
+  source plus a report-at prompt (D11) — SIGABRT `__yo_panic` sites move to
+  this path where reachable, else stay crashes (honestly labeled ICE).
+- Edges that need machine output (`--error-format=json`) read
+  `.diagnostics` directly; no dyn-downcasting is required anywhere.
+
+---
+
+## 4. Renderers
+
+### 4.1 `human` (default) — the parser's format, generalized
+
+```
+error[E0308]: Incompatible types
+  --> src/app.yo:12:7
+   |
+12 |   x : i32 = compute();
+   |       ^^^ expected `i32`, found `String`
+   |
+note: value moved here
+  --> src/app.yo:8:3
+8  |   y := consume(z);
+   |       ^ move occurs because `z` has type `Own(T)`
+   |
+help: run `yo explain E0308` for more information
+```
+
+- `error[E0308]: <first line of message>`; remaining message lines (the
+  multi-line guidance several messages already carry) print under it,
+  indented, verbatim.
+- Secondary entries render as `note:` blocks with their own `-->` + underline
+  (D6 fixed).
+- `help:` last; the explain tail line appears only when a code is attached.
+- One location per entry, printed exactly once (D1).
+- The top-level CLI line stays `yo: error:`-shaped but no longer doubles any
+  prefix (D4): the edge prints the wrapper line and the rendering, or just
+  the rendering when the wrapper adds nothing.
+
+### 4.2 `short`
+
+```
+src/app.yo:12:7: error[E0308]: Incompatible types
+```
+
+One line per diagnostic — for CI logs and quick greps. (`warning:` /
+`note:` by severity.)
+
+### 4.3 `json` — JSON Lines, one diagnostic per line
+
+Built on `std/encoding/json` (`JsonValue`, `json_stringify` — already a
+compiler dependency via the LSP, so no seed-availability risk).
+
+```json
+{"code":"E0308","severity":"error","message":"Incompatible types\n- Expected: i32\n- Given: String","span":{"file":"src/app.yo","row":11,"col":6,"end_col":9},"labels":[{"severity":"note","message":"value moved here","span":{"file":"src/app.yo","row":7,"col":2,"end_col":3}}],"notes":[],"help":null,"rendered":"error[E0308]: …full human text…"}
+```
+
+- **0-based** `row`/`col`/`end_col` (rune columns) — matches the internal
+   `Token` basis and LSP; the schema doc states this loudly because rustc's
+   JSON is 1-based-line/0-based-col and borrowing that asymmetry would
+   generate off-by-one agent bugs.
+- `rendered` carries the §4.1 text verbatim: agents get fields for logic and
+  the caret block for reading, without re-deriving either.
+- `code` is `null` until P2 assigns it — honest, and ratcheted by a census
+  test (§7.2).
+- Emitted to **stdout** (data channel), progress chatter to stderr; JSONL so
+  `head`/`jq` work per line.
+
+### 4.4 Flag and env plumbing
+
+- `--error-format=human|short|json` on `check`, `compile`, `build`, `test`
+  (unknown value → the target.yo-style did-you-mean error, not a bare throw).
+- `YO_ERROR_FORMAT` env var, same vocabulary, lower precedence than the flag —
+  lets an agent wrapper set it once for every invocation, including `yo
+  build` internals that shell out to child compiles.
+- The LSP ignores the flag (it consumes the structured channel, §8.3).
+
+---
+
+## 5. Error codes and the registry
+
+- Format: `E` + 4 digits. Loose band convention (not enforced, guidance
+  only): `E00xx–E02xx` syntax (lexer+parser), `E03xx–E05xx` name/scope/module
+  resolution, `E06xx–E08xx` types & traits, `E09xx–E10xx` ownership/moves/
+  effects/async, `E11xx–E12xx` comptime/macros/reflection, `E13xx` internal
+  codegen (ICE), `E15xx` CLI/build/deps/targets.
+- Codes are allocated **per error family**, not per site — the 1012 sites
+  collapse into an estimated 100–200 families (e.g. the ~200 "Incompatible
+  types" spellings are one family; D9's four layouts unify under it in P2's
+  catalog work, text still recognizable).
+- Allocation is **incremental and frequency-driven**: P2 assigns codes to the
+  families that dominate real emissions (measured by running the corpus and
+  tallying), not by sweeping all 111 files at once. Unassigned sites render
+  codeless. A census test (count of `format_error_message` sites reachable
+  without a code) ratchets downward.
+- **Never renumber.** The registry records a one-line history per code if a
+  family later splits.
+
+Registry entry (data, in `src/diagnostics_registry.yo`; ships inside the
+binary so `yo explain` works offline):
+
+```rust
+Example  :: struct(bad : String, good : String, why : String);
+Explain  :: struct(
+  code : String,            // "E0308"
+  title : String,           // "mismatched types"
+  summary : String,         // one sentence
+  explanation : String,     // paragraphs; markdown-ish
+  examples : ArrayList(Example),
+  related : ArrayList(String)
+);
+```
+
+A registry test enforces: every code referenced from the code table has an
+entry, titles/summaries/explanations non-empty, ≥1 example per entry, and —
+the strong gate, borrowed from rustc's error-index tests — **every `good`
+snippet compiles** (checked by a small harness shelling `yo check` on temp
+files) and every `bad` snippet errors *with that code* (checked the same
+way). The corpus therefore cannot rot.
+
+---
+
+## 6. `yo explain`
+
+Naming: **`yo explain <CODE>`** is recommended over `yo error <CODE>` — it
+matches the repo's verb-subcommands (`build`, `check`, `doc`, `fetch`,
+`install`, `version`) and is the spelling ROADMAP 4.5 already uses. `yo
+error` remains a fine alias if preferred (open question OQ1; the mechanics
+below are name-independent).
+
+```
+$ yo explain E0308
+
+E0308 — mismatched types
+
+The value's type does not satisfy the expected type at this position.
+…(explanation paragraphs)…
+
+Example — this fails:
+  …bad snippet…
+Example — write this instead:
+  …good snippet…
+  why: …
+Related: E0612 (variable not found), E0061 (argument count mismatch)
+
+$ yo explain E03099
+error: unknown error code `E03099`
+help: did you mean `E0308`? Run `yo explain --list` for all codes.
+```
+
+- `yo explain --list` — code + title per line; `yo explain --list --format
+  json` — the full registry dump (this is the ROADMAP 4.2 corpus export).
+- `yo explain E0308 --format json` — one entry, for agents pulling depth on
+  demand.
+- Exit 0 when found, 1 when not (with did-you-mean over the registry — the
+  same edit-distance helper as D8, §8.1).
+- No network, no repo presence needed — the registry is compiled in.
+
+---
+
+## 7. Phased implementation
+
+Each phase lands green (`yo check ./src`, full fast suite, gates_fast) and is
+a reviewable unit. Message text is **frozen verbatim** in P1–P2 — that choice
+is what keeps the 28 `stdout_keep_match` CLI cases and the 280
+`comptime_expect_error` uses green (§1.6), confining churn to ~19 internal
+tests + 1 golden.
+
+### P1 — structured core + unified human renderer
+
+Scope:
+1. `src/diagnostics.yo`: `Severity`, `Span`, `Label`, `Diagnostic`, the
+   human + short renderers (generalized from `parser.yo:56-81`).
+2. Re-base `YoError` onto `ArrayList(Diagnostic)`; delete
+   `ErrorKind`/`is_assertion_error` (D7); `format_error_message(s)` keep
+   signatures, stop baking location (D1); entry[0]=Error, rest=Note labels
+   (D6), verifying the ~12 batch sites.
+3. Lexer throws a diagnostic carrying `module_path` + source line; +1 the
+   rendered row:col (D3); delete dead `YoLexerError` (D3).
+4. Parser renders through the shared renderer; single `error:` prefix (D4).
+5. Single-print edge: module-manager handlers **stash only** (no print);
+   `run_check` renders per failed file at its own edge; `run_compile`'s
+   wrapper includes the rendered error (D2).
+6. Underline spans token length from its start (D5).
+7. **LSP adapter**: `parse_error_text` learns the new ` --> path:row:col`
+   anchor shape (still text-based; the typed channel is P3). Re-record the
+   lsp-handshake golden.
+8. Rewrite `tests/internal/error.test.yo` as the golden suite for the new
+   renderer; adjust the lexer/parser format pins; run the 28 CLI substring
+   cases and fix any that pinned structure rather than message text.
+
+Acceptance: every error prints its location exactly once (grep the suite
+output); lexer errors show file+line+caret; suite green; lsp-handshake golden
+re-recorded; `yo check ./src` green under the seed-built binary
+(two-generation rule respected — no new std API beyond what the seed ships).
+
+### P2 — codes, registry, explain, JSON
+
+Scope:
+1. Code table in `src/diagnostics.yo` + registry in
+   `src/diagnostics_registry.yo`; assign codes to the top families (target:
+   ≥60% of corpus-measured emissions coded, estimated 60–100 codes).
+2. `help: run \`yo explain E0xxx\`` tail on coded diagnostics.
+3. `yo explain` subcommand with `--list`, `--format json`, did-you-mean.
+4. Registry test incl. good-snippets-compile / bad-snippets-error-with-code.
+5. `--error-format=short|json` + `YO_ERROR_FORMAT` on check/compile; JSONL on
+   stdout (D10).
+6. D9's four expected/actual layouts unify *inside the catalog work* — the
+   family's canonical layout becomes part of its catalog entry, applied as
+   codes are assigned (text stays recognizable, e.g. keeps "Expected/Given"
+   vocabulary).
+
+Acceptance: two runs → byte-identical JSON; `jq` round-trips every field;
+explain offline; registry gates green; suite green.
+
+### P3 — repair-oriented upgrades (the LLM loop)
+
+1. **Did-you-mean** (D8): edit-distance helper + wiring into unresolved
+   identifier, enum variant, module field, method/trait lookup, `--error-format`
+   value, explain codes. Candidates render in `help:`.
+2. **Corrected form in-band** (§2.3) on the top families: type mismatch shows
+   the expected/actual + fix hint; arity mismatch shows the callee signature;
+   moved-value shows the consuming site (already a label).
+3. **Import-chain collapse** (D16): report the leaf diagnostic once + one
+   `note: in module imported from <path>` chain note (bounded, no cascade).
+4. **ICE wrapper** (D11): `codegen_fatal*` → `internal compiler error:` +
+   compiler file:line + report prompt; keep rc=1 (OQ4).
+5. **LSP typed channel**: `analyze_document` returns
+   `ArrayList(Diagnostic)`; `parse_error_text` and `_ident_len_at` retire —
+   the P4 remaining item closes; exact ranges from spans, not identifier
+   heuristics.
+6. **Runtime panic locations** (D13): `panic()`/`assert()` codegen embeds the
+   Yo file:line of the call site (`exprs/panic.yo` has the `Expr`; its token
+   is available); fix the StrLit quotes artifact. ⚠ some tests capture
+   runtime panic text — audit before landing (acceptance includes it).
+7. `--error-format` threaded through `build`/`test`; test runner honors
+   `--json-summary` (currently ignored) or removes the flag (pick during
+   implementation; CLI-compat tests decide).
+
+Acceptance: corpus diff shows did-you-mean on the classic typo classes; LSP
+golden re-recorded once more; runtime-panic-touching tests audited and green.
+
+### P4 — deferred, separate decisions (cross-referenced, not scheduled here)
+
+- `#line` directives mapping emitted C to `.yo` (ROADMAP 2.4 owns it; it
+  would also let C-compiler stderr be wrapped as diagnostics).
+- Color (tty-gated, `NO_COLOR`/`TERM=dumb`) — D14; cosmetic, after data work.
+- A live warnings channel (D15) — `Severity.Warning` exists since P1; wiring
+  unused-variable/etc. detection is its own small project.
+- SARIF output; `yo fix` (ROADMAP 4.5's bigger sibling); zh-CN registry.
+
+---
+
+## 8. Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Self-hosting / two-generation rule: `error.yo` is imported by ~everything; every edit is a full rebuild (stage2 ~38 min) | Phases are few, large, atomic edits; P1 keeps helper signatures identical so 1012 sites don't move; gates_fast after each |
+| New std dependency in the hot path | None: `std/encoding/json` is already compiled into the tree via the LSP; edit-distance stays compiler-local in P3 |
+| 28 CLI substring goldens + lsp-handshake golden churn | Message text frozen in P1–P2 (§1.6 census); only structure around it changes; each case verified in P1 acceptance |
+| LSP silently breaks mid-P1 (its parser keys on today's anchors) | P1 ships the `-->` anchor adapter in the same change as the renderer — never lands renderer-without-adapter |
+| Registry rots as messages evolve | Registry test compiles every `good` snippet and asserts every `bad` snippet errors with its code (rustc error-index model) |
+| Codes churn / renumbering temptation | Never-renumber rule in §5; registry keeps per-code history lines |
+| Runtime-panic location change (P3.6) breaks tests that capture panic text | Explicit audit listed as P3 acceptance, before landing |
+
+---
+
+## 9. Relationship to other plans
+
+- **ROADMAP 2.3 / 4.2 / 4.5** — this doc is their detailed design.
+- **ROADMAP 2.4 (`#line`)** — orthogonal; P4 cross-ref. Landing it would let
+  C-compiler stderr be wrapped as code-carrying diagnostics later.
+- **P4_LSP.md remaining item** — closed by P3.5 (typed channel).
+- **INCREMENTAL_COMPILATION** — unaffected; the structured channel makes
+  future incremental diagnostics trivially cacheable.
+- **TARGET_TRIPLES.md** — `target.yo`'s hint style is the house pattern this
+  plan generalizes; its errors get codes in the `E15xx` band.
+
+---
+
+## 10. Non-goals
+
+- **Multi-error batch output.** Fail-fast single-error stays (§1.5) — no
+  parser recovery / evaluator continuation machinery in this plan. Revisit
+  only if agent-iteration data shows batching pays for recovery complexity.
+- Renumbering or recycling codes; translating message text (English remains
+  the machine lingua franca; zh-CN is a registry-level add-on, OQ3).
+- A `yo fix` auto-rewriter (ROADMAP mentions it; separate doc when wanted).
+- Absorbing the `#line`/debug-info project.
+
+---
+
+## 11. Open questions for the maintainer
+
+1. **Subcommand name**: `yo explain E0308` (recommended; verb-form, matches
+   ROADMAP 4.5 spelling) vs `yo error E0308` (as originally floated). Alias
+   support is cheap either way.
+2. **Code format**: numeric `E0308` (recommended; rustc parity, terse,
+   typo-duck-typed by did-you-mean) vs semantic slugs (`type-mismatch`;
+   self-describing but long, and renames become compatibility hazards).
+3. **Registry language**: English-only at first (recommended) vs bilingual
+   entries from day one (doubles authoring; `docs/` bilingual rule then
+   applies to the rendered reference too).
+4. **Exit codes**: keep 0/1 everywhere (recommended; goldens and scripts
+   assume it) vs rustc-style distinct ICE code.
+5. **P3.6 runtime panic locations**: in scope here, or split into its own
+   change given the runtime-output churn across std tests?
+
+---
+
+## Appendix A — emission-site census (2026-09-03)
+
+Rerun: `grep -rn 'format_error_message(' --include='*.yo' src/ | grep -v
+format_error_messages | awk -F: '{print $1}' | sort | uniq -c | sort -rn | head -15`
+
+| Sites | File |
+| --- | --- |
+| 94 | `src/evaluator/types/function.yo` |
+| 58 | `src/evaluator/exprs/match.yo` |
+| 44 | `src/evaluator/builtins/type_fns.yo` |
+| 33 | `src/evaluator/builtins/comptime_list_fns.yo` |
+| 30 | `src/evaluator/types/trait.yo` |
+| 26 | `src/evaluator/calls/function.yo` |
+| 26 | `src/evaluator/builtins/asm.yo` |
+| 24 | `src/evaluator/builtins/comptime_index_fns.yo` |
+| 23 | `src/evaluator/builtins/expr_fns.yo` |
+| 22 | `src/evaluator/calls/index_trait.yo` |
+| 20 | `src/evaluator/exprs/property_access.yo` |
+| 20 | `src/evaluator/exprs/destructuring_assignment.yo` |
+| 19 | `src/evaluator/types/enum.yo` |
+| 18 | `src/evaluator/types/field.yo` |
+| 18 | `src/evaluator/exprs/cond.yo` |
+
+Subdirectory totals: `builtins` 304, `exprs` 252, `types` 225, `calls` 144,
+`values` 69, evaluator root 7, `src/expr.yo` 6, `src/types/` 5. Batch-form
+sites (`format_error_messages`): 17, of which 10 in
+`src/evaluator/utils.yo`. Codegen fatals: 95 `codegen_fatal_expr` + 30
+`codegen_fatal` + 14 `__yo_panic`. Parser: 33 throw sites. Lexer: 6.

--- a/plans/ERROR_DIAGNOSTICS_OVERHAUL.md
+++ b/plans/ERROR_DIAGNOSTICS_OVERHAUL.md
@@ -9,6 +9,10 @@
 > [P4_LSP.md](P4_LSP.md) header. Sections 1–4 are a verified audit of the
 > current `src/` (all numbers re-runnable, commands given); sections 5+ are
 > the design and phasing proposed for approval.
+>
+> **§11 decisions recorded 2026-09-03**: `yo explain` (no alias), numeric
+> `E0308`-style codes, a bilingual English + 简体中文 registry from day one,
+> exit codes stay 0/1, runtime-panic locations stay in P3 (details §11).
 
 Yo's positioning is "designed for the LLM era" — and the error channel is the
 highest-bandwidth feedback an iterating agent receives. Today that channel is
@@ -368,7 +372,7 @@ compiler dependency via the LSP, so no seed-availability risk).
 
 ## 5. Error codes and the registry
 
-- Format: `E` + 4 digits. Loose band convention (not enforced, guidance
+- Format (DECIDED, §11.2): `E` + 4 digits. Loose band convention (not enforced, guidance
   only): `E00xx–E02xx` syntax (lexer+parser), `E03xx–E05xx` name/scope/module
   resolution, `E06xx–E08xx` types & traits, `E09xx–E10xx` ownership/moves/
   effects/async, `E11xx–E12xx` comptime/macros/reflection, `E13xx` internal
@@ -389,19 +393,30 @@ Registry entry (data, in `src/diagnostics_registry.yo`; ships inside the
 binary so `yo explain` works offline):
 
 ```rust
-Example  :: struct(bad : String, good : String, why : String);
+Example  :: struct(bad : String, good : String, why : String, why_zh : String);
 Explain  :: struct(
   code : String,            // "E0308"
-  title : String,           // "mismatched types"
-  summary : String,         // one sentence
-  explanation : String,     // paragraphs; markdown-ish
-  examples : ArrayList(Example),
+  title : String,           // "mismatched types"        (English)
+  title_zh : String,        // 简体中文标题
+  summary : String,         // one sentence              (English)
+  summary_zh : String,
+  explanation : String,     // paragraphs; markdown-ish  (English)
+  explanation_zh : String,
+  examples : ArrayList(Example),  // snippets are language-neutral; `why` prose is bilingual
   related : ArrayList(String)
 );
 ```
 
+**Bilingual by decision (§11.3):** every prose field ships in English AND
+Simplified Chinese from day one — there is no English-only pass to retrofit.
+The compiler's own message text stays English-only (§10); the registry is
+the bilingual surface. `yo explain` prints English by default; `--lang
+zh-CN` (or the `YO_LANG` env var) selects the Chinese fields, and
+`--format json` carries both languages.
+
 A registry test enforces: every code referenced from the code table has an
-entry, titles/summaries/explanations non-empty, ≥1 example per entry, and —
+entry, titles/summaries/explanations non-empty **in both languages**, ≥1
+example per entry, and —
 the strong gate, borrowed from rustc's error-index tests — **every `good`
 snippet compiles** (checked by a small harness shelling `yo check` on temp
 files) and every `bad` snippet errors *with that code* (checked the same
@@ -411,11 +426,9 @@ way). The corpus therefore cannot rot.
 
 ## 6. `yo explain`
 
-Naming: **`yo explain <CODE>`** is recommended over `yo error <CODE>` — it
-matches the repo's verb-subcommands (`build`, `check`, `doc`, `fetch`,
-`install`, `version`) and is the spelling ROADMAP 4.5 already uses. `yo
-error` remains a fine alias if preferred (open question OQ1; the mechanics
-below are name-independent).
+Naming (DECIDED, §11.1): **`yo explain <CODE>`** — it matches the repo's
+verb-subcommands (`build`, `check`, `doc`, `fetch`, `install`, `version`)
+and is the spelling ROADMAP 4.5 already uses. No `yo error` alias.
 
 ```
 $ yo explain E0308
@@ -440,7 +453,8 @@ help: did you mean `E0308`? Run `yo explain --list` for all codes.
 - `yo explain --list` — code + title per line; `yo explain --list --format
   json` — the full registry dump (this is the ROADMAP 4.2 corpus export).
 - `yo explain E0308 --format json` — one entry, for agents pulling depth on
-  demand.
+  demand. `--lang zh-CN` prints the Chinese fields (default English; the
+  `YO_LANG` env var is equivalent); JSON always carries both languages.
 - Exit 0 when found, 1 when not (with did-you-mean over the registry — the
   same edit-distance helper as D8, §8.1).
 - No network, no repo presence needed — the registry is compiled in.
@@ -489,6 +503,8 @@ Scope:
 1. Code table in `src/diagnostics.yo` + registry in
    `src/diagnostics_registry.yo`; assign codes to the top families (target:
    ≥60% of corpus-measured emissions coded, estimated 60–100 codes).
+   Registry entries are bilingual (English + 简体中文) from the first entry
+   (§5) — no English-only pass to retrofit later.
 2. `help: run \`yo explain E0xxx\`` tail on coded diagnostics.
 3. `yo explain` subcommand with `--list`, `--format json`, did-you-mean.
 4. Registry test incl. good-snippets-compile / bad-snippets-error-with-code.
@@ -500,7 +516,8 @@ Scope:
    vocabulary).
 
 Acceptance: two runs → byte-identical JSON; `jq` round-trips every field;
-explain offline; registry gates green; suite green.
+explain offline in both languages; registry gates green (incl.
+both-language non-empty); suite green.
 
 ### P3 — repair-oriented upgrades (the LLM loop)
 
@@ -513,7 +530,7 @@ explain offline; registry gates green; suite green.
 3. **Import-chain collapse** (D16): report the leaf diagnostic once + one
    `note: in module imported from <path>` chain note (bounded, no cascade).
 4. **ICE wrapper** (D11): `codegen_fatal*` → `internal compiler error:` +
-   compiler file:line + report prompt; keep rc=1 (OQ4).
+   compiler file:line + report prompt; keep rc=1 (decided, §11.4).
 5. **LSP typed channel**: `analyze_document` returns
    `ArrayList(Diagnostic)`; `parse_error_text` and `_ident_len_at` retire —
    the P4 remaining item closes; exact ranges from spans, not identifier
@@ -521,7 +538,8 @@ explain offline; registry gates green; suite green.
 6. **Runtime panic locations** (D13): `panic()`/`assert()` codegen embeds the
    Yo file:line of the call site (`exprs/panic.yo` has the `Expr`; its token
    is available); fix the StrLit quotes artifact. ⚠ some tests capture
-   runtime panic text — audit before landing (acceptance includes it).
+   runtime panic text — audit before landing (acceptance includes it;
+   decided in-scope, §11.5).
 7. `--error-format` threaded through `build`/`test`; test runner honors
    `--json-summary` (currently ignored) or removes the flag (pick during
    implementation; CLI-compat tests decide).
@@ -536,7 +554,7 @@ golden re-recorded once more; runtime-panic-touching tests audited and green.
 - Color (tty-gated, `NO_COLOR`/`TERM=dumb`) — D14; cosmetic, after data work.
 - A live warnings channel (D15) — `Severity.Warning` exists since P1; wiring
   unused-variable/etc. detection is its own small project.
-- SARIF output; `yo fix` (ROADMAP 4.5's bigger sibling); zh-CN registry.
+- SARIF output; `yo fix` (ROADMAP 4.5's bigger sibling).
 
 ---
 
@@ -551,6 +569,7 @@ golden re-recorded once more; runtime-panic-touching tests audited and green.
 | Registry rots as messages evolve | Registry test compiles every `good` snippet and asserts every `bad` snippet errors with its code (rustc error-index model) |
 | Codes churn / renumbering temptation | Never-renumber rule in §5; registry keeps per-code history lines |
 | Runtime-panic location change (P3.6) breaks tests that capture panic text | Explicit audit listed as P3 acceptance, before landing |
+| Registry EN/zh entries drift apart | Both languages are authored in ONE entry side by side; the registry test fails on any empty `_zh` prose field |
 
 ---
 
@@ -572,28 +591,29 @@ golden re-recorded once more; runtime-panic-touching tests audited and green.
 - **Multi-error batch output.** Fail-fast single-error stays (§1.5) — no
   parser recovery / evaluator continuation machinery in this plan. Revisit
   only if agent-iteration data shows batching pays for recovery complexity.
-- Renumbering or recycling codes; translating message text (English remains
-  the machine lingua franca; zh-CN is a registry-level add-on, OQ3).
+- Renumbering or recycling codes; translating the compiler's own message
+  text (English remains the machine lingua franca — the bilingual surface is
+  the explanations registry, where both languages ship from day one, §11.3).
 - A `yo fix` auto-rewriter (ROADMAP mentions it; separate doc when wanted).
 - Absorbing the `#line`/debug-info project.
 
 ---
 
-## 11. Open questions for the maintainer
+## 11. Decisions (maintainer, 2026-09-03)
 
-1. **Subcommand name**: `yo explain E0308` (recommended; verb-form, matches
-   ROADMAP 4.5 spelling) vs `yo error E0308` (as originally floated). Alias
-   support is cheap either way.
-2. **Code format**: numeric `E0308` (recommended; rustc parity, terse,
-   typo-duck-typed by did-you-mean) vs semantic slugs (`type-mismatch`;
-   self-describing but long, and renames become compatibility hazards).
-3. **Registry language**: English-only at first (recommended) vs bilingual
-   entries from day one (doubles authoring; `docs/` bilingual rule then
-   applies to the rendered reference too).
-4. **Exit codes**: keep 0/1 everywhere (recommended; goldens and scripts
-   assume it) vs rustc-style distinct ICE code.
-5. **P3.6 runtime panic locations**: in scope here, or split into its own
-   change given the runtime-output churn across std tests?
+The former open questions, all decided:
+
+1. **Subcommand name**: `yo explain E0308` — verb-form, matches the ROADMAP
+   4.5 spelling. No `yo error` alias.
+2. **Code format**: numeric `E0308` (rustc parity, terse, typo-duck-typed by
+   did-you-mean). No semantic slugs.
+3. **Registry language**: bilingual — every entry carries English AND
+   Simplified Chinese prose from day one (`title`/`title_zh`, …; §5). The
+   compiler's own message text stays English-only.
+4. **Exit codes**: keep 0/1 everywhere (goldens and scripts assume it).
+5. **P3.6 runtime panic locations**: stays in Phase 3 scope, with its
+   audit-before-landing acceptance item (the runtime-output churn across std
+   tests is checked first).
 
 ---
 

--- a/plans/ROADMAP.md
+++ b/plans/ROADMAP.md
@@ -4,7 +4,8 @@ _Drafted 2026-07-27 from the bootstrap-campaign retrospective. Ordering
 reflects dependency and leverage, not just desirability: tooling speed
 multiplies everything after it, and verification is the flagship feature the
 language's existing machinery (CTFE + effects + contracts pragmas) is already
-shaped for._
+shaped for. Statuses last trued 2026-09-03 (Phase 0.5 complete; Phase 2.1/2.2
+landed; 2.3/4.5 in design; Phase 5 std maturation largely landed)._
 
 ## Positioning (what Yo is, in one line)
 
@@ -23,10 +24,10 @@ front — cluster-B `dyn(box(closure))` spec emission, cee validations, the
 contracts port, the REDs, the `||`-LHS trait-call miscompile,
 `await_analysis` triage — closed. Record: [`BOOTSTRAPPING.md`](BOOTSTRAPPING.md).
 
-The two-compiler lockstep is **not yet** retired to a maintenance cadence —
-that is what Phase 0.5 below is doing, and it is where current work sits.
+The two-compiler lockstep **was retired** by Phase 0.5 below — the TypeScript
+compiler is deleted and the self-hosted compiler lives as `src/`.
 
-## Phase 0.5 — self-hosting completion (in flight)
+## Phase 0.5 — self-hosting completion — **COMPLETE 2026-08-22**
 
 Retire `src/` and the bun/node toolchain, ship installers, rewrite the LSP in
 Yo. This was not a phase in the original draft: at the time, "bootstrap done"
@@ -35,9 +36,20 @@ was assumed to mean the TypeScript compiler could simply be dropped. It cannot
 all reach into `src/`, and the trust chain has to move to
 "previous release builds current compiler" first.
 
+Outcome, per phase: P1 CLI parity complete 2026-08-10; P2/P2.5 retired the
+TypeScript compiler (frozen at the `src-attic-final` tag) and moved
+`yo-self/` into the freed `src/` name (2026-08-20); P3's installers and
+releases channel are proven by shipped releases (`scripts/install.sh`, the
+GitHub-Releases version cache — the seed is now v0.2.23); P4's Yo-native LSP
+is feature-complete 2026-08-22 (`yo lsp` plus the extension's bundled
+client). Remaining P4 quality items (typed diagnostics channel, doc-comment
+plumbing) are listed in the P4_LSP.md header — the typed-diagnostics one is
+P3 of [`ERROR_DIAGNOSTICS_OVERHAUL.md`](ERROR_DIAGNOSTICS_OVERHAUL.md).
+
 Working docs: [`SELF_HOSTING_COMPLETION.md`](SELF_HOSTING_COMPLETION.md)
-(umbrella) → `P1_CLI_PARITY.md` (complete) → `P2_RETIRE_SRC.md` (active) →
-`P3_DISTRIBUTION.md` → `P4_LSP.md`.
+(umbrella) → `P1_CLI_PARITY.md` (COMPLETE) → `P2_RETIRE_SRC.md` +
+`P2_5_RETIRE_EXECUTION.md` (LANDED) → `P3_DISTRIBUTION.md` (shipped) →
+`P4_LSP.md` (feature-complete).
 
 ## Phase 1 — Formal verification (the flagship)
 
@@ -67,16 +79,23 @@ Dafny-inspired, but built on assets Dafny lacks:
 1. **Incremental compilation** — module-level caching keyed on content
    hashes. Clean builds are ~7 min for the compiler and the stage2
    self-compile is ~38 min; this is the single biggest tax on both human and
-   LLM development loops.
-2. **LSP maturity** — the VS Code extension exists but serves stale
-   diagnostics; a real language server (check-only pipeline is already fast
-   at ~30 s for all of std) with go-to-definition, hover types, and inline
-   errors.
+   LLM development loops. — **LANDED** (Phases A–C, revised scope:
+   build-runner artifact cache, LSP-correct invalidation at ~65 ms per edit,
+   in-process `--watch`; the original cross-process evaluated-export cache
+   was descoped — see [`INCREMENTAL_COMPILATION.md`](INCREMENTAL_COMPILATION.md)).
+2. **LSP maturity** — a real language server with go-to-definition, hover
+   types, and inline errors. — **LANDED** (P4, feature-complete 2026-08-22:
+   `yo lsp` serves diagnostics, hover, definition, symbols, references,
+   folding, rename, formatting, signature help and completion, and the VS
+   Code extension bundles the client — [`P4_LSP.md`](P4_LSP.md)).
 3. **Error-message overhaul** — errors are the language's actual UI, and
    (see Phase 4) the LLM repair loop. Every error should carry the corrected
    form the way the `unsafe(...)` gate hint does. Kill the 15-deep
    import-chain error cascades: report the leaf once, with the chain
-   collapsed.
+   collapsed. — detailed design **PROPOSED 2026-09-03**:
+   [`ERROR_DIAGNOSTICS_OVERHAUL.md`](ERROR_DIAGNOSTICS_OVERHAUL.md)
+   (structured diagnostics, `E`-codes with an offline `yo explain` registry,
+   `--error-format human|short|json`; awaiting review).
 4. **Debug info** — `#line` directives mapping emitted C back to `.yo`
    sources; cheap and transforms the debugger story.
 
@@ -106,7 +125,9 @@ design constraint, not an accident:
    like `.github/skills/` but as a product artifact. Small enough to sit in
    any model's context.
 2. **Errors as few-shot repairs** — see Phase 2.3; the error corpus doubles
-   as training/eval data.
+   as training/eval data. Design proposed in
+   [`ERROR_DIAGNOSTICS_OVERHAUL.md`](ERROR_DIAGNOSTICS_OVERHAUL.md) — the
+   `yo explain` registry's verified examples are the corpus export.
 3. **Syntax stability + sugar pass** — do the breaking cleanups NOW (the
    pointer-operator retirement was the right kind); then freeze. Consider a
    thin sugar layer for the noisiest forms (`(fn(x : i32) -> i32)({...})`)
@@ -114,6 +135,9 @@ design constraint, not an accident:
 4. **Publish for pretraining** — docs, a large idiomatic-example corpus,
    and permissively-licensed repos, so the next model generation knows Yo.
 5. **`yo explain <error-id>` / `yo fix`** — machine-consumable diagnostics.
+   `yo explain` is designed in
+   [`ERROR_DIAGNOSTICS_OVERHAUL.md`](ERROR_DIAGNOSTICS_OVERHAUL.md);
+   `yo fix` remains open.
 
 ## Phase 5 — Targets & ecosystem
 
@@ -123,7 +147,12 @@ design constraint, not an accident:
 - **Package registry** — `yo install` (git deps + lock file) exists; add a
   minimal registry + docs hosting (`yo doc` already renders HTML).
 - **Std maturation** — HTTP client/server hardening, TLS, time/date,
-  process/signal ergonomics; keep `public-safe-report` at zero findings.
+   process/signal ergonomics — **largely landed** by the std API audit
+   campaign (2026-08-23 → ongoing: the §2 correctness sweep, the conventions
+   + breaking sweep, TLS, HTTP client/server, time/date, process —
+   [`STD_API_AUDIT.md`](STD_API_AUDIT.md)). Remaining: the §7 S4/P1 addition
+   tail and the §9 S5 stability freeze (additive-only std); keep
+   `public-safe-report` at zero findings.
 - **Debugging/observability** — after Phase 2.4, a `yo test --debug` story
   and sanitizer presets (ASan path exists).
 
@@ -140,17 +169,17 @@ design constraint, not an accident:
 
 ```
 bootstrap done ──> Phase 0.5 self-hosting completion ──> Phase 1 verification
-   (COMPLETE)         (IN FLIGHT: retire src/,              (design + pure fragment)
-                       installers, LSP in Yo)                    │
-                                                                 │
-      ├── Phase 2 tooling (incremental, LSP, errors)   [parallel track]
-      │                   │
+   (COMPLETE)         (COMPLETE 2026-08-22)                (design + pure fragment)
+                                                                    │
+                                                                    │
+      ├── Phase 2 tooling (incremental + LSP landed;       [parallel track]
+      │    errors in design — ERROR_DIAGNOSTICS_OVERHAUL)         │
       ├── Phase 3 identity/perf debt (unblocks 1 & 2 at scale)
       │                   │
       └── Phase 4 LLM pack + publish  ──> Phase 5 targets/ecosystem
 ```
 
-Note Phase 0.5's LSP work (`P4_LSP.md`) and Phase 2's tooling track overlap:
-the Yo-native language server is the same deliverable seen from two roadmaps.
-Phase 2's "incremental re-check" is the part P4 explicitly does NOT cover —
-P4 ships a correct server, not yet a fast one.
+Note Phase 0.5's LSP work (`P4_LSP.md`) and Phase 2's tooling track overlapped:
+the Yo-native language server was the same deliverable seen from two roadmaps.
+Both halves have since landed — P4 shipped the correct server (2026-08-22),
+and Phase 2.1's Phase B landed the incremental re-check (~65 ms per edit).

--- a/src/check_watch.yo
+++ b/src/check_watch.yo
@@ -27,7 +27,7 @@
 //!     by the cli-case harness, which cannot mutate files concurrently.
 pragma(Pragma.AllowUnsafe);
 { String } :: import("std/string");
-{ println } :: import("std/fmt");
+{ println, eprintln } :: import("std/fmt");
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
@@ -43,7 +43,8 @@ sleep_mod :: import("std/sys/timer");
 {
   mm_load_file,
   mm_invalidate_document,
-  mm_resolve_entry_abs
+  mm_resolve_entry_abs,
+  _take_load_error
 } :: import("./module_manager.yo");
 /// `"${mtime}:${size}"` for a path, or `.None` when the stat fails (file
 /// deleted / transient editor rename). One string keeps the sweep's compare
@@ -111,6 +112,13 @@ watch_round :: (
           cond(
             ok => println(`watch: ${fp} — OK`),
             true => {
+              // The loader's handlers only stash the rendered diagnostic (the
+              // P1 single-print rule) — the watch round owns the print.
+              match(
+                _take_load_error(),
+                .Some(rendered) => eprintln(rendered),
+                .None => ()
+              );
               failed = (failed + usize(1));
               println(`watch: ${fp} — FAILED`);
             }

--- a/src/diagnostics.yo
+++ b/src/diagnostics.yo
@@ -1,0 +1,189 @@
+//! src/diagnostics — the structured diagnostic value and its renderers.
+//!
+//! P1 of plans/ERROR_DIAGNOSTICS_OVERHAUL.md: a diagnostic is DATA first —
+//! `code`/`severity`/`message`/`span` (+ the extracted `source_line`) — and
+//! every output format (human, short; JSON in P2) is a rendering of that
+//! value. No consumer ever parses a rendering back except the LSP adapter,
+//! which P3 replaces with the typed channel.
+//!
+//! Position conventions (stated once, load-bearing): rows and columns are
+//! 0-based internally (the `Token` basis) and RUNE columns, not bytes; the
+//! `+1` is display-only, and the caret padding counts runes so the underline
+//! lands under the right character on lines with multibyte text before it.
+open(import("std/string"));
+open(import("std/fmt"));
+{ ArrayList } :: import("std/collections/array_list");
+/// The severity of a diagnostic entry. The FIRST entry of an error group is
+/// the primary (`Error`, or `Warning` once a warnings channel exists);
+/// secondary entries ("value moved here", "Defined here:") are `Note`s.
+Severity :: enum(Error, Warning, Note, Help);
+derive(Severity, Clone);
+/// A source location: file, 0-based row, 0-based RUNE column, and the
+/// span's rune length (how many `^` the underline draws).
+Span :: struct(
+  path : String,
+  row : usize,
+  col : usize,
+  len : usize
+);
+/// A secondary location attached to a diagnostic. P1 carries secondary
+/// locations as follow-on `Note` entries instead; labels are the P2/P3
+/// channel (plans/ERROR_DIAGNOSTICS_OVERHAUL.md §3).
+Label :: struct(
+  severity : Severity,
+  message : String,
+  span : Span
+);
+/// One diagnostic entry. `source_line` is the source text at `span.row`,
+/// extracted once at construction — the renderer never re-reads files.
+Diagnostic :: struct(
+  code : Option(String),
+  severity : Severity,
+  message : String,
+  span : Span,
+  source_line : String
+);
+_max_usize :: (fn(a : usize, b : usize) -> usize)(
+  cond(
+    (a > b) => a,
+    true => b
+  )
+);
+_severity_prefix :: (fn(sev : Severity) -> String)(
+  match(
+    sev,
+    .Error => String.from("error"),
+    .Warning => String.from("warning"),
+    .Note => String.from("note"),
+    .Help => String.from("help")
+  )
+);
+/// Number of digits of `n` (≥ 1) — a row number's gutter width.
+_row_digits :: (fn(n : usize) -> usize)({
+  s := `${n}`;
+  cond(
+    (s.len() == usize(0)) => usize(1),
+    true => s.len()
+  )
+});
+/// The first line of `message` (the header line of a rendered block).
+_first_message_line :: (fn(message : String) -> String)({
+  lines := message.split(String.from("\n"));
+  match(
+    lines.get(usize(0)),
+    .Some(line) => line,
+    .None => String.new()
+  )
+});
+/// Render one entry into `out`: the `severity[code]: message` header, the
+/// message's continuation lines verbatim, and (when a path is known) the
+/// `-->` anchor plus gutter / source line / full-span underline. `w` is the
+/// shared gutter width — the max row digits over the whole group — so the
+/// `|` gutters of every block in the group align.
+_render_block :: (fn(d : Diagnostic, w : usize, out : ArrayList(String)) -> unit)({
+  prefix := _severity_prefix(d.severity);
+  msg_lines := d.message.split(String.from("\n"));
+  (mi : usize) = usize(0);
+  while(mi < msg_lines.len(), {
+    match(
+      msg_lines.get(mi),
+      .Some(line) => {
+        if(mi == usize(0), {
+          match(
+            d.code,
+            .Some(c) => out.push(`${prefix}[${c}]: ${line}`),
+            .None => out.push(`${prefix}: ${line}`)
+          );
+        }, {
+          out.push(line);
+        });
+      },
+      .None => ()
+    );
+    mi = (mi + usize(1));
+  });
+  if(d.span.path.len() > usize(0), {
+    row_plus1 := (d.span.row + usize(1));
+    col_plus1 := (d.span.col + usize(1));
+    indent := String.from(" ").repeat(w + usize(1));
+    out.push(`${indent}--> ${d.span.path}:${row_plus1}:${col_plus1}`);
+    if(d.source_line.len() > usize(0), {
+      out.push(`${indent}|`);
+      padded := `${row_plus1}`;
+      while(padded.len() < w, {
+        padded = ` ${padded}`;
+      });
+      out.push(`${padded} | ${d.source_line}`);
+      underline_len := cond(
+        (d.span.len == usize(0)) => usize(1),
+        true => d.span.len
+      );
+      col_spaces := String.from(" ").repeat(d.span.col);
+      carets := String.from("^").repeat(underline_len);
+      out.push(`${indent}| ${col_spaces}${carets}`);
+    });
+  });
+});
+/// The human rendering of a diagnostic group (rustc-shaped): each entry in
+/// order — entry 0 is the primary error, the rest are notes — separated by
+/// a blank line. This is what `YoError.to_string()` returns and what the
+/// CLI edges print; one location per entry, exactly once.
+render_diagnostics_human :: (fn(diagnostics : ArrayList(Diagnostic)) -> String)({
+  out := ArrayList(String).new();
+  w := usize(1);
+  (di : usize) = usize(0);
+  while(di < diagnostics.len(), {
+    match(
+      diagnostics.get(di),
+      .Some(d) => {
+        w = _max_usize(w, _row_digits(d.span.row + usize(1)));
+      },
+      .None => ()
+    );
+    di = (di + usize(1));
+  });
+  (dj : usize) = usize(0);
+  while(dj < diagnostics.len(), {
+    match(
+      diagnostics.get(dj),
+      .Some(d) => {
+        if(dj > usize(0), {
+          out.push(String.new());
+        });
+        _render_block(d, w, out);
+      },
+      .None => ()
+    );
+    dj = (dj + usize(1));
+  });
+  String.from("\n").join(out)
+});
+/// The one-line-per-entry rendering: `path:row:col: severity[code]: msg`
+/// (1-based positions, first message line) — for CI logs and greps.
+render_diagnostics_short :: (fn(diagnostics : ArrayList(Diagnostic)) -> String)({
+  out := ArrayList(String).new();
+  (di : usize) = usize(0);
+  while(di < diagnostics.len(), {
+    match(
+      diagnostics.get(di),
+      .Some(d) => {
+        prefix := _severity_prefix(d.severity);
+        head := _first_message_line(d.message);
+        match(
+          d.code,
+          .Some(c) => out.push(
+            `${d.span.path}:${(d.span.row + usize(1))}:${(d.span.col + usize(1))}: ${prefix}[${c}]: ${head}`
+          ),
+          .None => out.push(
+            `${d.span.path}:${(d.span.row + usize(1))}:${(d.span.col + usize(1))}: ${prefix}: ${head}`
+          )
+        );
+      },
+      .None => ()
+    );
+    di = (di + usize(1));
+  });
+  String.from("\n").join(out)
+});
+export(Severity, Span, Label, Diagnostic);
+export(render_diagnostics_human, render_diagnostics_short);

--- a/src/error.yo
+++ b/src/error.yo
@@ -1,38 +1,162 @@
 //! Error types and formatting utilities for the Yo compiler.
 //!
-//! Mirrors `src/error.ts`.
+//! P1 of plans/ERROR_DIAGNOSTICS_OVERHAUL.md: `YoError` carries structured
+//! `Diagnostic` values (code/severity/message/span/source-line); the human
+//! text — including the location block — is RENDERED from that data at the
+//! edge, never baked into the message string. The single-message and batch
+//! builders keep taking a `Token` (+ verbatim message), so the ~1000
+//! emission sites across the evaluator are untouched by the restructure.
 open(import("std/string"));
 open(import("std/fmt"));
 open(import("std/error"));
 { ArrayList } :: import("std/collections/array_list");
 { Token } :: import("./token.yo");
-{ assert, panic } :: import("std/assert");
-/// The kind of a compiler error.
-///
-/// Mirrors `ErrorKind` in `src/error.ts`.
-ErrorKind :: enum(
-  Overflow
-);
-derive(ErrorKind, Clone, Eq(ErrorKind), ToString);
-/// A token paired with an error message for error reporting.
-///
-/// Mirrors `TokenAndError` in `src/error.ts`.
+{ assert } :: import("std/assert");
+{
+  Severity,
+  Span,
+  Diagnostic,
+  render_diagnostics_human
+} :: import("./diagnostics.yo");
+/// A token paired with an error message for error reporting — the input
+/// currency of the batch builder (ownership-flow errors collect several
+/// related locations in one group).
 TokenAndError :: struct(
   token : Token,
   error_message : String
 );
 derive(TokenAndError, Clone);
 /// A token paired with a warning message for warning reporting.
-///
-/// Mirrors the inline `{ token; warningMessage }` type in `formatWarningMessages`.
 TokenAndWarning :: struct(
   token : Token,
   warning_message : String
 );
 derive(TokenAndWarning, Clone);
-/// Get the source line at the token's position with a caret indicator.
-///
-/// Mirrors `getLineAtToken` in `src/error.ts`.
+/// The `Span` of a token: its module path, 0-based row/rune column, and the
+/// token's rune length as the underline (D5 — the caret used to sit at the
+/// token's MIDDLE; it now underlines the whole token from its start).
+_span_of_token :: (fn(token : Token) -> Span)(
+  Span(
+    path : token.module_path,
+    row : token.row,
+    col : token.column,
+    len : token.value.chars().count()
+  )
+);
+/// The source line at the token's row ("" when the row is out of range).
+_source_line_of_token :: (fn(token : Token) -> String)({
+  lines := token.input.split(String.from("\n"));
+  match(
+    lines.get(token.row),
+    .Some(line) => line,
+    .None => String.new()
+  )
+});
+/// One diagnostic entry from a token + verbatim message.
+_diagnostic_of_token :: (
+  fn(token : Token, severity : Severity, error_message : String) -> Diagnostic
+)(
+  Diagnostic(
+    code : Option(String).None,
+    severity : severity,
+    message : error_message.trim(),
+    span : _span_of_token(token),
+    source_line : _source_line_of_token(token)
+  )
+);
+/// Compiler error: a group of diagnostics — entry 0 the primary error,
+/// every later entry a related location rendered as a `note:` block
+/// (D6 — they used to render with an `Error:` prefix).
+YoError :: ref(
+  struct(
+    diagnostics : ArrayList(Diagnostic)
+  )
+);
+impl(
+  YoError,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)(
+      render_diagnostics_human(self.diagnostics)
+    )
+  )
+);
+impl(YoError, Error());
+/// Wrap one diagnostic as a single-entry `YoError`.
+_yo_error_of :: (fn(entry : Diagnostic) -> YoError)({
+  entries := ArrayList(Diagnostic).new();
+  entries.push(entry);
+  YoError(diagnostics : entries)
+});
+/// Create a `YoError` from a single token and error message.
+format_error_message :: (fn(token : Token, error_message : String) -> YoError)(
+  _yo_error_of(_diagnostic_of_token(token, Severity.Error, error_message))
+);
+/// Create a `YoError` with a path anchor but no snippet — end-of-input and
+/// other position-less parser errors.
+format_raw_error :: (fn(module_path : String, error_message : String) -> YoError)(
+  _yo_error_of(
+    Diagnostic(
+      code : Option(String).None,
+      severity : Severity.Error,
+      message : error_message.trim(),
+      span : Span(path : module_path, row : usize(0), col : usize(0), len : usize(0)),
+      source_line : String.new()
+    )
+  )
+);
+/// Create a `YoError` from a list of token + error message pairs: the first
+/// entry is the primary error, every later entry renders as a note.
+format_error_messages :: (fn(token_and_error_list : ArrayList(TokenAndError)) -> YoError)({
+  assert(token_and_error_list.len() > usize(0), "token_and_error_list must not be empty");
+  entries := ArrayList(Diagnostic).new();
+  (i : usize) = usize(0);
+  while(i < token_and_error_list.len(), {
+    match(
+      token_and_error_list.get(i),
+      .Some(entry) => {
+        if(i == usize(0), {
+          entries.push(_diagnostic_of_token(entry.token, Severity.Error, entry.error_message));
+        }, {
+          entries.push(_diagnostic_of_token(entry.token, Severity.Note, entry.error_message));
+        });
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  YoError(diagnostics : entries)
+});
+/// A lexer error as a `YoError` diagnostic group. The lexer's internal
+/// struct carries no file context (D3), so the throw site supplies the
+/// module path, the full input (for the source line), and the 0-based
+/// row/rune column.
+format_lexer_error :: (
+  fn(
+    module_path : String,
+    input : String,
+    row : usize,
+    column : usize,
+    message : String
+  ) -> YoError
+)({
+  lines := input.split(String.from("\n"));
+  line := match(
+    lines.get(row),
+    .Some(l) => l,
+    .None => String.new()
+  );
+  _yo_error_of(
+    Diagnostic(
+      code : Option(String).None,
+      severity : Severity.Error,
+      message : message.trim(),
+      span : Span(path : module_path, row : row, col : column, len : usize(1)),
+      source_line : line
+    )
+  )
+});
+/// Get the source line at the token's position with a caret indicator
+/// (the legacy pre-P1 block, still used by the warnings path).
 get_line_at_token :: (fn(token : Token) -> String)({
   lines := token.input.split(String.from("\n"));
   row_line := match(
@@ -50,10 +174,11 @@ get_line_at_token :: (fn(token : Token) -> String)({
   col_plus1 := (token.column + usize(1));
   `${token.module_path}:${row_plus1}:${col_plus1}:\n${row_line}\n${spaces}^`
 });
-/// Get the source line at a given position with a caret indicator.
-///
-/// Mirrors `getLineAtPosition` in `src/error.ts`.
-get_line_at_position :: (fn(module_path : String, input_string : String, row : usize, column : usize) -> String)({
+/// Get the source line at a given position with a caret indicator
+/// (the legacy pre-P1 block).
+get_line_at_position :: (
+  fn(module_path : String, input_string : String, row : usize, column : usize) -> String
+)({
   lines := input_string.split(String.from("\n"));
   row_line := match(
     lines.get(row),
@@ -65,90 +190,11 @@ get_line_at_position :: (fn(module_path : String, input_string : String, row : u
   col_plus1 := (column + usize(1));
   `${module_path}:${row_plus1}:${col_plus1}:\n  \n${row_line}\n${spaces}^`
 });
-/// Lexer error with character index, message, and row.
-///
-/// Mirrors `YoLexerError` in `src/error.ts`.
-YoLexerError :: ref(
-  struct(
-    character_index : usize,
-    message : String,
-    row : usize
-  )
-);
-impl(
-  YoLexerError,
-  ToString(
-    to_string : (fn(inout(self) : Self) -> String)({
-      row_plus1 := (self.row + usize(1));
-      `Lexer Error at row ${row_plus1}: ${self.message}`
-    })
-  )
-);
-impl(YoLexerError, Error());
-/// Compiler error with a list of token + error message pairs.
-///
-/// Mirrors `YoError` in `src/error.ts`.
-YoError :: ref(
-  struct(
-    token_and_error_list : ArrayList(TokenAndError),
-    is_assertion_error : bool,
-    kind : Option(ErrorKind)
-  )
-);
-impl(
-  YoError,
-  ToString(
-    to_string : (fn(inout(self) : Self) -> String)({
-      parts := ArrayList(String).new();
-      n := self.token_and_error_list.len();
-      (i : usize) = usize(0);
-      while(i < n, {
-        match(
-          self.token_and_error_list.get(i),
-          .Some(entry) => {
-            line := get_line_at_token(entry.token);
-            parts.push(`Error: ${entry.error_message}\n${line}`);
-          },
-          .None => ()
-        );
-        i = (i + usize(1));
-      });
-      sep := String.from("\n\n");
-      sep.join(parts)
-    })
-  )
-);
-impl(YoError, Error());
-/// Create a `YoError` from a single token and error message.
-///
-/// Mirrors `formatErrorMessage` in `src/error.ts`.
-format_error_message :: (fn(token : Token, error_message : String, is_assertion_error : bool, kind : Option(ErrorKind)) -> YoError)({
-  line := get_line_at_token(token);
-  trimmed := error_message.trim();
-  full_message := `${trimmed}\n\n${line}`;
-  entries := ArrayList(TokenAndError).new();
-  entries.push(TokenAndError(token : token, error_message : full_message));
-  YoError(
-    token_and_error_list : entries,
-    is_assertion_error : is_assertion_error,
-    kind : kind
-  )
-});
-/// Create a `YoError` from a list of token + error message pairs.
-///
-/// Mirrors `formatErrorMessages` in `src/error.ts`.
-format_error_messages :: (fn(token_and_error_list : ArrayList(TokenAndError), is_assertion_error : bool, kind : Option(ErrorKind)) -> YoError)({
-  assert(token_and_error_list.len() > usize(0), "token_and_error_list must not be empty");
-  YoError(
-    token_and_error_list : token_and_error_list,
-    is_assertion_error : is_assertion_error,
-    kind : kind
-  )
-});
-/// Format warning messages into a single string.
-///
-/// Mirrors `formatWarningMessages` in `src/error.ts`.
-format_warning_messages :: (fn(warning_message : Option(String), token_and_warning_list : ArrayList(TokenAndWarning)) -> String)({
+/// Format warning messages into a single string (legacy pre-P1 block; the
+/// warnings channel itself is P4, plans/ERROR_DIAGNOSTICS_OVERHAUL.md §7).
+format_warning_messages :: (
+  fn(warning_message : Option(String), token_and_warning_list : ArrayList(TokenAndWarning)) -> String
+)({
   parts := ArrayList(String).new();
   n := token_and_warning_list.len();
   (i : usize) = usize(0);
@@ -171,12 +217,12 @@ format_warning_messages :: (fn(warning_message : Option(String), token_and_warni
     .None => warnings
   )
 });
-/// Print a `YoError` to stderr.
-///
-/// Mirrors `printYoError` in `src/error.ts`.
-print_yo_error :: (fn(inout(error) : YoError) -> unit)(
-  eprintln(error.to_string())
-);
-export(ErrorKind, TokenAndError, TokenAndWarning, YoLexerError, YoError);
+export(TokenAndError, TokenAndWarning, YoError);
 export(get_line_at_token, get_line_at_position);
-export(format_error_message, format_error_messages, format_warning_messages, print_yo_error);
+export(
+  format_error_message,
+  format_error_messages,
+  format_lexer_error,
+  format_raw_error,
+  format_warning_messages
+);

--- a/src/evaluator/builtins/alignof.yo
+++ b/src/evaluator/builtins/alignof.yo
@@ -42,9 +42,7 @@ evaluate_align_of :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "alignof" with 1 argument`,
-          false,
-          .None
+          `Expected "alignof" with 1 argument`
         )
       )
     );
@@ -72,9 +70,7 @@ evaluate_align_of :: (
         dyn(
           format_error_message(
             ast_expr_token(type_expr),
-            String.from("Failed to evaluate expression."),
-            false,
-            .None
+            String.from("Failed to evaluate expression.")
           )
         )
       );

--- a/src/evaluator/builtins/and_or.yo
+++ b/src/evaluator/builtins/and_or.yo
@@ -86,9 +86,7 @@ evaluate_and_or :: (
               dyn(
                 format_error_message(
                   ast_expr_token(arg),
-                  `Expected bool type for "${if(is_and, String.from("and"), String.from("or"))}" argument, got:\n${ast_expr_to_string(arg)}`,
-                  false,
-                  .None
+                  `Expected bool type for "${if(is_and, String.from("and"), String.from("or"))}" argument, got:\n${ast_expr_to_string(arg)}`
                 )
               )
             );
@@ -100,9 +98,7 @@ evaluate_and_or :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg),
-                `Expected bool type for "${if(is_and, String.from("and"), String.from("or"))}" argument, got:\n${ast_expr_to_string(arg)}`,
-                false,
-                .None
+                `Expected bool type for "${if(is_and, String.from("and"), String.from("or"))}" argument, got:\n${ast_expr_to_string(arg)}`
               )
             )
           );

--- a/src/evaluator/builtins/array_fns.yo
+++ b/src/evaluator/builtins/array_fns.yo
@@ -70,9 +70,7 @@ evaluate_yo_array_fill :: (
         dyn(
           format_error_message(
             ast_expr_token(array_type_arg),
-            String.from("__yo_array_fill: failed to evaluate array type argument"),
-            false,
-            .None
+            String.from("__yo_array_fill: failed to evaluate array type argument")
           )
         )
       );
@@ -94,9 +92,7 @@ evaluate_yo_array_fill :: (
         dyn(
           format_error_message(
             ast_expr_token(array_type_arg),
-            String.from("__yo_array_fill expects first argument to be an ArrayType"),
-            false,
-            .None
+            String.from("__yo_array_fill expects first argument to be an ArrayType")
           )
         )
       );
@@ -108,9 +104,7 @@ evaluate_yo_array_fill :: (
       dyn(
         format_error_message(
           ast_expr_token(array_type_arg),
-          `__yo_array_fill expects first argument to be an ArrayType, got ${type_to_string(array_type_tv)}`,
-          false,
-          .None
+          `__yo_array_fill expects first argument to be an ArrayType, got ${type_to_string(array_type_tv)}`
         )
       )
     );
@@ -137,9 +131,7 @@ evaluate_yo_array_fill :: (
         dyn(
           format_error_message(
             ast_expr_token(fill_value_arg),
-            String.from("Failed to evaluate fill value"),
-            false,
-            .None
+            String.from("Failed to evaluate fill value")
           )
         )
       );
@@ -153,9 +145,7 @@ evaluate_yo_array_fill :: (
       dyn(
         format_error_message(
           ast_expr_token(fill_value_arg),
-          `Fill value type ${type_to_string(fv_info.ty)} is not compatible with array element type ${type_to_string(element_type)}`,
-          false,
-          .None
+          `Fill value type ${type_to_string(fv_info.ty)} is not compatible with array element type ${type_to_string(element_type)}`
         )
       )
     );
@@ -169,9 +159,7 @@ evaluate_yo_array_fill :: (
         dyn(
           format_error_message(
             ast_expr_token(fill_value_arg),
-            String.from("__yo_array_fill expects second argument to be a compile-time known value, got runtime value"),
-            false,
-            .None
+            String.from("__yo_array_fill expects second argument to be a compile-time known value, got runtime value")
           )
         )
       );

--- a/src/evaluator/builtins/as.yo
+++ b/src/evaluator/builtins/as.yo
@@ -42,7 +42,7 @@ evaluate_as :: (
     expr,
     .FnCall(_, _, a, _, _) => a,
     _ => {
-      exn.throw(dyn(format_error_message(tok, String.from("as: expected FnCall"), false, .None)));
+      exn.throw(dyn(format_error_message(tok, String.from("as: expected FnCall"))));
       return(expr);
     }
   );
@@ -51,9 +51,7 @@ evaluate_as :: (
       dyn(
         format_error_message(
           tok,
-          `"as" function expects exactly 2 arguments, got ${args.len()}`,
-          false,
-          .None
+          `"as" function expects exactly 2 arguments, got ${args.len()}`
         )
       )
     );
@@ -83,9 +81,7 @@ evaluate_as :: (
         dyn(
           format_error_message(
             ast_expr_token(val_arg_expr),
-            `Failed to evaluate value argument for "as"`,
-            false,
-            .None
+            `Failed to evaluate value argument for "as"`
           )
         )
       );
@@ -103,9 +99,7 @@ evaluate_as :: (
         dyn(
           format_error_message(
             ast_expr_token(type_arg_expr),
-            `Failed to evaluate type argument for "as"`,
-            false,
-            .None
+            `Failed to evaluate type argument for "as"`
           )
         )
       );
@@ -118,9 +112,7 @@ evaluate_as :: (
       dyn(
         format_error_message(
           ast_expr_token(type_arg_expr),
-          `Second argument to "as" must be a type`,
-          false,
-          .None
+          `Second argument to "as" must be a type`
         )
       )
     );
@@ -143,9 +135,7 @@ evaluate_as :: (
       dyn(
         format_error_message(
           tok,
-          `Cannot cast from type "${type_to_string(source_type)}" to type "${type_to_string(target_type)}" - types are not compatible`,
-          false,
-          .None
+          `Cannot cast from type "${type_to_string(source_type)}" to type "${type_to_string(target_type)}" - types are not compatible`
         )
       )
     );

--- a/src/evaluator/builtins/asm.yo
+++ b/src/evaluator/builtins/asm.yo
@@ -192,9 +192,7 @@ _evaluate_constraint :: (
         ast_expr_token(constraint_expr),
         String.from(
           "Invalid asm constraint. Expected a register class (reg, imm, mem, ...), an explicit register name string, or raw(\"constraint\")."
-        ),
-        false,
-        .None
+        )
       )
     )
   );
@@ -210,9 +208,7 @@ _parse_special_operand :: (
       dyn(
         format_error_message(
           ast_expr_token(operand_expr),
-          `asm ${kind}() expects 1 or 2 arguments, got ${args.len().to_string()}.`,
-          false,
-          .None
+          `asm ${kind}() expects 1 or 2 arguments, got ${args.len().to_string()}.`
         )
       )
     );
@@ -257,9 +253,7 @@ _parse_operand :: (
       dyn(
         format_error_message(
           ast_expr_token(operand_expr),
-          `asm ${kind}() expects 1 to 3 arguments, got ${args.len().to_string()}.`,
-          false,
-          .None
+          `asm ${kind}() expects 1 to 3 arguments, got ${args.len().to_string()}.`
         )
       )
     );
@@ -311,9 +305,7 @@ _parse_operand :: (
         dyn(
           format_error_message(
             ast_expr_token(operand_expr),
-            `asm ${kind}() is missing its value/type argument.`,
-            false,
-            .None
+            `asm ${kind}() is missing its value/type argument.`
           )
         )
       );
@@ -363,9 +355,7 @@ _parse_operand :: (
               dyn(
                 format_error_message(
                   ast_expr_token(value_or_type_expr),
-                  `asm ${kind}() target variable '${var_name}' has type that is not valid for inline assembly. Must be a primitive numeric, pointer, or bool type.`,
-                  false,
-                  .None
+                  `asm ${kind}() target variable '${var_name}' has type that is not valid for inline assembly. Must be a primitive numeric, pointer, or bool type.`
                 )
               )
             );
@@ -419,9 +409,7 @@ _parse_operand :: (
             dyn(
               format_error_message(
                 ast_expr_token(value_or_type_expr),
-                `asm ${kind}() output type must be a primitive numeric, pointer, or bool type.`,
-                false,
-                .None
+                `asm ${kind}() output type must be a primitive numeric, pointer, or bool type.`
               )
             )
           );
@@ -444,9 +432,7 @@ _parse_operand :: (
       dyn(
         format_error_message(
           ast_expr_token(value_or_type_expr),
-          `asm ${kind}() last argument must be a type, variable, or _ (discard).`,
-          false,
-          .None
+          `asm ${kind}() last argument must be a type, variable, or _ (discard).`
         )
       )
     );
@@ -472,9 +458,7 @@ _parse_operand :: (
         dyn(
           format_error_message(
             ast_expr_token(value_or_type_expr),
-            `Failed to evaluate asm ${kind}() value expression.`,
-            false,
-            .None
+            `Failed to evaluate asm ${kind}() value expression.`
           )
         )
       );
@@ -486,9 +470,7 @@ _parse_operand :: (
       dyn(
         format_error_message(
           ast_expr_token(value_or_type_expr),
-          `asm ${kind}() value type is not valid for inline assembly. Must be a primitive numeric, pointer, or bool type.`,
-          false,
-          .None
+          `asm ${kind}() value type is not valid for inline assembly. Must be a primitive numeric, pointer, or bool type.`
         )
       )
     );
@@ -534,9 +516,7 @@ _parse_asm_options :: (
           dyn(
             format_error_message(
               ast_expr_token(arg),
-              `Unknown asm_options flag: '${flag}'. Valid flags: pure, nomem, readonly, nostack, preserves_flags, att_syntax, intel_syntax, volatile, noreturn.`,
-              false,
-              .None
+              `Unknown asm_options flag: '${flag}'. Valid flags: pure, nomem, readonly, nostack, preserves_flags, att_syntax, intel_syntax, volatile, noreturn.`
             )
           )
         );
@@ -549,9 +529,7 @@ _parse_asm_options :: (
         dyn(
           format_error_message(
             ast_expr_token(option_expr),
-            String.from("asm_options() arguments must be flag identifiers (e.g., pure, nomem, noreturn)."),
-            false,
-            .None
+            String.from("asm_options() arguments must be flag identifiers (e.g., pure, nomem, noreturn).")
           )
         )
       );
@@ -578,7 +556,7 @@ _validate_template_placeholders :: (
             if(_str_in(operand_names, nm.clone()), {
               exn.throw(
                 dyn(
-                  format_error_message(tok, `Duplicate asm operand name: '${nm}'.`, false, .None)
+                  format_error_message(tok, `Duplicate asm operand name: '${nm}'.`)
                 )
               );
             });
@@ -655,9 +633,7 @@ _validate_template_placeholders :: (
                 dyn(
                   format_error_message(
                     tok,
-                    `asm template references positional operand {${ref_str}} but only ${operands.len().to_string()} operands are defined.`,
-                    false,
-                    .None
+                    `asm template references positional operand {${ref_str}} but only ${operands.len().to_string()} operands are defined.`
                   )
                 )
               );
@@ -668,9 +644,7 @@ _validate_template_placeholders :: (
                 dyn(
                   format_error_message(
                     tok,
-                    `asm template references undefined operand '{${ref_str}}'.`,
-                    false,
-                    .None
+                    `asm template references undefined operand '{${ref_str}}'.`
                   )
                 )
               );
@@ -707,9 +681,7 @@ evaluate_asm :: (
           tok,
           String.from(
             "'asm(...)' is not available in safe code.\n\nInline assembly can corrupt memory, violate calling conventions, and\nbreak the type system. To use it, declare at the top of this file:\n\n    pragma(Pragma.AllowUnsafe);"
-          ),
-          false,
-          .None
+          )
         )
       )
     );
@@ -726,9 +698,7 @@ evaluate_asm :: (
       dyn(
         format_error_message(
           tok,
-          String.from("asm() can only be called inside a function body or test block."),
-          false,
-          .None
+          String.from("asm() can only be called inside a function body or test block.")
         )
       )
     );
@@ -740,9 +710,7 @@ evaluate_asm :: (
       dyn(
         format_error_message(
           tok,
-          String.from("Cannot use \"asm\" during compile-time function evaluation analysis."),
-          false,
-          .None
+          String.from("Cannot use \"asm\" during compile-time function evaluation analysis.")
         )
       )
     );
@@ -754,9 +722,7 @@ evaluate_asm :: (
       dyn(
         format_error_message(
           tok,
-          String.from("asm() requires at least one argument (the assembly template string)."),
-          false,
-          .None
+          String.from("asm() requires at least one argument (the assembly template string).")
         )
       )
     );
@@ -806,9 +772,7 @@ evaluate_asm :: (
       dyn(
         format_error_message(
           first_tok,
-          String.from("First argument to asm() must be a compile-time string (the assembly template)."),
-          false,
-          .None
+          String.from("First argument to asm() must be a compile-time string (the assembly template).")
         )
       )
     );
@@ -824,9 +788,7 @@ evaluate_asm :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            String.from("asm() arguments after the template must be operand or option calls (in, out, inout, clobber, asm_options, etc.)."),
-            false,
-            .None
+            String.from("asm() arguments after the template must be operand or option calls (in, out, inout, clobber, asm_options, etc.).")
           )
         )
       );
@@ -842,9 +804,7 @@ evaluate_asm :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            String.from("asm() operand must be a named call like in(...), out(...), etc."),
-            false,
-            .None
+            String.from("asm() operand must be a named call like in(...), out(...), etc.")
           )
         )
       );
@@ -871,9 +831,7 @@ evaluate_asm :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(carg),
-                      `${call_name}() arguments must be compile-time strings (e.g., "memory", "cc", "rax").`,
-                      false,
-                      .None
+                      `${call_name}() arguments must be compile-time strings (e.g., "memory", "cc", "rax").`
                     )
                   )
                 );
@@ -891,9 +849,7 @@ evaluate_asm :: (
           dyn(
             format_error_message(
               ast_expr_token(arg),
-              `Unknown asm() operand or option: '${call_name}'. Expected: in, out, inout, lateout, inlateout, const_val, sym, clobber, clobber_abi, asm_options.`,
-              false,
-              .None
+              `Unknown asm() operand or option: '${call_name}'. Expected: in, out, inout, lateout, inlateout, const_val, sym, clobber, clobber_abi, asm_options.`
             )
           )
         );
@@ -1034,9 +990,7 @@ evaluate_global_asm :: (
           tok,
           String.from(
             "'global_asm(...)' is not available in safe code. Declare 'pragma(Pragma.AllowUnsafe);' at the top of the file to use inline assembly."
-          ),
-          false,
-          .None
+          )
         )
       )
     );
@@ -1048,9 +1002,7 @@ evaluate_global_asm :: (
       dyn(
         format_error_message(
           tok,
-          String.from("global_asm() requires at least one argument (the assembly string)."),
-          false,
-          .None
+          String.from("global_asm() requires at least one argument (the assembly string).")
         )
       )
     );
@@ -1082,9 +1034,7 @@ evaluate_global_asm :: (
       dyn(
         format_error_message(
           ast_expr_token(template_expr),
-          String.from("global_asm() argument must be a compile-time string."),
-          false,
-          .None
+          String.from("global_asm() argument must be a compile-time string.")
         )
       )
     );

--- a/src/evaluator/builtins/build.yo
+++ b/src/evaluator/builtins/build.yo
@@ -795,9 +795,7 @@ _build_extract_string :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Build function: expected comptime_str for "${param}", got non-string`,
-              false,
-              .None
+              `Build function: expected comptime_str for "${param}", got non-string`
             )
           )
         );
@@ -809,9 +807,7 @@ _build_extract_string :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Build function: expected comptime_str for "${param}", got undefined`,
-            false,
-            .None
+            `Build function: expected comptime_str for "${param}", got undefined`
           )
         )
       );
@@ -931,9 +927,7 @@ _build_require_args :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `${message}, got ${args.len()}`,
-          false,
-          .None
+          `${message}, got ${args.len()}`
         )
       )
     );
@@ -1048,9 +1042,7 @@ evaluate_yo_build_functions :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `__yo_build_target_parse expects 1 argument (triple), got ${args.len()}`,
-            false,
-            .None
+            `__yo_build_target_parse expects 1 argument (triple), got ${args.len()}`
           )
         )
       );
@@ -1089,9 +1081,7 @@ evaluate_yo_build_functions :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `__yo_build_dep_module expects 2 arguments (dependency_name, module_name), got ${args.len()}`,
-            false,
-            .None
+            `__yo_build_dep_module expects 2 arguments (dependency_name, module_name), got ${args.len()}`
           )
         )
       );
@@ -1348,9 +1338,7 @@ evaluate_yo_build_functions :: (
               dyn(
                 format_error_message(
                   ast_expr_token(expr),
-                  `Duplicate import name "${imp_name}" on artifact "${imp_artifact}". Already imported from module "${existing.module_name}".`,
-                  false,
-                  .None
+                  `Duplicate import name "${imp_name}" on artifact "${imp_artifact}". Already imported from module "${existing.module_name}".`
                 )
               )
             );
@@ -1399,9 +1387,7 @@ evaluate_yo_build_functions :: (
     dyn(
       format_error_message(
         ast_expr_token(expr),
-        `Unknown build function: ${ast_expr_token(expr).value}`,
-        false,
-        .None
+        `Unknown build function: ${ast_expr_token(expr).value}`
       )
     )
   );

--- a/src/evaluator/builtins/comptime_assert.yo
+++ b/src/evaluator/builtins/comptime_assert.yo
@@ -70,9 +70,7 @@ evaluate_comptime_assert :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(arg_expr),
-                    `Expected bool expression for "comptime_assert", got:\n${ast_expr_to_string(arg_expr)}\n\nType:\n${String.from("unknown")}`,
-                    true,
-                    .None
+                    `Expected bool expression for "comptime_assert", got:\n${ast_expr_to_string(arg_expr)}\n\nType:\n${String.from("unknown")}`
                   )
                 )
               );
@@ -117,9 +115,7 @@ evaluate_comptime_assert :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Expected bool value for "comptime_assert", got:\n${ast_expr_to_string(arg_expr)}`,
-            true,
-            .None
+            `Expected bool value for "comptime_assert", got:\n${ast_expr_to_string(arg_expr)}`
           )
         )
       );
@@ -134,9 +130,7 @@ evaluate_comptime_assert :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Expected bool value for "comptime_assert", got:\n${ast_expr_to_string(arg_expr)}`,
-            true,
-            .None
+            `Expected bool value for "comptime_assert", got:\n${ast_expr_to_string(arg_expr)}`
           )
         )
       );
@@ -148,9 +142,7 @@ evaluate_comptime_assert :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `Expected bool value for "comptime_assert", got:\n${ast_expr_to_string(arg_expr)}\n\nValue:\n${value_to_string(arg_val)}`,
-          true,
-          .None
+          `Expected bool value for "comptime_assert", got:\n${ast_expr_to_string(arg_expr)}\n\nValue:\n${value_to_string(arg_val)}`
         )
       )
     );
@@ -188,15 +180,13 @@ evaluate_comptime_assert :: (
       .None => String.from("")
     );
     if(err_msg.len() > usize(0), {
-      exn.throw(dyn(format_error_message(ast_expr_token(expr), err_msg, true, .None)));
+      exn.throw(dyn(format_error_message(ast_expr_token(expr), err_msg)));
     }, {
       exn.throw(
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Assertion failed for "comptime_assert":\n${ast_expr_to_string(arg_expr)}`,
-            true,
-            .None
+            `Assertion failed for "comptime_assert":\n${ast_expr_to_string(arg_expr)}`
           )
         )
       );

--- a/src/evaluator/builtins/comptime_bool_fns.yo
+++ b/src/evaluator/builtins/comptime_bool_fns.yo
@@ -58,9 +58,7 @@ eval_bool_arg :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `Expected bool type for comptime_bool argument, got:\n${ast_expr_to_string(arg)}`,
-            false,
-            .None
+            `Expected bool type for comptime_bool argument, got:\n${ast_expr_to_string(arg)}`
           )
         )
       );
@@ -72,9 +70,7 @@ eval_bool_arg :: (
       dyn(
         format_error_message(
           ast_expr_token(arg),
-          `Expected bool type for comptime_bool argument, got:\n${ast_expr_to_string(arg)}`,
-          false,
-          .None
+          `Expected bool type for comptime_bool argument, got:\n${ast_expr_to_string(arg)}`
         )
       )
     );
@@ -133,9 +129,7 @@ evaluate_yo_comptime_boolean_functions :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              String.from("Unexpected unary comptime_bool function"),
-              false,
-              .None
+              String.from("Unexpected unary comptime_bool function")
             )
           )
         );
@@ -249,9 +243,7 @@ evaluate_yo_comptime_boolean_functions :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Unexpected function call for comptime_bool binary operations:\n${ast_expr_to_string(expr)}`,
-              false,
-              .None
+              `Unexpected function call for comptime_bool binary operations:\n${ast_expr_to_string(expr)}`
             )
           )
         );

--- a/src/evaluator/builtins/comptime_expect_error.yo
+++ b/src/evaluator/builtins/comptime_expect_error.yo
@@ -293,7 +293,7 @@ evaluate_comptime_expect_error :: (
             msg_info.value,
             .Some(v) => {
               err_msg := match(v, .StrLit(raw) => raw, _ => value_to_string(v));
-              exn.throw(dyn(format_error_message(ast_expr_token(expr), err_msg, false, .None)));
+              exn.throw(dyn(format_error_message(ast_expr_token(expr), err_msg)));
             },
             .None => ()
           );
@@ -308,9 +308,7 @@ evaluate_comptime_expect_error :: (
       format_error_message(
         ast_expr_token(expr),
         String.from("Expected compile error, but the expression was evaluated successfully:\n") +
-          ast_expr_to_string(arg_expr),
-        false,
-        .None
+          ast_expr_to_string(arg_expr)
       )
     )
   );

--- a/src/evaluator/builtins/comptime_fn.yo
+++ b/src/evaluator/builtins/comptime_fn.yo
@@ -61,9 +61,7 @@ evaluate_comptime_fn :: (
         dyn(
           format_error_message(
             tok,
-            String.from("comptime_fn requires exactly one argument (a function)"),
-            false,
-            .None
+            String.from("comptime_fn requires exactly one argument (a function)")
           )
         )
       );
@@ -81,9 +79,7 @@ evaluate_comptime_fn :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Failed to evaluate argument to comptime_fn"),
-            false,
-            .None
+            String.from("Failed to evaluate argument to comptime_fn")
           )
         )
       );
@@ -99,9 +95,7 @@ evaluate_comptime_fn :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("comptime_fn: argument has no compile-time value"),
-            false,
-            .None
+            String.from("comptime_fn: argument has no compile-time value")
           )
         )
       );
@@ -113,9 +107,7 @@ evaluate_comptime_fn :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          String.from("comptime_fn requires a function argument"),
-          false,
-          .None
+          String.from("comptime_fn requires a function argument")
         )
       )
     );
@@ -142,9 +134,7 @@ evaluate_comptime_fn :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          String.from("comptime_fn: cannot convert a generic (generic) function to comptime"),
-          false,
-          .None
+          String.from("comptime_fn: cannot convert a generic (generic) function to comptime")
         )
       )
     );
@@ -159,9 +149,7 @@ evaluate_comptime_fn :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("comptime_fn: a parameter type prohibits the comptime modifier"),
-            false,
-            .None
+            String.from("comptime_fn: a parameter type prohibits the comptime modifier")
           )
         )
       );
@@ -173,9 +161,7 @@ evaluate_comptime_fn :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          String.from("comptime_fn: return type prohibits the comptime modifier"),
-          false,
-          .None
+          String.from("comptime_fn: return type prohibits the comptime modifier")
         )
       )
     );
@@ -185,9 +171,7 @@ evaluate_comptime_fn :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          String.from("comptime_fn: return type cannot be promoted to comptime"),
-          false,
-          .None
+          String.from("comptime_fn: return type cannot be promoted to comptime")
         )
       )
     );
@@ -208,9 +192,7 @@ evaluate_comptime_fn :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("comptime_fn: Failed to create compile-time version of function. The function body cannot be evaluated at compile time."),
-            false,
-            .None
+            String.from("comptime_fn: Failed to create compile-time version of function. The function body cannot be evaluated at compile time.")
           )
         )
       );

--- a/src/evaluator/builtins/comptime_index_fns.yo
+++ b/src/evaluator/builtins/comptime_index_fns.yo
@@ -77,9 +77,7 @@ ci_eval_arg :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            label,
-            false,
-            .None
+            label
           )
         )
       );
@@ -304,9 +302,7 @@ ci_eval_list_index :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(idx_arg),
-                      String.from("Invalid integer literal for ComptimeList index"),
-                      false,
-                      .None
+                      String.from("Invalid integer literal for ComptimeList index")
                     )
                   )
                 );
@@ -318,9 +314,7 @@ ci_eval_list_index :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(idx_arg),
-                    `ComptimeList index out of bounds: ${idx_raw}`,
-                    false,
-                    .None
+                    `ComptimeList index out of bounds: ${idx_raw}`
                   )
                 )
               );
@@ -332,9 +326,7 @@ ci_eval_list_index :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(idx_arg),
-                    `ComptimeList index out of bounds: ${idx_raw}`,
-                    false,
-                    .None
+                    `ComptimeList index out of bounds: ${idx_raw}`
                   )
                 )
               );
@@ -347,9 +339,7 @@ ci_eval_list_index :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(idx_arg),
-                      String.from("ComptimeList index out of bounds"),
-                      false,
-                      .None
+                      String.from("ComptimeList index out of bounds")
                     )
                   )
                 );
@@ -442,9 +432,7 @@ ci_eval_list_range_index :: (
         dyn(
           format_error_message(
             ast_expr_token(range_arg),
-            String.from("Expected numeric start/end in Range for comptime list range index"),
-            false,
-            .None
+            String.from("Expected numeric start/end in Range for comptime list range index")
           )
         )
       );
@@ -472,9 +460,7 @@ ci_eval_list_range_index :: (
           dyn(
             format_error_message(
               ast_expr_token(range_arg),
-              `ComptimeList range start out of bounds: ${start_idx}`,
-              false,
-              .None
+              `ComptimeList range start out of bounds: ${start_idx}`
             )
           )
         );
@@ -484,9 +470,7 @@ ci_eval_list_range_index :: (
           dyn(
             format_error_message(
               ast_expr_token(range_arg),
-              `ComptimeList range end out of bounds: ${end_idx}`,
-              false,
-              .None
+              `ComptimeList range end out of bounds: ${end_idx}`
             )
           )
         );
@@ -496,9 +480,7 @@ ci_eval_list_range_index :: (
           dyn(
             format_error_message(
               ast_expr_token(range_arg),
-              `ComptimeList range end out of bounds: ${end_idx}`,
-              false,
-              .None
+              `ComptimeList range end out of bounds: ${end_idx}`
             )
           )
         );
@@ -591,9 +573,7 @@ ci_eval_array_index :: (
                       dyn(
                         format_error_message(
                           ast_expr_token(idx_arg),
-                          String.from("Invalid integer literal for array index"),
-                          false,
-                          .None
+                          String.from("Invalid integer literal for array index")
                         )
                       )
                     );
@@ -605,9 +585,7 @@ ci_eval_array_index :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(idx_arg),
-                        `Array index out of bounds: ${idx_raw}`,
-                        false,
-                        .None
+                        `Array index out of bounds: ${idx_raw}`
                       )
                     )
                   );
@@ -619,9 +597,7 @@ ci_eval_array_index :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(idx_arg),
-                        `Array index out of bounds: ${idx_raw}`,
-                        false,
-                        .None
+                        `Array index out of bounds: ${idx_raw}`
                       )
                     )
                   );
@@ -634,9 +610,7 @@ ci_eval_array_index :: (
                       dyn(
                         format_error_message(
                           ast_expr_token(idx_arg),
-                          String.from("Array index out of bounds"),
-                          false,
-                          .None
+                          String.from("Array index out of bounds")
                         )
                       )
                     );
@@ -743,9 +717,7 @@ ci_eval_string_index :: (
           dyn(
             format_error_message(
               ast_expr_token(idx_arg),
-              String.from("Invalid integer literal for string index"),
-              false,
-              .None
+              String.from("Invalid integer literal for string index")
             )
           )
         );
@@ -757,9 +729,7 @@ ci_eval_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(idx_arg),
-            `String index out of bounds: ${idx_raw}`,
-            false,
-            .None
+            `String index out of bounds: ${idx_raw}`
           )
         )
       );
@@ -771,9 +741,7 @@ ci_eval_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(idx_arg),
-            `String index out of bounds: ${idx_raw}`,
-            false,
-            .None
+            `String index out of bounds: ${idx_raw}`
           )
         )
       );
@@ -790,9 +758,7 @@ ci_eval_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(idx_arg),
-            `String index ${idx_raw} is not on a UTF-8 character boundary`,
-            false,
-            .None
+            `String index ${idx_raw} is not on a UTF-8 character boundary`
           )
         )
       );
@@ -833,9 +799,7 @@ ci_eval_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(idx_arg),
-            String.from("Expected numeric start/end in Range for comptime string range index"),
-            false,
-            .None
+            String.from("Expected numeric start/end in Range for comptime string range index")
           )
         )
       );
@@ -850,9 +814,7 @@ ci_eval_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(idx_arg),
-          `String slice start index out of bounds: ${start_idx}`,
-          false,
-          .None
+          `String slice start index out of bounds: ${start_idx}`
         )
       )
     );
@@ -862,9 +824,7 @@ ci_eval_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(idx_arg),
-          `String slice end index out of bounds: ${end_idx}`,
-          false,
-          .None
+          `String slice end index out of bounds: ${end_idx}`
         )
       )
     );
@@ -874,9 +834,7 @@ ci_eval_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(idx_arg),
-          `String slice end index out of bounds: ${end_idx}`,
-          false,
-          .None
+          `String slice end index out of bounds: ${end_idx}`
         )
       )
     );
@@ -890,9 +848,7 @@ ci_eval_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(idx_arg),
-          `String slice start index ${start_idx} is not on a UTF-8 character boundary`,
-          false,
-          .None
+          `String slice start index ${start_idx} is not on a UTF-8 character boundary`
         )
       )
     );
@@ -902,9 +858,7 @@ ci_eval_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(idx_arg),
-          `String slice end index ${end_idx} is not on a UTF-8 character boundary`,
-          false,
-          .None
+          `String slice end index ${end_idx} is not on a UTF-8 character boundary`
         )
       )
     );
@@ -951,9 +905,7 @@ evaluate_yo_comptime_index_functions :: (
     dyn(
       format_error_message(
         ast_expr_token(expr),
-        String.from("evaluate_yo_comptime_index_functions: unexpected function"),
-        false,
-        .None
+        String.from("evaluate_yo_comptime_index_functions: unexpected function")
       )
     )
   );

--- a/src/evaluator/builtins/comptime_list_fns.yo
+++ b/src/evaluator/builtins/comptime_list_fns.yo
@@ -64,9 +64,7 @@ evaluate_yo_comptime_list_car :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_COMPTIME_LIST_CAR}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_COMPTIME_LIST_CAR}"`
           )
         )
       );
@@ -79,9 +77,7 @@ evaluate_yo_comptime_list_car :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected ComptimeList type for "${BF_YO_COMPTIME_LIST_CAR}" argument`,
-          false,
-          .None
+          `Expected ComptimeList type for "${BF_YO_COMPTIME_LIST_CAR}" argument`
         )
       )
     );
@@ -95,9 +91,7 @@ evaluate_yo_comptime_list_car :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected ComptimeList value for "${BF_YO_COMPTIME_LIST_CAR}" argument`,
-            false,
-            .None
+            `Expected ComptimeList value for "${BF_YO_COMPTIME_LIST_CAR}" argument`
           )
         )
       );
@@ -130,9 +124,7 @@ evaluate_yo_comptime_list_car :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_e),
-              `Unexpected empty ComptimeList for "${BF_YO_COMPTIME_LIST_CAR}" argument`,
-              false,
-              .None
+              `Unexpected empty ComptimeList for "${BF_YO_COMPTIME_LIST_CAR}" argument`
             )
           )
         );
@@ -174,9 +166,7 @@ evaluate_yo_comptime_list_cdr :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_COMPTIME_LIST_CDR}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_COMPTIME_LIST_CDR}"`
           )
         )
       );
@@ -189,9 +179,7 @@ evaluate_yo_comptime_list_cdr :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected ComptimeList type for "${BF_YO_COMPTIME_LIST_CDR}" argument`,
-          false,
-          .None
+          `Expected ComptimeList type for "${BF_YO_COMPTIME_LIST_CDR}" argument`
         )
       )
     );
@@ -205,9 +193,7 @@ evaluate_yo_comptime_list_cdr :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected ComptimeList value for "${BF_YO_COMPTIME_LIST_CDR}" argument`,
-            false,
-            .None
+            `Expected ComptimeList value for "${BF_YO_COMPTIME_LIST_CDR}" argument`
           )
         )
       );
@@ -239,9 +225,7 @@ evaluate_yo_comptime_list_cdr :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_e),
-              `Unexpected empty ComptimeList for "${BF_YO_COMPTIME_LIST_CDR}" argument`,
-              false,
-              .None
+              `Unexpected empty ComptimeList for "${BF_YO_COMPTIME_LIST_CDR}" argument`
             )
           )
         );
@@ -290,9 +274,7 @@ evaluate_yo_comptime_list_cons :: (
         dyn(
           format_error_message(
             ast_expr_token(car_arg_e),
-            `Failed to evaluate car argument for "${BF_YO_COMPTIME_LIST_CONS}"`,
-            false,
-            .None
+            `Failed to evaluate car argument for "${BF_YO_COMPTIME_LIST_CONS}"`
           )
         )
       );
@@ -308,9 +290,7 @@ evaluate_yo_comptime_list_cons :: (
         dyn(
           format_error_message(
             ast_expr_token(car_arg_e),
-            `Expected compile-time car value for "${BF_YO_COMPTIME_LIST_CONS}"`,
-            false,
-            .None
+            `Expected compile-time car value for "${BF_YO_COMPTIME_LIST_CONS}"`
           )
         )
       );
@@ -326,9 +306,7 @@ evaluate_yo_comptime_list_cons :: (
         dyn(
           format_error_message(
             ast_expr_token(cdr_arg_e),
-            `Failed to evaluate cdr argument for "${BF_YO_COMPTIME_LIST_CONS}"`,
-            false,
-            .None
+            `Failed to evaluate cdr argument for "${BF_YO_COMPTIME_LIST_CONS}"`
           )
         )
       );
@@ -341,9 +319,7 @@ evaluate_yo_comptime_list_cons :: (
       dyn(
         format_error_message(
           ast_expr_token(cdr_arg_e),
-          `Expected ComptimeList type for cdr argument of "${BF_YO_COMPTIME_LIST_CONS}"`,
-          false,
-          .None
+          `Expected ComptimeList type for cdr argument of "${BF_YO_COMPTIME_LIST_CONS}"`
         )
       )
     );
@@ -356,9 +332,7 @@ evaluate_yo_comptime_list_cons :: (
         dyn(
           format_error_message(
             ast_expr_token(cdr_arg_e),
-            `Expected compile-time cdr value for "${BF_YO_COMPTIME_LIST_CONS}"`,
-            false,
-            .None
+            `Expected compile-time cdr value for "${BF_YO_COMPTIME_LIST_CONS}"`
           )
         )
       );
@@ -372,9 +346,7 @@ evaluate_yo_comptime_list_cons :: (
       dyn(
         format_error_message(
           ast_expr_token(car_arg_e),
-          `Type mismatch: car type is incompatible with ComptimeList element type in "${BF_YO_COMPTIME_LIST_CONS}"`,
-          false,
-          .None
+          `Type mismatch: car type is incompatible with ComptimeList element type in "${BF_YO_COMPTIME_LIST_CONS}"`
         )
       )
     );
@@ -443,9 +415,7 @@ evaluate_yo_comptime_list_append :: (
         dyn(
           format_error_message(
             ast_expr_token(first_arg_e),
-            `Failed to evaluate first argument for "${BF_YO_COMPTIME_LIST_APPEND}"`,
-            false,
-            .None
+            `Failed to evaluate first argument for "${BF_YO_COMPTIME_LIST_APPEND}"`
           )
         )
       );
@@ -458,9 +428,7 @@ evaluate_yo_comptime_list_append :: (
       dyn(
         format_error_message(
           ast_expr_token(first_arg_e),
-          `Expected ComptimeList type for first argument of "${BF_YO_COMPTIME_LIST_APPEND}"`,
-          false,
-          .None
+          `Expected ComptimeList type for first argument of "${BF_YO_COMPTIME_LIST_APPEND}"`
         )
       )
     );
@@ -473,9 +441,7 @@ evaluate_yo_comptime_list_append :: (
         dyn(
           format_error_message(
             ast_expr_token(first_arg_e),
-            `Expected compile-time value for first argument of "${BF_YO_COMPTIME_LIST_APPEND}"`,
-            false,
-            .None
+            `Expected compile-time value for first argument of "${BF_YO_COMPTIME_LIST_APPEND}"`
           )
         )
       );
@@ -491,9 +457,7 @@ evaluate_yo_comptime_list_append :: (
         dyn(
           format_error_message(
             ast_expr_token(second_arg_e),
-            `Failed to evaluate second argument for "${BF_YO_COMPTIME_LIST_APPEND}"`,
-            false,
-            .None
+            `Failed to evaluate second argument for "${BF_YO_COMPTIME_LIST_APPEND}"`
           )
         )
       );
@@ -506,9 +470,7 @@ evaluate_yo_comptime_list_append :: (
       dyn(
         format_error_message(
           ast_expr_token(second_arg_e),
-          `Expected ComptimeList type for second argument of "${BF_YO_COMPTIME_LIST_APPEND}"`,
-          false,
-          .None
+          `Expected ComptimeList type for second argument of "${BF_YO_COMPTIME_LIST_APPEND}"`
         )
       )
     );
@@ -521,9 +483,7 @@ evaluate_yo_comptime_list_append :: (
         dyn(
           format_error_message(
             ast_expr_token(second_arg_e),
-            `Expected compile-time value for second argument of "${BF_YO_COMPTIME_LIST_APPEND}"`,
-            false,
-            .None
+            `Expected compile-time value for second argument of "${BF_YO_COMPTIME_LIST_APPEND}"`
           )
         )
       );
@@ -535,9 +495,7 @@ evaluate_yo_comptime_list_append :: (
       dyn(
         format_error_message(
           ast_expr_token(first_arg_e),
-          `Type mismatch between the two ComptimeList arguments of "${BF_YO_COMPTIME_LIST_APPEND}"`,
-          false,
-          .None
+          `Type mismatch between the two ComptimeList arguments of "${BF_YO_COMPTIME_LIST_APPEND}"`
         )
       )
     );
@@ -615,9 +573,7 @@ evaluate_yo_comptime_list_length :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_COMPTIME_LIST_LENGTH}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_COMPTIME_LIST_LENGTH}"`
           )
         )
       );
@@ -629,9 +585,7 @@ evaluate_yo_comptime_list_length :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected ComptimeList type for "${BF_YO_COMPTIME_LIST_LENGTH}" argument`,
-          false,
-          .None
+          `Expected ComptimeList type for "${BF_YO_COMPTIME_LIST_LENGTH}" argument`
         )
       )
     );
@@ -644,9 +598,7 @@ evaluate_yo_comptime_list_length :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected compile-time value for "${BF_YO_COMPTIME_LIST_LENGTH}" argument`,
-            false,
-            .None
+            `Expected compile-time value for "${BF_YO_COMPTIME_LIST_LENGTH}" argument`
           )
         )
       );
@@ -696,9 +648,7 @@ evaluate_yo_comptime_list_element_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_COMPTIME_LIST_ELEMENT_TYPE}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_COMPTIME_LIST_ELEMENT_TYPE}"`
           )
         )
       );
@@ -716,9 +666,7 @@ evaluate_yo_comptime_list_element_type :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_e),
-              `Expected TypeVal for "${BF_YO_COMPTIME_LIST_ELEMENT_TYPE}" argument`,
-              false,
-              .None
+              `Expected TypeVal for "${BF_YO_COMPTIME_LIST_ELEMENT_TYPE}" argument`
             )
           )
         );
@@ -730,9 +678,7 @@ evaluate_yo_comptime_list_element_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected TypeVal for "${BF_YO_COMPTIME_LIST_ELEMENT_TYPE}" argument`,
-            false,
-            .None
+            `Expected TypeVal for "${BF_YO_COMPTIME_LIST_ELEMENT_TYPE}" argument`
           )
         )
       );
@@ -744,9 +690,7 @@ evaluate_yo_comptime_list_element_type :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected ComptimeList type inside TypeVal for "${BF_YO_COMPTIME_LIST_ELEMENT_TYPE}"`,
-          false,
-          .None
+          `Expected ComptimeList type inside TypeVal for "${BF_YO_COMPTIME_LIST_ELEMENT_TYPE}"`
         )
       )
     );
@@ -788,9 +732,7 @@ evaluate_yo_comptime_list_get :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate list argument for "${BF_YO_COMPTIME_LIST_GET}"`,
-            false,
-            .None
+            `Failed to evaluate list argument for "${BF_YO_COMPTIME_LIST_GET}"`
           )
         )
       );
@@ -802,9 +744,7 @@ evaluate_yo_comptime_list_get :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected ComptimeList type for "${BF_YO_COMPTIME_LIST_GET}" argument`,
-          false,
-          .None
+          `Expected ComptimeList type for "${BF_YO_COMPTIME_LIST_GET}" argument`
         )
       )
     );
@@ -854,9 +794,7 @@ evaluate_yo_comptime_list_get :: (
                               dyn(
                                 format_error_message(
                                   ast_expr_token(index_arg_e),
-                                  `ComptimeList index out of bounds in "${BF_YO_COMPTIME_LIST_GET}"`,
-                                  false,
-                                  .None
+                                  `ComptimeList index out of bounds in "${BF_YO_COMPTIME_LIST_GET}"`
                                 )
                               )
                             );
@@ -867,9 +805,7 @@ evaluate_yo_comptime_list_get :: (
                           dyn(
                             format_error_message(
                               ast_expr_token(index_arg_e),
-                              `ComptimeList index out of bounds in "${BF_YO_COMPTIME_LIST_GET}"`,
-                              false,
-                              .None
+                              `ComptimeList index out of bounds in "${BF_YO_COMPTIME_LIST_GET}"`
                             )
                           )
                         );
@@ -888,9 +824,7 @@ evaluate_yo_comptime_list_get :: (
               dyn(
                 format_error_message(
                   ast_expr_token(arg_e),
-                  `Failed to evaluate index argument for "${BF_YO_COMPTIME_LIST_GET}"`,
-                  false,
-                  .None
+                  `Failed to evaluate index argument for "${BF_YO_COMPTIME_LIST_GET}"`
                 )
               )
             );

--- a/src/evaluator/builtins/comptime_numeric_fns.yo
+++ b/src/evaluator/builtins/comptime_numeric_fns.yo
@@ -30,7 +30,7 @@ open(import("std/string"));
   is_float_type,
   is_comptime_float_type
 } :: import("../../types/guards.yo");
-{ format_error_message, ErrorKind } :: import("../../error.yo");
+{ format_error_message } :: import("../../error.yo");
 { type_to_string } :: import("../../types/string.yo");
 { IntRange, get_integer_type_range, get_integer_type_bits } :: import("../../types/utils.yo");
 { Token } :: import("../../token.yo");
@@ -218,9 +218,7 @@ check_int_overflow :: (
             token,
             `Integer overflow in compile-time evaluation
   ${ua.to_string()} ${u_symbol} ${ub.to_string()} = ${uv.to_string()}
-  Result ${uv.to_string()} exceeds ${type_to_string(ty)} range [0, ${rng.max.to_string()}]`,
-            false,
-            Option(ErrorKind).Some(ErrorKind.Overflow)
+  Result ${uv.to_string()} exceeds ${type_to_string(ty)} range [0, ${rng.max.to_string()}]`
           )
         )
       );
@@ -245,9 +243,7 @@ check_int_overflow :: (
           token,
           `Integer overflow in compile-time evaluation
   ${a.to_string()} ${op_symbol} ${b.to_string()} = ${value.to_string()}
-  Result ${value.to_string()} exceeds ${type_to_string(ty)} range [${rng.min.to_string()}, ${rng.max.to_string()}]`,
-          false,
-          Option(ErrorKind).Some(ErrorKind.Overflow)
+  Result ${value.to_string()} exceeds ${type_to_string(ty)} range [${rng.min.to_string()}, ${rng.max.to_string()}]`
         )
       )
     );
@@ -285,9 +281,7 @@ eval_numeric_arg :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `Expected numeric value for comptime numeric argument, got:\n${ast_expr_to_string(arg)}`,
-            false,
-            .None
+            `Expected numeric value for comptime numeric argument, got:\n${ast_expr_to_string(arg)}`
           )
         )
       );
@@ -411,9 +405,7 @@ evaluate_yo_comptime_numeric_functions :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `Cannot apply negation to unsigned type: ${fn_name}`,
-                false,
-                .None
+                `Cannot apply negation to unsigned type: ${fn_name}`
               )
             )
           );
@@ -483,9 +475,7 @@ evaluate_yo_comptime_numeric_functions :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Unexpected unary comptime numeric operation: ${op}`,
-              false,
-              .None
+              `Unexpected unary comptime numeric operation: ${op}`
             )
           )
         );
@@ -553,9 +543,7 @@ evaluate_yo_comptime_numeric_functions :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(arg1),
-                        `Division by zero in comptime float operation: ${fn_name}`,
-                        false,
-                        .None
+                        `Division by zero in comptime float operation: ${fn_name}`
                       )
                     )
                   );
@@ -611,9 +599,7 @@ evaluate_yo_comptime_numeric_functions :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `Modulo operation not supported for floating point types: ${fn_name}`,
-                false,
-                .None
+                `Modulo operation not supported for floating point types: ${fn_name}`
               )
             )
           );
@@ -623,9 +609,7 @@ evaluate_yo_comptime_numeric_functions :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `Unexpected binary comptime float operation: ${op}`,
-                false,
-                .None
+                `Unexpected binary comptime float operation: ${op}`
               )
             )
           );
@@ -689,9 +673,7 @@ evaluate_yo_comptime_numeric_functions :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(arg1),
-                        `Division by zero in comptime integer operation: ${fn_name}`,
-                        false,
-                        .None
+                        `Division by zero in comptime integer operation: ${fn_name}`
                       )
                     )
                   );
@@ -718,9 +700,7 @@ evaluate_yo_comptime_numeric_functions :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(arg1),
-                        `Modulo by zero in comptime integer operation: ${fn_name}`,
-                        false,
-                        .None
+                        `Modulo by zero in comptime integer operation: ${fn_name}`
                       )
                     )
                   );
@@ -813,9 +793,7 @@ evaluate_yo_comptime_numeric_functions :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `Unexpected binary comptime integer operation: ${op}`,
-                false,
-                .None
+                `Unexpected binary comptime integer operation: ${op}`
               )
             )
           );

--- a/src/evaluator/builtins/comptime_print.yo
+++ b/src/evaluator/builtins/comptime_print.yo
@@ -45,9 +45,7 @@ evaluate_comptime_print :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Expected at least 1 argument for "comptime_print", got 0`,
-              false,
-              .None
+              `Expected at least 1 argument for "comptime_print", got 0`
             )
           )
         );
@@ -58,9 +56,7 @@ evaluate_comptime_print :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("comptime_print: expected FnCall"),
-            false,
-            .None
+            String.from("comptime_print: expected FnCall")
           )
         )
       );
@@ -94,9 +90,7 @@ evaluate_comptime_print :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              `Failed to evaluate argument for "comptime_print": ${ast_expr_to_string(arg_expr)}`,
-              false,
-              .None
+              `Failed to evaluate argument for "comptime_print": ${ast_expr_to_string(arg_expr)}`
             )
           )
         );

--- a/src/evaluator/builtins/comptime_string_fns.yo
+++ b/src/evaluator/builtins/comptime_string_fns.yo
@@ -79,9 +79,7 @@ eval_comptime_str_arg :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `Expected comptime_str type for comptime_str argument, got:\n${ast_expr_to_string(arg)}`,
-            false,
-            .None
+            `Expected comptime_str type for comptime_str argument, got:\n${ast_expr_to_string(arg)}`
           )
         )
       );
@@ -93,9 +91,7 @@ eval_comptime_str_arg :: (
       dyn(
         format_error_message(
           ast_expr_token(arg),
-          `Expected comptime_str type for comptime_str argument, got:\n${ast_expr_to_string(arg)}`,
-          false,
-          .None
+          `Expected comptime_str type for comptime_str argument, got:\n${ast_expr_to_string(arg)}`
         )
       )
     );
@@ -123,9 +119,7 @@ eval_comptime_int_arg :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `Expected comptime_int type for comptime_str argument, got:\n${ast_expr_to_string(arg)}`,
-            false,
-            .None
+            `Expected comptime_int type for comptime_str argument, got:\n${ast_expr_to_string(arg)}`
           )
         )
       );
@@ -137,9 +131,7 @@ eval_comptime_int_arg :: (
       dyn(
         format_error_message(
           ast_expr_token(arg),
-          `Expected comptime_int type for comptime_str argument, got:\n${ast_expr_to_string(arg)}`,
-          false,
-          .None
+          `Expected comptime_int type for comptime_str argument, got:\n${ast_expr_to_string(arg)}`
         )
       )
     );
@@ -222,9 +214,7 @@ evaluate_yo_comptime_string_functions :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              String.from("Unexpected comptime_str unary function"),
-              false,
-              .None
+              String.from("Unexpected comptime_str unary function")
             )
           )
         );
@@ -247,9 +237,7 @@ evaluate_yo_comptime_string_functions :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `"${BF_COMPTIME_STRING_SLICE}" expects 2 or 3 arguments, got ${n_args.to_string()}`,
-            false,
-            .None
+            `"${BF_COMPTIME_STRING_SLICE}" expects 2 or 3 arguments, got ${n_args.to_string()}`
           )
         )
       );
@@ -337,9 +325,7 @@ evaluate_yo_comptime_string_functions :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(expr),
-                        `comptime slice start ${start_b} is not on a UTF-8 character boundary`,
-                        false,
-                        .None
+                        `comptime slice start ${start_b} is not on a UTF-8 character boundary`
                       )
                     )
                   );
@@ -349,9 +335,7 @@ evaluate_yo_comptime_string_functions :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(expr),
-                        `comptime slice end ${end_b} is not on a UTF-8 character boundary`,
-                        false,
-                        .None
+                        `comptime slice end ${end_b} is not on a UTF-8 character boundary`
                       )
                     )
                   );
@@ -479,9 +463,7 @@ evaluate_yo_comptime_string_functions :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Unexpected function call for comptime_str operations:\n${ast_expr_to_string(expr)}`,
-              false,
-              .None
+              `Unexpected function call for comptime_str operations:\n${ast_expr_to_string(expr)}`
             )
           )
         );

--- a/src/evaluator/builtins/consume.yo
+++ b/src/evaluator/builtins/consume.yo
@@ -58,9 +58,7 @@ set_variable_as_consumed :: (
       dyn(
         format_error_message(
           token,
-          `Variable "${variable_name}" is not defined.`,
-          false,
-          .None
+          `Variable "${variable_name}" is not defined.`
         )
       )
     );
@@ -89,7 +87,7 @@ set_variable_as_consumed :: (
             error_message : String.from("value moved here")
           )
         );
-        exn.throw(dyn(format_error_messages(entries, false, .None)));
+        exn.throw(dyn(format_error_messages(entries)));
       });
     },
     .None => {
@@ -137,9 +135,7 @@ evaluate_consume :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("consume: failed to evaluate expression."),
-            false,
-            .None
+            String.from("consume: failed to evaluate expression.")
           )
         )
       );

--- a/src/evaluator/builtins/contracts.yo
+++ b/src/evaluator/builtins/contracts.yo
@@ -76,9 +76,7 @@ _evaluate_contract_marker :: (
           dyn(
             format_error_message(
               ast_expr_token(arg),
-              String.from("Failed to evaluate argument of contract clause."),
-              false,
-              .None
+              String.from("Failed to evaluate argument of contract clause.")
             )
           )
         );
@@ -103,7 +101,7 @@ _reject_zero_arg_marker :: (fn(expr : AstExpr, message : String, exn : Exception
     .Atom(_, _) => usize(0)
   );
   if(n == usize(0), {
-    exn.throw(dyn(format_error_message(ast_expr_token(expr), message, false, .None)));
+    exn.throw(dyn(format_error_message(ast_expr_token(expr), message)));
   });
 });
 evaluate_requires :: (fn(expr : AstExpr, env : Environment, ctx : EvalContext, exn : Exception) -> AstExpr)({
@@ -166,9 +164,7 @@ _evaluate_transparent_unary :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            String.from("Failed to evaluate argument of contract clause."),
-            false,
-            .None
+            String.from("Failed to evaluate argument of contract clause.")
           )
         )
       );
@@ -184,9 +180,7 @@ evaluate_ghost_fn :: (fn(expr : AstExpr, env : Environment, ctx : EvalContext, e
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `'ghost_fn(...)' takes exactly one argument, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `'ghost_fn(...)' takes exactly one argument, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -201,9 +195,7 @@ evaluate_old :: (fn(expr : AstExpr, env : Environment, ctx : EvalContext, exn : 
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `'old(...)' takes exactly one argument, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `'old(...)' takes exactly one argument, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );

--- a/src/evaluator/builtins/derive.yo
+++ b/src/evaluator/builtins/derive.yo
@@ -189,7 +189,7 @@ call_registered_derive_rule :: (
     ctx_info.value,
     .Some(v) => v,
     .None => {
-      exn.throw(dyn(format_error_message(tok, String.from("derive: failed to create DeriveContext"), false, .None)));
+      exn.throw(dyn(format_error_message(tok, String.from("derive: failed to create DeriveContext"))));
       EvalValue.UnitVal
     }
   );
@@ -239,7 +239,7 @@ call_registered_derive_rule :: (
     call_info.value,
     .Some(v) => v,
     .None => {
-      exn.throw(dyn(format_error_message(tok, String.from("derive: derive rule function failed"), false, .None)));
+      exn.throw(dyn(format_error_message(tok, String.from("derive: derive rule function failed"))));
       EvalValue.UnitVal
     }
   );
@@ -247,7 +247,7 @@ call_registered_derive_rule :: (
     call_val,
     .ExprVal(e) => e,
     _ => {
-      exn.throw(dyn(format_error_message(tok, `derive: derive rule must return(comptime(Expr)); got ${value_to_string(call_val)}`, false, .None)));
+      exn.throw(dyn(format_error_message(tok, `derive: derive rule must return(comptime(Expr)); got ${value_to_string(call_val)}`)));
       make_err_expr()
     }
   );
@@ -294,9 +294,7 @@ process_trait_arg :: (
         dyn(
           format_error_message(
             tok,
-            String.from("derive: trait argument must be a trait name or trait constructor call"),
-            false,
-            .None
+            String.from("derive: trait argument must be a trait name or trait constructor call")
           )
         )
       );
@@ -313,9 +311,7 @@ process_trait_arg :: (
         dyn(
           format_error_message(
             tok,
-            `derive: trait '${key}' does not have a derive rule. Use derive_rule() to register one.`,
-            false,
-            .None
+            `derive: trait '${key}' does not have a derive rule. Use derive_rule() to register one.`
           )
         )
       );
@@ -373,9 +369,7 @@ evaluate_derive :: (
       dyn(
         format_error_message(
           tok,
-          String.from("derive requires at least 2 arguments: derive(Type, Trait1, ...)."),
-          false,
-          .None
+          String.from("derive requires at least 2 arguments: derive(Type, Trait1, ...).")
         )
       )
     );
@@ -461,9 +455,7 @@ evaluate_derive :: (
         dyn(
           format_error_message(
             tok,
-            String.from("derive requires a target type"),
-            false,
-            .None
+            String.from("derive requires a target type")
           )
         )
       );
@@ -481,9 +473,7 @@ evaluate_derive :: (
         dyn(
           format_error_message(
             tok,
-            String.from("derive: failed to evaluate target type"),
-            false,
-            .None
+            String.from("derive: failed to evaluate target type")
           )
         )
       );
@@ -501,9 +491,7 @@ evaluate_derive :: (
           dyn(
             format_error_message(
               tok,
-              String.from("derive: expected a type"),
-              false,
-              .None
+              String.from("derive: expected a type")
             )
           )
         );
@@ -515,9 +503,7 @@ evaluate_derive :: (
         dyn(
           format_error_message(
             tok,
-            String.from("derive: expected a type"),
-            false,
-            .None
+            String.from("derive: expected a type")
           )
         )
       );
@@ -534,9 +520,7 @@ evaluate_derive :: (
         dyn(
           format_error_message(
             tok,
-            String.from("derive only works on struct and enum types"),
-            false,
-            .None
+            String.from("derive only works on struct and enum types")
           )
         )
       );
@@ -565,9 +549,7 @@ evaluate_derive :: (
       dyn(
         format_error_message(
           tok,
-          String.from("derive requires at least one trait argument after the target type"),
-          false,
-          .None
+          String.from("derive requires at least one trait argument after the target type")
         )
       )
     );

--- a/src/evaluator/builtins/derive_rule.yo
+++ b/src/evaluator/builtins/derive_rule.yo
@@ -85,9 +85,7 @@ evaluate_derive_rule :: (
       dyn(
         format_error_message(
           tok,
-          String.from("derive_rule requires exactly 2 arguments"),
-          false,
-          .None
+          String.from("derive_rule requires exactly 2 arguments")
         )
       )
     );
@@ -104,9 +102,7 @@ evaluate_derive_rule :: (
         dyn(
           format_error_message(
             tok,
-            String.from("derive_rule: first argument must be a trait name or trait constructor call"),
-            false,
-            .None
+            String.from("derive_rule: first argument must be a trait name or trait constructor call")
           )
         )
       );
@@ -124,9 +120,7 @@ evaluate_derive_rule :: (
         dyn(
           format_error_message(
             tok,
-            String.from("derive_rule: failed to evaluate derive function"),
-            false,
-            .None
+            String.from("derive_rule: failed to evaluate derive function")
           )
         )
       );
@@ -141,9 +135,7 @@ evaluate_derive_rule :: (
         dyn(
           format_error_message(
             tok,
-            String.from("derive_rule: derive function has no compile-time value"),
-            false,
-            .None
+            String.from("derive_rule: derive function has no compile-time value")
           )
         )
       );
@@ -155,9 +147,7 @@ evaluate_derive_rule :: (
       dyn(
         format_error_message(
           tok,
-          String.from("derive_rule: second argument must be a function"),
-          false,
-          .None
+          String.from("derive_rule: second argument must be a function")
         )
       )
     );

--- a/src/evaluator/builtins/downcast.yo
+++ b/src/evaluator/builtins/downcast.yo
@@ -72,9 +72,7 @@ evaluate_downcast :: (
       dyn(
         format_error_message(
           ast_expr_token(dyn_expr),
-          String.from("Failed to evaluate dyn value argument for downcast."),
-          false,
-          .None
+          String.from("Failed to evaluate dyn value argument for downcast.")
         )
       )
     );
@@ -87,9 +85,7 @@ evaluate_downcast :: (
       dyn(
         format_error_message(
           ast_expr_token(dyn_expr),
-          `downcast expects a Dyn type as first argument, got ${type_to_string(dyn_type)}.`,
-          false,
-          .None
+          `downcast expects a Dyn type as first argument, got ${type_to_string(dyn_type)}.`
         )
       )
     );
@@ -109,9 +105,7 @@ evaluate_downcast :: (
       dyn(
         format_error_message(
           ast_expr_token(type_expr),
-          String.from("Failed to evaluate type argument for downcast."),
-          false,
-          .None
+          String.from("Failed to evaluate type argument for downcast.")
         )
       )
     );
@@ -123,9 +117,7 @@ evaluate_downcast :: (
       dyn(
         format_error_message(
           ast_expr_token(type_expr),
-          `downcast expects a type as second argument, got ${type_to_string(type_info.ty)}.`,
-          false,
-          .None
+          `downcast expects a type as second argument, got ${type_to_string(type_info.ty)}.`
         )
       )
     );

--- a/src/evaluator/builtins/drop.yo
+++ b/src/evaluator/builtins/drop.yo
@@ -56,9 +56,7 @@ evaluate_drop :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("___drop: failed to evaluate the argument expression."),
-            false,
-            .None
+            String.from("___drop: failed to evaluate the argument expression.")
           )
         )
       );

--- a/src/evaluator/builtins/dup.yo
+++ b/src/evaluator/builtins/dup.yo
@@ -58,9 +58,7 @@ evaluate_dup :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("___dup: failed to evaluate the argument expression."),
-            false,
-            .None
+            String.from("___dup: failed to evaluate the argument expression.")
           )
         )
       );

--- a/src/evaluator/builtins/expr_fns.yo
+++ b/src/evaluator/builtins/expr_fns.yo
@@ -74,9 +74,7 @@ evaluate_yo_expr_is_atom :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_EXPR_IS_ATOM}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_EXPR_IS_ATOM}"`
           )
         )
       );
@@ -88,9 +86,7 @@ evaluate_yo_expr_is_atom :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected expression type for "${BF_YO_EXPR_IS_ATOM}" argument`,
-          false,
-          .None
+          `Expected expression type for "${BF_YO_EXPR_IS_ATOM}" argument`
         )
       )
     );
@@ -108,9 +104,7 @@ evaluate_yo_expr_is_atom :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected expression value for "${BF_YO_EXPR_IS_ATOM}" argument`,
-            false,
-            .None
+            `Expected expression value for "${BF_YO_EXPR_IS_ATOM}" argument`
           )
         )
       );
@@ -156,9 +150,7 @@ evaluate_yo_expr_is_fn_call :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_EXPR_IS_FN_CALL}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_EXPR_IS_FN_CALL}"`
           )
         )
       );
@@ -170,9 +162,7 @@ evaluate_yo_expr_is_fn_call :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected expression type for "${BF_YO_EXPR_IS_FN_CALL}" argument`,
-          false,
-          .None
+          `Expected expression type for "${BF_YO_EXPR_IS_FN_CALL}" argument`
         )
       )
     );
@@ -190,9 +180,7 @@ evaluate_yo_expr_is_fn_call :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected expression value for "${BF_YO_EXPR_IS_FN_CALL}" argument`,
-            false,
-            .None
+            `Expected expression value for "${BF_YO_EXPR_IS_FN_CALL}" argument`
           )
         )
       );
@@ -238,9 +226,7 @@ evaluate_yo_expr_get_callee :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_EXPR_GET_CALLEE}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_EXPR_GET_CALLEE}"`
           )
         )
       );
@@ -252,9 +238,7 @@ evaluate_yo_expr_get_callee :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected expression type for "${BF_YO_EXPR_GET_CALLEE}" argument`,
-          false,
-          .None
+          `Expected expression type for "${BF_YO_EXPR_GET_CALLEE}" argument`
         )
       )
     );
@@ -280,9 +264,7 @@ evaluate_yo_expr_get_callee :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg_e),
-                `Expected function call expression for argument to "${BF_YO_EXPR_GET_CALLEE}"`,
-                false,
-                .None
+                `Expected function call expression for argument to "${BF_YO_EXPR_GET_CALLEE}"`
               )
             )
           );
@@ -297,9 +279,7 @@ evaluate_yo_expr_get_callee :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected expression value for "${BF_YO_EXPR_GET_CALLEE}" argument`,
-            false,
-            .None
+            `Expected expression value for "${BF_YO_EXPR_GET_CALLEE}" argument`
           )
         )
       );
@@ -343,9 +323,7 @@ evaluate_yo_expr_get_args :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_EXPR_GET_ARGS}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_EXPR_GET_ARGS}"`
           )
         )
       );
@@ -357,9 +335,7 @@ evaluate_yo_expr_get_args :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected expression type for "${BF_YO_EXPR_GET_ARGS}" argument`,
-          false,
-          .None
+          `Expected expression type for "${BF_YO_EXPR_GET_ARGS}" argument`
         )
       )
     );
@@ -392,9 +368,7 @@ evaluate_yo_expr_get_args :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg_e),
-                `Expected function call expression for argument to "${BF_YO_EXPR_GET_ARGS}"`,
-                false,
-                .None
+                `Expected function call expression for argument to "${BF_YO_EXPR_GET_ARGS}"`
               )
             )
           );
@@ -409,9 +383,7 @@ evaluate_yo_expr_get_args :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected expression value for "${BF_YO_EXPR_GET_ARGS}" argument`,
-            false,
-            .None
+            `Expected expression value for "${BF_YO_EXPR_GET_ARGS}" argument`
           )
         )
       );
@@ -455,9 +427,7 @@ evaluate_yo_expr_to_string :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Failed to evaluate argument for "${BF_YO_EXPR_TO_STRING}"`,
-            false,
-            .None
+            `Failed to evaluate argument for "${BF_YO_EXPR_TO_STRING}"`
           )
         )
       );
@@ -469,9 +439,7 @@ evaluate_yo_expr_to_string :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_e),
-          `Expected expression type for "${BF_YO_EXPR_TO_STRING}" argument`,
-          false,
-          .None
+          `Expected expression type for "${BF_YO_EXPR_TO_STRING}" argument`
         )
       )
     );
@@ -495,9 +463,7 @@ evaluate_yo_expr_to_string :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_e),
-            `Expected expression value for "${BF_YO_EXPR_TO_STRING}" argument`,
-            false,
-            .None
+            `Expected expression value for "${BF_YO_EXPR_TO_STRING}" argument`
           )
         )
       );
@@ -548,9 +514,7 @@ evaluate_yo_expr_eq :: (
         dyn(
           format_error_message(
             ast_expr_token(first_e),
-            `Failed to evaluate first argument for "${BF_YO_EXPR_EQ}"`,
-            false,
-            .None
+            `Failed to evaluate first argument for "${BF_YO_EXPR_EQ}"`
           )
         )
       );
@@ -562,9 +526,7 @@ evaluate_yo_expr_eq :: (
       dyn(
         format_error_message(
           ast_expr_token(first_e),
-          `Expected expression type for "${BF_YO_EXPR_EQ}" first argument`,
-          false,
-          .None
+          `Expected expression type for "${BF_YO_EXPR_EQ}" first argument`
         )
       )
     );
@@ -578,9 +540,7 @@ evaluate_yo_expr_eq :: (
         dyn(
           format_error_message(
             ast_expr_token(first_e),
-            `Expected expression value for "${BF_YO_EXPR_EQ}" first argument`,
-            false,
-            .None
+            `Expected expression value for "${BF_YO_EXPR_EQ}" first argument`
           )
         )
       );
@@ -597,9 +557,7 @@ evaluate_yo_expr_eq :: (
         dyn(
           format_error_message(
             ast_expr_token(second_e),
-            `Failed to evaluate second argument for "${BF_YO_EXPR_EQ}"`,
-            false,
-            .None
+            `Failed to evaluate second argument for "${BF_YO_EXPR_EQ}"`
           )
         )
       );
@@ -611,9 +569,7 @@ evaluate_yo_expr_eq :: (
       dyn(
         format_error_message(
           ast_expr_token(second_e),
-          `Expected expression type for "${BF_YO_EXPR_EQ}" second argument`,
-          false,
-          .None
+          `Expected expression type for "${BF_YO_EXPR_EQ}" second argument`
         )
       )
     );
@@ -627,9 +583,7 @@ evaluate_yo_expr_eq :: (
         dyn(
           format_error_message(
             ast_expr_token(second_e),
-            `Expected expression value for "${BF_YO_EXPR_EQ}" second argument`,
-            false,
-            .None
+            `Expected expression value for "${BF_YO_EXPR_EQ}" second argument`
           )
         )
       );

--- a/src/evaluator/builtins/gc.yo
+++ b/src/evaluator/builtins/gc.yo
@@ -34,9 +34,7 @@ evaluate_yo_gc_collect :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "__yo_gc_collect" with 0 arguments`,
-          false,
-          .None
+          `Expected "__yo_gc_collect" with 0 arguments`
         )
       )
     );

--- a/src/evaluator/builtins/gensym.yo
+++ b/src/evaluator/builtins/gensym.yo
@@ -59,9 +59,7 @@ evaluate_gensym :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Expected "gensym" with 0 or 1 argument, got more`,
-              false,
-              .None
+              `Expected "gensym" with 0 or 1 argument, got more`
             )
           )
         );
@@ -77,9 +75,7 @@ evaluate_gensym :: (
             dyn(
               format_error_message(
                 ast_expr_token(prefix_arg),
-                `Failed to evaluate the prefix argument for "gensym":\n${ast_expr_to_string(prefix_arg)}`,
-                false,
-                .None
+                `Failed to evaluate the prefix argument for "gensym":\n${ast_expr_to_string(prefix_arg)}`
               )
             )
           );
@@ -95,9 +91,7 @@ evaluate_gensym :: (
               dyn(
                 format_error_message(
                   ast_expr_token(prefix_arg),
-                  `Expected comptime_str for prefix argument, got:\n${ast_expr_to_string(prefix_arg)}`,
-                  false,
-                  .None
+                  `Expected comptime_str for prefix argument, got:\n${ast_expr_to_string(prefix_arg)}`
                 )
               )
             );
@@ -121,9 +115,7 @@ evaluate_gensym :: (
             dyn(
               format_error_message(
                 ast_expr_token(prefix_arg),
-                `Expected comptime_str for prefix argument, got:\n${ast_expr_to_string(prefix_arg)}`,
-                false,
-                .None
+                `Expected comptime_str for prefix argument, got:\n${ast_expr_to_string(prefix_arg)}`
               )
             )
           );

--- a/src/evaluator/builtins/impl_constraint.yo
+++ b/src/evaluator/builtins/impl_constraint.yo
@@ -55,9 +55,7 @@ evaluate_impl_constraint :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Impl requires at least one trait argument."),
-          false,
-          .None
+          String.from("Impl requires at least one trait argument.")
         )
       )
     );
@@ -106,9 +104,7 @@ evaluate_impl_constraint :: (
               dyn(
                 format_error_message(
                   ast_expr_token(module_expr),
-                  String.from("Failed to evaluate Impl argument."),
-                  false,
-                  .None
+                  String.from("Failed to evaluate Impl argument.")
                 )
               )
             );
@@ -122,9 +118,7 @@ evaluate_impl_constraint :: (
             dyn(
               format_error_message(
                 ast_expr_token(module_expr),
-                `Impl argument must be a trait type, got: ${ast_expr_to_string(module_expr)}`,
-                false,
-                .None
+                `Impl argument must be a trait type, got: ${ast_expr_to_string(module_expr)}`
               )
             )
           );
@@ -143,9 +137,7 @@ evaluate_impl_constraint :: (
             dyn(
               format_error_message(
                 ast_expr_token(module_expr),
-                `Impl argument must be a trait type, got: ${ast_expr_to_string(module_expr)}`,
-                false,
-                .None
+                `Impl argument must be a trait type, got: ${ast_expr_to_string(module_expr)}`
               )
             )
           );
@@ -165,9 +157,7 @@ evaluate_impl_constraint :: (
               dyn(
                 format_error_message(
                   ast_expr_token(module_expr),
-                  String.from("Impl can only have one Concrete(T) specifier"),
-                  false,
-                  .None
+                  String.from("Impl can only have one Concrete(T) specifier")
                 )
               )
             );

--- a/src/evaluator/builtins/macro_expand.yo
+++ b/src/evaluator/builtins/macro_expand.yo
@@ -51,7 +51,7 @@ evaluate_macro_expand :: (
     expr,
     .FnCall(_, _, a, _, _) => a,
     _ => {
-      exn.throw(dyn(format_error_message(tok, String.from("macro_expand: expected FnCall"), false, .None)));
+      exn.throw(dyn(format_error_message(tok, String.from("macro_expand: expected FnCall"))));
       return(expr);
     }
   );
@@ -62,9 +62,7 @@ evaluate_macro_expand :: (
       dyn(
         format_error_message(
           tok,
-          `"macro_expand" expects 1 or 2 arguments, but got ${n}`,
-          false,
-          .None
+          `"macro_expand" expects 1 or 2 arguments, but got ${n}`
         )
       )
     );
@@ -85,9 +83,7 @@ evaluate_macro_expand :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Failed to evaluate the argument expression for "macro_expand"`,
-            false,
-            .None
+            `Failed to evaluate the argument expression for "macro_expand"`
           )
         )
       );
@@ -100,9 +96,7 @@ evaluate_macro_expand :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `The argument expression for "macro_expand" must be an Expr value, but got: ${type_to_string(arg_info.ty)}`,
-          false,
-          .None
+          `The argument expression for "macro_expand" must be an Expr value, but got: ${type_to_string(arg_info.ty)}`
         )
       )
     );
@@ -126,9 +120,7 @@ evaluate_macro_expand :: (
           dyn(
             format_error_message(
               ast_expr_token(level_arg),
-              `Failed to evaluate the level argument expression for "macro_expand"`,
-              false,
-              .None
+              `Failed to evaluate the level argument expression for "macro_expand"`
             )
           )
         );
@@ -140,9 +132,7 @@ evaluate_macro_expand :: (
         dyn(
           format_error_message(
             ast_expr_token(level_arg),
-            `The level argument for "macro_expand" must be a comptime_int value, but got: ${type_to_string(level_info.ty)}`,
-            false,
-            .None
+            `The level argument for "macro_expand" must be a comptime_int value, but got: ${type_to_string(level_info.ty)}`
           )
         )
       );
@@ -154,9 +144,7 @@ evaluate_macro_expand :: (
         dyn(
           format_error_message(
             ast_expr_token(level_arg),
-            `The level argument for "macro_expand" must be a comptime_int value`,
-            false,
-            .None
+            `The level argument for "macro_expand" must be a comptime_int value`
           )
         )
       );
@@ -177,9 +165,7 @@ evaluate_macro_expand :: (
         dyn(
           format_error_message(
             ast_expr_token(level_arg),
-            `The level argument for "macro_expand" must be non-negative, but got: ${lv_parsed}`,
-            false,
-            .None
+            `The level argument for "macro_expand" must be non-negative, but got: ${lv_parsed}`
           )
         )
       );

--- a/src/evaluator/builtins/panic.yo
+++ b/src/evaluator/builtins/panic.yo
@@ -47,9 +47,7 @@ evaluate_panic :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("__yo_panic() can only be called inside a function body or test block"),
-            false,
-            .None
+            String.from("__yo_panic() can only be called inside a function body or test block")
           )
         )
       );
@@ -62,9 +60,7 @@ evaluate_panic :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Cannot use \"__yo_panic\" during compile-time function evaluation analysis. Functions containing \"__yo_panic\" cannot be evaluated at compile time."),
-          false,
-          .None
+          String.from("Cannot use \"__yo_panic\" during compile-time function evaluation analysis. Functions containing \"__yo_panic\" cannot be evaluated at compile time.")
         )
       )
     );
@@ -121,9 +117,7 @@ evaluate_panic :: (
           dyn(
             format_error_message(
               ast_expr_token(msg_expr),
-              String.from("Failed to evaluate panic message"),
-              false,
-              .None
+              String.from("Failed to evaluate panic message")
             )
           )
         );
@@ -167,9 +161,7 @@ evaluate_panic :: (
             dyn(
               format_error_message(
                 ast_expr_token(msg_expr),
-                String.from("__yo_panic message must be comptime_str, str, or *(u8)"),
-                false,
-                .None
+                String.from("__yo_panic message must be comptime_str, str, or *(u8)")
               )
             )
           );

--- a/src/evaluator/builtins/pragma.yo
+++ b/src/evaluator/builtins/pragma.yo
@@ -187,9 +187,7 @@ evaluate_pragma :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected 1 arguments, got ${args.len()}:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected 1 arguments, got ${args.len()}:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -233,9 +231,7 @@ evaluate_pragma :: (
       dyn(
         format_error_message(
           ast_expr_token(arg),
-          `Failed to evaluate the argument of 'pragma(...)'.`,
-          false,
-          .None
+          `Failed to evaluate the argument of 'pragma(...)'.`
         )
       )
     ),
@@ -257,9 +253,7 @@ evaluate_pragma :: (
       dyn(
         format_error_message(
           ast_expr_token(arg),
-          `'pragma(...)' expects a 'Pragma.X' argument (e.g. 'pragma(Pragma.AllowUnsafe);'). Got value of type ${got_ty_str} from: ${ast_expr_to_string(arg)}`,
-          false,
-          .None
+          `'pragma(...)' expects a 'Pragma.X' argument (e.g. 'pragma(Pragma.AllowUnsafe);'). Got value of type ${got_ty_str} from: ${ast_expr_to_string(arg)}`
         )
       )
     ),
@@ -269,9 +263,7 @@ evaluate_pragma :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `Unknown 'Pragma' variant '${vname}'. The compiler does not recognize this pragma — make sure the prelude's 'Pragma' enum and 'evaluator/memory_safety.yo' agree on the set of supported variants.`,
-            false,
-            .None
+            `Unknown 'Pragma' variant '${vname}'. The compiler does not recognize this pragma — make sure the prelude's 'Pragma' enum and 'evaluator/memory_safety.yo' agree on the set of supported variants.`
           )
         )
       ),

--- a/src/evaluator/builtins/process.yo
+++ b/src/evaluator/builtins/process.yo
@@ -81,9 +81,7 @@ evaluate_yo_process_functions :: (
     dyn(
       format_error_message(
         ast_expr_token(expr),
-        `Unknown process function`,
-        false,
-        .None
+        `Unknown process function`
       )
     )
   );

--- a/src/evaluator/builtins/ptr_fns.yo
+++ b/src/evaluator/builtins/ptr_fns.yo
@@ -70,9 +70,7 @@ evaluate_address_call :: (
       dyn(
         format_error_message(
           ptok,
-          `Taking an address with '&(...)' produces a raw pointer ('*(T)'), which is not available in safe code.\n\nFor in-place mutation of a value, use the 'inout(name) : T' parameter form on the receiving function. For collections, the safe types (Slice(T), ArrayList(T), HashMap(K, V)) own their interior pointers — don't take an address of an element manually. If this file genuinely needs raw pointers, add 'pragma(Pragma.AllowUnsafe);' at the top.`,
-          false,
-          .None
+          `Taking an address with '&(...)' produces a raw pointer ('*(T)'), which is not available in safe code.\n\nFor in-place mutation of a value, use the 'inout(name) : T' parameter form on the receiving function. For collections, the safe types (Slice(T), ArrayList(T), HashMap(K, V)) own their interior pointers — don't take an address of an element manually. If this file genuinely needs raw pointers, add 'pragma(Pragma.AllowUnsafe);' at the top.`
         )
       )
     );
@@ -111,9 +109,7 @@ evaluate_address_call :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("&: failed to evaluate the argument expression for reference."),
-            false,
-            .None
+            String.from("&: failed to evaluate the argument expression for reference.")
           )
         )
       );
@@ -133,9 +129,7 @@ evaluate_address_call :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          String.from("Cannot create a pointer to a type. Did you mean to use \"*\"?"),
-          false,
-          .None
+          String.from("Cannot create a pointer to a type. Did you mean to use \"*\"?")
         )
       )
     );

--- a/src/evaluator/builtins/quote.yo
+++ b/src/evaluator/builtins/quote.yo
@@ -130,9 +130,7 @@ process_unquotes_in_expr :: (
               dyn(
                 format_error_message(
                   tok,
-                  String.from("unquote: failed to evaluate argument"),
-                  false,
-                  .None
+                  String.from("unquote: failed to evaluate argument")
                 )
               )
             );
@@ -142,7 +140,7 @@ process_unquotes_in_expr :: (
         val := match(
           arg_info.value,
           .None => {
-            exn.throw(dyn(format_error_message(tok, String.from("unquote: argument must have a compile-time value"), false, .None)));
+            exn.throw(dyn(format_error_message(tok, String.from("unquote: argument must have a compile-time value"))));
             EvalValue.ExprVal(make_err_expr())
           },
           .Some(v) => v
@@ -152,7 +150,7 @@ process_unquotes_in_expr :: (
           if(is_unknown_val(val), {
             return(expr);
           });
-          exn.throw(dyn(format_error_message(tok, String.from("unquote: expected Expr type"), false, .None)));
+          exn.throw(dyn(format_error_message(tok, String.from("unquote: expected Expr type"))));
         });
         if(is_unknown_val(val), {
           return(expr);
@@ -164,7 +162,7 @@ process_unquotes_in_expr :: (
           val,
           .ExprVal(eb) => clone_expr_fresh_ids(eb),
           _ => {
-            exn.throw(dyn(format_error_message(tok, String.from("unquote: expected ExprVal"), false, .None)));
+            exn.throw(dyn(format_error_message(tok, String.from("unquote: expected ExprVal"))));
             make_err_expr()
           }
         );
@@ -219,9 +217,7 @@ process_unquotes_in_expr :: (
                             dyn(
                               format_error_message(
                                 ast_expr_token(arg),
-                                String.from("unquote_splicing: expected ComptimeList(Expr) type"),
-                                false,
-                                .None
+                                String.from("unquote_splicing: expected ComptimeList(Expr) type")
                               )
                             )
                           );

--- a/src/evaluator/builtins/rc.yo
+++ b/src/evaluator/builtins/rc.yo
@@ -54,9 +54,7 @@ evaluate_rc :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_ast),
-            String.from("rc: failed to evaluate argument"),
-            false,
-            .None
+            String.from("rc: failed to evaluate argument")
           )
         )
       );

--- a/src/evaluator/builtins/rc_fns.yo
+++ b/src/evaluator/builtins/rc_fns.yo
@@ -85,9 +85,7 @@ _eval_arg :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Failed to evaluate argument for ${fn_name}`,
-            false,
-            .None
+            `Failed to evaluate argument for ${fn_name}`
           )
         )
       );
@@ -272,9 +270,7 @@ evaluate_yo_iso_extract :: (
       dyn(
         format_error_message(
           tok,
-          `evaluate_yo_iso_extract: expected Iso type, but got: ${type_to_string(arg_type)}`,
-          false,
-          .None
+          `evaluate_yo_iso_extract: expected Iso type, but got: ${type_to_string(arg_type)}`
         )
       )
     );
@@ -352,9 +348,7 @@ evaluate_yo_dup_array_element :: (
       dyn(
         format_error_message(
           tok,
-          `evaluate_yo_dup_array_element: expected array type, got: ${type_to_string(array_type)}`,
-          false,
-          .None
+          `evaluate_yo_dup_array_element: expected array type, got: ${type_to_string(array_type)}`
         )
       )
     );
@@ -384,9 +378,7 @@ evaluate_yo_dup_tuple_element :: (
       dyn(
         format_error_message(
           tok,
-          `evaluate_yo_dup_tuple_element: expected tuple type, got: ${type_to_string(tuple_type)}`,
-          false,
-          .None
+          `evaluate_yo_dup_tuple_element: expected tuple type, got: ${type_to_string(tuple_type)}`
         )
       )
     );
@@ -408,9 +400,7 @@ evaluate_yo_dup_tuple_element :: (
         dyn(
           format_error_message(
             tok,
-            `evaluate_yo_dup_tuple_element: index ${index_i64} out of bounds for tuple`,
-            false,
-            .None
+            `evaluate_yo_dup_tuple_element: index ${index_i64} out of bounds for tuple`
           )
         )
       );

--- a/src/evaluator/builtins/sizeof.yo
+++ b/src/evaluator/builtins/sizeof.yo
@@ -42,9 +42,7 @@ evaluate_size_of :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "sizeof" with 1 argument`,
-          false,
-          .None
+          `Expected "sizeof" with 1 argument`
         )
       )
     );
@@ -72,9 +70,7 @@ evaluate_size_of :: (
         dyn(
           format_error_message(
             ast_expr_token(type_expr),
-            String.from("Failed to evaluate expression."),
-            false,
-            .None
+            String.from("Failed to evaluate expression.")
           )
         )
       );

--- a/src/evaluator/builtins/the.yo
+++ b/src/evaluator/builtins/the.yo
@@ -65,9 +65,7 @@ evaluate_the :: (
         dyn(
           format_error_message(
             ast_expr_token(type_arg),
-            String.from("the: failed to evaluate type expression"),
-            false,
-            .None
+            String.from("the: failed to evaluate type expression")
           )
         )
       );
@@ -86,9 +84,7 @@ evaluate_the :: (
           dyn(
             format_error_message(
               ast_expr_token(type_arg),
-              String.from("the: first argument must be a type"),
-              false,
-              .None
+              String.from("the: first argument must be a type")
             )
           )
         );
@@ -100,9 +96,7 @@ evaluate_the :: (
         dyn(
           format_error_message(
             ast_expr_token(type_arg),
-            String.from("the: first argument must be a compile-time type"),
-            false,
-            .None
+            String.from("the: first argument must be a compile-time type")
           )
         )
       );
@@ -124,9 +118,7 @@ evaluate_the :: (
         dyn(
           format_error_message(
             ast_expr_token(value_arg),
-            String.from("the: failed to evaluate value expression"),
-            false,
-            .None
+            String.from("the: failed to evaluate value expression")
           )
         )
       );
@@ -140,9 +132,7 @@ evaluate_the :: (
       dyn(
         format_error_message(
           ast_expr_token(value_arg),
-          `the: type mismatch: expected '${type_to_string(expected_type)}', got '${type_to_string(val_info.ty)}'`,
-          false,
-          .None
+          `the: type mismatch: expected '${type_to_string(expected_type)}', got '${type_to_string(val_info.ty)}'`
         )
       )
     );

--- a/src/evaluator/builtins/type_fns.yo
+++ b/src/evaluator/builtins/type_fns.yo
@@ -70,9 +70,7 @@ _extract_type_val :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `${fn_name}: expected a type value, got runtime expression`,
-            false,
-            .None
+            `${fn_name}: expected a type value, got runtime expression`
           )
         )
       );
@@ -86,9 +84,7 @@ _extract_type_val :: (
           dyn(
             format_error_message(
               ast_expr_token(arg),
-              `${fn_name}: expected a TypeVal, got a non-type value`,
-              false,
-              .None
+              `${fn_name}: expected a TypeVal, got a non-type value`
             )
           )
         );
@@ -130,9 +126,7 @@ evaluate_yo_type_to_string :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_type_to_comptime_string: failed to evaluate argument"),
-            false,
-            .None
+            String.from("__yo_type_to_comptime_string: failed to evaluate argument")
           )
         )
       );
@@ -144,9 +138,7 @@ evaluate_yo_type_to_string :: (
       dyn(
         format_error_message(
           ast_expr_token(arg0),
-          `__yo_type_to_comptime_string: expected a Type argument, got: ${type_to_string(arg_info.ty)}`,
-          false,
-          .None
+          `__yo_type_to_comptime_string: expected a Type argument, got: ${type_to_string(arg_info.ty)}`
         )
       )
     );
@@ -180,9 +172,7 @@ evaluate_yo_type_to_string :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_type_to_comptime_string: expected type value, got runtime expression"),
-            false,
-            .None
+            String.from("__yo_type_to_comptime_string: expected type value, got runtime expression")
           )
         )
       );
@@ -238,9 +228,7 @@ evaluate_yo_are_types_compatible :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_are_types_compatible: failed to evaluate first argument"),
-            false,
-            .None
+            String.from("__yo_are_types_compatible: failed to evaluate first argument")
           )
         )
       );
@@ -252,9 +240,7 @@ evaluate_yo_are_types_compatible :: (
       dyn(
         format_error_message(
           ast_expr_token(arg0),
-          `__yo_are_types_compatible: expected a Type for first argument, got: ${type_to_string(info_0.ty)}`,
-          false,
-          .None
+          `__yo_are_types_compatible: expected a Type for first argument, got: ${type_to_string(info_0.ty)}`
         )
       )
     );
@@ -275,9 +261,7 @@ evaluate_yo_are_types_compatible :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_are_types_compatible: failed to evaluate second argument"),
-            false,
-            .None
+            String.from("__yo_are_types_compatible: failed to evaluate second argument")
           )
         )
       );
@@ -289,9 +273,7 @@ evaluate_yo_are_types_compatible :: (
       dyn(
         format_error_message(
           ast_expr_token(arg1),
-          `__yo_are_types_compatible: expected a Type for second argument, got: ${type_to_string(info_1.ty)}`,
-          false,
-          .None
+          `__yo_are_types_compatible: expected a Type for second argument, got: ${type_to_string(info_1.ty)}`
         )
       )
     );
@@ -351,9 +333,7 @@ evaluate_yo_are_types_equal :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_are_types_equal: failed to evaluate first argument"),
-            false,
-            .None
+            String.from("__yo_are_types_equal: failed to evaluate first argument")
           )
         )
       );
@@ -375,9 +355,7 @@ evaluate_yo_are_types_equal :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_are_types_equal: failed to evaluate second argument"),
-            false,
-            .None
+            String.from("__yo_are_types_equal: failed to evaluate second argument")
           )
         )
       );
@@ -427,9 +405,7 @@ evaluate_yo_type_contains_rc_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_type_contains_rc_type: failed to evaluate argument"),
-            false,
-            .None
+            String.from("__yo_type_contains_rc_type: failed to evaluate argument")
           )
         )
       );
@@ -441,9 +417,7 @@ evaluate_yo_type_contains_rc_type :: (
       dyn(
         format_error_message(
           ast_expr_token(arg0),
-          `__yo_type_contains_rc_type: expected a Type argument, got: ${type_to_string(arg_info.ty)}`,
-          false,
-          .None
+          `__yo_type_contains_rc_type: expected a Type argument, got: ${type_to_string(arg_info.ty)}`
         )
       )
     );
@@ -489,9 +463,7 @@ evaluate_yo_type_can_form_rc_cycle :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_type_can_form_rc_cycle: failed to evaluate argument"),
-            false,
-            .None
+            String.from("__yo_type_can_form_rc_cycle: failed to evaluate argument")
           )
         )
       );
@@ -503,9 +475,7 @@ evaluate_yo_type_can_form_rc_cycle :: (
       dyn(
         format_error_message(
           ast_expr_token(arg0),
-          `__yo_type_can_form_rc_cycle: expected a Type argument, got: ${type_to_string(arg_info.ty)}`,
-          false,
-          .None
+          `__yo_type_can_form_rc_cycle: expected a Type argument, got: ${type_to_string(arg_info.ty)}`
         )
       )
     );
@@ -559,9 +529,7 @@ evaluate_yo_type_impls :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_type_impls: failed to evaluate type argument"),
-            false,
-            .None
+            String.from("__yo_type_impls: failed to evaluate type argument")
           )
         )
       );
@@ -574,9 +542,7 @@ evaluate_yo_type_impls :: (
       dyn(
         format_error_message(
           ast_expr_token(arg0),
-          String.from("__yo_type_impls: expected Type for first argument"),
-          false,
-          .None
+          String.from("__yo_type_impls: expected Type for first argument")
         )
       )
     );
@@ -592,9 +558,7 @@ evaluate_yo_type_impls :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_type_impls: failed to evaluate trait argument"),
-            false,
-            .None
+            String.from("__yo_type_impls: failed to evaluate trait argument")
           )
         )
       );
@@ -639,9 +603,7 @@ evaluate_yo_type_impls :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_type_impls: expected trait type for second argument"),
-            false,
-            .None
+            String.from("__yo_type_impls: expected trait type for second argument")
           )
         )
       );
@@ -1155,9 +1117,7 @@ evaluate_yo_type_get_info :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_type_get_info: failed to evaluate type argument"),
-            false,
-            .None
+            String.from("__yo_type_get_info: failed to evaluate type argument")
           )
         )
       );
@@ -1223,9 +1183,7 @@ evaluate_yo_type_get_info :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              String.from("__yo_type_get_info: unsupported Int bits"),
-              false,
-              .None
+              String.from("__yo_type_get_info: unsupported Int bits")
             )
           )
         );
@@ -1390,9 +1348,7 @@ evaluate_yo_type_get_info :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("__yo_type_get_info: unsupported type variant"),
-            false,
-            .None
+            String.from("__yo_type_get_info: unsupported type variant")
           )
         )
       );
@@ -1413,9 +1369,7 @@ evaluate_yo_type_get_info :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("__yo_type_get_info: failed to create TypeInfo value"),
-            false,
-            .None
+            String.from("__yo_type_get_info: failed to create TypeInfo value")
           )
         )
       );
@@ -1460,9 +1414,7 @@ evaluate_comptime_eval :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("comptime_eval: failed to evaluate argument"),
-            false,
-            .None
+            String.from("comptime_eval: failed to evaluate argument")
           )
         )
       );
@@ -1508,9 +1460,7 @@ evaluate_comptime_eval :: (
           dyn(
             format_error_message(
               ast_expr_token(arg0),
-              String.from("comptime_eval: failed to evaluate code expression"),
-              false,
-              .None
+              String.from("comptime_eval: failed to evaluate code expression")
             )
           )
         );
@@ -1558,9 +1508,7 @@ evaluate_comptime_string_to_expr :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_comptime_string_to_expr: failed to evaluate argument"),
-            false,
-            .None
+            String.from("__yo_comptime_string_to_expr: failed to evaluate argument")
           )
         )
       );
@@ -1586,9 +1534,7 @@ evaluate_comptime_string_to_expr :: (
           dyn(
             format_error_message(
               ast_expr_token(arg0),
-              String.from("__yo_comptime_string_to_expr: expected a comptime_str argument"),
-              false,
-              .None
+              String.from("__yo_comptime_string_to_expr: expected a comptime_str argument")
             )
           )
         );
@@ -1664,9 +1610,7 @@ evaluate_type_join_fields :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_type_join_fields: failed to evaluate type argument"),
-            false,
-            .None
+            String.from("__yo_type_join_fields: failed to evaluate type argument")
           )
         )
       );
@@ -1688,9 +1632,7 @@ evaluate_type_join_fields :: (
       dyn(
         format_error_message(
           ast_expr_token(arg0),
-          String.from("__yo_type_join_fields: expected a struct type"),
-          false,
-          .None
+          String.from("__yo_type_join_fields: expected a struct type")
         )
       )
     );
@@ -1705,9 +1647,7 @@ evaluate_type_join_fields :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_type_join_fields: failed to evaluate mapper"),
-            false,
-            .None
+            String.from("__yo_type_join_fields: failed to evaluate mapper")
           )
         )
       );
@@ -1722,9 +1662,7 @@ evaluate_type_join_fields :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_type_join_fields: second argument must be a function"),
-            false,
-            .None
+            String.from("__yo_type_join_fields: second argument must be a function")
           )
         )
       );
@@ -1735,9 +1673,7 @@ evaluate_type_join_fields :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_type_join_fields: mapper is a runtime expression"),
-            false,
-            .None
+            String.from("__yo_type_join_fields: mapper is a runtime expression")
           )
         )
       );
@@ -1754,9 +1690,7 @@ evaluate_type_join_fields :: (
         dyn(
           format_error_message(
             ast_expr_token(arg2),
-            String.from("__yo_type_join_fields: failed to evaluate combiner"),
-            false,
-            .None
+            String.from("__yo_type_join_fields: failed to evaluate combiner")
           )
         )
       );
@@ -1774,9 +1708,7 @@ evaluate_type_join_fields :: (
           dyn(
             format_error_message(
               ast_expr_token(arg2),
-              String.from("__yo_type_join_fields: third argument must be a quoted expression"),
-              false,
-              .None
+              String.from("__yo_type_join_fields: third argument must be a quoted expression")
             )
           )
         );
@@ -1788,9 +1720,7 @@ evaluate_type_join_fields :: (
         dyn(
           format_error_message(
             ast_expr_token(arg2),
-            String.from("__yo_type_join_fields: combiner is a runtime expression"),
-            false,
-            .None
+            String.from("__yo_type_join_fields: combiner is a runtime expression")
           )
         )
       );
@@ -1827,9 +1757,7 @@ evaluate_type_join_fields :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("__yo_type_join_fields: struct has no fields"),
-          false,
-          .None
+          String.from("__yo_type_join_fields: struct has no fields")
         )
       )
     );
@@ -1894,9 +1822,7 @@ evaluate_type_join_fields :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg1),
-                String.from("__yo_type_join_fields: mapper must return(comptime(Expr))"),
-                false,
-                .None
+                String.from("__yo_type_join_fields: mapper must return(comptime(Expr))")
               )
             )
           );
@@ -1908,9 +1834,7 @@ evaluate_type_join_fields :: (
           dyn(
             format_error_message(
               ast_expr_token(arg1),
-              String.from("__yo_type_join_fields: mapper returned no value"),
-              false,
-              .None
+              String.from("__yo_type_join_fields: mapper returned no value")
             )
           )
         );
@@ -1980,9 +1904,7 @@ evaluate_type_map_variants :: (
         dyn(
           format_error_message(
             ast_expr_token(arg0),
-            String.from("__yo_type_map_variants: failed to evaluate type argument"),
-            false,
-            .None
+            String.from("__yo_type_map_variants: failed to evaluate type argument")
           )
         )
       );
@@ -2005,9 +1927,7 @@ evaluate_type_map_variants :: (
       dyn(
         format_error_message(
           ast_expr_token(arg0),
-          String.from("__yo_type_map_variants: expected an enum type"),
-          false,
-          .None
+          String.from("__yo_type_map_variants: expected an enum type")
         )
       )
     );
@@ -2022,9 +1942,7 @@ evaluate_type_map_variants :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_type_map_variants: failed to evaluate mapper"),
-            false,
-            .None
+            String.from("__yo_type_map_variants: failed to evaluate mapper")
           )
         )
       );
@@ -2039,9 +1957,7 @@ evaluate_type_map_variants :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_type_map_variants: second argument must be a function"),
-            false,
-            .None
+            String.from("__yo_type_map_variants: second argument must be a function")
           )
         )
       );
@@ -2052,9 +1968,7 @@ evaluate_type_map_variants :: (
         dyn(
           format_error_message(
             ast_expr_token(arg1),
-            String.from("__yo_type_map_variants: mapper is a runtime expression"),
-            false,
-            .None
+            String.from("__yo_type_map_variants: mapper is a runtime expression")
           )
         )
       );
@@ -2140,9 +2054,7 @@ evaluate_type_map_variants :: (
           dyn(
             format_error_message(
               ast_expr_token(arg1),
-              String.from("__yo_type_map_variants: mapper returned no value"),
-              false,
-              .None
+              String.from("__yo_type_map_variants: mapper returned no value")
             )
           )
         );

--- a/src/evaluator/builtins/typeid.yo
+++ b/src/evaluator/builtins/typeid.yo
@@ -49,9 +49,7 @@ evaluate_type_id :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `"typeid" expects exactly 1 argument.`,
-            false,
-            .None
+            `"typeid" expects exactly 1 argument.`
           )
         )
       );
@@ -69,9 +67,7 @@ evaluate_type_id :: (
         dyn(
           format_error_message(
             ast_expr_token(type_expr),
-            `Failed to evaluate expression for typeid.`,
-            false,
-            .None
+            `Failed to evaluate expression for typeid.`
           )
         )
       );
@@ -85,9 +81,7 @@ evaluate_type_id :: (
       dyn(
         format_error_message(
           ast_expr_token(type_expr),
-          `typeid expects a type argument. Use is() or downcast() for runtime type checks on Dyn values.`,
-          false,
-          .None
+          `typeid expects a type argument. Use is() or downcast() for runtime type checks on Dyn values.`
         )
       )
     );

--- a/src/evaluator/builtins/unsafe.yo
+++ b/src/evaluator/builtins/unsafe.yo
@@ -50,9 +50,7 @@ evaluate_unsafe :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected unsafe(expr), got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected unsafe(expr), got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -67,9 +65,7 @@ evaluate_unsafe :: (
       dyn(
         format_error_message(
           tok,
-          String.from("'unsafe(...)' is not available in safe code.\n\nTo use raw pointer operations in this file, declare at the top:\n\n    pragma(Pragma.AllowUnsafe);\n\nThis marks the file as unsafe-capable and accepts responsibility for\nthe raw memory operations it contains."),
-          false,
-          .None
+          String.from("'unsafe(...)' is not available in safe code.\n\nTo use raw pointer operations in this file, declare at the top:\n\n    pragma(Pragma.AllowUnsafe);\n\nThis marks the file as unsafe-capable and accepts responsibility for\nthe raw memory operations it contains.")
         )
       )
     );
@@ -97,9 +93,7 @@ evaluate_unsafe :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Failed to evaluate the argument of 'unsafe(...)'."),
-            false,
-            .None
+            String.from("Failed to evaluate the argument of 'unsafe(...)'.")
           )
         )
       );

--- a/src/evaluator/builtins/va_start.yo
+++ b/src/evaluator/builtins/va_start.yo
@@ -58,9 +58,7 @@ evaluate_va_start :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg),
-                `Invalid argument for va_start. Expected identifier, got:\n${ast_expr_to_string(arg)}`,
-                false,
-                .None
+                `Invalid argument for va_start. Expected identifier, got:\n${ast_expr_to_string(arg)}`
               )
             )
           );
@@ -74,9 +72,7 @@ evaluate_va_start :: (
               dyn(
                 format_error_message(
                   ast_expr_token(arg),
-                  `Variable '${var_name}' not found in the environment.`,
-                  false,
-                  .None
+                  `Variable '${var_name}' not found in the environment.`
                 )
               )
             );
@@ -120,9 +116,7 @@ evaluate_va_start :: (
               dyn(
                 format_error_message(
                   ast_expr_token(arg),
-                  `Variable '${var_name}' not found in the environment.`,
-                  false,
-                  .None
+                  `Variable '${var_name}' not found in the environment.`
                 )
               )
             );

--- a/src/evaluator/calls/array_type.yo
+++ b/src/evaluator/calls/array_type.yo
@@ -59,9 +59,7 @@ try_to_implement_array_by_array_type :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `try_to_implement_array_by_array_type: expected Array type, got ${type_to_string(array_type)}`,
-            false,
-            .None
+            `try_to_implement_array_by_array_type: expected Array type, got ${type_to_string(array_type)}`
           )
         )
       );
@@ -96,9 +94,7 @@ try_to_implement_array_by_array_type :: (
       dyn(
         format_error_message(
           func_tok,
-          `Array constructor expects ${expected_len.to_string()} elements, got ${n_args.to_string()}.`,
-          false,
-          .None
+          `Array constructor expects ${expected_len.to_string()} elements, got ${n_args.to_string()}.`
         )
       )
     );
@@ -129,9 +125,7 @@ try_to_implement_array_by_array_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Failed to evaluate array element at index ${i.to_string()}.`,
-            false,
-            .None
+            `Failed to evaluate array element at index ${i.to_string()}.`
           )
         )
       );
@@ -155,9 +149,7 @@ try_to_implement_array_by_array_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Array element at index ${i.to_string()} has incompatible type:\n- Expected: ${type_to_string(expected_element_type)}\n- Given   : ${type_to_string(arg_info.ty)}`,
-            false,
-            .None
+            `Array element at index ${i.to_string()} has incompatible type:\n- Expected: ${type_to_string(expected_element_type)}\n- Given   : ${type_to_string(arg_info.ty)}`
           )
         )
       );

--- a/src/evaluator/calls/closure_type.yo
+++ b/src/evaluator/calls/closure_type.yo
@@ -97,9 +97,7 @@ try_to_implement_closure_by_fn_module_type :: (
       dyn(
         format_error_message(
           tok,
-          `Fn module type expects exactly 1 argument (the closure body), got ${arg_list.len()}`,
-          false,
-          .None
+          `Fn module type expects exactly 1 argument (the closure body), got ${arg_list.len()}`
         )
       )
     );
@@ -288,9 +286,7 @@ try_to_implement_closure_by_fn_module_type :: (
       dyn(
         format_error_message(
           tok,
-          `Incompatible closure return type`,
-          false,
-          .None
+          `Incompatible closure return type`
         )
       )
     );

--- a/src/evaluator/calls/comptime_fn.yo
+++ b/src/evaluator/calls/comptime_fn.yo
@@ -619,9 +619,7 @@ evaluate_comptime_fn_call :: (
               .Some(e) => ast_expr_token(e),
               .None => ast_expr_token(make_err_expr())
             ),
-            String.from("evaluate_comptime_fn_call: function_value is not a FuncVal"),
-            false,
-            .None
+            String.from("evaluate_comptime_fn_call: function_value is not a FuncVal")
           )
         )
       );
@@ -764,9 +762,7 @@ evaluate_comptime_fn_call :: (
             .Some(e) => ast_expr_token(e),
             .None => ast_expr_token(make_err_expr())
           ),
-          String.from("Failed to call the function for compile-time. Some arguments are not compile-time evaluated correctly."),
-          false,
-          .None
+          String.from("Failed to call the function for compile-time. Some arguments are not compile-time evaluated correctly.")
         )
       )
     );
@@ -1144,9 +1140,7 @@ evaluate_comptime_fn_call :: (
         dyn(
           format_error_message(
             ast_expr_token(body_expr),
-            String.from("Function body is not evaluated correctly"),
-            false,
-            .None
+            String.from("Function body is not evaluated correctly")
           )
         )
       );
@@ -1169,9 +1163,7 @@ evaluate_comptime_fn_call :: (
         dyn(
           format_error_message(
             ast_expr_token(body_expr),
-            String.from("Function body is not evaluated correctly. Expected to return(a compile-time known value.)"),
-            false,
-            .None
+            String.from("Function body is not evaluated correctly. Expected to return(a compile-time known value.)")
           )
         )
       );

--- a/src/evaluator/calls/comptime_list_type.yo
+++ b/src/evaluator/calls/comptime_list_type.yo
@@ -70,9 +70,7 @@ try_to_implement_comptime_list_by_comptime_list_type :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              `Failed to evaluate ComptimeList element at index ${i.to_string()}.`,
-              false,
-              .None
+              `Failed to evaluate ComptimeList element at index ${i.to_string()}.`
             )
           )
         );
@@ -91,9 +89,7 @@ try_to_implement_comptime_list_by_comptime_list_type :: (
             ast_expr_token(arg_expr),
             `ComptimeList element at index ${i.to_string()} has incompatible type:
 - Expected: ${type_to_string(expected_element_type)}
-- Given   : ${type_to_string(info.ty)}`,
-            false,
-            .None
+- Given   : ${type_to_string(info.ty)}`
           )
         )
       );
@@ -109,9 +105,7 @@ try_to_implement_comptime_list_by_comptime_list_type :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              `Expected compile-time known value for ComptimeList element at index ${i.to_string()}, got ${type_to_string(info.ty)}`,
-              false,
-              .None
+              `Expected compile-time known value for ComptimeList element at index ${i.to_string()}, got ${type_to_string(info.ty)}`
             )
           )
         );

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -993,9 +993,7 @@ _try_expand_call_overload :: (
         format_error_message(
           ast_expr_token(call_expr),
           `No matching call found with arguments:
-${ast_expr_to_string(call_expr)}`,
-          false,
-          .None
+${ast_expr_to_string(call_expr)}`
         )
       )
     );
@@ -1845,9 +1843,7 @@ _evaluate_funcval_runtime_call :: (
                       dyn(
                         format_error_message(
                           ast_expr_token(expr),
-                          _ac_mmsg,
-                          false,
-                          .None
+                          _ac_mmsg
                         )
                       )
                     );
@@ -2777,9 +2773,7 @@ evaluate_function_call :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `No matching call found for operator "${op_name}" with receiver type "${type_to_string(receiver_ty)}"`,
-            false,
-            .None
+            `No matching call found for operator "${op_name}" with receiver type "${type_to_string(receiver_ty)}"`
           )
         )
       );
@@ -3301,9 +3295,7 @@ C functions are outside Yo's type-checking reach — wrong argument types, contr
 
 Fix: wrap the call:
 
-  unsafe(${ast_expr_to_string(expr)})`,
-          false,
-          .None
+  unsafe(${ast_expr_to_string(expr)})`
         )
       )
     );
@@ -3326,9 +3318,7 @@ Fix: wrap the call:
                 dyn(
                   format_error_message(
                     tok,
-                    `Expected 1 body argument for function definition, got ${args.len()}`,
-                    false,
-                    .None
+                    `Expected 1 body argument for function definition, got ${args.len()}`
                   )
                 )
               );
@@ -3353,9 +3343,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       tok,
-                      String.from("evaluate_function_call: closure creation failed"),
-                      false,
-                      .None
+                      String.from("evaluate_function_call: closure creation failed")
                     )
                   )
                 );
@@ -3415,9 +3403,7 @@ Fix: wrap the call:
                           dyn(
                             format_error_message(
                               tok,
-                              String.from("evaluate_function_call: SomeT closure creation failed"),
-                              false,
-                              .None
+                              String.from("evaluate_function_call: SomeT closure creation failed")
                             )
                           )
                         );
@@ -3430,9 +3416,7 @@ Fix: wrap the call:
                       dyn(
                         format_error_message(
                           tok,
-                          String.from("evaluate_function_call: TypeVal SomeT callee without FnTrait (Phase 4)"),
-                          false,
-                          .None
+                          String.from("evaluate_function_call: TypeVal SomeT callee without FnTrait (Phase 4)")
                         )
                       )
                     );
@@ -3462,9 +3446,7 @@ Fix: wrap the call:
                       dyn(
                         format_error_message(
                           tok,
-                          String.from("evaluate_function_call: DynT closure creation failed"),
-                          false,
-                          .None
+                          String.from("evaluate_function_call: DynT closure creation failed")
                         )
                       )
                     );
@@ -3477,9 +3459,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       tok,
-                      String.from("evaluate_function_call: TypeVal DynT callee without FnTrait (Phase 4)"),
-                      false,
-                      .None
+                      String.from("evaluate_function_call: TypeVal DynT callee without FnTrait (Phase 4)")
                     )
                   )
                 );
@@ -3719,9 +3699,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       tok,
-                      String.from("evaluate_function_call: EnumT callee has no selected variant"),
-                      false,
-                      .None
+                      String.from("evaluate_function_call: EnumT callee has no selected variant")
                     )
                   )
                 );
@@ -3749,9 +3727,7 @@ Fix: wrap the call:
                 dyn(
                   format_error_message(
                     tok,
-                    `evaluate_function_call: enum variant not found: ${variant_name}`,
-                    false,
-                    .None
+                    `evaluate_function_call: enum variant not found: ${variant_name}`
                   )
                 )
               );
@@ -3937,9 +3913,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       tok,
-                      String.from("evaluate_function_call: pointer cast expects 1 argument"),
-                      false,
-                      .None
+                      String.from("evaluate_function_call: pointer cast expects 1 argument")
                     )
                   )
                 );
@@ -3955,9 +3929,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       tok,
-                      String.from("evaluate_function_call: pointer type conversion failed"),
-                      false,
-                      .None
+                      String.from("evaluate_function_call: pointer type conversion failed")
                     )
                   )
                 );
@@ -3979,9 +3951,7 @@ Fix: wrap the call:
                     dyn(
                       format_error_message(
                         tok,
-                        String.from("evaluate_function_call: numeric cast expects 1 argument"),
-                        false,
-                        .None
+                        String.from("evaluate_function_call: numeric cast expects 1 argument")
                       )
                     )
                   );
@@ -3997,9 +3967,7 @@ Fix: wrap the call:
                     dyn(
                       format_error_message(
                         tok,
-                        String.from("evaluate_function_call: numeric type conversion failed"),
-                        false,
-                        .None
+                        String.from("evaluate_function_call: numeric type conversion failed")
                       )
                     )
                   );
@@ -4011,9 +3979,7 @@ Fix: wrap the call:
                 dyn(
                   format_error_message(
                     tok,
-                    String.from("evaluate_function_call: TypeVal callee with unsupported type (Phase 5)"),
-                    false,
-                    .None
+                    String.from("evaluate_function_call: TypeVal callee with unsupported type (Phase 5)")
                   )
                 )
               );
@@ -4064,9 +4030,7 @@ Fix: wrap the call:
                 dyn(
                   format_error_message(
                     tok,
-                    `Partial application: expected ${pa_pt.len()} argument(s), got ${n_a}`,
-                    false,
-                    .None
+                    `Partial application: expected ${pa_pt.len()} argument(s), got ${n_a}`
                   )
                 )
               );
@@ -4375,7 +4339,7 @@ Fix: wrap the call:
           if(n_required_reg != n_p, {
             fv_count_msg = `Argument count mismatch: expected ${(n_required_reg + n_ev)}..${(n_p + n_ev)}, got ${n_a}`;
           });
-          exn.throw(dyn(format_error_message(tok, fv_count_msg, false, .None)));
+          exn.throw(dyn(format_error_message(tok, fv_count_msg)));
         });
         // Number of regular args actually supplied (the rest of `n_a` are
         // evidence args, which follow the regulars in `evaled_arg_infos`).
@@ -4511,9 +4475,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       ast_expr_token(cl_label_expr),
-                      `Expected identifier for label, got:\n${ast_expr_to_string(cl_label_expr)}`,
-                      false,
-                      .None
+                      `Expected identifier for label, got:\n${ast_expr_to_string(cl_label_expr)}`
                     )
                   )
                 );
@@ -4525,9 +4487,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       ast_expr_token(cl_label_expr),
-                      String.from("Named argument call is not allowed for this parameter (it has no label)."),
-                      false,
-                      .None
+                      String.from("Named argument call is not allowed for this parameter (it has no label).")
                     )
                   )
                 );
@@ -4537,9 +4497,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       ast_expr_token(cl_label_expr),
-                      `Named argument is not supported. Label is only used for readibility.\n    Expected label "${cl_param_label}" at the argument position, but got "${cl_label}".`,
-                      false,
-                      .None
+                      `Named argument is not supported. Label is only used for readibility.\n    Expected label "${cl_param_label}" at the argument position, but got "${cl_label}".`
                     )
                   )
                 );
@@ -4830,9 +4788,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       ast_expr_token(arg_expr),
-                      String.from("evaluate_function_call: arg not evaluated"),
-                      false,
-                      .None
+                      String.from("evaluate_function_call: arg not evaluated")
                     )
                   )
                 );
@@ -5349,9 +5305,7 @@ Fix: wrap the call:
                     ast_expr_token(match(fv_args.get(pi), .Some(ae) => ae, .None => expr)),
                     `Incompatible type with expected type:
 - Expected: ${type_to_string(resolved_decl_pt)}
-- Actual  : ${type_to_string(etc_arg_ty)}`,
-                    false,
-                    .None
+- Actual  : ${type_to_string(etc_arg_ty)}`
                   )
                 )
               );
@@ -5718,9 +5672,7 @@ Fix: wrap the call:
                   dyn(
                     format_error_message(
                       tok,
-                      String.from("Expected macro function to return an Expr value."),
-                      false,
-                      .None
+                      String.from("Expected macro function to return an Expr value.")
                     )
                   )
                 );
@@ -6760,9 +6712,7 @@ Fix: wrap the call:
                 format_error_message(
                   ast_expr_token(func_expr),
                   `No matching call found with arguments:
-${ast_expr_to_string(expr)}`,
-                  false,
-                  .None
+${ast_expr_to_string(expr)}`
                 )
               )
             );

--- a/src/evaluator/calls/function_type.yo
+++ b/src/evaluator/calls/function_type.yo
@@ -878,9 +878,7 @@ try_to_implement_function_by_function_type :: (
               tok,
               `A function's result type cannot be control-bound (transitively contain a \`ctl(...) -> ret\` function type). A \`ctl\` handler unwinds the frame it is installed in at the throw site; returning one out of its defining function would let it be invoked after that frame is gone. Pass the handler (or the record holding it) downward as a parameter instead.
 
-Result type: ${type_to_string(result_box)}`,
-              false,
-              .None
+Result type: ${type_to_string(result_box)}`
             )
           )
         );
@@ -896,9 +894,7 @@ Result type: ${type_to_string(result_box)}`,
           dyn(
             format_error_message(
               tok,
-              `Expected 1 argument for function body, got ${args.len()}`,
-              false,
-              .None
+              `Expected 1 argument for function body, got ${args.len()}`
             )
           )
         );
@@ -1340,7 +1336,7 @@ Result type: ${type_to_string(result_box)}`,
           if(flow_violation_pending(), {
             viol_msg := flow_violation_message();
             clear_flow_violation();
-            exn.throw(dyn(format_error_message(ast_expr_token(fb), viol_msg, false, .None)));
+            exn.throw(dyn(format_error_message(ast_expr_token(fb), viol_msg)));
           });
           // FATAL (TS parity, function-type.ts:499): this is the CONCRETE-fn
           // path — TS's evaluateBeginExpression here has NO catch, so a
@@ -1378,9 +1374,7 @@ Result type: ${type_to_string(result_box)}`,
               dyn(
                 format_error_message(
                   ast_expr_token(fb),
-                  String.from("Function body raised a compile-time error during definition-time evaluation."),
-                  false,
-                  .None
+                  String.from("Function body raised a compile-time error during definition-time evaluation.")
                 )
               )
             );
@@ -1406,9 +1400,7 @@ Result type: ${type_to_string(result_box)}`,
                 dyn(
                   format_error_message(
                     ast_expr_token(seb),
-                    `Function returning '${type_to_string(result_box)}' carries a raw pointer in its representation; the returned value must be rooted in caller-owned storage. The body's final expression is not flowable:\n  ${ast_expr_to_string(seb)}`,
-                    false,
-                    .None
+                    `Function returning '${type_to_string(result_box)}' carries a raw pointer in its representation; the returned value must be rooted in caller-owned storage. The body's final expression is not flowable:\n  ${ast_expr_to_string(seb)}`
                   )
                 )
               );
@@ -1558,7 +1550,7 @@ Result type: ${type_to_string(result_box)}`,
                 hard_swallow_diagnostic(_trial_swallow_message()),
                 .Some(fwd_msg) => {
                   _clear_trial_swallow();
-                  exn.throw(dyn(format_error_message(ast_expr_token(body_expr), fwd_msg, false, .None)));
+                  exn.throw(dyn(format_error_message(ast_expr_token(body_expr), fwd_msg)));
                 },
                 .None => ()
               );
@@ -1633,9 +1625,7 @@ Result type: ${type_to_string(result_box)}`,
                       dyn(
                         format_error_message(
                           tok,
-                          `Incompatible function return type for:\n- Expected: ${dg_exp_str}\n- Given  : ${dg_got_str}`,
-                          false,
-                          .None
+                          `Incompatible function return type for:\n- Expected: ${dg_exp_str}\n- Given  : ${dg_got_str}`
                         )
                       )
                     );
@@ -1655,9 +1645,7 @@ Result type: ${type_to_string(result_box)}`,
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("try_to_implement_function_by_function_type: expected Func type"),
-            false,
-            .None
+            String.from("try_to_implement_function_by_function_type: expected Func type")
           )
         )
       );

--- a/src/evaluator/calls/helper.yo
+++ b/src/evaluator/calls/helper.yo
@@ -414,9 +414,7 @@ validate_function_return_type :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(expr),
-                        String.from("Failed to infer the function call return type.\nPlease consider providing the expected type."),
-                        false,
-                        .None
+                        String.from("Failed to infer the function call return type.\nPlease consider providing the expected type.")
                       )
                     )
                   );
@@ -667,9 +665,7 @@ check_if_function_parameter_matches_argument :: (
         dyn(
           format_error_message(
             ast_expr_token(cl_label_expr),
-            `Expected identifier for label, got:\n${ast_expr_to_string(cl_label_expr)}`,
-            false,
-            .None
+            `Expected identifier for label, got:\n${ast_expr_to_string(cl_label_expr)}`
           )
         )
       );
@@ -680,9 +676,7 @@ check_if_function_parameter_matches_argument :: (
         dyn(
           format_error_message(
             ast_expr_token(cl_label_expr),
-            String.from("Named argument call is not allowed for this parameter (it has no label)."),
-            false,
-            .None
+            String.from("Named argument call is not allowed for this parameter (it has no label).")
           )
         )
       );
@@ -692,9 +686,7 @@ check_if_function_parameter_matches_argument :: (
         dyn(
           format_error_message(
             ast_expr_token(cl_label_expr),
-            `Named argument is not supported. Label is only used for readibility.\n    Expected label "${param_label}" at the argument position, but got "${cl_label}".`,
-            false,
-            .None
+            `Named argument is not supported. Label is only used for readibility.\n    Expected label "${param_label}" at the argument position, but got "${cl_label}".`
           )
         )
       );
@@ -750,9 +742,7 @@ check_if_function_parameter_matches_argument :: (
         dyn(
           format_error_message(
             ast_expr_token(actual_arg),
-            String.from("check_if_function_parameter_matches_argument: arg has no ExprInfo"),
-            false,
-            .None
+            String.from("check_if_function_parameter_matches_argument: arg has no ExprInfo")
           )
         )
       );
@@ -902,9 +892,7 @@ check_if_function_parameter_matches_argument :: (
         dyn(
           format_error_message(
             ast_expr_token(actual_arg),
-            `Cannot assign runtime argument to compile-time parameter "${param_label}"`,
-            false,
-            .None
+            `Cannot assign runtime argument to compile-time parameter "${param_label}"`
           )
         )
       );
@@ -960,9 +948,7 @@ ${ast_expr_to_string(actual_arg)}`
             dyn(
               format_error_message(
                 ast_expr_token(actual_arg),
-                `Value mismatch for parameter "${param_label}"`,
-                false,
-                .None
+                `Value mismatch for parameter "${param_label}"`
               )
             )
           );
@@ -1073,9 +1059,7 @@ ${ast_expr_to_string(actual_arg)}`
       dyn(
         format_error_message(
           ast_expr_token(actual_arg),
-          `Type mismatch for parameter "${param_label}":\n- Expected: ${type_to_string(final_pt)}\n- Got     : ${type_to_string(arg_type)}`,
-          false,
-          .None
+          `Type mismatch for parameter "${param_label}":\n- Expected: ${type_to_string(final_pt)}\n- Got     : ${type_to_string(arg_type)}`
         )
       )
     );
@@ -4356,9 +4340,7 @@ validate_where_constraints_for_call :: (
                       dyn(
                         format_error_message(
                           tok,
-                          `Type ${type_to_string(bound_ty)} must NOT implement ${type_to_string(wce.trait_ty)}, but it does.`,
-                          false,
-                          .None
+                          `Type ${type_to_string(bound_ty)} must NOT implement ${type_to_string(wce.trait_ty)}, but it does.`
                         )
                       )
                     );
@@ -4369,9 +4351,7 @@ validate_where_constraints_for_call :: (
                       dyn(
                         format_error_message(
                           tok,
-                          `Type ${type_to_string(bound_ty)} does not implement required trait ${type_to_string(wce.trait_ty)}.`,
-                          false,
-                          .None
+                          `Type ${type_to_string(bound_ty)} does not implement required trait ${type_to_string(wce.trait_ty)}.`
                         )
                       )
                     );
@@ -4978,9 +4958,7 @@ try_to_call_function_with_arguments :: (
           dyn(
             format_error_message(
               tok,
-              count_msg,
-              false,
-              .None
+              count_msg
             )
           )
         );
@@ -6193,9 +6171,7 @@ try_to_call_function_with_arguments :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(ebc_arg),
-                            `Effect argument does not match the future's effect bundle:\n- The future's effect type: ${type_to_string(ebc_te)}\n- The argument's type      : ${type_to_string(ebc_eff_ty)}\nPass the future's own bundle (e.g. \`IoExn(io : io, exn : exn)\` or a record with exactly its fields, or forward \`e\` inside a handler) — a mismatched record corrupts the task's effect state.`,
-                            false,
-                            .None
+                            `Effect argument does not match the future's effect bundle:\n- The future's effect type: ${type_to_string(ebc_te)}\n- The argument's type      : ${type_to_string(ebc_eff_ty)}\nPass the future's own bundle (e.g. \`IoExn(io : io, exn : exn)\` or a record with exactly its fields, or forward \`e\` inside a handler) — a mismatched record corrupts the task's effect state.`
                           )
                         )
                       );
@@ -6707,9 +6683,7 @@ try_to_call_function_with_arguments :: (
                             dyn(
                               format_error_message(
                                 ast_expr_token(ua_expr),
-                                `Incompatible type for implicit parameter "${impl_label}"`,
-                                false,
-                                .None
+                                `Incompatible type for implicit parameter "${impl_label}"`
                               )
                             )
                           );
@@ -6784,9 +6758,7 @@ try_to_call_function_with_arguments :: (
               dyn(
                 format_error_message(
                   tok,
-                  `No "given" variable found for implicit parameter "${impl_label}"`,
-                  false,
-                  .None
+                  `No "given" variable found for implicit parameter "${impl_label}"`
                 )
               )
             );
@@ -6821,9 +6793,7 @@ try_to_call_function_with_arguments :: (
                 dyn(
                   format_error_message(
                     tok,
-                    `The "given" variable "${given_name}" has no compile-time value`,
-                    false,
-                    .None
+                    `The "given" variable "${given_name}" has no compile-time value`
                   )
                 )
               );

--- a/src/evaluator/calls/index_trait.yo
+++ b/src/evaluator/calls/index_trait.yo
@@ -544,9 +544,7 @@ _try_comptime_element_access :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg_expr),
-                String.from("Invalid integer literal for array/slice index"),
-                false,
-                .None
+                String.from("Invalid integer literal for array/slice index")
               )
             )
           );
@@ -558,9 +556,7 @@ _try_comptime_element_access :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              `Array/slice index out of bounds: ${idx_raw}`,
-              false,
-              .None
+              `Array/slice index out of bounds: ${idx_raw}`
             )
           )
         );
@@ -579,9 +575,7 @@ _try_comptime_element_access :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(arg_expr),
-                      `Array index out of bounds: ${idx_raw}. Expected index in range [0, ${(arr_len - usize(1))}].`,
-                      false,
-                      .None
+                      `Array index out of bounds: ${idx_raw}. Expected index in range [0, ${(arr_len - usize(1))}].`
                     )
                   )
                 );
@@ -594,9 +588,7 @@ _try_comptime_element_access :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(arg_expr),
-                        String.from("Array index out of bounds"),
-                        false,
-                        .None
+                        String.from("Array index out of bounds")
                       )
                     )
                   );
@@ -697,9 +689,7 @@ _try_comptime_array_index :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Failed to evaluate index argument"),
-            false,
-            .None
+            String.from("Failed to evaluate index argument")
           )
         )
       );
@@ -750,9 +740,7 @@ _compute_comptime_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Expected comptime_int index for comptime string index"),
-            false,
-            .None
+            String.from("Expected comptime_int index for comptime string index")
           )
         )
       );
@@ -766,9 +754,7 @@ _compute_comptime_string_index :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              String.from("Invalid integer literal for string index"),
-              false,
-              .None
+              String.from("Invalid integer literal for string index")
             )
           )
         );
@@ -780,9 +766,7 @@ _compute_comptime_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `String index out of bounds: ${idx_raw}`,
-            false,
-            .None
+            `String index out of bounds: ${idx_raw}`
           )
         )
       );
@@ -794,9 +778,7 @@ _compute_comptime_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `String index out of bounds: ${idx_raw}. Expected index in range [0, ${(str_len - usize(1))}].`,
-            false,
-            .None
+            `String index out of bounds: ${idx_raw}. Expected index in range [0, ${(str_len - usize(1))}].`
           )
         )
       );
@@ -813,9 +795,7 @@ _compute_comptime_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `String index ${idx_raw} is not on a UTF-8 character boundary`,
-            false,
-            .None
+            `String index ${idx_raw} is not on a UTF-8 character boundary`
           )
         )
       );
@@ -832,9 +812,7 @@ _compute_comptime_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          String.from("Expected comptime Range value for comptime string range index"),
-          false,
-          .None
+          String.from("Expected comptime Range value for comptime string range index")
         )
       )
     );
@@ -848,9 +826,7 @@ _compute_comptime_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Expected numeric start/end in Range for comptime string range index"),
-            false,
-            .None
+            String.from("Expected numeric start/end in Range for comptime string range index")
           )
         )
       );
@@ -865,9 +841,7 @@ _compute_comptime_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `String slice start index out of bounds: ${start_idx}. Expected index in range [0, ${str_len}].`,
-          false,
-          .None
+          `String slice start index out of bounds: ${start_idx}. Expected index in range [0, ${str_len}].`
         )
       )
     );
@@ -877,9 +851,7 @@ _compute_comptime_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `String slice end index out of bounds: ${end_idx}. Expected index in range [${start_idx}, ${str_len}].`,
-          false,
-          .None
+          `String slice end index out of bounds: ${end_idx}. Expected index in range [${start_idx}, ${str_len}].`
         )
       )
     );
@@ -893,9 +865,7 @@ _compute_comptime_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `String slice start index ${start_idx} is not on a UTF-8 character boundary`,
-          false,
-          .None
+          `String slice start index ${start_idx} is not on a UTF-8 character boundary`
         )
       )
     );
@@ -905,9 +875,7 @@ _compute_comptime_string_index :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `String slice end index ${end_idx} is not on a UTF-8 character boundary`,
-          false,
-          .None
+          `String slice end index ${end_idx} is not on a UTF-8 character boundary`
         )
       )
     );
@@ -942,9 +910,7 @@ _try_comptime_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Failed to evaluate index argument for comptime string indexing"),
-            false,
-            .None
+            String.from("Failed to evaluate index argument for comptime string indexing")
           )
         )
       );
@@ -959,9 +925,7 @@ _try_comptime_string_index :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Failed to evaluate index argument for comptime string indexing"),
-            false,
-            .None
+            String.from("Failed to evaluate index argument for comptime string indexing")
           )
         )
       );
@@ -1458,9 +1422,7 @@ try_to_call_with_index_trait :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Index trait expects exactly 1 argument, got ${arg_exprs.len()}.`,
-          false,
-          .None
+          `Index trait expects exactly 1 argument, got ${arg_exprs.len()}.`
         )
       )
     );
@@ -1473,9 +1435,7 @@ try_to_call_with_index_trait :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("Index trait: missing argument"),
-            false,
-            .None
+            String.from("Index trait: missing argument")
           )
         )
       );
@@ -1580,9 +1540,7 @@ try_to_call_with_index_trait :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Failed to evaluate index argument"),
-            false,
-            .None
+            String.from("Failed to evaluate index argument")
           )
         )
       );
@@ -1622,9 +1580,7 @@ try_to_call_with_index_trait :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("Type does not implement Index for the given argument type."),
-            false,
-            .None
+            String.from("Type does not implement Index for the given argument type.")
           )
         )
       );

--- a/src/evaluator/calls/iso.yo
+++ b/src/evaluator/calls/iso.yo
@@ -78,9 +78,7 @@ evaluate_iso_type_call :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `evaluate_iso_type_call: expected FnCall expr`,
-            false,
-            .None
+            `evaluate_iso_type_call: expected FnCall expr`
           )
         )
       );
@@ -95,9 +93,7 @@ evaluate_iso_type_call :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Iso requires exactly one argument`,
-            false,
-            .None
+            `Iso requires exactly one argument`
           )
         )
       );
@@ -111,9 +107,7 @@ evaluate_iso_type_call :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `Failed to evaluate the argument expression for Iso`,
-          false,
-          .None
+          `Failed to evaluate the argument expression for Iso`
         )
       )
     );
@@ -129,9 +123,7 @@ evaluate_iso_type_call :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `Iso expects a type as argument`,
-          false,
-          .None
+          `Iso expects a type as argument`
         )
       )
     );
@@ -155,9 +147,7 @@ evaluate_iso_type_call :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Iso(Arc(T)) is not allowed.\n  - To send an Arc handle across a thread, send the Arc directly — the spawn closure already consumes it. Iso adds nothing.\n  - If you want unique-owned heap data, use Iso(Box(T)) or Iso(...your struct...).`,
-          false,
-          .None
+          `Iso(Arc(T)) is not allowed.\n  - To send an Arc handle across a thread, send the Arc directly — the spawn closure already consumes it. Iso adds nothing.\n  - If you want unique-owned heap data, use Iso(Box(T)) or Iso(...your struct...).`
         )
       )
     );
@@ -266,9 +256,7 @@ evaluate_iso_value_call :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Iso value constructor requires exactly one argument`,
-            false,
-            .None
+            `Iso value constructor requires exactly one argument`
           )
         )
       );
@@ -286,9 +274,7 @@ evaluate_iso_value_call :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `Failed to evaluate argument for Iso value constructor`,
-          false,
-          .None
+          `Failed to evaluate argument for Iso value constructor`
         )
       )
     );
@@ -313,9 +299,7 @@ evaluate_iso_value_call :: (
               dyn(
                 format_error_message(
                   ast_expr_token(arg_expr),
-                  `Variable ${var_name} not found in env.`,
-                  false,
-                  .None
+                  `Variable ${var_name} not found in env.`
                 )
               )
             );
@@ -328,9 +312,7 @@ evaluate_iso_value_call :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg_expr),
-                `Cannot isolate variable ${var_name} because its type may form RC cycles.`,
-                false,
-                .None
+                `Cannot isolate variable ${var_name} because its type may form RC cycles.`
               )
             )
           );
@@ -341,9 +323,7 @@ evaluate_iso_value_call :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg_expr),
-                `Cannot isolate variable ${var_name} because it does not own its RC value.`,
-                false,
-                .None
+                `Cannot isolate variable ${var_name} because it does not own its RC value.`
               )
             )
           );
@@ -359,9 +339,7 @@ evaluate_iso_value_call :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg_expr),
-                `Cannot isolate ${var_name}, also owned by: ${alias_list}\nIso requires unique ownership (no aliases). Drop other aliases first.`,
-                false,
-                .None
+                `Cannot isolate ${var_name}, also owned by: ${alias_list}\nIso requires unique ownership (no aliases). Drop other aliases first.`
               )
             )
           );
@@ -371,9 +349,7 @@ evaluate_iso_value_call :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              `Variable ${var_name} not found in the environment.`,
-              false,
-              .None
+              `Variable ${var_name} not found in the environment.`
             )
           )
         );

--- a/src/evaluator/calls/numeric_type.yo
+++ b/src/evaluator/calls/numeric_type.yo
@@ -264,9 +264,7 @@ try_to_convert_to_numeric_type :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `Failed to evaluate argument: ${ast_expr_to_string(arg_expr)}`,
-          false,
-          .None
+          `Failed to evaluate argument: ${ast_expr_to_string(arg_expr)}`
         )
       )
     );
@@ -300,9 +298,7 @@ try_to_convert_to_numeric_type :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(arg_expr),
-                            `Failed to get discriminant for enum variant "${variant}"`,
-                            false,
-                            .None
+                            `Failed to get discriminant for enum variant "${variant}"`
                           )
                         )
                       );
@@ -388,9 +384,7 @@ try_to_convert_to_numeric_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Cannot convert runtime value to ${type_to_string(target_type)}. Only compile-time values can be converted to ${type_to_string(target_type)}.`,
-            false,
-            .None
+            `Cannot convert runtime value to ${type_to_string(target_type)}. Only compile-time values can be converted to ${type_to_string(target_type)}.`
           )
         )
       );
@@ -478,9 +472,7 @@ try_to_convert_to_numeric_type :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("Unexpected case in numeric type conversion"),
-            false,
-            .None
+            String.from("Unexpected case in numeric type conversion")
           )
         )
       );

--- a/src/evaluator/calls/pointer.yo
+++ b/src/evaluator/calls/pointer.yo
@@ -67,9 +67,7 @@ evaluate_raw_pointer_call :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Failed to evaluate the argument expression for pointer:\n${ast_expr_to_string(arg_expr)}`,
-            false,
-            .None
+            `Failed to evaluate the argument expression for pointer:\n${ast_expr_to_string(arg_expr)}`
           )
         )
       );
@@ -100,9 +98,7 @@ evaluate_raw_pointer_call :: (
           dyn(
             format_error_message(
               ptok,
-              `Raw pointer types ('*(${type_to_string(inner_ty)})') are not available in safe code.\n\nUse 'ArrayList(T)' (or 'Array(T, N)') for bounded byte/element storage, 'inout(name) : T' parameters for in-place mutation, or wrap the underlying pointer in an 'object' type. If this file genuinely needs raw pointers, add 'pragma(Pragma.AllowUnsafe);' at the top — but consider whether the unsafe surface really belongs in this module.`,
-              false,
-              .None
+              `Raw pointer types ('*(${type_to_string(inner_ty)})') are not available in safe code.\n\nUse 'ArrayList(T)' (or 'Array(T, N)') for bounded byte/element storage, 'inout(name) : T' parameters for in-place mutation, or wrap the underlying pointer in an 'object' type. If this file genuinely needs raw pointers, add 'pragma(Pragma.AllowUnsafe);' at the top — but consider whether the unsafe surface really belongs in this module.`
             )
           )
         );
@@ -121,9 +117,7 @@ evaluate_raw_pointer_call :: (
 
 Pointee type: ${type_to_string(inner_ty)}
 
-If you need to thread a handler through code, pass it by value (handlers are fn-pointer-sized; copying is free).`,
-              false,
-              .None
+If you need to thread a handler through code, pass it by value (handlers are fn-pointer-sized; copying is free).`
             )
           )
         );
@@ -145,9 +139,7 @@ If you need to thread a handler through code, pass it by value (handlers are fn-
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Cannot create a pointer to a value. Use "&" to create a pointer to a value:\n${ast_expr_to_string(arg_expr)}`,
-            false,
-            .None
+            `Cannot create a pointer to a value. Use "&" to create a pointer to a value:\n${ast_expr_to_string(arg_expr)}`
           )
         )
       );

--- a/src/evaluator/calls/pointer_type.yo
+++ b/src/evaluator/calls/pointer_type.yo
@@ -68,9 +68,7 @@ try_to_convert_to_pointer_type :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `Failed to evaluate argument: ${ast_expr_to_string(arg_expr)}`,
-          false,
-          .None
+          `Failed to evaluate argument: ${ast_expr_to_string(arg_expr)}`
         )
       )
     );
@@ -117,9 +115,7 @@ try_to_convert_to_pointer_type :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `Cannot cast ${type_to_string(arg_type)} to ${type_to_string(target_type)}. Expected a pointer type or comptime_str.`,
-          false,
-          .None
+          `Cannot cast ${type_to_string(arg_type)} to ${type_to_string(target_type)}. Expected a pointer type or comptime_str.`
         )
       )
     );

--- a/src/evaluator/calls/record_type.yo
+++ b/src/evaluator/calls/record_type.yo
@@ -92,9 +92,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
       dyn(
         format_error_message(
           ast_expr_token(module_expr),
-          String.from("Failed to implement the module. Too many fields provided."),
-          false,
-          .None
+          String.from("Failed to implement the module. Too many fields provided.")
         )
       )
     );
@@ -125,9 +123,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              `Expected member label, but got:\n${ast_expr_to_string(arg_expr)}`,
-              false,
-              .None
+              `Expected member label, but got:\n${ast_expr_to_string(arg_expr)}`
             )
           )
         );
@@ -139,7 +135,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
         label_sub_opt,
         .Some(s) => s,
         .None => {
-          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), String.from("Label arg missing label sub-expr."), false, .None)));
+          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), String.from("Label arg missing label sub-expr."))));
           arg_expr
         }
       );
@@ -147,7 +143,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
         value_sub_opt,
         .Some(s) => s,
         .None => {
-          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), String.from("Label arg missing value sub-expr."), false, .None)));
+          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), String.from("Label arg missing value sub-expr."))));
           arg_expr
         }
       );
@@ -156,9 +152,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
           dyn(
             format_error_message(
               ast_expr_token(label_sub),
-              `Expected identifier for label, got:\n${ast_expr_to_string(label_sub)}`,
-              false,
-              .None
+              `Expected identifier for label, got:\n${ast_expr_to_string(label_sub)}`
             )
           )
         );
@@ -185,9 +179,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
           dyn(
             format_error_message(
               ast_expr_token(label_sub),
-              `Module member with label "${label_tok}" does not exist in the module type.`,
-              false,
-              .None
+              `Module member with label "${label_tok}" does not exist in the module type.`
             )
           )
         );
@@ -206,9 +198,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(value_sub),
-                `Failed to evaluate module member "${field_label}".`,
-                false,
-                .None
+                `Failed to evaluate module member "${field_label}".`
               )
             )
           );
@@ -222,9 +212,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(value_sub),
-                `Type mismatch for the module member "${field_label}":\nExpected: ${type_to_string(field_type)}\nGot:   ${type_to_string(arg_type)}`,
-                false,
-                .None
+                `Type mismatch for the module member "${field_label}":\nExpected: ${type_to_string(field_type)}\nGot:   ${type_to_string(arg_type)}`
               )
             )
           );
@@ -243,9 +231,7 @@ try_to_implement_module_with_arguments_by_module_type :: (
         dyn(
           format_error_message(
             ast_expr_token(module_expr),
-            `Module member "${field_label}" is not provided and has no required/default value.`,
-            false,
-            .None
+            `Module member "${field_label}" is not provided and has no required/default value.`
           )
         )
       );

--- a/src/evaluator/calls/trait_type.yo
+++ b/src/evaluator/calls/trait_type.yo
@@ -107,9 +107,7 @@ try_to_specialize_trait_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `Expected ":=" for trait specialization (binding associated types), got:\n${ast_expr_to_string(arg)}`,
-            false,
-            .None
+            `Expected ":=" for trait specialization (binding associated types), got:\n${ast_expr_to_string(arg)}`
           )
         )
       );
@@ -120,7 +118,7 @@ try_to_specialize_trait_type :: (
       label_sub_opt,
       .Some(s) => s,
       .None => {
-        exn.throw(dyn(format_error_message(ast_expr_token(arg), String.from("Missing label in :="), false, .None)));
+        exn.throw(dyn(format_error_message(ast_expr_token(arg), String.from("Missing label in :="))));
         arg
       }
     );
@@ -128,7 +126,7 @@ try_to_specialize_trait_type :: (
       value_sub_opt,
       .Some(s) => s,
       .None => {
-        exn.throw(dyn(format_error_message(ast_expr_token(arg), String.from("Missing value in :="), false, .None)));
+        exn.throw(dyn(format_error_message(ast_expr_token(arg), String.from("Missing value in :="))));
         arg
       }
     );
@@ -137,9 +135,7 @@ try_to_specialize_trait_type :: (
         dyn(
           format_error_message(
             ast_expr_token(label_sub),
-            `Expected identifier for associated type label, got:\n${ast_expr_to_string(label_sub)}`,
-            false,
-            .None
+            `Expected identifier for associated type label, got:\n${ast_expr_to_string(label_sub)}`
           )
         )
       );
@@ -165,9 +161,7 @@ try_to_specialize_trait_type :: (
         dyn(
           format_error_message(
             ast_expr_token(label_sub),
-            `Field "${label_tok}" not found in trait "${trait_name}".`,
-            false,
-            .None
+            `Field "${label_tok}" not found in trait "${trait_name}".`
           )
         )
       );
@@ -192,9 +186,7 @@ try_to_specialize_trait_type :: (
         dyn(
           format_error_message(
             ast_expr_token(label_sub),
-            `Field "${label_tok}" is not an associated type. Only associated type fields can be constrained with ":=".`,
-            false,
-            .None
+            `Field "${label_tok}" is not an associated type. Only associated type fields can be constrained with ":=".`
           )
         )
       );
@@ -207,9 +199,7 @@ try_to_specialize_trait_type :: (
         dyn(
           format_error_message(
             ast_expr_token(value_sub),
-            `Expected type for associated type constraint "${label_tok}", got:\n${ast_expr_to_string(value_sub)}`,
-            false,
-            .None
+            `Expected type for associated type constraint "${label_tok}", got:\n${ast_expr_to_string(value_sub)}`
           )
         )
       );
@@ -280,9 +270,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
       dyn(
         format_error_message(
           ast_expr_token(trait_expr),
-          String.from("Failed to implement the trait. Too many fields provided."),
-          false,
-          .None
+          String.from("Failed to implement the trait. Too many fields provided.")
         )
       )
     );
@@ -293,9 +281,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
       dyn(
         format_error_message(
           ast_expr_token(trait_expr),
-          String.from("Receiver type is undefined when implementing trait.\nPlease use \"impl\" to specify the receiver type explicitly."),
-          false,
-          .None
+          String.from("Receiver type is undefined when implementing trait.\nPlease use \"impl\" to specify the receiver type explicitly.")
         )
       )
     );
@@ -370,9 +356,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              `Expected member label, but got:\n${ast_expr_to_string(arg_expr)}`,
-              false,
-              .None
+              `Expected member label, but got:\n${ast_expr_to_string(arg_expr)}`
             )
           )
         );
@@ -383,7 +367,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
         label_sub_opt,
         .Some(s) => s,
         .None => {
-          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), String.from("Label arg missing label sub-expr."), false, .None)));
+          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), String.from("Label arg missing label sub-expr."))));
           arg_expr
         }
       );
@@ -391,7 +375,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
         value_sub_opt,
         .Some(s) => s,
         .None => {
-          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), String.from("Label arg missing value sub-expr."), false, .None)));
+          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), String.from("Label arg missing value sub-expr."))));
           arg_expr
         }
       );
@@ -400,9 +384,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
           dyn(
             format_error_message(
               ast_expr_token(label_sub),
-              `Expected identifier for label, got:\n${ast_expr_to_string(label_sub)}`,
-              false,
-              .None
+              `Expected identifier for label, got:\n${ast_expr_to_string(label_sub)}`
             )
           )
         );
@@ -428,9 +410,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
           dyn(
             format_error_message(
               ast_expr_token(label_sub),
-              `Trait member with label "${label_tok}" does not exist in the trait type.`,
-              false,
-              .None
+              `Trait member with label "${label_tok}" does not exist in the trait type.`
             )
           )
         );
@@ -448,9 +428,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(value_sub),
-                `Failed to evaluate trait member "${field_label}".`,
-                false,
-                .None
+                `Failed to evaluate trait member "${field_label}".`
               )
             )
           );
@@ -464,9 +442,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(value_sub),
-                `Type mismatch for the trait member "${field_label}":\nExpected: ${type_to_string(field_type)}\nGot:   ${type_to_string(arg_type)}`,
-                false,
-                .None
+                `Type mismatch for the trait member "${field_label}":\nExpected: ${type_to_string(field_type)}\nGot:   ${type_to_string(arg_type)}`
               )
             )
           );
@@ -485,9 +461,7 @@ try_to_implement_trait_with_arguments_by_trait_type :: (
         dyn(
           format_error_message(
             ast_expr_token(trait_expr),
-            `Trait member "${field_label}" is not provided and has no required/default value.`,
-            false,
-            .None
+            `Trait member "${field_label}" is not provided and has no required/default value.`
           )
         )
       );

--- a/src/evaluator/calls/type.yo
+++ b/src/evaluator/calls/type.yo
@@ -87,9 +87,7 @@ try_to_call_type_with_arguments :: (
       dyn(
         format_error_message(
           ast_expr_token(function_callee_expr),
-          `Failed to call the type. Too many members provided. Expected ${n_fields.to_string()} arguments, got ${n_args.to_string()}.`,
-          false,
-          .None
+          `Failed to call the type. Too many members provided. Expected ${n_fields.to_string()} arguments, got ${n_args.to_string()}.`
         )
       )
     );
@@ -99,9 +97,7 @@ try_to_call_type_with_arguments :: (
       dyn(
         format_error_message(
           ast_expr_token(function_callee_expr),
-          `Failed to call the union type. Expected exactly one argument, got ${n_args.to_string()}.`,
-          false,
-          .None
+          `Failed to call the union type. Expected exactly one argument, got ${n_args.to_string()}.`
         )
       )
     );
@@ -137,9 +133,7 @@ try_to_call_type_with_arguments :: (
           dyn(
             format_error_message(
               ast_expr_token(arg_expr),
-              `No field at index ${i.to_string()} in type.`,
-              false,
-              .None
+              `No field at index ${i.to_string()} in type.`
             )
           )
         );
@@ -158,7 +152,7 @@ try_to_call_type_with_arguments :: (
         label_sub_opt,
         .Some(s) => s,
         .None => {
-          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), `Label arg missing label sub-expr.`, false, .None)));
+          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), `Label arg missing label sub-expr.`)));
           arg_expr
         }
       );
@@ -166,7 +160,7 @@ try_to_call_type_with_arguments :: (
         value_sub_opt,
         .Some(s) => s,
         .None => {
-          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), `Label arg missing value sub-expr.`, false, .None)));
+          exn.throw(dyn(format_error_message(ast_expr_token(arg_expr), `Label arg missing value sub-expr.`)));
           arg_expr
         }
       );
@@ -175,9 +169,7 @@ try_to_call_type_with_arguments :: (
           dyn(
             format_error_message(
               ast_expr_token(label_sub),
-              `Expected identifier for label, got:\n${ast_expr_to_string(label_sub)}`,
-              false,
-              .None
+              `Expected identifier for label, got:\n${ast_expr_to_string(label_sub)}`
             )
           )
         );
@@ -208,9 +200,7 @@ try_to_call_type_with_arguments :: (
               dyn(
                 format_error_message(
                   ast_expr_token(value_sub),
-                  `Cannot use label "${found_field.label}" for already assigned value:\n${found_field.label}: ${type_to_string(found_field.ty)}`,
-                  false,
-                  .None
+                  `Cannot use label "${found_field.label}" for already assigned value:\n${found_field.label}: ${type_to_string(found_field.ty)}`
                 )
               )
             );
@@ -224,9 +214,7 @@ try_to_call_type_with_arguments :: (
             dyn(
               format_error_message(
                 ast_expr_token(value_sub),
-                `Failed to find "${label_tok}" in the type.`,
-                false,
-                .None
+                `Failed to find "${label_tok}" in the type.`
               )
             )
           );
@@ -239,9 +227,7 @@ try_to_call_type_with_arguments :: (
         dyn(
           format_error_message(
             ast_expr_token(actual_arg_expr),
-            `Type member "${member_element.label}" is already implemented.`,
-            false,
-            .None
+            `Type member "${member_element.label}" is already implemented.`
           )
         )
       );
@@ -266,9 +252,7 @@ try_to_call_type_with_arguments :: (
         dyn(
           format_error_message(
             ast_expr_token(actual_arg_expr),
-            `Failed to evaluate argument expression:\n${ast_expr_to_string(actual_arg_expr)}`,
-            false,
-            .None
+            `Failed to evaluate argument expression:\n${ast_expr_to_string(actual_arg_expr)}`
           )
         )
       );
@@ -341,9 +325,7 @@ try_to_call_type_with_arguments :: (
         dyn(
           format_error_message(
             ast_expr_token(actual_arg_expr),
-            `Type mismatch for type member "${member_element.label}":\nExpected: ${type_to_string(member_element.ty)}\nGot:   ${type_to_string(arg_type)}`,
-            false,
-            .None
+            `Type mismatch for type member "${member_element.label}":\nExpected: ${type_to_string(member_element.ty)}\nGot:   ${type_to_string(arg_type)}`
           )
         )
       );
@@ -383,9 +365,7 @@ try_to_call_type_with_arguments :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(function_callee_expr),
-                    mf_msg,
-                    false,
-                    .None
+                    mf_msg
                   )
                 )
               );

--- a/src/evaluator/exprs/_expr.yo
+++ b/src/evaluator/exprs/_expr.yo
@@ -481,9 +481,7 @@ _evaluate_expression :: (
             dyn(
               format_error_message(
                 tok,
-                `(1) Evaluating the expression (token: ${tok.value}) is not implemented:\n${ast_expr_to_string(expr)}`,
-                false,
-                .None
+                `(1) Evaluating the expression (token: ${tok.value}) is not implemented:\n${ast_expr_to_string(expr)}`
               )
             )
           );
@@ -673,9 +671,7 @@ _evaluate_expression :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(expr),
-                    `"atomic" expects exactly one argument: atomic object(...)`,
-                    false,
-                    .None
+                    `"atomic" expects exactly one argument: atomic object(...)`
                   )
                 )
               );
@@ -707,9 +703,7 @@ _evaluate_expression :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(ref_inner),
-                            `"atomic(ref(...))" wraps an inline "struct(...)" or "enum(...)" literal. Got:\n${ast_expr_to_string(ref_inner)}`,
-                            false,
-                            .None
+                            `"atomic(ref(...))" wraps an inline "struct(...)" or "enum(...)" literal. Got:\n${ast_expr_to_string(ref_inner)}`
                           )
                         )
                       );
@@ -722,9 +716,7 @@ _evaluate_expression :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(inner_expr),
-                        `"atomic" modifier is only valid before "ref(struct(...))". Got:\n${ast_expr_to_string(inner_expr)}`,
-                        false,
-                        .None
+                        `"atomic" modifier is only valid before "ref(struct(...))". Got:\n${ast_expr_to_string(inner_expr)}`
                       )
                     )
                   );
@@ -748,9 +740,7 @@ _evaluate_expression :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(expr),
-                    `"ref" expects exactly one argument: ref(struct(...))`,
-                    false,
-                    .None
+                    `"ref" expects exactly one argument: ref(struct(...))`
                   )
                 )
               );
@@ -773,9 +763,7 @@ _evaluate_expression :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(ref_inner),
-                        `"ref(...)" wraps an inline "struct(...)" or "enum(...)" literal. Got:\n${ast_expr_to_string(ref_inner)}`,
-                        false,
-                        .None
+                        `"ref(...)" wraps an inline "struct(...)" or "enum(...)" literal. Got:\n${ast_expr_to_string(ref_inner)}`
                       )
                     )
                   );

--- a/src/evaluator/exprs/assignment.yo
+++ b/src/evaluator/exprs/assignment.yo
@@ -130,9 +130,7 @@ throw_rhs_contains_control_flow_expression_error :: (
     dyn(
       format_error_message(
         ast_expr_token(rhs),
-        error_msg,
-        false,
-        .None
+        error_msg
       )
     )
   );
@@ -294,9 +292,7 @@ evaluate_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "=" for assignment.`,
-          false,
-          .None
+          `Expected "=" for assignment.`
         )
       )
     );
@@ -332,9 +328,7 @@ evaluate_assignment :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs),
-                `Cannot write to field of atomic object '${ast_expr_to_string(root_expr)}' (type ${type_to_string(atomic_obj_type)}) in safe code. Atomic objects shared across threads must use AtomicX / Mutex / RwLock for mutation. Use Arc(AtomicI32), Arc(Mutex(T)), or Arc(RwLock(T)) instead.`,
-                false,
-                .None
+                `Cannot write to field of atomic object '${ast_expr_to_string(root_expr)}' (type ${type_to_string(atomic_obj_type)}) in safe code. Atomic objects shared across threads must use AtomicX / Mutex / RwLock for mutation. Use Arc(AtomicI32), Arc(Mutex(T)), or Arc(RwLock(T)) instead.`
               )
             )
           );
@@ -356,9 +350,7 @@ evaluate_assignment :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs),
-            `Failed to evaluate left-hand side of assignment: ${ast_expr_to_string(lhs)}`,
-            false,
-            .None
+            `Failed to evaluate left-hand side of assignment: ${ast_expr_to_string(lhs)}`
           )
         )
       );
@@ -375,9 +367,7 @@ evaluate_assignment :: (
         dyn(
           format_error_message(
             ast_expr_token(rhs),
-            `Failed to evaluate right-hand side of assignment: ${ast_expr_to_string(rhs)}`,
-            false,
-            .None
+            `Failed to evaluate right-hand side of assignment: ${ast_expr_to_string(rhs)}`
           )
         )
       );
@@ -449,7 +439,7 @@ evaluate_assignment :: (
         // Flag so a def-time trial-eval swallow re-raises it via the real `exn`
         // (function_type.yo), mirroring the simple-variable assignment gate.
         flag_flow_violation(prop_viol_msg);
-        exn.throw(dyn(format_error_message(ast_expr_token(rhs), prop_viol_msg, false, .None)));
+        exn.throw(dyn(format_error_message(ast_expr_token(rhs), prop_viol_msg)));
       });
     });
     // Step 4 — Type compatibility check
@@ -483,9 +473,7 @@ evaluate_assignment :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs),
-            `Incompatible types:\n- Expected: ${exp_str}\n- Given   : ${rhs_str}`,
-            false,
-            .None
+            `Incompatible types:\n- Expected: ${exp_str}\n- Given   : ${rhs_str}`
           )
         )
       );
@@ -791,9 +779,7 @@ evaluate_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs_resolved),
-          `Cannot reassign "_". Use ":=" to discard a value, or use a named variable for reassignment.`,
-          false,
-          .None
+          `Cannot reassign "_". Use ":=" to discard a value, or use a named variable for reassignment.`
         )
       )
     );
@@ -805,9 +791,7 @@ evaluate_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs_resolved),
-          `Variable ${variable_name} not found in the environment`,
-          false,
-          .None
+          `Variable ${variable_name} not found in the environment`
         )
       )
     );
@@ -836,9 +820,7 @@ evaluate_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs_resolved),
-          `Cannot reassign "${variable_name}".\nYou can mutate fields (e.g., ${variable_name}.field = value) but cannot reassign itself.`,
-          false,
-          .None
+          `Cannot reassign "${variable_name}".\nYou can mutate fields (e.g., ${variable_name}.field = value) but cannot reassign itself.`
         )
       )
     );
@@ -860,9 +842,7 @@ evaluate_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(rhs),
-          `Failed to evaluate right-hand side of assignment: ${ast_expr_to_string(rhs)}`,
-          false,
-          .None
+          `Failed to evaluate right-hand side of assignment: ${ast_expr_to_string(rhs)}`
         )
       )
     );
@@ -899,9 +879,7 @@ ${dgc_ty_str}
 Generic functions must be compile-time known to enable monomorphization. Consider using:
 comptime(${variable_name}) : ${dgc_ty_str}
 
-(Carve-out: a ctl handler whose body always unwinds is accepted automatically; the analysis did not see an all-paths-unwind body.)`,
-            false,
-            .None
+(Carve-out: a ctl handler whose body always unwinds is accepted automatically; the analysis did not see an all-paths-unwind body.)`
           )
         )
       );
@@ -936,7 +914,7 @@ comptime(${variable_name}) : ${dgc_ty_str}
       // Flag the violation so a def-time trial-eval swallow re-raises it via the
       // real `exn` (function_type.yo), mirroring the `inout(name) :=` binding-site.
       flag_flow_violation(viol_msg);
-      exn.throw(dyn(format_error_message(ast_expr_token(rhs), viol_msg, false, .None)));
+      exn.throw(dyn(format_error_message(ast_expr_token(rhs), viol_msg)));
     });
   });
   // Check if the LHS variable was consumed by the RHS (e.g., via own parameter).
@@ -1008,9 +986,7 @@ comptime(${variable_name}) : ${dgc_ty_str}
       dyn(
         format_error_message(
           ast_expr_token(lhs_resolved),
-          `Incompatible types:\n- Expected: ${var_ty_str}\n- Given   : ${rhs_ty_str}`,
-          false,
-          .None
+          `Incompatible types:\n- Expected: ${var_ty_str}\n- Given   : ${rhs_ty_str}`
         )
       )
     );
@@ -1062,7 +1038,7 @@ comptime(${variable_name}) : ${dgc_ty_str}
               error_message : String.from("Defined here:")
             )
           );
-          exn.throw(dyn(format_error_messages(wl_entries, false, .None)));
+          exn.throw(dyn(format_error_messages(wl_entries)));
         });
       },
       .None => ()
@@ -1086,7 +1062,7 @@ comptime(${variable_name}) : ${dgc_ty_str}
                 error_message : String.from("Defined here:")
               )
             );
-            exn.throw(dyn(format_error_messages(of_entries, false, .None)));
+            exn.throw(dyn(format_error_messages(of_entries)));
           });
         },
         _ => ()
@@ -1123,7 +1099,7 @@ comptime(${variable_name}) : ${dgc_ty_str}
           error_message : String.from("First assigned here:")
         )
       );
-      exn.throw(dyn(format_error_messages(ra_entries, false, .None)));
+      exn.throw(dyn(format_error_messages(ra_entries)));
     });
   });
   // Record FIRST-INITIALIZATIONS into the per-branch init log — consumed by

--- a/src/evaluator/exprs/begin.yo
+++ b/src/evaluator/exprs/begin.yo
@@ -531,9 +531,7 @@ _check_keyword_position :: (
       dyn(
         format_error_message(
           ast_expr_token(expr_to_eval),
-          `The "${keyword}" keyword can only be used as the last expression.`,
-          false,
-          .None
+          `The "${keyword}" keyword can only be used as the last expression.`
         )
       )
     );
@@ -1465,9 +1463,7 @@ evaluate_begin_expression :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr_to_eval),
-                String.from("The \"return\" keyword can only be used inside a function body or async block."),
-                false,
-                .None
+                String.from("The \"return\" keyword can only be used inside a function body or async block.")
               )
             )
           );
@@ -1528,9 +1524,7 @@ evaluate_begin_expression :: (
               dyn(
                 format_error_message(
                   ast_expr_token(ret_arg),
-                  String.from("Return expression is not evaluated correctly."),
-                  false,
-                  .None
+                  String.from("Return expression is not evaluated correctly.")
                 )
               )
             );
@@ -1575,9 +1569,7 @@ evaluate_begin_expression :: (
                           dyn(
                             format_error_message(
                               ast_expr_token(ret_arg),
-                              `'return(...)' from a function returning '${type_to_string(rfb)}' carries a raw pointer in its representation; the returned value must be rooted in caller-owned storage. The returned expression is not flowable:\n  ${ast_expr_to_string(ret_arg)}`,
-                              false,
-                              .None
+                              `'return(...)' from a function returning '${type_to_string(rfb)}' carries a raw pointer in its representation; the returned value must be rooted in caller-owned storage. The returned expression is not flowable:\n  ${ast_expr_to_string(ret_arg)}`
                             )
                           )
                         );
@@ -1646,7 +1638,7 @@ evaluate_begin_expression :: (
                             error_message : `Conflicting return has concrete type: ${type_to_string(ret_info.ty)}`
                           )
                         );
-                        exn.throw(dyn(format_error_messages(ir_entries, false, .None)));
+                        exn.throw(dyn(format_error_messages(ir_entries)));
                       });
                     },
                     .None => ()
@@ -1684,9 +1676,7 @@ evaluate_begin_expression :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr_to_eval),
-                String.from("The \"break\" keyword can only be used inside a loop."),
-                false,
-                .None
+                String.from("The \"break\" keyword can only be used inside a loop.")
               )
             )
           );
@@ -1708,9 +1698,7 @@ evaluate_begin_expression :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr_to_eval),
-                String.from("The \"continue\" keyword can only be used inside a loop."),
-                false,
-                .None
+                String.from("The \"continue\" keyword can only be used inside a loop.")
               )
             )
           );
@@ -1732,9 +1720,7 @@ evaluate_begin_expression :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr_to_eval),
-                String.from("The \"unwind\" keyword can only be used inside a function that has an enclosing function."),
-                false,
-                .None
+                String.from("The \"unwind\" keyword can only be used inside a function that has an enclosing function.")
               )
             )
           );
@@ -1751,9 +1737,7 @@ evaluate_begin_expression :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr_to_eval),
-                String.from("The \"unwind\" keyword accepts at most one argument."),
-                false,
-                .None
+                String.from("The \"unwind\" keyword accepts at most one argument.")
               )
             )
           );
@@ -1778,9 +1762,7 @@ evaluate_begin_expression :: (
               dyn(
                 format_error_message(
                   ast_expr_token(expr_to_eval),
-                  `Incompatible type for \`escape\` argument:\n- Expected (enclosing function return type): ${type_to_string(enclosing_ret)}\n- Got: ${type_to_string(TypeValue.Unit)}`,
-                  false,
-                  .None
+                  `Incompatible type for \`escape\` argument:\n- Expected (enclosing function return type): ${type_to_string(enclosing_ret)}\n- Got: ${type_to_string(TypeValue.Unit)}`
                 )
               )
             );
@@ -1809,9 +1791,7 @@ evaluate_begin_expression :: (
               dyn(
                 format_error_message(
                   ast_expr_token(esc_arg),
-                  String.from("Unwind expression is not evaluated correctly."),
-                  false,
-                  .None
+                  String.from("Unwind expression is not evaluated correctly.")
                 )
               )
             );
@@ -1825,9 +1805,7 @@ evaluate_begin_expression :: (
               dyn(
                 format_error_message(
                   ast_expr_token(esc_arg),
-                  `Incompatible type for \`unwind\` argument:\n- Expected: ${type_to_string(enclosing_ret)}\n- Got: ${type_to_string(esc_info.ty)}`,
-                  false,
-                  .None
+                  `Incompatible type for \`unwind\` argument:\n- Expected: ${type_to_string(enclosing_ret)}\n- Got: ${type_to_string(esc_info.ty)}`
                 )
               )
             );
@@ -1936,9 +1914,7 @@ evaluate_begin_expression :: (
       dyn(
         format_error_message(
           ast_expr_token(last_expr),
-          `Last expression in "begin" is not evaluated correctly:\n${ast_expr_to_string(last_expr)}`,
-          false,
-          .None
+          `Last expression in "begin" is not evaluated correctly:\n${ast_expr_to_string(last_expr)}`
         )
       )
     );
@@ -1981,9 +1957,7 @@ evaluate_begin_expression :: (
                           dyn(
                             format_error_message(
                               ast_expr_token(last_expr),
-                              `Return type mismatch. Expected type "${type_to_string(expected_ret)}", but got "${type_to_string(return_type)}".`,
-                              false,
-                              .None
+                              `Return type mismatch. Expected type "${type_to_string(expected_ret)}", but got "${type_to_string(return_type)}".`
                             )
                           )
                         );
@@ -2009,9 +1983,7 @@ evaluate_begin_expression :: (
                       dyn(
                         format_error_message(
                           ast_expr_token(last_expr),
-                          `Return type mismatch. Expected type "${type_to_string(et.ty)}", but got "${type_to_string(return_type)}".`,
-                          false,
-                          .None
+                          `Return type mismatch. Expected type "${type_to_string(et.ty)}", but got "${type_to_string(return_type)}".`
                         )
                       )
                     );

--- a/src/evaluator/exprs/binding.yo
+++ b/src/evaluator/exprs/binding.yo
@@ -99,9 +99,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "${BK_COLON}" for variable binding.`,
-          false,
-          .None
+          `Expected "${BK_COLON}" for variable binding.`
         )
       )
     );
@@ -125,9 +123,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           ast_expr_token(rhs),
-          `Failed to evaluate rhs expression:\n${ast_expr_to_string(rhs)}`,
-          false,
-          .None
+          `Failed to evaluate rhs expression:\n${ast_expr_to_string(rhs)}`
         )
       )
     );
@@ -144,9 +140,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           ast_expr_token(rhs),
-          `Expected type for rhs, got ${ast_expr_to_string(rhs)}`,
-          false,
-          .None
+          `Expected type for rhs, got ${ast_expr_to_string(rhs)}`
         )
       )
     );
@@ -175,9 +169,7 @@ evaluate_binding :: (
         dyn(
           format_error_message(
             ast_expr_token(rhs),
-            `Array type with inferred length '_' is not allowed in type annotations.\nUse explicit length like 'Array(i32, 3)' or omit the type annotation and initialize with 'arr := Array(i32, _)(1, 2, 3)'`,
-            false,
-            .None
+            `Array type with inferred length '_' is not allowed in type annotations.\nUse explicit length like 'Array(i32, 3)' or omit the type annotation and initialize with 'arr := Array(i32, _)(1, 2, 3)'`
           )
         )
       );
@@ -201,9 +193,7 @@ evaluate_binding :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs),
-            `Expected one argument for "comptime", got ${n_comptime_args.to_string()}`,
-            false,
-            .None
+            `Expected one argument for "comptime", got ${n_comptime_args.to_string()}`
           )
         )
       );
@@ -227,9 +217,7 @@ evaluate_binding :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs),
-            `Expected exactly one argument for "given", got ${n_given_args.to_string()}`,
-            false,
-            .None
+            `Expected exactly one argument for "given", got ${n_given_args.to_string()}`
           )
         )
       );
@@ -267,9 +255,7 @@ evaluate_binding :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs),
-            `Unexpected runtime variable binding in a compile-time only function body.`,
-            false,
-            .None
+            `Unexpected runtime variable binding in a compile-time only function body.`
           )
         )
       );
@@ -282,9 +268,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs),
-          `Invalid binding to "${lhs_tok_val}", expected identifier or operator`,
-          false,
-          .None
+          `Invalid binding to "${lhs_tok_val}", expected identifier or operator`
         )
       )
     );
@@ -297,9 +281,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           res_tok,
-          `Operator "${res_tok.value}" is reserved and cannot be bound or overloaded (plans/OPERATOR_SET_AND_PRECEDENCE.md).`,
-          false,
-          .None
+          `Operator "${res_tok.value}" is reserved and cannot be bound or overloaded (plans/OPERATOR_SET_AND_PRECEDENCE.md).`
         )
       )
     );
@@ -324,9 +306,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs),
-          `Expected "comptime" for compile-time known value binding:\n${ty_str}`,
-          false,
-          .None
+          `Expected "comptime" for compile-time known value binding:\n${ty_str}`
         )
       )
     );
@@ -338,9 +318,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs),
-          `Unexpected "comptime" for ${ty_str} which can only be used at runtime.`,
-          false,
-          .None
+          `Unexpected "comptime" for ${ty_str} which can only be used at runtime.`
         )
       )
     );
@@ -357,9 +335,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs),
-          `Runtime variables with generic function types are not allowed:\n${ty_str}\n\nGeneric functions must be compile-time known to enable monomorphization. Consider using:\ncomptime(${variable_name}) : ${ty_str}`,
-          false,
-          .None
+          `Runtime variables with generic function types are not allowed:\n${ty_str}\n\nGeneric functions must be compile-time known to enable monomorphization. Consider using:\ncomptime(${variable_name}) : ${ty_str}`
         )
       )
     );
@@ -375,9 +351,7 @@ evaluate_binding :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs),
-          `Mutable runtime variable "${variable_name}" is not allowed inside an impl block.\nUse "::" for compile-time definitions inside impl.`,
-          false,
-          .None
+          `Mutable runtime variable "${variable_name}" is not allowed inside an impl block.\nUse "::" for compile-time definitions inside impl.`
         )
       )
     );
@@ -411,7 +385,7 @@ evaluate_binding :: (
               error_message : `Variable "${variable_name}" is already defined here (variable shadowing is not allowed):`
             )
           );
-          exn.throw(dyn(format_error_messages(sh_entries, false, .None)));
+          exn.throw(dyn(format_error_messages(sh_entries)));
         },
         .None => ()
       );

--- a/src/evaluator/exprs/c_include.yo
+++ b/src/evaluator/exprs/c_include.yo
@@ -69,9 +69,7 @@ evaluate_c_include :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected c_include, got ${ast_expr_token(expr).value}`,
-          false,
-          .None
+          `Expected c_include, got ${ast_expr_token(expr).value}`
         )
       )
     );
@@ -95,9 +93,7 @@ type-checking reach. To use them, declare at the top of this file:
     pragma(Pragma.AllowUnsafe);
 
 User code should normally call stdlib wrappers (e.g. functions in
-'std/sys', 'std/fs') instead of pulling in C headers directly.`,
-          false,
-          .None
+'std/sys', 'std/fs') instead of pulling in C headers directly.`
         )
       )
     );
@@ -111,9 +107,7 @@ User code should normally call stdlib wrappers (e.g. functions in
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Expected C header file as first argument to c_include, such as:\n\nc_include \"<stdio.h>\" ...;"),
-          false,
-          .None
+          String.from("Expected C header file as first argument to c_include, such as:\n\nc_include \"<stdio.h>\" ...;")
         )
       )
     );
@@ -136,9 +130,7 @@ User code should normally call stdlib wrappers (e.g. functions in
           dyn(
             format_error_message(
               ast_expr_token(c_header_file_arg),
-              `Expected string for C header file argument`,
-              false,
-              .None
+              `Expected string for C header file argument`
             )
           )
         );
@@ -150,9 +142,7 @@ User code should normally call stdlib wrappers (e.g. functions in
         dyn(
           format_error_message(
             ast_expr_token(c_header_file_arg),
-            `Failed to evaluate C header file argument`,
-            false,
-            .None
+            `Failed to evaluate C header file argument`
           )
         )
       );
@@ -171,9 +161,7 @@ User code should normally call stdlib wrappers (e.g. functions in
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Expected C header file as first argument to c_include, such as:\n\nc_include \"<stdio.h>\" ...;"),
-          false,
-          .None
+          String.from("Expected C header file as first argument to c_include, such as:\n\nc_include \"<stdio.h>\" ...;")
         )
       )
     );
@@ -210,9 +198,7 @@ User code should normally call stdlib wrappers (e.g. functions in
         dyn(
           format_error_message(
             err_tok,
-            `Duplicate label "${result.label}" in module`,
-            false,
-            .None
+            `Duplicate label "${result.label}" in module`
           )
         )
       );

--- a/src/evaluator/exprs/cond.yo
+++ b/src/evaluator/exprs/cond.yo
@@ -100,9 +100,7 @@ evaluate_cond :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "cond"`,
-          false,
-          .None
+          `Expected "cond"`
         )
       )
     );
@@ -119,9 +117,7 @@ evaluate_cond :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected at least one statement in "cond", got 0`,
-          false,
-          .None
+          `Expected at least one statement in "cond", got 0`
         )
       )
     );
@@ -139,9 +135,7 @@ evaluate_cond :: (
         dyn(
           format_error_message(
             ast_expr_token(statement),
-            `Expected => for cond statement, got ${ast_expr_to_string(statement)}`,
-            false,
-            .None
+            `Expected => for cond statement, got ${ast_expr_to_string(statement)}`
           )
         )
       );
@@ -200,9 +194,7 @@ evaluate_cond :: (
         dyn(
           format_error_message(
             ast_expr_token(evaluated_cond_expr),
-            `Failed to evaluate condition expression: ${ast_expr_to_string(evaluated_cond_expr)}`,
-            false,
-            .None
+            `Failed to evaluate condition expression: ${ast_expr_to_string(evaluated_cond_expr)}`
           )
         )
       );
@@ -225,9 +217,7 @@ evaluate_cond :: (
         dyn(
           format_error_message(
             ast_expr_token(evaluated_cond_expr),
-            `Expected bool for cond statement, got ${ast_expr_to_string(evaluated_cond_expr)} of type ${type_to_string(cond_info.ty)}`,
-            false,
-            .None
+            `Expected bool for cond statement, got ${ast_expr_to_string(evaluated_cond_expr)} of type ${type_to_string(cond_info.ty)}`
           )
         )
       );
@@ -242,9 +232,7 @@ evaluate_cond :: (
         dyn(
           format_error_message(
             ast_expr_token(evaluated_cond_expr),
-            `Expect the last condition to be compile-time known "true".`,
-            false,
-            .None
+            `Expect the last condition to be compile-time known "true".`
           )
         )
       );
@@ -372,9 +360,7 @@ evaluate_cond :: (
               dyn(
                 format_error_message(
                   ast_expr_token(evaluated_body),
-                  `Expected type for cond statement, got ${ast_expr_to_string(evaluated_body)}`,
-                  false,
-                  .None
+                  `Expected type for cond statement, got ${ast_expr_to_string(evaluated_body)}`
                 )
               )
             );
@@ -480,9 +466,7 @@ evaluate_cond :: (
                       dyn(
                         format_error_message(
                           ast_expr_token(evaluated_case_body),
-                          `Expected type for cond statement, got ${ast_expr_to_string(evaluated_case_body)}`,
-                          false,
-                          .None
+                          `Expected type for cond statement, got ${ast_expr_to_string(evaluated_case_body)}`
                         )
                       )
                     );
@@ -527,9 +511,7 @@ evaluate_cond :: (
                           dyn(
                             format_error_message(
                               ast_expr_token(evaluated_case_body),
-                              `Incompatible type with expected type:\n- Expected: ${type_to_string(et.ty)}\n- Actual  : ${type_to_string(body_einfo.ty)}`,
-                              false,
-                              .None
+                              `Incompatible type with expected type:\n- Expected: ${type_to_string(et.ty)}\n- Actual  : ${type_to_string(body_einfo.ty)}`
                             )
                           )
                         );
@@ -555,9 +537,7 @@ evaluate_cond :: (
                             dyn(
                               format_error_message(
                                 ast_expr_token(evaluated_case_body),
-                                `Incompatible types:\n- Previous: ${type_to_string(vt.ty)}\n- Current : ${type_to_string(body_einfo.ty)}`,
-                                false,
-                                .None
+                                `Incompatible types:\n- Previous: ${type_to_string(vt.ty)}\n- Current : ${type_to_string(body_einfo.ty)}`
                               )
                             )
                           );
@@ -584,9 +564,7 @@ evaluate_cond :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `Failed to determine the type of value from the cond.`,
-                false,
-                .None
+                `Failed to determine the type of value from the cond.`
               )
             )
           );
@@ -646,9 +624,7 @@ evaluate_cond :: (
                           dyn(
                             format_error_message(
                               ast_expr_token(ir_body),
-                              String.from("Branches produce different concrete closure types for an Impl(...) result. Impl(...) uses static dispatch and requires the same concrete type across branches. Consider using Dyn(...) for dynamic dispatch if different concrete types are needed."),
-                              false,
-                              .None
+                              String.from("Branches produce different concrete closure types for an Impl(...) result. Impl(...) uses static dispatch and requires the same concrete type across branches. Consider using Dyn(...) for dynamic dispatch if different concrete types are needed.")
                             )
                           )
                         );
@@ -686,9 +662,7 @@ evaluate_cond :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `No control flows found but expected some.`,
-                false,
-                .None
+                `No control flows found but expected some.`
               )
             )
           );
@@ -701,9 +675,7 @@ evaluate_cond :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(expr),
-                    `All cases in cond are returning from function, but not evaluating in function body.`,
-                    false,
-                    .None
+                    `All cases in cond are returning from function, but not evaluating in function body.`
                   )
                 )
               );
@@ -765,9 +737,7 @@ evaluate_cond :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(expr),
-                      `Failed to determine the return type for cond statement.`,
-                      false,
-                      .None
+                      `Failed to determine the return type for cond statement.`
                     )
                   )
                 );
@@ -808,9 +778,7 @@ evaluate_cond :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(expr),
-                    `All cases in cond use "unwind", but not inside a function with an enclosing function.`,
-                    false,
-                    .None
+                    `All cases in cond use "unwind", but not inside a function with an enclosing function.`
                   )
                 )
               );
@@ -827,9 +795,7 @@ evaluate_cond :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(expr),
-                    `All cases in cond are breaking from loop, but not inside a loop.`,
-                    false,
-                    .None
+                    `All cases in cond are breaking from loop, but not inside a loop.`
                   )
                 )
               );
@@ -846,9 +812,7 @@ evaluate_cond :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(expr),
-                    `All cases in cond are continuing loop, but not inside a loop.`,
-                    false,
-                    .None
+                    `All cases in cond are continuing loop, but not inside a loop.`
                   )
                 )
               );

--- a/src/evaluator/exprs/destructuring_assignment.yo
+++ b/src/evaluator/exprs/destructuring_assignment.yo
@@ -146,9 +146,7 @@ handle_member_destructuring :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs_func),
-          `Expected "_" for non-tuple destructuring, got "${lhs_func_name}"`,
-          false,
-          .None
+          `Expected "_" for non-tuple destructuring, got "${lhs_func_name}"`
         )
       )
     );
@@ -160,9 +158,7 @@ handle_member_destructuring :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs),
-            `Destructuring union type requires a single field, got ${lhs_fields.len()}`,
-            false,
-            .None
+            `Destructuring union type requires a single field, got ${lhs_fields.len()}`
           )
         )
       );
@@ -174,9 +170,7 @@ handle_member_destructuring :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs),
-          `Too many fields in destructuring pattern. Expected at most ${rhs_field_labels.len()}, got ${lhs_fields.len()}`,
-          false,
-          .None
+          `Too many fields in destructuring pattern. Expected at most ${rhs_field_labels.len()}, got ${lhs_fields.len()}`
         )
       )
     );
@@ -229,9 +223,7 @@ handle_member_destructuring :: (
           dyn(
             format_error_message(
               ast_expr_token(lhs_field),
-              `Cannot destructure union type with _, got ${type_to_string(rhs_type)}`,
-              false,
-              .None
+              `Cannot destructure union type with _, got ${type_to_string(rhs_type)}`
             )
           )
         );
@@ -264,9 +256,7 @@ handle_member_destructuring :: (
               dyn(
                 format_error_message(
                   ast_expr_token(lhs_field),
-                  `Destructuring field "${flab}" is not defined in compile-time only context.`,
-                  false,
-                  .None
+                  `Destructuring field "${flab}" is not defined in compile-time only context.`
                 )
               )
             );
@@ -319,9 +309,7 @@ handle_member_destructuring :: (
             dyn(
               format_error_message(
                 ast_expr_token(left_side),
-                `Expected identifier for label in destructuring pattern, got ${ast_expr_token(left_side).value}`,
-                false,
-                .None
+                `Expected identifier for label in destructuring pattern, got ${ast_expr_token(left_side).value}`
               )
             )
           );
@@ -336,9 +324,7 @@ handle_member_destructuring :: (
               dyn(
                 format_error_message(
                   ast_expr_token(lhs_field),
-                  `Label "${label}" being destructured not found.`,
-                  false,
-                  .None
+                  `Label "${label}" being destructured not found.`
                 )
               )
             );
@@ -364,9 +350,7 @@ handle_member_destructuring :: (
             dyn(
               format_error_message(
                 ast_expr_token(right_side),
-                `Nested destructuring is not supported: ${ast_expr_token(right_side).value}`,
-                false,
-                .None
+                `Nested destructuring is not supported: ${ast_expr_token(right_side).value}`
               )
             )
           );
@@ -376,9 +360,7 @@ handle_member_destructuring :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_field),
-                `Label "${label}" being destructured already exists.`,
-                false,
-                .None
+                `Label "${label}" being destructured already exists.`
               )
             )
           );
@@ -404,9 +386,7 @@ handle_member_destructuring :: (
           dyn(
             format_error_message(
               ast_expr_token(lhs_field),
-              `Nested destructuring is not supported: ${ast_expr_token(lhs_field).value}`,
-              false,
-              .None
+              `Nested destructuring is not supported: ${ast_expr_token(lhs_field).value}`
             )
           )
         );
@@ -422,9 +402,7 @@ handle_member_destructuring :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_field),
-                `Cannot destructure union type with positional destructuring, got ${type_to_string(rhs_type)}`,
-                false,
-                .None
+                `Cannot destructure union type with positional destructuring, got ${type_to_string(rhs_type)}`
               )
             )
           );
@@ -434,9 +412,7 @@ handle_member_destructuring :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_field),
-                `Label "${rhs_field_label}" being destructured already exists.`,
-                false,
-                .None
+                `Label "${rhs_field_label}" being destructured already exists.`
               )
             )
           );
@@ -470,9 +446,7 @@ handle_member_destructuring :: (
           dyn(
             format_error_message(
               ast_expr_token(lhs_field),
-              `Unsupported destructuring pattern for: ${ast_expr_token(lhs_field).value}`,
-              false,
-              .None
+              `Unsupported destructuring pattern for: ${ast_expr_token(lhs_field).value}`
             )
           )
         );
@@ -489,9 +463,7 @@ handle_member_destructuring :: (
               dyn(
                 format_error_message(
                   ast_expr_token(lhs_field),
-                  `Destructuring field "${var_name}" is not defined in compile-time only context.`,
-                  false,
-                  .None
+                  `Destructuring field "${var_name}" is not defined in compile-time only context.`
                 )
               )
             );
@@ -576,9 +548,7 @@ evaluate_destructuring_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(rhs),
-          `(1) Expected type for right-hand side, got ${ast_expr_token(rhs).value}`,
-          false,
-          .None
+          `(1) Expected type for right-hand side, got ${ast_expr_token(rhs).value}`
         )
       )
     );
@@ -662,9 +632,7 @@ evaluate_destructuring_assignment :: (
           dyn(
             format_error_message(
               ast_expr_token(rhs),
-              `Expected enum variant name to be determined, got ${type_to_string(rhs_type)}`,
-              false,
-              .None
+              `Expected enum variant name to be determined, got ${type_to_string(rhs_type)}`
             )
           )
         );
@@ -683,9 +651,7 @@ evaluate_destructuring_assignment :: (
           dyn(
             format_error_message(
               ast_expr_token(rhs),
-              `Expected enum variant "${svn}" to be defined, got ${type_to_string(rhs_type)}`,
-              false,
-              .None
+              `Expected enum variant "${svn}" to be defined, got ${type_to_string(rhs_type)}`
             )
           )
         );
@@ -699,9 +665,7 @@ evaluate_destructuring_assignment :: (
         dyn(
           format_error_message(
             ast_expr_token(rhs),
-            `Cannot destructure enum variant "${svn}" without fields, got ${type_to_string(rhs_type)}`,
-            false,
-            .None
+            `Cannot destructure enum variant "${svn}" without fields, got ${type_to_string(rhs_type)}`
           )
         )
       );
@@ -741,9 +705,7 @@ evaluate_destructuring_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(rhs),
-          `Destructuring assignment not supported for the right-hand type: ${type_to_string(rhs_type)}`,
-          false,
-          .None
+          `Destructuring assignment not supported for the right-hand type: ${type_to_string(rhs_type)}`
         )
       )
     );
@@ -752,9 +714,7 @@ evaluate_destructuring_assignment :: (
     dyn(
       format_error_message(
         ast_expr_token(lhs),
-        `Destructuring assignment not supported for the left-hand pattern: ${ast_expr_token(lhs).value}`,
-        false,
-        .None
+        `Destructuring assignment not supported for the left-hand pattern: ${ast_expr_token(lhs).value}`
       )
     )
   );

--- a/src/evaluator/exprs/exists.yo
+++ b/src/evaluator/exprs/exists.yo
@@ -34,9 +34,7 @@ evaluate_exists :: (
     dyn(
       format_error_message(
         ast_expr_token(expr),
-        String.from("evaluate_exists: not yet implemented (Phase 2 stub)"),
-        false,
-        .None
+        String.from("evaluate_exists: not yet implemented (Phase 2 stub)")
       )
     )
   );

--- a/src/evaluator/exprs/extern.yo
+++ b/src/evaluator/exprs/extern.yo
@@ -47,9 +47,7 @@ evaluate_extern :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected extern, got ${ast_expr_token(expr).value}`,
-          false,
-          .None
+          `Expected extern, got ${ast_expr_token(expr).value}`
         )
       )
     );
@@ -71,9 +69,7 @@ reach. To use them, declare at the top of this file:
     pragma(Pragma.AllowUnsafe);
 
 User code should normally call stdlib wrappers (e.g. functions in
-'std/sys', 'std/fs') instead of declaring FFI directly.`,
-          false,
-          .None
+'std/sys', 'std/fs') instead of declaring FFI directly.`
         )
       )
     );
@@ -105,9 +101,7 @@ User code should normally call stdlib wrappers (e.g. functions in
             dyn(
               format_error_message(
                 ast_expr_token(lang_arg),
-                `Expected string for language argument`,
-                false,
-                .None
+                `Expected string for language argument`
               )
             )
           );
@@ -119,9 +113,7 @@ User code should normally call stdlib wrappers (e.g. functions in
           dyn(
             format_error_message(
               ast_expr_token(lang_arg),
-              `Failed to evaluate language argument`,
-              false,
-              .None
+              `Failed to evaluate language argument`
             )
           )
         );
@@ -148,9 +140,7 @@ User code should normally call stdlib wrappers (e.g. functions in
         dyn(
           format_error_message(
             ast_expr_token(lang_arg),
-            `Unsupported language "${lang_lower}" for extern, expected "c" or "yo"`,
-            false,
-            .None
+            `Unsupported language "${lang_lower}" for extern, expected "c" or "yo"`
           )
         )
       );
@@ -191,9 +181,7 @@ User code should normally call stdlib wrappers (e.g. functions in
         dyn(
           format_error_message(
             err_tok,
-            `Duplicate label "${result.label}" in module`,
-            false,
-            .None
+            `Duplicate label "${result.label}" in module`
           )
         )
       );

--- a/src/evaluator/exprs/identifer_and_operator.yo
+++ b/src/evaluator/exprs/identifer_and_operator.yo
@@ -33,7 +33,7 @@ _(env : ident_dbg_env) :: import("std/env");
 { EvalValue, create_type_value, create_unknown_val, is_type_value, is_unknown_val }
 :: import("../../value.yo");
 { get_value_of_some_type_from_env } :: import("../../types/env_lookup.yo");
-{ format_error_message, ErrorKind } :: import("../../error.yo");
+{ format_error_message } :: import("../../error.yo");
 { Exception } :: import("std/error");
 /// Evaluate an identifier or operator expression.
 ///
@@ -208,9 +208,7 @@ evaluate_identifier_and_operator :: (
         dyn(
           format_error_message(
             token,
-            `Variable "${identifier_string}" not found.`,
-            false,
-            Option(ErrorKind).None
+            `Variable "${identifier_string}" not found.`
           )
         )
       );
@@ -224,9 +222,7 @@ evaluate_identifier_and_operator :: (
         dyn(
           format_error_message(
             token,
-            String.from("Variable \"") + identifier_string + String.from("\" is not initialized"),
-            false,
-            Option(ErrorKind).None
+            String.from("Variable \"") + identifier_string + String.from("\" is not initialized")
           )
         )
       );

--- a/src/evaluator/exprs/import.yo
+++ b/src/evaluator/exprs/import.yo
@@ -256,9 +256,7 @@ evaluate_import :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Expected `import` with exactly 1 argument."),
-          false,
-          .None
+          String.from("Expected `import` with exactly 1 argument.")
         )
       )
     );
@@ -274,9 +272,7 @@ evaluate_import :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              String.from("import: missing path argument."),
-              false,
-              .None
+              String.from("import: missing path argument.")
             )
           )
         );
@@ -288,9 +284,7 @@ evaluate_import :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("import: expected FnCall expression."),
-            false,
-            .None
+            String.from("import: expected FnCall expression.")
           )
         )
       );
@@ -308,9 +302,7 @@ evaluate_import :: (
         dyn(
           format_error_message(
             ast_expr_token(module_arg),
-            String.from("import: failed to evaluate module path argument."),
-            false,
-            .None
+            String.from("import: failed to evaluate module path argument.")
           )
         )
       );
@@ -334,9 +326,7 @@ evaluate_import :: (
           dyn(
             format_error_message(
               ast_expr_token(module_arg),
-              String.from("Expected comptime_str for module path."),
-              false,
-              .None
+              String.from("Expected comptime_str for module path.")
             )
           )
         );
@@ -348,9 +338,7 @@ evaluate_import :: (
         dyn(
           format_error_message(
             ast_expr_token(module_arg),
-            String.from("Expected comptime_str for module path."),
-            false,
-            .None
+            String.from("Expected comptime_str for module path.")
           )
         )
       );
@@ -370,9 +358,7 @@ evaluate_import :: (
       dyn(
         format_error_message(
           ast_expr_token(module_arg),
-          String.from("Importing the prelude module is not allowed — it is automatically loaded for every file."),
-          false,
-          .None
+          String.from("Importing the prelude module is not allowed — it is automatically loaded for every file.")
         )
       )
     );
@@ -397,9 +383,7 @@ evaluate_import :: (
         dyn(
           format_error_message(
             ast_expr_token(module_arg),
-            `Ambiguous import("${base}": both "${base}.yo" and "${base}/index.yo" exist. Use an explicit path to resolve the ambiguity.)`,
-            false,
-            .None
+            `Ambiguous import("${base}": both "${base}.yo" and "${base}/index.yo" exist. Use an explicit path to resolve the ambiguity.)`
           )
         )
       );
@@ -410,9 +394,7 @@ evaluate_import :: (
         dyn(
           format_error_message(
             ast_expr_token(module_arg),
-            `Module not found: tried "${base}.yo" and "${base}/index.yo"`,
-            false,
-            .None
+            `Module not found: tried "${base}.yo" and "${base}/index.yo"`
           )
         )
       );
@@ -446,9 +428,7 @@ evaluate_import :: (
         dyn(
           format_error_message(
             ast_expr_token(module_arg),
-            `Failed to import module "${module_path_to_import}":\n${err_msg}`,
-            false,
-            .None
+            `Failed to import module "${module_path_to_import}":\n${err_msg}`
           )
         )
       );

--- a/src/evaluator/exprs/initialization_assignment.yo
+++ b/src/evaluator/exprs/initialization_assignment.yo
@@ -104,9 +104,7 @@ evaluate_initialization_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Expected \":=\" or \"::\" for initialization assignment."),
-          false,
-          .None
+          String.from("Expected \":=\" or \"::\" for initialization assignment.")
         )
       )
     );
@@ -136,9 +134,7 @@ evaluate_initialization_assignment :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("Unexpected runtime variable declaration in a compile-time only function body."),
-            false,
-            .None
+            String.from("Unexpected runtime variable declaration in a compile-time only function body.")
           )
         )
       );
@@ -166,9 +162,7 @@ evaluate_initialization_assignment :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs),
-          String.from("'inout(name) := ...' local bindings were removed — 'ref' exists only in parameter position. Read and write fields directly ('h.s = v'), or bind the handle ('b := a.b') to keep an object alive."),
-          false,
-          .None
+          String.from("'inout(name) := ...' local bindings were removed — 'ref' exists only in parameter position. Read and write fields directly ('h.s = v'), or bind the handle ('b := a.b') to keep an object alive.")
         )
       )
     );
@@ -184,9 +178,7 @@ evaluate_initialization_assignment :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs),
-            `Expected exactly one argument for "given", got ${n_given_args.to_string()}`,
-            false,
-            .None
+            `Expected exactly one argument for "given", got ${n_given_args.to_string()}`
           )
         )
       );
@@ -206,9 +198,7 @@ evaluate_initialization_assignment :: (
         format_error_message(
           ast_expr_token(actual_lhs),
           `Unexpected use of ":" in type declaration with "${op_str}". Please consider using "=":
-(${ast_expr_to_string(actual_lhs)}) = ${ast_expr_to_string(rhs)}`,
-          false,
-          .None
+(${ast_expr_to_string(actual_lhs)}) = ${ast_expr_to_string(rhs)}`
         )
       )
     );
@@ -272,9 +262,7 @@ evaluate_initialization_assignment :: (
               ast_expr_token(rhs),
               `Cannot bind a value whose type is control-bound (transitively contains a \`ctl(...) -> ret\` function type) at module level. Module-level bindings outlive every call frame; invoking the contained control-function later would unwind to a dead frame.
 
-Bound type: ${type_to_string(rhs_info.ty)}`,
-              false,
-              .None
+Bound type: ${type_to_string(rhs_info.ty)}`
             )
           )
         );
@@ -327,9 +315,7 @@ Bound type: ${type_to_string(rhs_info.ty)}`,
         dyn(
           format_error_message(
             ast_expr_token(actual_lhs),
-            `Invalid assignment to ${lhs_tok_val}, expected identifier or operator`,
-            false,
-            .None
+            `Invalid assignment to ${lhs_tok_val}, expected identifier or operator`
           )
         )
       );
@@ -343,9 +329,7 @@ Bound type: ${type_to_string(rhs_info.ty)}`,
         dyn(
           format_error_message(
             res_tok,
-            `Operator "${res_tok.value}" is reserved and cannot be bound or overloaded (plans/OPERATOR_SET_AND_PRECEDENCE.md).`,
-            false,
-            .None
+            `Operator "${res_tok.value}" is reserved and cannot be bound or overloaded (plans/OPERATOR_SET_AND_PRECEDENCE.md).`
           )
         )
       );
@@ -381,9 +365,7 @@ Bound type: ${type_to_string(rhs_info.ty)}`,
             dyn(
               format_error_message(
                 ast_expr_token(rhs),
-                `Failed to evaluate, got ${ast_expr_to_string(rhs)}`,
-                false,
-                .None
+                `Failed to evaluate, got ${ast_expr_to_string(rhs)}`
               )
             )
           );
@@ -424,9 +406,7 @@ Bound type: ${type_to_string(rhs_info.ty)}`,
               ast_expr_token(actual_lhs),
               `Incompatible types:
 - Defined: ${pre_ty_str}
-- Given  : ${rhs_ty_str}`,
-              false,
-              .None
+- Given  : ${rhs_ty_str}`
             )
           )
         );
@@ -463,9 +443,7 @@ Bound type: ${type_to_string(rhs_info.ty)}`,
 ${expr_str}
 
 Type:
-${lhs_type_str}`,
-            false,
-            .None
+${lhs_type_str}`
           )
         )
       );
@@ -478,9 +456,7 @@ ${lhs_type_str}`,
           format_error_message(
             ast_expr_token(expr),
             `Expected ":=" instead of "::" for value type "${lhs_type_str}" which can only be used at the runtime:
-${expr_str}`,
-            false,
-            .None
+${expr_str}`
           )
         )
       );
@@ -517,9 +493,7 @@ ${expr_str}`,
             ast_expr_token(actual_lhs),
             `Expected compile-time value for "${lhs_tok_val}".
 Got runtime value. Please consider using ":=" instead of "::":
-${rhs_str}`,
-            false,
-            .None
+${rhs_str}`
           )
         )
       );
@@ -638,9 +612,7 @@ ${rhs_str}`,
           format_error_message(
             actual_lhs_tok,
             `Mutable runtime variable "${var_name}" is not allowed inside an impl block.
-Use \`::\` for compile-time definitions inside impl.`,
-            false,
-            .None
+Use \`::\` for compile-time definitions inside impl.`
           )
         )
       );
@@ -685,7 +657,7 @@ Use \`::\` for compile-time definitions inside impl.`,
                 error_message : `Variable "${var_name}" is already defined here (variable shadowing is not allowed):`
               )
             );
-            exn.throw(dyn(format_error_messages(sh_entries, false, .None)));
+            exn.throw(dyn(format_error_messages(sh_entries)));
           },
           .None => ()
         );

--- a/src/evaluator/exprs/match.yo
+++ b/src/evaluator/exprs/match.yo
@@ -292,9 +292,7 @@ evaluate_primitive_match :: (
         dyn(
           format_error_message(
             ast_expr_token(pattern),
-            `Expected "=>" for match pattern, got ${ast_expr_to_string(pattern)}`,
-            false,
-            .None
+            `Expected "=>" for match pattern, got ${ast_expr_to_string(pattern)}`
           )
         )
       );
@@ -319,9 +317,7 @@ evaluate_primitive_match :: (
           dyn(
             format_error_message(
               ast_expr_token(match_arm_expr),
-              `Wildcard pattern "_" can only be used once and must be the last match arm in a "match" expression.`,
-              false,
-              .None
+              `Wildcard pattern "_" can only be used once and must be the last match arm in a "match" expression.`
             )
           )
         );
@@ -361,9 +357,7 @@ evaluate_primitive_match :: (
           dyn(
             format_error_message(
               ast_expr_token(rhs_expr),
-              `Expected type for match result expression, got ${ast_expr_to_string(rhs_expr)}`,
-              false,
-              .None
+              `Expected type for match result expression, got ${ast_expr_to_string(rhs_expr)}`
             )
           )
         );
@@ -426,9 +420,7 @@ evaluate_primitive_match :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(evaluated_body_wc),
-                    `Incompatible type with expected type:\n- Expected: ${type_to_string(et.ty)}\n- Actual  : ${type_to_string(body_info_wc.ty)}`,
-                    false,
-                    .None
+                    `Incompatible type with expected type:\n- Expected: ${type_to_string(et.ty)}\n- Actual  : ${type_to_string(body_info_wc.ty)}`
                   )
                 )
               );
@@ -490,9 +482,7 @@ evaluate_primitive_match :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(evaluated_body_wc),
-                      `Incompatible types in match branches:\n- Previous: ${type_to_string(rt)}\n- Current : ${type_to_string(body_info_wc.ty)}`,
-                      false,
-                      .None
+                      `Incompatible types in match branches:\n- Previous: ${type_to_string(rt)}\n- Current : ${type_to_string(body_info_wc.ty)}`
                     )
                   )
                 );
@@ -523,9 +513,7 @@ evaluate_primitive_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(fp_expr),
-                `Failed to evaluate pattern expression: ${ast_expr_to_string(fp_expr)}`,
-                false,
-                .None
+                `Failed to evaluate pattern expression: ${ast_expr_to_string(fp_expr)}`
               )
             )
           );
@@ -546,9 +534,7 @@ evaluate_primitive_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(fp_expr),
-                `Pattern type ${type_to_string(fp_info.ty)} is not compatible with scrutinee type ${type_to_string(scrutinee_type)}`,
-                false,
-                .None
+                `Pattern type ${type_to_string(fp_info.ty)} is not compatible with scrutinee type ${type_to_string(scrutinee_type)}`
               )
             )
           );
@@ -559,9 +545,7 @@ evaluate_primitive_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(fp_expr),
-                `Match patterns must be compile-time known values. "${ast_expr_to_string(fp_expr)}" is a runtime value.`,
-                false,
-                .None
+                `Match patterns must be compile-time known values. "${ast_expr_to_string(fp_expr)}" is a runtime value.`
               )
             )
           );
@@ -575,9 +559,7 @@ evaluate_primitive_match :: (
               dyn(
                 format_error_message(
                   ast_expr_token(fp_expr),
-                  `Duplicate pattern value: ${lit_key}`,
-                  false,
-                  .None
+                  `Duplicate pattern value: ${lit_key}`
                 )
               )
             );
@@ -652,9 +634,7 @@ evaluate_primitive_match :: (
           dyn(
             format_error_message(
               ast_expr_token(rhs_expr),
-              `Expected type for match result expression, got ${ast_expr_to_string(rhs_expr)}`,
-              false,
-              .None
+              `Expected type for match result expression, got ${ast_expr_to_string(rhs_expr)}`
             )
           )
         );
@@ -712,9 +692,7 @@ evaluate_primitive_match :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(evaluated_body_lit),
-                    `Incompatible type with expected type:\n- Expected: ${type_to_string(et.ty)}\n- Actual  : ${type_to_string(body_info_lit.ty)}`,
-                    false,
-                    .None
+                    `Incompatible type with expected type:\n- Expected: ${type_to_string(et.ty)}\n- Actual  : ${type_to_string(body_info_lit.ty)}`
                   )
                 )
               );
@@ -761,9 +739,7 @@ evaluate_primitive_match :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(evaluated_body_lit),
-                      `Incompatible types in match branches:\n- Previous: ${type_to_string(rt2)}\n- Current : ${type_to_string(body_info_lit.ty)}`,
-                      false,
-                      .None
+                      `Incompatible types in match branches:\n- Previous: ${type_to_string(rt2)}\n- Current : ${type_to_string(body_info_lit.ty)}`
                     )
                   )
                 );
@@ -790,9 +766,7 @@ evaluate_primitive_match :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Match expression on bool is not exhaustive. Missing cases for: ${missing_str}`,
-              false,
-              .None
+              `Match expression on bool is not exhaustive. Missing cases for: ${missing_str}`
             )
           )
         );
@@ -803,9 +777,7 @@ evaluate_primitive_match :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Match expression on ${type_to_string(scrutinee_type)} requires a wildcard pattern "_" for exhaustiveness.`,
-            false,
-            .None
+            `Match expression on ${type_to_string(scrutinee_type)} requires a wildcard pattern "_" for exhaustiveness.`
           )
         )
       );
@@ -823,9 +795,7 @@ evaluate_primitive_match :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Failed to determine the type of value from the match.`,
-            false,
-            .None
+            `Failed to determine the type of value from the match.`
           )
         )
       );
@@ -905,9 +875,7 @@ evaluate_primitive_match :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `No control flows found but expected some.`,
-            false,
-            .None
+            `No control flows found but expected some.`
           )
         )
       );
@@ -920,9 +888,7 @@ evaluate_primitive_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `All cases in match are returning from function, but not evaluating in function body.`,
-                false,
-                .None
+                `All cases in match are returning from function, but not evaluating in function body.`
               )
             )
           );
@@ -982,9 +948,7 @@ evaluate_primitive_match :: (
               dyn(
                 format_error_message(
                   ast_expr_token(expr),
-                  `Failed to determine the return type for match statement.`,
-                  false,
-                  .None
+                  `Failed to determine the return type for match statement.`
                 )
               )
             );
@@ -1026,9 +990,7 @@ evaluate_primitive_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `All cases in match use "unwind", but not inside a function with an enclosing function.`,
-                false,
-                .None
+                `All cases in match use "unwind", but not inside a function with an enclosing function.`
               )
             )
           );
@@ -1046,9 +1008,7 @@ evaluate_primitive_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `All cases in match are breaking from loop, but not inside a loop.`,
-                false,
-                .None
+                `All cases in match are breaking from loop, but not inside a loop.`
               )
             )
           );
@@ -1066,9 +1026,7 @@ evaluate_primitive_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `All cases in match are continuing loop, but not inside a loop.`,
-                false,
-                .None
+                `All cases in match are continuing loop, but not inside a loop.`
               )
             )
           );
@@ -1218,9 +1176,7 @@ evaluate_match :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "match"`,
-          false,
-          .None
+          `Expected "match"`
         )
       )
     );
@@ -1236,9 +1192,7 @@ evaluate_match :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected at least 2 arguments for "match", got ${all_args.len()}`,
-          false,
-          .None
+          `Expected at least 2 arguments for "match", got ${all_args.len()}`
         )
       )
     );
@@ -1267,9 +1221,7 @@ evaluate_match :: (
       dyn(
         format_error_message(
           ast_expr_token(scrutinee_expr),
-          `Failed to evaluate the match scrutinee expression: ${ast_expr_to_string(scrutinee_expr)}`,
-          false,
-          .None
+          `Failed to evaluate the match scrutinee expression: ${ast_expr_to_string(scrutinee_expr)}`
         )
       )
     );
@@ -1283,9 +1235,7 @@ evaluate_match :: (
         dyn(
           format_error_message(
             ast_expr_token(scrutinee_expr),
-            `Internal error: no ExprInfo for scrutinee`,
-            false,
-            .None
+            `Internal error: no ExprInfo for scrutinee`
           )
         )
       );
@@ -1325,9 +1275,7 @@ evaluate_match :: (
       dyn(
         format_error_message(
           ast_expr_token(scrutinee_expr),
-          `Expected enum type or primitive type (integer, bool) for match expression, got ${type_to_string(scrutinee_type)}`,
-          false,
-          .None
+          `Expected enum type or primitive type (integer, bool) for match expression, got ${type_to_string(scrutinee_type)}`
         )
       )
     );
@@ -1393,9 +1341,7 @@ evaluate_match :: (
         dyn(
           format_error_message(
             ast_expr_token(pattern_em),
-            `Expected ":" for match pattern, got ${ast_expr_to_string(pattern_em)}`,
-            false,
-            .None
+            `Expected ":" for match pattern, got ${ast_expr_to_string(pattern_em)}`
           )
         )
       );
@@ -1438,9 +1384,7 @@ evaluate_match :: (
           dyn(
             format_error_message(
               ast_expr_token(match_arm_expr),
-              `Wildcard pattern "_" can only be used once and must be the last match arm in a "match" expression.`,
-              false,
-              .None
+              `Wildcard pattern "_" can only be used once and must be the last match arm in a "match" expression.`
             )
           )
         );
@@ -1461,9 +1405,7 @@ evaluate_match :: (
           dyn(
             format_error_message(
               ast_expr_token(match_arm_expr),
-              `Expected identifier for enum variant, got ${ast_expr_to_string(variant_name_expr)}`,
-              false,
-              .None
+              `Expected identifier for enum variant, got ${ast_expr_to_string(variant_name_expr)}`
             )
           )
         );
@@ -1484,9 +1426,7 @@ evaluate_match :: (
           dyn(
             format_error_message(
               ast_expr_token(match_arm_expr),
-              `Enum variant "${variant_name_fl}" not found in ${type_to_string(matched_type)}`,
-              false,
-              .None
+              `Enum variant "${variant_name_fl}" not found in ${type_to_string(matched_type)}`
             )
           )
         );
@@ -1584,9 +1524,7 @@ evaluate_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(rhs_expr_em),
-                `Expected type for match result expression, got ${ast_expr_to_string(rhs_expr_em)}`,
-                false,
-                .None
+                `Expected type for match result expression, got ${ast_expr_to_string(rhs_expr_em)}`
               )
             )
           );
@@ -1657,9 +1595,7 @@ evaluate_match :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(evaluated_body_fl),
-                      `Incompatible type with expected type:\n- Expected: ${type_to_string(et.ty)}\n- Actual  : ${type_to_string(body_info_fl.ty)}`,
-                      false,
-                      .None
+                      `Incompatible type with expected type:\n- Expected: ${type_to_string(et.ty)}\n- Actual  : ${type_to_string(body_info_fl.ty)}`
                     )
                   )
                 );
@@ -1714,9 +1650,7 @@ evaluate_match :: (
                       dyn(
                         format_error_message(
                           ast_expr_token(evaluated_body_fl),
-                          `GADT type mismatch in branch ".${variant_name_fl}":\n- Expected: ${type_to_string(refined_fl)}\n- Actual  : ${type_to_string(body_info_fl.ty)}`,
-                          false,
-                          .None
+                          `GADT type mismatch in branch ".${variant_name_fl}":\n- Expected: ${type_to_string(refined_fl)}\n- Actual  : ${type_to_string(body_info_fl.ty)}`
                         )
                       )
                     );
@@ -1745,9 +1679,7 @@ evaluate_match :: (
                       dyn(
                         format_error_message(
                           ast_expr_token(evaluated_body_fl),
-                          `Incompatible types:\n- Previous: ${type_to_string(rt_fl)}\n- Current : ${type_to_string(body_info_fl.ty)}`,
-                          false,
-                          .None
+                          `Incompatible types:\n- Previous: ${type_to_string(rt_fl)}\n- Current : ${type_to_string(body_info_fl.ty)}`
                         )
                       )
                     );
@@ -1769,9 +1701,7 @@ evaluate_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(match_arm_expr),
-                `Wildcard pattern "_" can only be used once and must be the last match arm in a "match" expression.`,
-                false,
-                .None
+                `Wildcard pattern "_" can only be used once and must be the last match arm in a "match" expression.`
               )
             )
           );
@@ -1789,9 +1719,7 @@ evaluate_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(match_arm_expr),
-                `Expected identifier for enum variant, got ${ast_expr_to_string(variant_name_expr_wf)}`,
-                false,
-                .None
+                `Expected identifier for enum variant, got ${ast_expr_to_string(variant_name_expr_wf)}`
               )
             )
           );
@@ -1809,9 +1737,7 @@ evaluate_match :: (
             dyn(
               format_error_message(
                 ast_expr_token(match_arm_expr),
-                `Enum variant "${variant_name_wf}" not found in ${type_to_string(matched_type)}`,
-                false,
-                .None
+                `Enum variant "${variant_name_wf}" not found in ${type_to_string(matched_type)}`
               )
             )
           );
@@ -1875,9 +1801,7 @@ evaluate_match :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(cv_elem),
-                      `Nested curly destructuring "{...}" inside another "{...}" is not supported.`,
-                      false,
-                      .None
+                      `Nested curly destructuring "{...}" inside another "{...}" is not supported.`
                     )
                   )
                 );
@@ -1888,9 +1812,7 @@ evaluate_match :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(cv_elem),
-                      `Bare "_" inside curly destructuring "{...}" is meaningless. Either omit the field, or write "label: _" to assert presence without binding.`,
-                      false,
-                      .None
+                      `Bare "_" inside curly destructuring "{...}" is meaningless. Either omit the field, or write "label: _" to assert presence without binding.`
                     )
                   )
                 );
@@ -1932,9 +1854,7 @@ evaluate_match :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(match_arm_expr),
-                    `Variant "${variant_name_wf}" expects ${variant_fields_wf.len()} parameters, got ${destr_params.len()}`,
-                    false,
-                    .None
+                    `Variant "${variant_name_wf}" expects ${variant_fields_wf.len()} parameters, got ${destr_params.len()}`
                   )
                 )
               );
@@ -1946,9 +1866,7 @@ evaluate_match :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(match_arm_expr),
-                    `Variant "${variant_name_wf}" has no fields, but destructuring parameters were provided`,
-                    false,
-                    .None
+                    `Variant "${variant_name_wf}" has no fields, but destructuring parameters were provided`
                   )
                 )
               );
@@ -2007,9 +1925,7 @@ evaluate_match :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(label_expr),
-                        `Expected identifier for label in destructuring pattern, got ${ast_expr_to_string(label_expr)}`,
-                        false,
-                        .None
+                        `Expected identifier for label in destructuring pattern, got ${ast_expr_to_string(label_expr)}`
                       )
                     )
                   );
@@ -2043,9 +1959,7 @@ evaluate_match :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(label_expr),
-                        `Label "${lbl_str}" not found in variant "${variant_name_wf}". Available labels: ${available_labels}`,
-                        false,
-                        .None
+                        `Label "${lbl_str}" not found in variant "${variant_name_wf}". Available labels: ${available_labels}`
                       )
                     )
                   );
@@ -2056,9 +1970,7 @@ evaluate_match :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(label_expr),
-                        `Label "${lbl_str}" is already destructured`,
-                        false,
-                        .None
+                        `Label "${lbl_str}" is already destructured`
                       )
                     )
                   );
@@ -2085,9 +1997,7 @@ evaluate_match :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(variable_expr),
-                        `Expected identifier or "_" for variable in labeled destructuring, got ${ast_expr_to_string(variable_expr)}`,
-                        false,
-                        .None
+                        `Expected identifier or "_" for variable in labeled destructuring, got ${ast_expr_to_string(variable_expr)}`
                       )
                     )
                   );
@@ -2162,9 +2072,7 @@ evaluate_match :: (
                         cond(
                           is_curly_wf => `Expected labeled pattern (label: variable) inside curly destructuring "{...}", got ${ast_expr_to_string(param)}`,
                           true => `Expected identifier, "_", or labeled pattern (label: variable) for destructuring parameter, got ${ast_expr_to_string(param)}`
-                        ),
-                        false,
-                        .None
+                        )
                       )
                     )
                   );
@@ -2217,9 +2125,7 @@ evaluate_match :: (
               dyn(
                 format_error_message(
                   ast_expr_token(rhs_expr_em),
-                  `Expected type for match result expression, got ${ast_expr_to_string(rhs_expr_em)}`,
-                  false,
-                  .None
+                  `Expected type for match result expression, got ${ast_expr_to_string(rhs_expr_em)}`
                 )
               )
             );
@@ -2317,9 +2223,7 @@ evaluate_match :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(evaluated_body_wf),
-                            `GADT type mismatch in branch ".${variant_name_wf}":\n- Expected: ${type_to_string(refined_wf)}\n- Actual  : ${type_to_string(body_info_wf.ty)}`,
-                            false,
-                            .None
+                            `GADT type mismatch in branch ".${variant_name_wf}":\n- Expected: ${type_to_string(refined_wf)}\n- Actual  : ${type_to_string(body_info_wf.ty)}`
                           )
                         )
                       );
@@ -2348,9 +2252,7 @@ evaluate_match :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(evaluated_body_wf),
-                            `Incompatible types:\n- Previous: ${type_to_string(rt_wf)}\n- Current : ${type_to_string(body_info_wf.ty)}`,
-                            false,
-                            .None
+                            `Incompatible types:\n- Previous: ${type_to_string(rt_wf)}\n- Current : ${type_to_string(body_info_wf.ty)}`
                           )
                         )
                       );
@@ -2374,9 +2276,7 @@ evaluate_match :: (
 Supported patterns:
 - .VariantName (for variants without fields)
 - .VariantName(param1, param2, ...) (for variants with fields)
-- _ (wildcard pattern)`,
-              false,
-              .None
+- _ (wildcard pattern)`
             )
           )
         );
@@ -2397,9 +2297,7 @@ Supported patterns:
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Failed to determine the type of value from the cond.`,
-            false,
-            .None
+            `Failed to determine the type of value from the cond.`
           )
         )
       );
@@ -2450,9 +2348,7 @@ Supported patterns:
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Match expression is not exhaustive. Missing cases for variants:${missing_str_em}`,
-              false,
-              .None
+              `Match expression is not exhaustive. Missing cases for variants:${missing_str_em}`
             )
           )
         );
@@ -2577,9 +2473,7 @@ Supported patterns:
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `No control flows found but expected some.`,
-            false,
-            .None
+            `No control flows found but expected some.`
           )
         )
       );
@@ -2592,9 +2486,7 @@ Supported patterns:
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `All cases in match are returning from function, but not evaluating in function body.`,
-                false,
-                .None
+                `All cases in match are returning from function, but not evaluating in function body.`
               )
             )
           );
@@ -2654,9 +2546,7 @@ Supported patterns:
               dyn(
                 format_error_message(
                   ast_expr_token(expr),
-                  `Failed to determine the return type for match statement.`,
-                  false,
-                  .None
+                  `Failed to determine the return type for match statement.`
                 )
               )
             );
@@ -2697,9 +2587,7 @@ Supported patterns:
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `All cases in match use "unwind", but not inside a function with an enclosing function.`,
-                false,
-                .None
+                `All cases in match use "unwind", but not inside a function with an enclosing function.`
               )
             )
           );
@@ -2716,9 +2604,7 @@ Supported patterns:
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `All cases in match are breaking from loop, but not inside a loop.`,
-                false,
-                .None
+                `All cases in match are breaking from loop, but not inside a loop.`
               )
             )
           );
@@ -2735,9 +2621,7 @@ Supported patterns:
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `All cases in match are continuing loop, but not inside a loop.`,
-                false,
-                .None
+                `All cases in match are continuing loop, but not inside a loop.`
               )
             )
           );

--- a/src/evaluator/exprs/open.yo
+++ b/src/evaluator/exprs/open.yo
@@ -98,9 +98,7 @@ evaluate_open :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "${BK_OPEN}" with 1 argument, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "${BK_OPEN}" with 1 argument, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -134,9 +132,7 @@ evaluate_open :: (
               dyn(
                 format_error_message(
                   ast_expr_token(arg_expr),
-                  `Cannot use "open" on implicit variable "${v.name}". Implicit variables must be passed via  parameters.`,
-                  false,
-                  .None
+                  `Cannot use "open" on implicit variable "${v.name}". Implicit variables must be passed via  parameters.`
                 )
               )
             );
@@ -161,9 +157,7 @@ evaluate_open :: (
         dyn(
           format_error_message(
             ast_expr_token(evaluated),
-            `Failed to evaluate the module argument:\n${ast_expr_to_string(evaluated)}`,
-            false,
-            .None
+            `Failed to evaluate the module argument:\n${ast_expr_to_string(evaluated)}`
           )
         )
       );
@@ -326,9 +320,7 @@ evaluate_open :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            `Expected module/struct for "${BK_OPEN}", got:\n${ast_expr_to_string(arg_expr)}`,
-            false,
-            .None
+            `Expected module/struct for "${BK_OPEN}", got:\n${ast_expr_to_string(arg_expr)}`
           )
         )
       );

--- a/src/evaluator/exprs/property_access.yo
+++ b/src/evaluator/exprs/property_access.yo
@@ -333,9 +333,7 @@ evaluate_property_access :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "." for property access, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "." for property access, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -390,9 +388,7 @@ evaluate_property_access :: (
         dyn(
           format_error_message(
             ast_expr_token(prop_expr_1),
-            `Expected identifier for enum variant access, got:\n${ast_expr_to_string(prop_expr_1)}`,
-            false,
-            .None
+            `Expected identifier for enum variant access, got:\n${ast_expr_to_string(prop_expr_1)}`
           )
         )
       );
@@ -406,9 +402,7 @@ evaluate_property_access :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              String.from("Failed to infer enum variant type."),
-              false,
-              .None
+              String.from("Failed to infer enum variant type.")
             )
           )
         );
@@ -420,9 +414,7 @@ evaluate_property_access :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                String.from("Failed to infer enum variant type."),
-                false,
-                .None
+                String.from("Failed to infer enum variant type.")
               )
             )
           );
@@ -445,9 +437,7 @@ evaluate_property_access :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(prop_expr_1),
-                      `Enum variant "${variant_name_1}" not found in enum`,
-                      false,
-                      .None
+                      `Enum variant "${variant_name_1}" not found in enum`
                     )
                   )
                 );
@@ -496,9 +486,7 @@ evaluate_property_access :: (
               dyn(
                 format_error_message(
                   ast_expr_token(expr),
-                  String.from("Failed to infer enum variant type."),
-                  false,
-                  .None
+                  String.from("Failed to infer enum variant type.")
                 )
               )
             );
@@ -517,9 +505,7 @@ evaluate_property_access :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "." with 2 arguments, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "." with 2 arguments, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -588,9 +574,7 @@ evaluate_property_access :: (
 
 Wrap as: unsafe(${ast_expr_to_string(object_expr)}.*)
 
-Raw pointer operations may dereference invalid memory.`,
-                  false,
-                  .None
+Raw pointer operations may dereference invalid memory.`
                 )
               )
             );
@@ -821,9 +805,7 @@ Raw pointer operations may dereference invalid memory.`,
           dyn(
             format_error_message(
               ast_expr_token(property_expr),
-              `Expected identifier for enum variant, got:\n${ast_expr_to_string(property_expr)}`,
-              false,
-              .None
+              `Expected identifier for enum variant, got:\n${ast_expr_to_string(property_expr)}`
             )
           )
         );
@@ -879,9 +861,7 @@ Raw pointer operations may dereference invalid memory.`,
                 dyn(
                   format_error_message(
                     ast_expr_token(property_expr),
-                    `Enum variant "${variant_name_tv}" not found in enum`,
-                    false,
-                    .None
+                    `Enum variant "${variant_name_tv}" not found in enum`
                   )
                 )
               );
@@ -937,9 +917,7 @@ Raw pointer operations may dereference invalid memory.`,
           dyn(
             format_error_message(
               ast_expr_token(property_expr),
-              `Expected identifier for type method, got:\n${ast_expr_to_string(property_expr)}`,
-              false,
-              .None
+              `Expected identifier for type method, got:\n${ast_expr_to_string(property_expr)}`
             )
           )
         );
@@ -1105,9 +1083,7 @@ Raw pointer operations may dereference invalid memory.`,
           dyn(
             format_error_message(
               ast_expr_token(property_expr),
-              `Expected identifier for type method, got:\n${ast_expr_to_string(property_expr)}`,
-              false,
-              .None
+              `Expected identifier for type method, got:\n${ast_expr_to_string(property_expr)}`
             )
           )
         );
@@ -1151,9 +1127,7 @@ Raw pointer operations may dereference invalid memory.`,
           dyn(
             format_error_message(
               ast_expr_token(property_expr),
-              `Expected identifier for type method, got:\n${ast_expr_to_string(property_expr)}`,
-              false,
-              .None
+              `Expected identifier for type method, got:\n${ast_expr_to_string(property_expr)}`
             )
           )
         );
@@ -1492,9 +1466,7 @@ Raw pointer operations may dereference invalid memory.`,
             dyn(
               format_error_message(
                 ast_expr_token(property_expr),
-                String.from("Accessing tuple field by index is only allowed for tuples."),
-                false,
-                .None
+                String.from("Accessing tuple field by index is only allowed for tuples.")
               )
             )
           );
@@ -1508,9 +1480,7 @@ Raw pointer operations may dereference invalid memory.`,
               dyn(
                 format_error_message(
                   ast_expr_token(property_expr),
-                  `Expected integer for tuple index, got:\n${ast_expr_to_string(property_expr)}`,
-                  false,
-                  .None
+                  `Expected integer for tuple index, got:\n${ast_expr_to_string(property_expr)}`
                 )
               )
             );
@@ -1524,9 +1494,7 @@ Raw pointer operations may dereference invalid memory.`,
                 dyn(
                   format_error_message(
                     ast_expr_token(property_expr),
-                    `Index out of bounds: ${idx_str} for accessing field in:\n${type_to_string(base_ty)}`,
-                    false,
-                    .None
+                    `Index out of bounds: ${idx_str} for accessing field in:\n${type_to_string(base_ty)}`
                   )
                 )
               );
@@ -1595,9 +1563,7 @@ Raw pointer operations may dereference invalid memory.`,
                 dyn(
                   format_error_message(
                     ast_expr_token(property_expr),
-                    `Module field "${label_str}" not found in module type`,
-                    false,
-                    .None
+                    `Module field "${label_str}" not found in module type`
                   )
                 )
               );
@@ -1736,9 +1702,7 @@ Raw pointer operations may dereference invalid memory.`,
           dyn(
             format_error_message(
               ast_expr_token(property_expr),
-              `Accessing module field by index is not allowed, got:\n${ast_expr_to_string(property_expr)}`,
-              false,
-              .None
+              `Accessing module field by index is not allowed, got:\n${ast_expr_to_string(property_expr)}`
             )
           )
         );
@@ -1766,9 +1730,7 @@ Raw pointer operations may dereference invalid memory.`,
                 dyn(
                   format_error_message(
                     ast_expr_token(property_expr),
-                    `Module field "${mod_label}" not found in module type`,
-                    false,
-                    .None
+                    `Module field "${mod_label}" not found in module type`
                   )
                 )
               );
@@ -1865,9 +1827,7 @@ Raw pointer operations may dereference invalid memory.`,
           dyn(
             format_error_message(
               ast_expr_token(property_expr),
-              `Expected identifier for enum variant property, got:\n${ast_expr_to_string(property_expr)}`,
-              false,
-              .None
+              `Expected identifier for enum variant property, got:\n${ast_expr_to_string(property_expr)}`
             )
           )
         );

--- a/src/evaluator/exprs/recur.yo
+++ b/src/evaluator/exprs/recur.yo
@@ -83,9 +83,7 @@ evaluate_recur :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected a function type for recur, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected a function type for recur, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -108,9 +106,7 @@ evaluate_recur :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected recur, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected recur, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -125,9 +121,7 @@ evaluate_recur :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("recur: missing function type in context"),
-            false,
-            .None
+            String.from("recur: missing function type in context")
           )
         )
       );

--- a/src/evaluator/exprs/runtime.yo
+++ b/src/evaluator/exprs/runtime.yo
@@ -48,9 +48,7 @@ evaluate_runtime :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected runtime(expr), got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected runtime(expr), got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -61,9 +59,7 @@ evaluate_runtime :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Cannot use \"runtime\" during compile-time function evaluation analysis. The \"runtime\" keyword forces runtime evaluation and prevents CTFE."),
-          false,
-          .None
+          String.from("Cannot use \"runtime\" during compile-time function evaluation analysis. The \"runtime\" keyword forces runtime evaluation and prevents CTFE.")
         )
       )
     );
@@ -89,9 +85,7 @@ evaluate_runtime :: (
         dyn(
           format_error_message(
             ast_expr_token(evaluated),
-            `Failed to evaluate runtime argument:\n${ast_expr_to_string(evaluated)}`,
-            false,
-            .None
+            `Failed to evaluate runtime argument:\n${ast_expr_to_string(evaluated)}`
           )
         )
       );

--- a/src/evaluator/exprs/subtype_of.yo
+++ b/src/evaluator/exprs/subtype_of.yo
@@ -45,9 +45,7 @@ evaluate_subtype_of :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("`<:` requires exactly two arguments."),
-          false,
-          .None
+          String.from("`<:` requires exactly two arguments.")
         )
       )
     );
@@ -82,9 +80,7 @@ evaluate_subtype_of :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_expr),
-            String.from("Expected type for left-hand side of `<:`."),
-            false,
-            .None
+            String.from("Expected type for left-hand side of `<:`.")
           )
         )
       );
@@ -103,9 +99,7 @@ evaluate_subtype_of :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_expr),
-            String.from("Expected type for left-hand side expression of `<:`."),
-            false,
-            .None
+            String.from("Expected type for left-hand side expression of `<:`.")
           )
         )
       );
@@ -116,9 +110,7 @@ evaluate_subtype_of :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_expr),
-            String.from("Expected type for left-hand side expression of `<:`."),
-            false,
-            .None
+            String.from("Expected type for left-hand side expression of `<:`.")
           )
         )
       );
@@ -136,9 +128,7 @@ evaluate_subtype_of :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs_expr),
-          `In a where clause, the left-hand side of <: must be a type parameter (SomeType), got: ${type_to_string(lhs_ty)}`,
-          false,
-          .None
+          `In a where clause, the left-hand side of <: must be a type parameter (SomeType), got: ${type_to_string(lhs_ty)}`
         )
       )
     );
@@ -222,9 +212,7 @@ evaluate_subtype_of :: (
           dyn(
             format_error_message(
               ast_expr_token(te),
-              String.from("Expected trait type for right-hand side of `<:`."),
-              false,
-              .None
+              String.from("Expected trait type for right-hand side of `<:`.")
             )
           )
         );
@@ -245,9 +233,7 @@ evaluate_subtype_of :: (
             dyn(
               format_error_message(
                 ast_expr_token(te),
-                String.from("Expected trait type for right-hand side of `<:`."),
-                false,
-                .None
+                String.from("Expected trait type for right-hand side of `<:`.")
               )
             )
           );
@@ -258,9 +244,7 @@ evaluate_subtype_of :: (
             dyn(
               format_error_message(
                 ast_expr_token(te),
-                String.from("Expected trait type for right-hand side of `<:`."),
-                false,
-                .None
+                String.from("Expected trait type for right-hand side of `<:`.")
               )
             )
           );
@@ -272,9 +256,7 @@ evaluate_subtype_of :: (
           dyn(
             format_error_message(
               ast_expr_token(te),
-              String.from("Expected trait type for right-hand side of `<:`."),
-              false,
-              .None
+              String.from("Expected trait type for right-hand side of `<:`.")
             )
           )
         );
@@ -287,9 +269,7 @@ evaluate_subtype_of :: (
         dyn(
           format_error_message(
             ast_expr_token(te),
-            String.from("Negated trait constraints !(Trait) are only allowed in where clauses."),
-            false,
-            .None
+            String.from("Negated trait constraints !(Trait) are only allowed in where clauses.")
           )
         )
       );
@@ -300,9 +280,7 @@ evaluate_subtype_of :: (
         dyn(
           format_error_message(
             ast_expr_token(te),
-            String.from("Expected trait type already has a receiver type assigned."),
-            false,
-            .None
+            String.from("Expected trait type already has a receiver type assigned.")
           )
         )
       );
@@ -336,9 +314,7 @@ evaluate_subtype_of :: (
         dyn(
           format_error_message(
             ast_expr_token(rhs_expr),
-            String.from("Multiple trait constraints (tuple form) are only allowed in where clauses."),
-            false,
-            .None
+            String.from("Multiple trait constraints (tuple form) are only allowed in where clauses.")
           )
         )
       );
@@ -351,9 +327,7 @@ evaluate_subtype_of :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              String.from("No trait found in `<:` expression."),
-              false,
-              .None
+              String.from("No trait found in `<:` expression.")
             )
           )
         );
@@ -367,9 +341,7 @@ evaluate_subtype_of :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Type "${type_to_string(lhs_ty)}" does not implement trait "${type_to_string(trait_ty)}".`,
-              false,
-              .None
+              `Type "${type_to_string(lhs_ty)}" does not implement trait "${type_to_string(trait_ty)}".`
             )
           )
         );

--- a/src/evaluator/exprs/test.yo
+++ b/src/evaluator/exprs/test.yo
@@ -120,9 +120,7 @@ evaluate_test :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected test, got ${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected test, got ${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -138,9 +136,7 @@ evaluate_test :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `test expects 2 arguments (name, body), got ${arg_count}. Io is implicitly available via "io" — no using clause needed.`,
-          false,
-          .None
+          `test expects 2 arguments (name, body), got ${arg_count}. Io is implicitly available via "io" — no using clause needed.`
         )
       )
     );
@@ -163,9 +159,7 @@ evaluate_test :: (
       dyn(
         format_error_message(
           ast_expr_token(test_name_expr),
-          `Failed to evaluate test name: ${ast_expr_to_string(test_name_expr)}`,
-          false,
-          .None
+          `Failed to evaluate test name: ${ast_expr_to_string(test_name_expr)}`
         )
       )
     );
@@ -187,9 +181,7 @@ evaluate_test :: (
       dyn(
         format_error_message(
           ast_expr_token(test_name_expr),
-          `Expected string for test name, got ${ast_expr_to_string(test_name_expr)}`,
-          false,
-          .None
+          `Expected string for test name, got ${ast_expr_to_string(test_name_expr)}`
         )
       )
     );
@@ -203,9 +195,7 @@ evaluate_test :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Io module not found in environment. Is the prelude loaded?"),
-          false,
-          .None
+          String.from("Io module not found in environment. Is the prelude loaded?")
         )
       )
     );
@@ -218,9 +208,7 @@ evaluate_test :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("Io module not found in environment."),
-            false,
-            .None
+            String.from("Io module not found in environment.")
           )
         )
       );

--- a/src/evaluator/exprs/typeof.yo
+++ b/src/evaluator/exprs/typeof.yo
@@ -46,9 +46,7 @@ evaluate_typeof :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "typeof" with 1 argument, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "typeof" with 1 argument, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -74,9 +72,7 @@ evaluate_typeof :: (
         dyn(
           format_error_message(
             ast_expr_token(type_expr),
-            `Expected type for expression, got:\n${ast_expr_to_string(type_expr)}`,
-            false,
-            .None
+            `Expected type for expression, got:\n${ast_expr_to_string(type_expr)}`
           )
         )
       );

--- a/src/evaluator/exprs/unwind.yo
+++ b/src/evaluator/exprs/unwind.yo
@@ -54,9 +54,7 @@ evaluate_unwind :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Expected `unwind`."),
-          false,
-          .None
+          String.from("Expected `unwind`.")
         )
       )
     );
@@ -69,9 +67,7 @@ evaluate_unwind :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("`unwind` can only be used inside a function that has an enclosing function."),
-            false,
-            .None
+            String.from("`unwind` can only be used inside a function that has an enclosing function.")
           )
         )
       );
@@ -90,9 +86,7 @@ evaluate_unwind :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("`unwind` accepts at most one argument."),
-          false,
-          .None
+          String.from("`unwind` accepts at most one argument.")
         )
       )
     );
@@ -113,9 +107,7 @@ evaluate_unwind :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Incompatible type for \`unwind\` argument:\n- Expected (enclosing function return type): ${type_to_string(enclosing_ret)}\n- Got: ${type_to_string(t_unit())}`,
-            false,
-            .None
+            `Incompatible type for \`unwind\` argument:\n- Expected (enclosing function return type): ${type_to_string(enclosing_ret)}\n- Got: ${type_to_string(t_unit())}`
           )
         )
       );
@@ -149,9 +141,7 @@ evaluate_unwind :: (
         dyn(
           format_error_message(
             ast_expr_token(arg_expr),
-            String.from("Failed to evaluate the argument of `unwind`."),
-            false,
-            .None
+            String.from("Failed to evaluate the argument of `unwind`.")
           )
         )
       );
@@ -169,9 +159,7 @@ evaluate_unwind :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_expr),
-          `Incompatible type for \`unwind\` argument:\n- Expected (enclosing function return type): ${type_to_string(enclosing_ret)}\n- Got: ${type_to_string(arg_info.ty)}`,
-          false,
-          .None
+          `Incompatible type for \`unwind\` argument:\n- Expected (enclosing function return type): ${type_to_string(enclosing_ret)}\n- Got: ${type_to_string(arg_info.ty)}`
         )
       )
     );

--- a/src/evaluator/exprs/while.yo
+++ b/src/evaluator/exprs/while.yo
@@ -226,7 +226,7 @@ _throw_max_iterations_error :: (
     true =>
       `Infinite compile-time while loop detected. The condition is compile-time \`true\` but the loop body has no \`break\`, \`return\`, or \`unwind\` to terminate it.\nIf you need an infinite runtime loop, use \`while true, { ... }\` without the comptime modifier.\nTo increase the limit, set the YO_MAX_COMPTIME_LOOP_ITERATIONS environment variable.`
   );
-  exn.throw(dyn(format_error_message(ast_expr_token(expr), err_msg, false, .None)));
+  exn.throw(dyn(format_error_message(ast_expr_token(expr), err_msg)));
   make_err_expr()
 });
 // ---------------------------------------------------------------------------
@@ -268,9 +268,7 @@ evaluate_while :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected 2 or 3 arguments for while loop, got ${n_args.to_string()}`,
-          false,
-          .None
+          `Expected 2 or 3 arguments for while loop, got ${n_args.to_string()}`
         )
       )
     );
@@ -294,7 +292,7 @@ evaluate_while :: (
         inv_viol.non_first_stmt => String.from("'invariant(...)' must be the first statement of a 'while(...)' loop body. Move this invariant to the top of the loop body, before any other statements."),
         true => String.from("'invariant(...)' must be the first statement of the enclosing 'while(...)' loop body. It cannot appear inside cond/match branches, nested blocks, or as a non-first statement.")
       );
-      exn.throw(dyn(format_error_message(ast_expr_token(inv_viol.node), inv_msg, false, .None)));
+      exn.throw(dyn(format_error_message(ast_expr_token(inv_viol.node), inv_msg)));
     },
     .None => ()
   );
@@ -328,9 +326,7 @@ evaluate_while :: (
       dyn(
         format_error_message(
           ast_expr_token(inner_cond_expr),
-          `Failed to evaluate the condition expression: ${ast_expr_to_string(inner_cond_expr)}`,
-          false,
-          .None
+          `Failed to evaluate the condition expression: ${ast_expr_to_string(inner_cond_expr)}`
         )
       )
     );
@@ -348,9 +344,7 @@ evaluate_while :: (
       dyn(
         format_error_message(
           ast_expr_token(inner_cond_expr),
-          `Expected bool type for condition expression, got: ${ast_expr_to_string(inner_cond_expr)}`,
-          false,
-          .None
+          `Expected bool type for condition expression, got: ${ast_expr_to_string(inner_cond_expr)}`
         )
       )
     );
@@ -371,9 +365,7 @@ evaluate_while :: (
       dyn(
         format_error_message(
           ast_expr_token(inner_cond_expr),
-          `"while comptime(...)" requires a compile-time known condition, but the condition evaluates to a runtime value.\nRemove the "comptime" modifier to use a runtime while loop: \`while cond, body\`.`,
-          false,
-          .None
+          `"while comptime(...)" requires a compile-time known condition, but the condition evaluates to a runtime value.\nRemove the "comptime" modifier to use a runtime while loop: \`while cond, body\`.`
         )
       )
     );
@@ -406,9 +398,7 @@ evaluate_while :: (
         dyn(
           format_error_message(
             ast_expr_token(inner_cond_expr),
-            `while loop condition is compile-time known but the \`comptime\` modifier is missing.\nThe condition depends on comptime-only variable(s) that cannot change inside a runtime loop, which will cause an infinite loop.\nUse \`while comptime(cond), body\` to unroll the loop at compile time.`,
-            false,
-            .None
+            `while loop condition is compile-time known but the \`comptime\` modifier is missing.\nThe condition depends on comptime-only variable(s) that cannot change inside a runtime loop, which will cause an infinite loop.\nUse \`while comptime(cond), body\` to unroll the loop at compile time.`
           )
         )
       );
@@ -460,9 +450,7 @@ evaluate_while :: (
       dyn(
         format_error_message(
           ast_expr_token(body_expr),
-          `Failed to evaluate the body expression: ${ast_expr_to_string(body_expr)}`,
-          false,
-          .None
+          `Failed to evaluate the body expression: ${ast_expr_to_string(body_expr)}`
         )
       )
     );
@@ -530,9 +518,7 @@ evaluate_while :: (
               dyn(
                 format_error_message(
                   ast_expr_token(step_expr_cont),
-                  `Failed to evaluate the step expression: ${ast_expr_to_string(step_expr_cont)}`,
-                  false,
-                  .None
+                  `Failed to evaluate the step expression: ${ast_expr_to_string(step_expr_cont)}`
                 )
               )
             );
@@ -623,9 +609,7 @@ evaluate_while :: (
       dyn(
         format_error_message(
           ast_expr_token(body_expr),
-          `Expected the while loop body to return unit, but got: ${type_to_string(body_info.ty)}`,
-          false,
-          .None
+          `Expected the while loop body to return unit, but got: ${type_to_string(body_info.ty)}`
         )
       )
     );
@@ -647,9 +631,7 @@ evaluate_while :: (
           dyn(
             format_error_message(
               ast_expr_token(step_expr_s),
-              `Failed to evaluate the step expression: ${ast_expr_to_string(step_expr_s)}`,
-              false,
-              .None
+              `Failed to evaluate the step expression: ${ast_expr_to_string(step_expr_s)}`
             )
           )
         );

--- a/src/evaluator/trait_checking.yo
+++ b/src/evaluator/trait_checking.yo
@@ -47,7 +47,7 @@ open(import("std/string"));
 { type_to_string } :: import("../types/string.yo");
 { Environment, get_where_clause_constraints_for_some_type } :: import("../env.yo");
 { Token } :: import("../token.yo");
-{ YoError, ErrorKind, format_error_message } :: import("../error.yo");
+{ YoError, format_error_message } :: import("../error.yo");
 {
   find_matching_generic_impl,
   find_matching_negative_generic_impl,
@@ -1244,7 +1244,7 @@ check_type_implements_self_constraints :: (
 )(
   match(
     check_self_constraints_violation_msg(target_type, trait_type, env),
-    .Some(msg) => exn.throw(dyn(format_error_message(error_token, msg, false, Option(ErrorKind).None))),
+    .Some(msg) => exn.throw(dyn(format_error_message(error_token, msg))),
     .None => ()
   )
 );
@@ -1838,7 +1838,7 @@ validate_type_availability :: (
   });
   if(!(type_implements_comptime(ty, env) || type_implements_runtime_full(ty, env)), {
     msg := `Type `.concat(type_to_string(ty)).concat(` has incompatible field contexts and cannot be used in any evaluation context.`);
-    exn.throw(dyn(format_error_message(token, msg, false, Option(ErrorKind).None)));
+    exn.throw(dyn(format_error_message(token, msg)));
   })
 });
 // ---------------------------------------------------------------------------

--- a/src/evaluator/types/array.yo
+++ b/src/evaluator/types/array.yo
@@ -48,9 +48,7 @@ evaluate_array_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "Array(comptime(Type), comptime(usize))" with 2 arguments, like "Array(i32, 10)"\nGot:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "Array(comptime(Type), comptime(usize))" with 2 arguments, like "Array(i32, 10)"\nGot:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -70,9 +68,7 @@ evaluate_array_type :: (
       dyn(
         format_error_message(
           ast_expr_token(element_type_expr),
-          `Failed to evaluate the element type expression:\n${ast_expr_to_string(element_type_expr)}`,
-          false,
-          .None
+          `Failed to evaluate the element type expression:\n${ast_expr_to_string(element_type_expr)}`
         )
       )
     );
@@ -87,9 +83,7 @@ evaluate_array_type :: (
       dyn(
         format_error_message(
           ast_expr_token(element_type_expr),
-          `Expected type for element type, got:\n${ast_expr_to_string(element_type_expr)}\n\nIf you are creating an array value with 1 element, please consider adding a "," in the end, like [1,]`,
-          false,
-          .None
+          `Expected type for element type, got:\n${ast_expr_to_string(element_type_expr)}\n\nIf you are creating an array value with 1 element, please consider adding a "," in the end, like [1,]`
         )
       )
     );
@@ -104,9 +98,7 @@ evaluate_array_type :: (
           dyn(
             format_error_message(
               ast_expr_token(element_type_expr),
-              `Expected TypeVal for element type`,
-              false,
-              .None
+              `Expected TypeVal for element type`
             )
           )
         );
@@ -118,9 +110,7 @@ evaluate_array_type :: (
         dyn(
           format_error_message(
             ast_expr_token(element_type_expr),
-            `Expected type value for element type`,
-            false,
-            .None
+            `Expected type value for element type`
           )
         )
       );
@@ -169,9 +159,7 @@ evaluate_array_type :: (
       dyn(
         format_error_message(
           ast_expr_token(length_expr),
-          `Failed to evaluate the length expression:\n${ast_expr_to_string(length_expr)}`,
-          false,
-          .None
+          `Failed to evaluate the length expression:\n${ast_expr_to_string(length_expr)}`
         )
       )
     );
@@ -192,9 +180,7 @@ evaluate_array_type :: (
       dyn(
         format_error_message(
           ast_expr_token(length_expr),
-          `Expected compile-time known value for length, got:\n${ast_expr_to_string(length_expr)}`,
-          false,
-          .None
+          `Expected compile-time known value for length, got:\n${ast_expr_to_string(length_expr)}`
         )
       )
     );
@@ -228,9 +214,7 @@ evaluate_array_type :: (
           dyn(
             format_error_message(
               ast_expr_token(length_expr),
-              `Failed to parse array length as integer`,
-              false,
-              .None
+              `Failed to parse array length as integer`
             )
           )
         );

--- a/src/evaluator/types/comptime_list.yo
+++ b/src/evaluator/types/comptime_list.yo
@@ -43,9 +43,7 @@ evaluate_comptime_list_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "ComptimeList" with 1 argument, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "ComptimeList" with 1 argument, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -71,9 +69,7 @@ evaluate_comptime_list_type :: (
         dyn(
           format_error_message(
             ast_expr_token(elem_expr),
-            `Failed to evaluate the element type expression:\n${ast_expr_to_string(elem_expr)}`,
-            false,
-            .None
+            `Failed to evaluate the element type expression:\n${ast_expr_to_string(elem_expr)}`
           )
         )
       );
@@ -91,9 +87,7 @@ evaluate_comptime_list_type :: (
       dyn(
         format_error_message(
           ast_expr_token(elem_expr),
-          `Expected type for element type, got:\n${ast_expr_to_string(elem_expr)}`,
-          false,
-          .None
+          `Expected type for element type, got:\n${ast_expr_to_string(elem_expr)}`
         )
       )
     );

--- a/src/evaluator/types/concrete_trait.yo
+++ b/src/evaluator/types/concrete_trait.yo
@@ -51,9 +51,7 @@ evaluate_concrete_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Concrete type constructor expects exactly 1 argument, got ${args.len()}. Usage: Concrete(T)`,
-          false,
-          .None
+          `Concrete type constructor expects exactly 1 argument, got ${args.len()}. Usage: Concrete(T)`
         )
       )
     );
@@ -73,9 +71,7 @@ evaluate_concrete_type :: (
         dyn(
           format_error_message(
             ast_expr_token(concrete_type_expr),
-            `Failed to evaluate the concrete type expression for Concrete:\n${ast_expr_to_string(concrete_type_expr)}`,
-            false,
-            .None
+            `Failed to evaluate the concrete type expression for Concrete:\n${ast_expr_to_string(concrete_type_expr)}`
           )
         )
       );
@@ -93,9 +89,7 @@ evaluate_concrete_type :: (
       dyn(
         format_error_message(
           ast_expr_token(concrete_type_expr),
-          `Concrete type constructor expects a type as its argument, but got:\n${ast_expr_to_string(concrete_type_expr)}`,
-          false,
-          .None
+          `Concrete type constructor expects a type as its argument, but got:\n${ast_expr_to_string(concrete_type_expr)}`
         )
       )
     );

--- a/src/evaluator/types/dyn.yo
+++ b/src/evaluator/types/dyn.yo
@@ -70,9 +70,7 @@ evaluate_dyn_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "Dyn", got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "Dyn", got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -121,9 +119,7 @@ evaluate_dyn_type :: (
           dyn(
             format_error_message(
               ast_expr_token(actual_arg),
-              `Failed to evaluate argument ${(i + usize(1))} of 'Dyn' expression.`,
-              false,
-              .None
+              `Failed to evaluate argument ${(i + usize(1))} of 'Dyn' expression.`
             )
           )
         );
@@ -145,9 +141,7 @@ evaluate_dyn_type :: (
         dyn(
           format_error_message(
             ast_expr_token(actual_arg),
-            `Expected a trait type for argument ${(i + usize(1))} of 'Dyn' expression.`,
-            false,
-            .None
+            `Expected a trait type for argument ${(i + usize(1))} of 'Dyn' expression.`
           )
         )
       );
@@ -157,9 +151,7 @@ evaluate_dyn_type :: (
         dyn(
           format_error_message(
             ast_expr_token(actual_arg),
-            `Expected a trait type for argument ${(i + usize(1))} of 'Dyn' expression, got:\n${type_to_string(inner_ty)}`,
-            false,
-            .None
+            `Expected a trait type for argument ${(i + usize(1))} of 'Dyn' expression, got:\n${type_to_string(inner_ty)}`
           )
         )
       );
@@ -182,9 +174,7 @@ evaluate_dyn_type :: (
           dyn(
             format_error_message(
               ast_expr_token(actual_arg),
-              `Trait type ${type_to_string(inner_ty)} is already included in negative constraints of 'Dyn' expression.`,
-              false,
-              .None
+              `Trait type ${type_to_string(inner_ty)} is already included in negative constraints of 'Dyn' expression.`
             )
           )
         );
@@ -217,9 +207,7 @@ evaluate_dyn_type :: (
           dyn(
             format_error_message(
               ast_expr_token(actual_arg),
-              `Trait type ${type_to_string(inner_ty)} is already included in 'Dyn' expression.`,
-              false,
-              .None
+              `Trait type ${type_to_string(inner_ty)} is already included in 'Dyn' expression.`
             )
           )
         );

--- a/src/evaluator/types/enum.yo
+++ b/src/evaluator/types/enum.yo
@@ -102,9 +102,7 @@ _evaluate_discriminant :: (
         dyn(
           format_error_message(
             ast_expr_token(discriminant_expr),
-            `Failed to evaluate discriminant value: ${ast_expr_to_string(discriminant_expr)}`,
-            false,
-            .None
+            `Failed to evaluate discriminant value: ${ast_expr_to_string(discriminant_expr)}`
           )
         )
       );
@@ -116,9 +114,7 @@ _evaluate_discriminant :: (
       dyn(
         format_error_message(
           ast_expr_token(discriminant_expr),
-          `Failed to evaluate discriminant value: ${ast_expr_to_string(discriminant_expr)}`,
-          false,
-          .None
+          `Failed to evaluate discriminant value: ${ast_expr_to_string(discriminant_expr)}`
         )
       )
     );
@@ -134,9 +130,7 @@ _evaluate_discriminant :: (
       dyn(
         format_error_message(
           ast_expr_token(discriminant_expr),
-          `Enum discriminant must be a compile-time integer, got: ${ast_expr_to_string(discriminant_expr)}`,
-          false,
-          .None
+          `Enum discriminant must be a compile-time integer, got: ${ast_expr_to_string(discriminant_expr)}`
         )
       )
     );
@@ -146,9 +140,7 @@ _evaluate_discriminant :: (
       dyn(
         format_error_message(
           ast_expr_token(discriminant_expr),
-          `Enum discriminant must be a compile-time known value, got: ${ast_expr_to_string(discriminant_expr)}`,
-          false,
-          .None
+          `Enum discriminant must be a compile-time known value, got: ${ast_expr_to_string(discriminant_expr)}`
         )
       )
     );
@@ -166,9 +158,7 @@ _evaluate_discriminant :: (
         dyn(
           format_error_message(
             ast_expr_token(discriminant_expr),
-            `Failed to parse discriminant integer value: ${raw}`,
-            false,
-            .None
+            `Failed to parse discriminant integer value: ${raw}`
           )
         )
       );
@@ -195,9 +185,7 @@ evaluate_enum_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "enum", got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "enum", got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -314,9 +302,7 @@ evaluate_enum_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(variant_name_expr),
-                `Expected identifier for enum variant, got:\n${ast_expr_to_string(variant_name_expr)}`,
-                false,
-                .None
+                `Expected identifier for enum variant, got:\n${ast_expr_to_string(variant_name_expr)}`
               )
             )
           );
@@ -327,9 +313,7 @@ evaluate_enum_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(variant_name_expr),
-                `Duplicate variant name "${variant_name}" in enum`,
-                false,
-                .None
+                `Duplicate variant name "${variant_name}" in enum`
               )
             )
           );
@@ -355,9 +339,7 @@ evaluate_enum_type :: (
           dyn(
             format_error_message(
               ast_expr_token(enum_arg),
-              String.from("Please use \"impl\" block to define members/methods for enum types."),
-              false,
-              .None
+              String.from("Please use \"impl\" block to define members/methods for enum types.")
             )
           )
         );
@@ -372,9 +354,7 @@ evaluate_enum_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(enum_arg),
-                `Expected identifier for enum variant, got:\n${ast_expr_to_string(enum_arg)}`,
-                false,
-                .None
+                `Expected identifier for enum variant, got:\n${ast_expr_to_string(enum_arg)}`
               )
             )
           );
@@ -384,9 +364,7 @@ evaluate_enum_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(enum_arg),
-                `Duplicate variant name "${variant_name}" in enum`,
-                false,
-                .None
+                `Duplicate variant name "${variant_name}" in enum`
               )
             )
           );
@@ -415,9 +393,7 @@ evaluate_enum_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(variant_expr),
-                String.from("Enum variant with : is not implemented yet"),
-                false,
-                .None
+                String.from("Enum variant with : is not implemented yet")
               )
             )
           );
@@ -428,9 +404,7 @@ evaluate_enum_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(variant_expr),
-                `Expected identifier for enum variant, got:\n${ast_expr_to_string(variant_expr)}`,
-                false,
-                .None
+                `Expected identifier for enum variant, got:\n${ast_expr_to_string(variant_expr)}`
               )
             )
           );
@@ -441,9 +415,7 @@ evaluate_enum_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(_fn_call_func(variant_expr)),
-                `Duplicate variant name "${variant_name}" in enum`,
-                false,
-                .None
+                `Duplicate variant name "${variant_name}" in enum`
               )
             )
           );
@@ -477,9 +449,7 @@ evaluate_enum_type :: (
               dyn(
                 format_error_message(
                   err_tok,
-                  `Duplicate field label "${field.label}" in enum variant`,
-                  false,
-                  .None
+                  `Duplicate field label "${field.label}" in enum variant`
                 )
               )
             );
@@ -489,9 +459,7 @@ evaluate_enum_type :: (
               dyn(
                 format_error_message(
                   ast_expr_token(field_arg),
-                  String.from("Enum variant field cannot have compile-time assigned value."),
-                  false,
-                  .None
+                  String.from("Enum variant field cannot have compile-time assigned value.")
                 )
               )
             );
@@ -524,9 +492,7 @@ evaluate_enum_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(gre),
-                `Expected recur(...) for GADT return type, got:\n${ast_expr_to_string(gre)}`,
-                false,
-                .None
+                `Expected recur(...) for GADT return type, got:\n${ast_expr_to_string(gre)}`
               )
             )
           );
@@ -544,9 +510,7 @@ evaluate_enum_type :: (
               dyn(
                 format_error_message(
                   ast_expr_token(ra),
-                  `Expected type for GADT return type argument, got ${ast_expr_to_string(ra)}`,
-                  false,
-                  .None
+                  `Expected type for GADT return type argument, got ${ast_expr_to_string(ra)}`
                 )
               )
             );
@@ -733,9 +697,7 @@ evaluate_enum_type :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Type ${type_to_string(enum_ty)} has incompatible field contexts and cannot be used in any evaluation context.`,
-            false,
-            .None
+            `Type ${type_to_string(enum_ty)} has incompatible field contexts and cannot be used in any evaluation context.`
           )
         )
       );

--- a/src/evaluator/types/field.yo
+++ b/src/evaluator/types/field.yo
@@ -150,9 +150,7 @@ evaluate_type_field :: (
           dyn(
             format_error_message(
               ast_expr_token(lhs_expr),
-              `Expected identifier for element label, got ${ast_expr_to_string(lhs_expr)}`,
-              false,
-              .None
+              `Expected identifier for element label, got ${ast_expr_to_string(lhs_expr)}`
             )
           )
         );
@@ -170,9 +168,7 @@ evaluate_type_field :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Cannot have both default value and required value for element."),
-          false,
-          .None
+          String.from("Cannot have both default value and required value for element.")
         )
       )
     );
@@ -190,9 +186,7 @@ evaluate_type_field :: (
           dyn(
             format_error_message(
               ast_expr_token(lhs_),
-              String.from("Cannot combine the use of \"comptime\" with ::"),
-              false,
-              .None
+              String.from("Cannot combine the use of \"comptime\" with ::")
             )
           )
         );
@@ -206,9 +200,7 @@ evaluate_type_field :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_),
-            `Expected identifier for element label, got ${ast_expr_to_string(lhs_)}`,
-            false,
-            .None
+            `Expected identifier for element label, got ${ast_expr_to_string(lhs_)}`
           )
         )
       );
@@ -221,9 +213,7 @@ evaluate_type_field :: (
         dyn(
           format_error_message(
             ast_expr_token(expr_),
-            String.from("Cannot combine the use of \"comptime\" with \"::\""),
-            false,
-            .None
+            String.from("Cannot combine the use of \"comptime\" with \"::\"")
           )
         )
       );
@@ -236,9 +226,7 @@ evaluate_type_field :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_),
-            `Expected identifier for element label, got ${ast_expr_to_string(lhs_)}`,
-            false,
-            .None
+            `Expected identifier for element label, got ${ast_expr_to_string(lhs_)}`
           )
         )
       );
@@ -266,9 +254,7 @@ evaluate_type_field :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Failed to get the field at index ${tuple_field_index}`,
-              false,
-              .None
+              `Failed to get the field at index ${tuple_field_index}`
             )
           )
         );
@@ -305,9 +291,7 @@ evaluate_type_field :: (
         dyn(
           format_error_message(
             ast_expr_token(te),
-            `(1) Expected type for element, got ${ast_expr_to_string(te)}`,
-            false,
-            .None
+            `(1) Expected type for element, got ${ast_expr_to_string(te)}`
           )
         )
       );
@@ -330,9 +314,7 @@ evaluate_type_field :: (
         dyn(
           format_error_message(
             ast_expr_token(av_expr),
-            String.from("Assigned value expression is only allowed for compile-time only.\nPlease consider adding \"comptime\" modifier to the field label."),
-            false,
-            .None
+            String.from("Assigned value expression is only allowed for compile-time only.\nPlease consider adding \"comptime\" modifier to the field label.")
           )
         )
       );
@@ -373,9 +355,7 @@ evaluate_type_field :: (
           dyn(
             format_error_message(
               ast_expr_token(av_expr),
-              `Failed to evaluate required value expression: ${ast_expr_to_string(av_expr)}`,
-              false,
-              .None
+              `Failed to evaluate required value expression: ${ast_expr_to_string(av_expr)}`
             )
           )
         );
@@ -391,9 +371,7 @@ evaluate_type_field :: (
         dyn(
           format_error_message(
             ast_expr_token(av_expr),
-            `Expected compile-time known value for required value, got ${ast_expr_to_string(av_expr)}`,
-            false,
-            .None
+            `Expected compile-time known value for required value, got ${ast_expr_to_string(av_expr)}`
           )
         )
       );
@@ -407,9 +385,7 @@ evaluate_type_field :: (
           dyn(
             format_error_message(
               ast_expr_token(av_expr),
-              `Assigned value type mismatch:\nExpected type: ${type_to_string(ft)}\nGiven type: ${type_to_string(av_type)}`,
-              false,
-              .None
+              `Assigned value type mismatch:\nExpected type: ${type_to_string(ft)}\nGiven type: ${type_to_string(av_type)}`
             )
           )
         );
@@ -454,9 +430,7 @@ evaluate_type_field :: (
           dyn(
             format_error_message(
               ast_expr_token(dv_expr),
-              `Failed to evaluate default value expression: ${ast_expr_to_string(dv_expr)}`,
-              false,
-              .None
+              `Failed to evaluate default value expression: ${ast_expr_to_string(dv_expr)}`
             )
           )
         );
@@ -472,9 +446,7 @@ evaluate_type_field :: (
         dyn(
           format_error_message(
             ast_expr_token(dv_expr),
-            `Expected compile-time known value for default value, got ${ast_expr_to_string(dv_expr)}`,
-            false,
-            .None
+            `Expected compile-time known value for default value, got ${ast_expr_to_string(dv_expr)}`
           )
         )
       );
@@ -488,9 +460,7 @@ evaluate_type_field :: (
           dyn(
             format_error_message(
               ast_expr_token(dv_expr),
-              `Default value type mismatch:\nExpected type: ${type_to_string(ft)}\nGiven type: ${type_to_string(dv_type)}`,
-              false,
-              .None
+              `Default value type mismatch:\nExpected type: ${type_to_string(ft)}\nGiven type: ${type_to_string(dv_type)}`
             )
           )
         );
@@ -506,9 +476,7 @@ evaluate_type_field :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Failed to infer the element type"),
-          false,
-          .None
+          String.from("Failed to infer the element type")
         )
       )
     );
@@ -520,9 +488,7 @@ evaluate_type_field :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected label for ${for_type} field, got ${ast_expr_to_string(expr_)}`,
-          false,
-          .None
+          `Expected label for ${for_type} field, got ${ast_expr_to_string(expr_)}`
         )
       )
     );
@@ -574,9 +540,7 @@ evaluate_type_field :: (
           dyn(
             format_error_message(
               ast_expr_token(te),
-              `Cannot use Impl(Fn(...)) as a field type:\n  ${type_to_string(final_type)}\n\nEach closure has a unique anonymous type with a capture-dependent size, so an Impl(Fn(...)) field has no fixed runtime size.\n\nOptions:\n  - Use Dyn(Fn(...)) for a heap-allocated, type-erased closure (and wrap the value with dyn(...)).\n  - Make the containing type generic over a closure type parameter, e.g.\n      MyStruct :: (fn(comptime(F) : Type) -> comptime(Type))(struct(cb : F));`,
-              false,
-              .None
+              `Cannot use Impl(Fn(...)) as a field type:\n  ${type_to_string(final_type)}\n\nEach closure has a unique anonymous type with a capture-dependent size, so an Impl(Fn(...)) field has no fixed runtime size.\n\nOptions:\n  - Use Dyn(Fn(...)) for a heap-allocated, type-erased closure (and wrap the value with dyn(...)).\n  - Make the containing type generic over a closure type parameter, e.g.\n      MyStruct :: (fn(comptime(F) : Type) -> comptime(Type))(struct(cb : F));`
             )
           )
         );

--- a/src/evaluator/types/fn_trait.yo
+++ b/src/evaluator/types/fn_trait.yo
@@ -63,9 +63,7 @@ evaluate_fn_trait_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected -> operator for Fn trait type, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected -> operator for Fn trait type, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -79,9 +77,7 @@ evaluate_fn_trait_type :: (
       dyn(
         format_error_message(
           ast_expr_token(fn_call_expr),
-          `Expected Fn(...) for function trait, got:\n${ast_expr_to_string(fn_call_expr)}`,
-          false,
-          .None
+          `Expected Fn(...) for function trait, got:\n${ast_expr_to_string(fn_call_expr)}`
         )
       )
     );
@@ -109,9 +105,7 @@ evaluate_fn_trait_type :: (
           dyn(
             format_error_message(
               ast_expr_token(return_type_expr),
-              `Expected a type for Fn return type, got:\n${ast_expr_to_string(return_type_expr)}`,
-              false,
-              .None
+              `Expected a type for Fn return type, got:\n${ast_expr_to_string(return_type_expr)}`
             )
           )
         );
@@ -127,9 +121,7 @@ evaluate_fn_trait_type :: (
         dyn(
           format_error_message(
             ast_expr_token(return_type_expr),
-            String.from("Failed to evaluate return type for Fn trait."),
-            false,
-            .None
+            String.from("Failed to evaluate return type for Fn trait.")
           )
         )
       );

--- a/src/evaluator/types/function.yo
+++ b/src/evaluator/types/function.yo
@@ -749,9 +749,7 @@ _get_expr_type :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Failed to get expr info after evaluation`,
-            false,
-            .None
+            `Failed to get expr info after evaluation`
           )
         )
       );
@@ -763,9 +761,7 @@ _get_expr_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected a type value, got ${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected a type value, got ${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -1076,9 +1072,7 @@ evaluate_function_parameter :: (
         dyn(
           format_error_message(
             ast_expr_token(expr_mut),
-            `Use "?=" for default parameter values. Assigned values require an explicit type: (name : Type) = value.`,
-            false,
-            .None
+            `Use "?=" for default parameter values. Assigned values require an explicit type: (name : Type) = value.`
           )
         )
       );
@@ -1090,9 +1084,7 @@ evaluate_function_parameter :: (
       dyn(
         format_error_message(
           ast_expr_token(expr_mut),
-          `":=" is not allowed in parameter lists. Use (name : Type) = value instead.`,
-          false,
-          .None
+          `":=" is not allowed in parameter lists. Use (name : Type) = value instead.`
         )
       )
     );
@@ -1130,9 +1122,7 @@ evaluate_function_parameter :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          _type_err_msg,
-          false,
-          .None
+          _type_err_msg
         )
       )
     );
@@ -1149,9 +1139,7 @@ evaluate_function_parameter :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_mut),
-                `"generic"/"using" parameters are "comptime" by default. Not needed to use "comptime" modifier.`,
-                false,
-                .None
+                `"generic"/"using" parameters are "comptime" by default. Not needed to use "comptime" modifier.`
               )
             )
           );
@@ -1163,9 +1151,7 @@ evaluate_function_parameter :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_mut),
-                `Expected one argument for "comptime", got ${c_args.len()}`,
-                false,
-                .None
+                `Expected one argument for "comptime", got ${c_args.len()}`
               )
             )
           );
@@ -1184,9 +1170,7 @@ evaluate_function_parameter :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_mut),
-                `Expected one argument for "own", got ${o_args.len()}`,
-                false,
-                .None
+                `Expected one argument for "own", got ${o_args.len()}`
               )
             )
           );
@@ -1199,7 +1183,7 @@ evaluate_function_parameter :: (
         r_args := _fn_call_args(lhs_mut);
         if(!(r_args.len() == usize(1)), {
           exn.throw(
-            dyn(format_error_message(ast_expr_token(lhs_mut), `Expected one argument for "inout", got ${r_args.len()}`, false, .None))
+            dyn(format_error_message(ast_expr_token(lhs_mut), `Expected one argument for "inout", got ${r_args.len()}`))
           );
         });
         if(is_owning_rc_value, {
@@ -1207,9 +1191,7 @@ evaluate_function_parameter :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_mut),
-                `Cannot combine 'own' and 'inout' on the same parameter — they have opposite calling conventions.`,
-                false,
-                .None
+                `Cannot combine 'own' and 'inout' on the same parameter — they have opposite calling conventions.`
               )
             )
           );
@@ -1223,9 +1205,7 @@ evaluate_function_parameter :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_mut),
-                `'inout' cannot combine with 'generic'/'using' parameters — they are erased at runtime and have no callee-side binding to mutate.`,
-                false,
-                .None
+                `'inout' cannot combine with 'generic'/'using' parameters — they are erased at runtime and have no callee-side binding to mutate.`
               )
             )
           );
@@ -1242,9 +1222,7 @@ evaluate_function_parameter :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_mut),
-                `Expected one argument for "quote" (or ":"), got ${q_args.len()}`,
-                false,
-                .None
+                `Expected one argument for "quote" (or ":"), got ${q_args.len()}`
               )
             )
           );
@@ -1254,9 +1232,7 @@ evaluate_function_parameter :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_mut),
-                `Cannot use "comptime" with "quote" (or ":"). "quote" parameters means compile-time only, so "comptime" is redundant.`,
-                false,
-                .None
+                `Cannot use "comptime" with "quote" (or ":"). "quote" parameters means compile-time only, so "comptime" is redundant.`
               )
             )
           );
@@ -1269,9 +1245,7 @@ evaluate_function_parameter :: (
           dyn(
             format_error_message(
               ast_expr_token(lhs_mut),
-              `Expected identifier for parameter label, got ${ast_expr_to_string(lhs_mut)}`,
-              false,
-              .None
+              `Expected identifier for parameter label, got ${ast_expr_to_string(lhs_mut)}`
             )
           )
         );
@@ -1287,9 +1261,7 @@ evaluate_function_parameter :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected a label for function parameter, got ${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected a label for function parameter, got ${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -1300,9 +1272,7 @@ evaluate_function_parameter :: (
       dyn(
         format_error_message(
           match(label_expr, .Some(e) => ast_expr_token(e), .None => ast_expr_token(expr)),
-          String.from("Not allowed to use 'Self' as the label."),
-          false,
-          .None
+          String.from("Not allowed to use 'Self' as the label.")
         )
       )
     );
@@ -1319,9 +1289,7 @@ evaluate_function_parameter :: (
           dyn(
             format_error_message(
               ast_expr_token(ave),
-              `Expected type value for = assignment, got ${ast_expr_to_string(ave)}`,
-              false,
-              .None
+              `Expected type value for = assignment, got ${ast_expr_to_string(ave)}`
             )
           )
         );
@@ -1333,9 +1301,7 @@ evaluate_function_parameter :: (
           dyn(
             format_error_message(
               ast_expr_token(ave),
-              `Assigned value (=) is only allowed for compile-time parameters. Use "comptime(${match(label, .Some(l) => l, .None => String.from("?"))})" or put this in "generic(...)".`,
-              false,
-              .None
+              `Assigned value (=) is only allowed for compile-time parameters. Use "comptime(${match(label, .Some(l) => l, .None => String.from("?"))})" or put this in "generic(...)".`
             )
           )
         );
@@ -1353,9 +1319,7 @@ evaluate_function_parameter :: (
           dyn(
             format_error_message(
               ast_expr_token(te),
-              `(3) Failed to evaluate type expression: ${ast_expr_to_string(te)}`,
-              false,
-              .None
+              `(3) Failed to evaluate type expression: ${ast_expr_to_string(te)}`
             )
           )
         );
@@ -1428,9 +1392,7 @@ evaluate_function_parameter :: (
                       dyn(
                         format_error_message(
                           ast_expr_token(dve),
-                          `Incompatible default value type:\n- Expected: ${type_to_string(pt)}\n- Got     : ${type_to_string(dv_ty)}`,
-                          false,
-                          .None
+                          `Incompatible default value type:\n- Expected: ${type_to_string(pt)}\n- Got     : ${type_to_string(dv_ty)}`
                         )
                       )
                     );
@@ -1443,9 +1405,7 @@ evaluate_function_parameter :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(dve),
-                    `Expected a compile-time known value for default parameter, got ${ast_expr_to_string(dve)}`,
-                    false,
-                    .None
+                    `Expected a compile-time known value for default parameter, got ${ast_expr_to_string(dve)}`
                   )
                 )
               );
@@ -1457,9 +1417,7 @@ evaluate_function_parameter :: (
             dyn(
               format_error_message(
                 ast_expr_token(dve),
-                `Failed to evaluate default value expression`,
-                false,
-                .None
+                `Failed to evaluate default value expression`
               )
             )
           );
@@ -1477,9 +1435,7 @@ evaluate_function_parameter :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("Expected type for function parameter}"),
-            false,
-            .None
+            String.from("Expected type for function parameter}")
           )
         )
       );
@@ -1497,9 +1453,7 @@ evaluate_function_parameter :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Raw-pointer-carrying types ('${type_to_string(final_param_type)}') are not available in safe code.\n\nUse owned collections (ArrayList/String), 'inout(name) : T' parameters for in-place mutation, or 'str' for static string views. If this file genuinely needs the raw view, add 'pragma(Pragma.AllowUnsafe);' at the top.`,
-          false,
-          .None
+          `Raw-pointer-carrying types ('${type_to_string(final_param_type)}') are not available in safe code.\n\nUse owned collections (ArrayList/String), 'inout(name) : T' parameters for in-place mutation, or 'str' for static string views. If this file genuinely needs the raw view, add 'pragma(Pragma.AllowUnsafe);' at the top.`
         )
       )
     );
@@ -1512,9 +1466,7 @@ evaluate_function_parameter :: (
       dyn(
         format_error_message(
           match(label_expr, .Some(e) => ast_expr_token(e), .None => ast_expr_token(expr)),
-          `Parameter marked as "comptime" but type is not available at compile-time:\n${type_to_string(final_param_type)}`,
-          false,
-          .None
+          `Parameter marked as "comptime" but type is not available at compile-time:\n${type_to_string(final_param_type)}`
         )
       )
     );
@@ -1524,9 +1476,7 @@ evaluate_function_parameter :: (
       dyn(
         format_error_message(
           match(label_expr, .Some(e) => ast_expr_token(e), .None => ast_expr_token(expr)),
-          `Parameter marked as runtime but type is not available at runtime:\n${type_to_string(final_param_type)}`,
-          false,
-          .None
+          `Parameter marked as runtime but type is not available at runtime:\n${type_to_string(final_param_type)}`
         )
       )
     );
@@ -1543,9 +1493,7 @@ evaluate_function_parameter :: (
         dyn(
           format_error_message(
             match(label_expr, .Some(e) => ast_expr_token(e), .None => ast_expr_token(expr)),
-            `Runtime function parameters with generic function types are not allowed:\n${type_to_string(final_param_type)}\n\nGeneric functions must be compile-time known to enable monomorphization. Consider using:\ncomptime(${match(label, .Some(l) => l, .None => String.from("?"))}) : ${type_to_string(final_param_type)}`,
-            false,
-            .None
+            `Runtime function parameters with generic function types are not allowed:\n${type_to_string(final_param_type)}\n\nGeneric functions must be compile-time known to enable monomorphization. Consider using:\ncomptime(${match(label, .Some(l) => l, .None => String.from("?"))}) : ${type_to_string(final_param_type)}`
           )
         )
       );
@@ -1559,9 +1507,7 @@ evaluate_function_parameter :: (
       dyn(
         format_error_message(
           match(label_expr, .Some(e) => ast_expr_token(e), .None => ast_expr_token(expr)),
-          `Expected Expr or ExprList type for "quote" (or ":") parameter, got ${type_to_string(final_param_type)}`,
-          false,
-          .None
+          `Expected Expr or ExprList type for "quote" (or ":") parameter, got ${type_to_string(final_param_type)}`
         )
       )
     );
@@ -1593,9 +1539,7 @@ use_id :: (fn(generic(T : Type),
               where(T <: Id)
           ) -> T)({
   return(val.id());
-})`,
-            false,
-            .None
+})`
           )
         )
       );
@@ -1918,9 +1862,7 @@ validate_concrete_type_constraints :: (
           dyn(
             format_error_message(
               ast_expr_token(t_expr),
-              String.from("validate_concrete_type_constraints: failed to evaluate trait expression"),
-              false,
-              .None
+              String.from("validate_concrete_type_constraints: failed to evaluate trait expression")
             )
           )
         );
@@ -1942,9 +1884,7 @@ validate_concrete_type_constraints :: (
               dyn(
                 format_error_message(
                   ast_expr_token(t_expr),
-                  String.from("Expected trait type for right-hand side of where clause constraint."),
-                  false,
-                  .None
+                  String.from("Expected trait type for right-hand side of where clause constraint.")
                 )
               )
             );
@@ -1956,9 +1896,7 @@ validate_concrete_type_constraints :: (
             dyn(
               format_error_message(
                 ast_expr_token(t_expr),
-                String.from("Expected trait type for right-hand side of where clause constraint."),
-                false,
-                .None
+                String.from("Expected trait type for right-hand side of where clause constraint.")
               )
             )
           );
@@ -1970,9 +1908,7 @@ validate_concrete_type_constraints :: (
           dyn(
             format_error_message(
               ast_expr_token(t_expr),
-              String.from("Expected trait type for right-hand side of where clause constraint, got: ").concat(type_to_string(tv)),
-              false,
-              .None
+              String.from("Expected trait type for right-hand side of where clause constraint, got: ").concat(type_to_string(tv))
             )
           )
         );
@@ -1993,9 +1929,7 @@ validate_concrete_type_constraints :: (
             dyn(
               format_error_message(
                 ast_expr_token(constraint_expr),
-                String.from("Type ").concat(type_to_string(concrete_type)).concat(String.from(" must NOT implement ")).concat(type_to_string(tv)).concat(String.from(", but it does.")),
-                false,
-                .None
+                String.from("Type ").concat(type_to_string(concrete_type)).concat(String.from(" must NOT implement ")).concat(type_to_string(tv)).concat(String.from(", but it does."))
               )
             )
           );
@@ -2006,9 +1940,7 @@ validate_concrete_type_constraints :: (
             dyn(
               format_error_message(
                 ast_expr_token(constraint_expr),
-                String.from("Type ").concat(type_to_string(concrete_type)).concat(String.from(" does not implement required trait ")).concat(type_to_string(tv)).concat(String.from(".")),
-                false,
-                .None
+                String.from("Type ").concat(type_to_string(concrete_type)).concat(String.from(" does not implement required trait ")).concat(type_to_string(tv)).concat(String.from("."))
               )
             )
           );
@@ -2019,9 +1951,7 @@ validate_concrete_type_constraints :: (
         dyn(
           format_error_message(
             ast_expr_token(t_expr),
-            String.from("Expected trait type for right-hand side of where clause constraint."),
-            false,
-            .None
+            String.from("Expected trait type for right-hand side of where clause constraint.")
           )
         )
       );
@@ -2150,9 +2080,7 @@ apply_single_trait_constraint :: (
       dyn(
         format_error_message(
           ast_expr_token(unwrapped_trait_expr),
-          `Expected trait type for right-hand side of where clause constraint, got: ${type_to_string(trait_ty)}`,
-          false,
-          .None
+          `Expected trait type for right-hand side of where clause constraint, got: ${type_to_string(trait_ty)}`
         )
       )
     );
@@ -2163,9 +2091,7 @@ apply_single_trait_constraint :: (
       dyn(
         format_error_message(
           ast_expr_token(unwrapped_trait_expr),
-          String.from("Trait type in where clause already has a receiver type assigned."),
-          false,
-          .None
+          String.from("Trait type in where clause already has a receiver type assigned.")
         )
       )
     );
@@ -2207,9 +2133,7 @@ parse_where_clause_constraints :: (
         dyn(
           format_error_message(
             ast_expr_token(constraint_expr),
-            `Expected constraint in the form "T <: Trait" or "T <: (Trait1, Trait2)", got: ${ast_expr_to_string(constraint_expr)}`,
-            false,
-            .None
+            `Expected constraint in the form "T <: Trait" or "T <: (Trait1, Trait2)", got: ${ast_expr_to_string(constraint_expr)}`
           )
         )
       );
@@ -2252,9 +2176,7 @@ parse_where_clause_constraints :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(lhs_expr),
-                      `Expected type for left-hand side of where clause constraint, got variable "${var_name}".`,
-                      false,
-                      .None
+                      `Expected type for left-hand side of where clause constraint, got variable "${var_name}".`
                     )
                   )
                 );
@@ -2266,9 +2188,7 @@ parse_where_clause_constraints :: (
               dyn(
                 format_error_message(
                   ast_expr_token(lhs_expr),
-                  `Expected type for left-hand side of where clause constraint, got variable "${var_name}".`,
-                  false,
-                  .None
+                  `Expected type for left-hand side of where clause constraint, got variable "${var_name}".`
                 )
               )
             );
@@ -2316,9 +2236,7 @@ parse_where_clause_constraints :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_expr),
-                String.from("Expected type for left-hand side of where clause constraint."),
-                false,
-                .None
+                String.from("Expected type for left-hand side of where clause constraint.")
               )
             )
           );
@@ -2330,9 +2248,7 @@ parse_where_clause_constraints :: (
           dyn(
             format_error_message(
               ast_expr_token(lhs_expr),
-              String.from("Expected type for left-hand side of where clause constraint."),
-              false,
-              .None
+              String.from("Expected type for left-hand side of where clause constraint.")
             )
           )
         );
@@ -2420,9 +2336,7 @@ parse_where_clause_constraints :: (
               dyn(
                 format_error_message(
                   ast_expr_token(unwrapped_te),
-                  String.from("Expected trait type for right-hand side of where clause constraint."),
-                  false,
-                  .None
+                  String.from("Expected trait type for right-hand side of where clause constraint.")
                 )
               )
             );
@@ -2441,9 +2355,7 @@ parse_where_clause_constraints :: (
             dyn(
               format_error_message(
                 ast_expr_token(unwrapped_te),
-                String.from("Expected trait type for right-hand side of where clause constraint."),
-                false,
-                .None
+                String.from("Expected trait type for right-hand side of where clause constraint.")
               )
             )
           );
@@ -2464,9 +2376,7 @@ parse_where_clause_constraints :: (
           dyn(
             format_error_message(
               ast_expr_token(unwrapped_te),
-              `Expected trait type for right-hand side of where clause constraint, got: ${type_to_string(trait_ty2)}`,
-              false,
-              .None
+              `Expected trait type for right-hand side of where clause constraint, got: ${type_to_string(trait_ty2)}`
             )
           )
         );
@@ -2476,9 +2386,7 @@ parse_where_clause_constraints :: (
           dyn(
             format_error_message(
               ast_expr_token(unwrapped_te),
-              String.from("Trait type in where clause already has a receiver type assigned."),
-              false,
-              .None
+              String.from("Trait type in where clause already has a receiver type assigned.")
             )
           )
         );
@@ -2720,9 +2628,7 @@ evaluate_function_parameters :: (
               dyn(
                 format_error_message(
                   ast_expr_token(tp_expr),
-                  `Duplicate label "${row_var_name}" in type parameter`,
-                  false,
-                  .None
+                  `Duplicate label "${row_var_name}" in type parameter`
                 )
               )
             );
@@ -2801,9 +2707,7 @@ evaluate_function_parameters :: (
             dyn(
               format_error_message(
                 ast_expr_token(tp_expr),
-                `Duplicate label "${param.label}" in type parameter`,
-                false,
-                .None
+                `Duplicate label "${param.label}" in type parameter`
               )
             )
           );
@@ -2829,9 +2733,7 @@ evaluate_function_parameters :: (
         dyn(
           format_error_message(
             ast_expr_token(param_expr),
-            `Only one "..." clause is allowed per function signature. Combine all implicit parameters into a single , e.g.: a : TypeA, b : TypeB`,
-            false,
-            .None
+            `Only one "..." clause is allowed per function signature. Combine all implicit parameters into a single , e.g.: a : TypeA, b : TypeB`
           )
         )
       );
@@ -2854,9 +2756,7 @@ evaluate_function_parameters :: (
             dyn(
               format_error_message(
                 ast_expr_token(impl_expr),
-                `Effect row variable "${row_var_name2}" not found in scope. Declare it with generic(..., ...(${row_var_name2}))`,
-                false,
-                .None
+                `Effect row variable "${row_var_name2}" not found in scope. Declare it with generic(..., ...(${row_var_name2}))`
               )
             )
           );
@@ -2869,9 +2769,7 @@ evaluate_function_parameters :: (
               dyn(
                 format_error_message(
                   ast_expr_token(impl_expr),
-                  String.from("Effect row variable not found"),
-                  false,
-                  .None
+                  String.from("Effect row variable not found")
                 )
               )
             );
@@ -2926,9 +2824,7 @@ evaluate_function_parameters :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(impl_expr),
-                            `"...(${row_var_name2})" requires "${row_var_name2}" to be a generic-declared effect row variable, but it resolves to a concrete type.`,
-                            false,
-                            .None
+                            `"...(${row_var_name2})" requires "${row_var_name2}" to be a generic-declared effect row variable, but it resolves to a concrete type.`
                           )
                         )
                       );
@@ -3026,9 +2922,7 @@ evaluate_function_parameters :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(impl_expr),
-                        `Effect row variable "${row_var_name2}" has invalid value. Expected a type.`,
-                        false,
-                        .None
+                        `Effect row variable "${row_var_name2}" has invalid value. Expected a type.`
                       )
                     )
                   );
@@ -3039,9 +2933,7 @@ evaluate_function_parameters :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(impl_expr),
-                      `Effect row variable "${row_var_name2}" has no value.`,
-                      false,
-                      .None
+                      `Effect row variable "${row_var_name2}" has no value.`
                     )
                   )
                 );
@@ -3066,9 +2958,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(impl_expr),
-              `Implicit parameter requires a label. Use "name : Type" instead of "Type".`,
-              false,
-              .None
+              `Implicit parameter requires a label. Use "name : Type" instead of "Type".`
             )
           )
         );
@@ -3097,9 +2987,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(impl_expr),
-              `Duplicate label "${param.label}" in implicit parameter (already in generic)`,
-              false,
-              .None
+              `Duplicate label "${param.label}" in implicit parameter (already in generic)`
             )
           )
         );
@@ -3126,9 +3014,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(impl_expr),
-              `Duplicate label "${param.label}" in implicit parameter`,
-              false,
-              .None
+              `Duplicate label "${param.label}" in implicit parameter`
             )
           )
         );
@@ -3191,9 +3077,7 @@ evaluate_function_parameters :: (
         dyn(
           format_error_message(
             ast_expr_token(z_expr),
-            `${z_name} appears after ${max_name} in the function signature. The canonical clause order is: generic(...), parameters, where(...), requires(...), ensures(...). Move ${z_name} before ${_zone_label(max_zone)}.`,
-            false,
-            .None
+            `${z_name} appears after ${max_name} in the function signature. The canonical clause order is: generic(...), parameters, where(...), requires(...), ensures(...). Move ${z_name} before ${_zone_label(max_zone)}.`
           )
         )
       );
@@ -3220,9 +3104,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(c_expr),
-              String.from("'requires(...)' with zero arguments is a syntax error. Omit the clause entirely if there is no precondition."),
-              false,
-              .None
+              String.from("'requires(...)' with zero arguments is a syntax error. Omit the clause entirely if there is no precondition.")
             )
           )
         );
@@ -3232,9 +3114,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(c_expr),
-              String.from("Multiple 'requires(...)' clauses in the same signature are a syntax error. Combine the predicates into one call: 'requires(P1, P2, ...)'."),
-              false,
-              .None
+              String.from("Multiple 'requires(...)' clauses in the same signature are a syntax error. Combine the predicates into one call: 'requires(P1, P2, ...)'.")
             )
           )
         );
@@ -3260,9 +3140,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(c_expr),
-              String.from("'ensures(...)' with zero arguments is a syntax error. Omit the clause entirely if there is no postcondition."),
-              false,
-              .None
+              String.from("'ensures(...)' with zero arguments is a syntax error. Omit the clause entirely if there is no postcondition.")
             )
           )
         );
@@ -3272,9 +3150,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(c_expr),
-              String.from("Multiple 'ensures(...)' clauses in the same signature are a syntax error. Combine the predicates into one call: 'ensures(Q1, Q2, ...)'."),
-              false,
-              .None
+              String.from("Multiple 'ensures(...)' clauses in the same signature are a syntax error. Combine the predicates into one call: 'ensures(Q1, Q2, ...)'.")
             )
           )
         );
@@ -3397,9 +3273,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(last_param),
-              String.from("The where clause must have at least one constraint."),
-              false,
-              .None
+              String.from("The where clause must have at least one constraint.")
             )
           )
         );
@@ -3423,9 +3297,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(param_expr),
-              `Expected type parameters to be the first argument, got ${(current_i + usize(1))}`,
-              false,
-              .None
+              `Expected type parameters to be the first argument, got ${(current_i + usize(1))}`
             )
           )
         );
@@ -3503,9 +3375,7 @@ evaluate_function_parameters :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(vlhs_arg),
-                      `Expected a valid variable name for variadic parameter, got ${ast_expr_to_string(vlhs_arg)}`,
-                      false,
-                      .None
+                      `Expected a valid variable name for variadic parameter, got ${ast_expr_to_string(vlhs_arg)}`
                     )
                   )
                 );
@@ -3522,9 +3392,7 @@ evaluate_function_parameters :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(vtype_arg),
-                    `Expected type for variadic parameter, got ${ast_expr_to_string(vtype_arg)}`,
-                    false,
-                    .None
+                    `Expected type for variadic parameter, got ${ast_expr_to_string(vtype_arg)}`
                   )
                 )
               );
@@ -3559,9 +3427,7 @@ evaluate_function_parameters :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(varg),
-                      String.from("...(param_name) is not supported yet."),
-                      false,
-                      .None
+                      String.from("...(param_name) is not supported yet.")
                     )
                   )
                 );
@@ -3570,9 +3436,7 @@ evaluate_function_parameters :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(varg),
-                      `Expected a valid variable name for variadic parameter, got ${ast_expr_to_string(varg)}`,
-                      false,
-                      .None
+                      `Expected a valid variable name for variadic parameter, got ${ast_expr_to_string(varg)}`
                     )
                   )
                 );
@@ -3632,9 +3496,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               ast_expr_token(param_expr),
-              String.from("Expected variadic parameter to be the last parameter before the normal parameters."),
-              false,
-              .None
+              String.from("Expected variadic parameter to be the last parameter before the normal parameters.")
             )
           )
         );
@@ -3668,9 +3530,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               _dup_err_tok,
-              `Duplicate label "${param.label}" in function parameter`,
-              false,
-              .None
+              `Duplicate label "${param.label}" in function parameter`
             )
           )
         );
@@ -3700,9 +3560,7 @@ evaluate_function_parameters :: (
           dyn(
             format_error_message(
               _eli_tok,
-              String.from("Expected ExprList type to be the last parameter."),
-              false,
-              .None
+              String.from("Expected ExprList type to be the last parameter.")
             )
           )
         );
@@ -3761,9 +3619,7 @@ evaluate_function_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected -> for function type, got:\n${ast_expr_to_string(expr)}\n\nNote: For closures, use Impl(Fn(...) -> ...) syntax.`,
-          false,
-          .None
+          `Expected -> for function type, got:\n${ast_expr_to_string(expr)}\n\nNote: For closures, use Impl(Fn(...) -> ...) syntax.`
         )
       )
     );
@@ -3785,9 +3641,7 @@ evaluate_function_type :: (
       dyn(
         format_error_message(
           ast_expr_token(arg_list_expr),
-          `Expected a "fn", "ctl", or "unsafe_fn" call for parameter list, got:\n${ast_expr_to_string(arg_list_expr)}`,
-          false,
-          .None
+          `Expected a "fn", "ctl", or "unsafe_fn" call for parameter list, got:\n${ast_expr_to_string(arg_list_expr)}`
         )
       )
     );
@@ -3827,9 +3681,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(rl_expr),
-            String.from("Functions cannot return 'ref' — return the value instead (object values are handles that mutate in place; struct values copy), or take a callback parameter that receives 'inout(name) : T'."),
-            false,
-            .None
+            String.from("Functions cannot return 'ref' — return the value instead (object values are handles that mutate in place; struct values copy), or take a callback parameter that receives 'inout(name) : T'.")
           )
         )
       );
@@ -3843,9 +3695,7 @@ evaluate_function_type :: (
           dyn(
             format_error_message(
               ast_expr_token(rl_expr),
-              `Expected one argument for "comptime", got ${ct_args.len()}`,
-              false,
-              .None
+              `Expected one argument for "comptime", got ${ct_args.len()}`
             )
           )
         );
@@ -3866,9 +3716,7 @@ evaluate_function_type :: (
           dyn(
             format_error_message(
               ast_expr_token(rl_expr),
-              `Expected one argument for "unquote", got ${uq_args.len()}`,
-              false,
-              .None
+              `Expected one argument for "unquote", got ${uq_args.len()}`
             )
           )
         );
@@ -3878,9 +3726,7 @@ evaluate_function_type :: (
           dyn(
             format_error_message(
               ast_expr_token(rl_expr),
-              `Cannot use "comptime" with "unquote". "unquote" return type means compile-time only, so "comptime" is redundant.`,
-              false,
-              .None
+              `Cannot use "comptime" with "unquote". "unquote" return type means compile-time only, so "comptime" is redundant.`
             )
           )
         );
@@ -3894,9 +3740,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(rl_expr),
-            `To define a macro function, please use "unquote" for the return type, not "quote".`,
-            false,
-            .None
+            `To define a macro function, please use "unquote" for the return type, not "quote".`
           )
         )
       );
@@ -3911,9 +3755,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(return_type_expr),
-            String.from("In a labeled return slot, 'ref' goes on the label, not the type. Use '-> (inout(name) : T)' (or unlabeled '-> inout(T)'), not '-> (name : inout(T))'."),
-            false,
-            .None
+            String.from("In a labeled return slot, 'ref' goes on the label, not the type. Use '-> (inout(name) : T)' (or unlabeled '-> inout(T)'), not '-> (name : inout(T))'.")
           )
         )
       );
@@ -3923,9 +3765,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(return_type_expr),
-            String.from("In a labeled return slot, 'comptime' goes on the label, not the type. Use '-> (comptime(name) : T)' (or unlabeled '-> comptime(T)'), not '-> (name : comptime(T))'."),
-            false,
-            .None
+            String.from("In a labeled return slot, 'comptime' goes on the label, not the type. Use '-> (comptime(name) : T)' (or unlabeled '-> comptime(T)'), not '-> (name : comptime(T))'.")
           )
         )
       );
@@ -3935,9 +3775,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(rl_expr),
-            `Expected a valid variable name for return label, got ${ast_expr_to_string(rl_expr)}`,
-            false,
-            .None
+            `Expected a valid variable name for return label, got ${ast_expr_to_string(rl_expr)}`
           )
         )
       );
@@ -3953,9 +3791,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(return_type_expr),
-            String.from("Functions cannot return 'ref' — return the value instead (object values are handles that mutate in place; struct values copy), or take a callback parameter that receives 'inout(name) : T'."),
-            false,
-            .None
+            String.from("Functions cannot return 'ref' — return the value instead (object values are handles that mutate in place; struct values copy), or take a callback parameter that receives 'inout(name) : T'.")
           )
         )
       );
@@ -3968,9 +3804,7 @@ evaluate_function_type :: (
           dyn(
             format_error_message(
               ast_expr_token(return_type_expr),
-              `Expected one argument for "comptime", got ${ct_args2.len()}`,
-              false,
-              .None
+              `Expected one argument for "comptime", got ${ct_args2.len()}`
             )
           )
         );
@@ -3989,9 +3823,7 @@ evaluate_function_type :: (
           dyn(
             format_error_message(
               ast_expr_token(return_type_expr),
-              `Expected one argument for "unquote", got ${uq_args2.len()}`,
-              false,
-              .None
+              `Expected one argument for "unquote", got ${uq_args2.len()}`
             )
           )
         );
@@ -4001,9 +3833,7 @@ evaluate_function_type :: (
           dyn(
             format_error_message(
               ast_expr_token(return_type_expr),
-              `Cannot use "comptime" with "unquote". "unquote" return type means compile-time only, so "comptime" is redundant.`,
-              false,
-              .None
+              `Cannot use "comptime" with "unquote". "unquote" return type means compile-time only, so "comptime" is redundant.`
             )
           )
         );
@@ -4016,9 +3846,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(return_type_expr),
-            `To define a macro function, please use "unquote" for the return type, not "quote".`,
-            false,
-            .None
+            `To define a macro function, please use "unquote" for the return type, not "quote".`
           )
         )
       );
@@ -4032,9 +3860,7 @@ evaluate_function_type :: (
       dyn(
         format_error_message(
           ast_expr_token(return_type_expr),
-          String.from("Functions cannot return 'ref' — return the value instead (object values are handles that mutate in place; struct values copy), or take a callback parameter that receives 'inout(name) : T'."),
-          false,
-          .None
+          String.from("Functions cannot return 'ref' — return the value instead (object values are handles that mutate in place; struct values copy), or take a callback parameter that receives 'inout(name) : T'.")
         )
       )
     );
@@ -4052,9 +3878,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(return_type_expr),
-            `Expected a type for function return type, got:\n${ast_expr_to_string(return_type_expr)}`,
-            false,
-            .None
+            `Expected a type for function return type, got:\n${ast_expr_to_string(return_type_expr)}`
           )
         )
       );
@@ -4070,9 +3894,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(return_type_expr),
-            `Expected a "comptime" for return type, like:\n\ncomptime(${ast_expr_to_string(return_type_expr)})\n\nGiven type:\n${type_to_string(return_type)}`,
-            false,
-            .None
+            `Expected a "comptime" for return type, like:\n\ncomptime(${ast_expr_to_string(return_type_expr)})\n\nGiven type:\n${type_to_string(return_type)}`
           )
         )
       );
@@ -4090,9 +3912,7 @@ evaluate_function_type :: (
       dyn(
         format_error_message(
           ast_expr_token(return_type_expr),
-          `Unexpected "comptime" for return type of ${type_to_string(return_type)} which can only be used at runtime.`,
-          false,
-          .None
+          `Unexpected "comptime" for return type of ${type_to_string(return_type)} which can only be used at runtime.`
         )
       )
     );
@@ -4114,9 +3934,7 @@ evaluate_function_type :: (
           dyn(
             format_error_message(
               ast_expr_token(match(param_exprs_for_error(arg_list, rci), .Some(e) => e, .None => make_err_expr())),
-              String.from("Expected all parameters to be compile time only given the return type is compile time only."),
-              false,
-              .None
+              String.from("Expected all parameters to be compile time only given the return type is compile time only.")
             )
           )
         );
@@ -4130,9 +3948,7 @@ evaluate_function_type :: (
       dyn(
         format_error_message(
           ast_expr_token(return_type_expr),
-          `Expected Expr type for "unquote" return type, got ${type_to_string(return_type)}`,
-          false,
-          .None
+          `Expected Expr type for "unquote" return type, got ${type_to_string(return_type)}`
         )
       )
     );
@@ -4295,9 +4111,7 @@ evaluate_function_type :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("Defining a macro (a 'quote(...)' parameter or an 'unquote(...)' return type) requires 'pragma(Pragma.AllowMacroDef);' at the top of the file. See plans/MACRO_POLICY.md."),
-            false,
-            .None
+            String.from("Defining a macro (a 'quote(...)' parameter or an 'unquote(...)' return type) requires 'pragma(Pragma.AllowMacroDef);' at the top of the file. See plans/MACRO_POLICY.md.")
           )
         )
       );

--- a/src/evaluator/types/future_trait.yo
+++ b/src/evaluator/types/future_trait.yo
@@ -79,9 +79,7 @@ _resolve_effect_row_spread :: (
       dyn(
         format_error_message(
           ast_expr_token(effect_expr),
-          `Effect row variable "${row_var_name}" not found in scope. Declare it with generic(..., ...(${row_var_name}))`,
-          false,
-          .None
+          `Effect row variable "${row_var_name}" not found in scope. Declare it with generic(..., ...(${row_var_name}))`
         )
       )
     );
@@ -135,9 +133,7 @@ _resolve_effect_row_spread :: (
                     dyn(
                       format_error_message(
                         ast_expr_token(effect_expr),
-                        `"...(${row_var_name})" requires "${row_var_name}" to be a generic-declared effect row variable, but it resolves to a concrete type. Use individual effect types directly instead of spreading them, e.g. Future(T, ${row_var_name}) instead of Future(T, ...(${row_var_name}))`,
-                        false,
-                        .None
+                        `"...(${row_var_name})" requires "${row_var_name}" to be a generic-declared effect row variable, but it resolves to a concrete type. Use individual effect types directly instead of spreading them, e.g. Future(T, ${row_var_name}) instead of Future(T, ...(${row_var_name}))`
                       )
                     )
                   );
@@ -210,9 +206,7 @@ _resolve_effect_row_spread :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(effect_expr),
-                    `Effect row variable "${row_var_name}" has invalid value. Expected a type.`,
-                    false,
-                    .None
+                    `Effect row variable "${row_var_name}" has invalid value. Expected a type.`
                   )
                 )
               );
@@ -224,9 +218,7 @@ _resolve_effect_row_spread :: (
             dyn(
               format_error_message(
                 ast_expr_token(effect_expr),
-                `Effect row variable "${row_var_name}" has invalid value. Expected a type.`,
-                false,
-                .None
+                `Effect row variable "${row_var_name}" has invalid value. Expected a type.`
               )
             )
           );
@@ -238,9 +230,7 @@ _resolve_effect_row_spread :: (
         dyn(
           format_error_message(
             ast_expr_token(effect_expr),
-            `Effect row variable "${row_var_name}" not found in scope.`,
-            false,
-            .None
+            `Effect row variable "${row_var_name}" not found in scope.`
           )
         )
       );
@@ -284,9 +274,7 @@ _resolve_effect_arg :: (
               dyn(
                 format_error_message(
                   ast_expr_token(effect_expr),
-                  `Future effect argument must be an effect type or E : Type.Struct spread, but got:\n${ast_expr_to_string(effect_expr)}`,
-                  false,
-                  .None
+                  `Future effect argument must be an effect type or E : Type.Struct spread, but got:\n${ast_expr_to_string(effect_expr)}`
                 )
               )
             );
@@ -307,9 +295,7 @@ _resolve_effect_arg :: (
             dyn(
               format_error_message(
                 ast_expr_token(effect_expr),
-                `Future effect argument must be an effect type or E : Type.Struct spread, but got:\n${ast_expr_to_string(effect_expr)}`,
-                false,
-                .None
+                `Future effect argument must be an effect type or E : Type.Struct spread, but got:\n${ast_expr_to_string(effect_expr)}`
               )
             )
           );
@@ -340,9 +326,7 @@ evaluate_future_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Future type constructor expects 1 or 2 arguments (output type, optional effect bundle struct).\nUsage: Future(T) or Future(T, E).\nTo combine multiple effects, declare a struct that bundles them and pass that struct as E."),
-          false,
-          .None
+          String.from("Future type constructor expects 1 or 2 arguments (output type, optional effect bundle struct).\nUsage: Future(T) or Future(T, E).\nTo combine multiple effects, declare a struct that bundles them and pass that struct as E.")
         )
       )
     );
@@ -359,9 +343,7 @@ evaluate_future_type :: (
         dyn(
           format_error_message(
             ast_expr_token(element_type_expr),
-            `Failed to evaluate the element type expression for Future:\n${ast_expr_to_string(element_type_expr)}`,
-            false,
-            .None
+            `Failed to evaluate the element type expression for Future:\n${ast_expr_to_string(element_type_expr)}`
           )
         )
       );
@@ -374,9 +356,7 @@ evaluate_future_type :: (
       dyn(
         format_error_message(
           ast_expr_token(element_type_expr),
-          `Future type constructor expects a type as its first argument, but got:\n${ast_expr_to_string(element_type_expr)}`,
-          false,
-          .None
+          `Future type constructor expects a type as its first argument, but got:\n${ast_expr_to_string(element_type_expr)}`
         )
       )
     );

--- a/src/evaluator/types/record.yo
+++ b/src/evaluator/types/record.yo
@@ -77,9 +77,7 @@ evaluate_module_field :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("evaluate_module_field: ?= (default value) is not yet supported (Phase 3)"),
-          false,
-          .None
+          String.from("evaluate_module_field: ?= (default value) is not yet supported (Phase 3)")
         )
       )
     );
@@ -90,9 +88,7 @@ evaluate_module_field :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Cannot use \"::\" for module field. Use \":=\" instead.\nAll module fields are compile-time only by default."),
-          false,
-          .None
+          String.from("Cannot use \"::\" for module field. Use \":=\" instead.\nAll module fields are compile-time only by default.")
         )
       )
     );
@@ -103,9 +99,7 @@ evaluate_module_field :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("evaluate_module_field: assigned value form is not yet supported (Phase 3)"),
-          false,
-          .None
+          String.from("evaluate_module_field: assigned value form is not yet supported (Phase 3)")
         )
       )
     );
@@ -116,9 +110,7 @@ evaluate_module_field :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected label for module field, got ${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected label for module field, got ${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -132,9 +124,7 @@ evaluate_module_field :: (
       dyn(
         format_error_message(
           ast_expr_token(label_expr),
-          `Expected identifier for module field label, got ${ast_expr_to_string(label_expr)}`,
-          false,
-          .None
+          `Expected identifier for module field label, got ${ast_expr_to_string(label_expr)}`
         )
       )
     );
@@ -154,9 +144,7 @@ evaluate_module_field :: (
       dyn(
         format_error_message(
           ast_expr_token(type_expr),
-          `Expected type for module field, got ${ast_expr_to_string(type_expr)}`,
-          false,
-          .None
+          `Expected type for module field, got ${ast_expr_to_string(type_expr)}`
         )
       )
     );

--- a/src/evaluator/types/struct.yo
+++ b/src/evaluator/types/struct.yo
@@ -64,9 +64,7 @@ evaluate_struct_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "struct" or "newtype", got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "struct" or "newtype", got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -155,9 +153,7 @@ evaluate_struct_type :: (
         dyn(
           format_error_message(
             err_tok,
-            `Duplicate label "${field.label}" in struct`,
-            false,
-            .None
+            `Duplicate label "${field.label}" in struct`
           )
         )
       );
@@ -189,9 +185,7 @@ evaluate_struct_type :: (
         dyn(
           format_error_message(
             res_tok,
-            String.from("\"header\" is a reserved field name in a reference struct: the generated C layout already carries a `header` member (the reference-count header), so a field of that name would collide with it. Rename the field."),
-            false,
-            .None
+            String.from("\"header\" is a reserved field name in a reference struct: the generated C layout already carries a `header` member (the reference-count header), so a field of that name would collide with it. Rename the field.")
           )
         )
       );
@@ -234,9 +228,7 @@ evaluate_struct_type :: (
             dyn(
               format_error_message(
                 ast_expr_token(expr),
-                `Arc(Iso(T)) is not allowed.\n  - Arc is for shared ownership; Iso is for unique ownership. The composition is contradictory.\n  - If you want a "one of many threads races to claim a value" pattern, build a Oneshot(T) primitive on top of Mutex + Option (or wait for std/sync to expose one).`,
-                false,
-                .None
+                `Arc(Iso(T)) is not allowed.\n  - Arc is for shared ownership; Iso is for unique ownership. The composition is contradictory.\n  - If you want a "one of many threads races to claim a value" pattern, build a Oneshot(T) primitive on top of Mutex + Option (or wait for std/sync to expose one).`
               )
             )
           );
@@ -251,9 +243,7 @@ evaluate_struct_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Newtype struct must have exactly one field, but got ${fields.len()} fields.`,
-          false,
-          .None
+          `Newtype struct must have exactly one field, but got ${fields.len()} fields.`
         )
       )
     );
@@ -339,9 +329,7 @@ evaluate_struct_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Type ${type_to_string(struct_ty)} has incompatible field contexts and cannot be used in any evaluation context.`,
-          false,
-          .None
+          `Type ${type_to_string(struct_ty)} has incompatible field contexts and cannot be used in any evaluation context.`
         )
       )
     );

--- a/src/evaluator/types/synthesizer.yo
+++ b/src/evaluator/types/synthesizer.yo
@@ -72,7 +72,7 @@ _is_runtime_numeric :: (fn(t : TypeValue) -> bool)(
 { type_to_string, type_to_string_key } :: import("../../types/string.yo");
 { EvalValue, lookup_enum_cfid, value_to_string } :: import("../../value.yo");
 { get_gadt_type_constructor_args } :: import("./gadt_registry.yo");
-{ format_error_message, ErrorKind } :: import("../../error.yo");
+{ format_error_message } :: import("../../error.yo");
 { Exception } :: import("std/error");
 // ---------------------------------------------------------------------------
 // Public data types
@@ -159,9 +159,7 @@ synthesize_types :: (
       dyn(
         format_error_message(
           synthetic_token(String.from("E"), expected_env.module_path),
-          String.from("synthesize_types called before initialization"),
-          false,
-          Option(ErrorKind).None
+          String.from("synthesize_types called before initialization")
         )
       )
     ),
@@ -189,9 +187,7 @@ _synthesize_call :: (
       dyn(
         format_error_message(
           synthetic_token(String.from("E"), expected_env.module_path),
-          String.from("_synthesize_call: synthesize_types not initialized"),
-          false,
-          Option(ErrorKind).None
+          String.from("_synthesize_call: synthesize_types not initialized")
         )
       )
     ),
@@ -847,9 +843,7 @@ _synthesize_implicit_params :: (
       dyn(
         format_error_message(
           synthetic_token(String.from("E"), expected_env.module_path),
-          String.from("Ambiguous effect row unification: multiple unsolved effect row variables. At most one effect row spread can be unsolved during type unification."),
-          false,
-          Option(ErrorKind).None
+          String.from("Ambiguous effect row unification: multiple unsolved effect row variables. At most one effect row spread can be unsolved during type unification.")
         )
       )
     );
@@ -1019,9 +1013,7 @@ _synthesize_implicit_params :: (
         dyn(
           format_error_message(
             synthetic_token(String.from("E"), expected_env.module_path),
-            String.from("Effect row unification failed: some expected effects not found in given implicit parameters."),
-            false,
-            Option(ErrorKind).None
+            String.from("Effect row unification failed: some expected effects not found in given implicit parameters.")
           )
         )
       );
@@ -1373,9 +1365,7 @@ _synthesize_types_impl :: (
             dyn(
               format_error_message(
                 synthetic_token(exp_name, ee.module_path),
-                `Cannot unify type variable "${exp_name}" with type "${type_to_string(given_ty)}" because it would create an infinite type.`,
-                false,
-                Option(ErrorKind).None
+                `Cannot unify type variable "${exp_name}" with type "${type_to_string(given_ty)}" because it would create an infinite type.`
               )
             )
           );
@@ -1464,9 +1454,7 @@ _synthesize_types_impl :: (
             dyn(
               format_error_message(
                 synthetic_token(giv_name, ge.module_path),
-                `Cannot unify type variable "${giv_name}" with type "${type_to_string(expected_ty)}" because it would create an infinite type.`,
-                false,
-                Option(ErrorKind).None
+                `Cannot unify type variable "${giv_name}" with type "${type_to_string(expected_ty)}" because it would create an infinite type.`
               )
             )
           );
@@ -1505,9 +1493,7 @@ _synthesize_types_impl :: (
         dyn(
           format_error_message(
             synthetic_token(String.from("tuple"), ee.module_path),
-            `Cannot unify incompatible tuple types: "${type_to_string(expected_ty)}" and "${type_to_string(given_ty)}"`,
-            false,
-            Option(ErrorKind).None
+            `Cannot unify incompatible tuple types: "${type_to_string(expected_ty)}" and "${type_to_string(given_ty)}"`
           )
         )
       );
@@ -1626,9 +1612,7 @@ _synthesize_types_impl :: (
         dyn(
           format_error_message(
             synthetic_token(String.from("struct"), ee.module_path),
-            `Cannot unify incompatible struct types: "${type_to_string(expected_ty)}" and "${type_to_string(given_ty)}"`,
-            false,
-            Option(ErrorKind).None
+            `Cannot unify incompatible struct types: "${type_to_string(expected_ty)}" and "${type_to_string(given_ty)}"`
           )
         )
       );
@@ -1719,9 +1703,7 @@ _synthesize_types_impl :: (
         dyn(
           format_error_message(
             synthetic_token(String.from("enum"), ee.module_path),
-            `Cannot unify incompatible enum types: "${type_to_string(exp_en_ty)}" and "${type_to_string(giv_en_ty)}"`,
-            false,
-            Option(ErrorKind).None
+            `Cannot unify incompatible enum types: "${type_to_string(exp_en_ty)}" and "${type_to_string(giv_en_ty)}"`
           )
         )
       );
@@ -2221,9 +2203,7 @@ _synthesize_types_impl :: (
         dyn(
           format_error_message(
             synthetic_token(String.from("type"), ee.module_path),
-            `Cannot unify incompatible types: "${type_to_string(expected_ty)}" and "${type_to_string(given_ty)}"`,
-            false,
-            Option(ErrorKind).None
+            `Cannot unify incompatible types: "${type_to_string(expected_ty)}" and "${type_to_string(given_ty)}"`
           )
         )
       );

--- a/src/evaluator/types/trait.yo
+++ b/src/evaluator/types/trait.yo
@@ -128,9 +128,7 @@ _get_or_create_some_ty_for_trait :: (
             dyn(
               format_error_message(
                 ast_expr_token(lhs_expr),
-                String.from("Expected type for left-hand side of where clause constraint."),
-                false,
-                .None
+                String.from("Expected type for left-hand side of where clause constraint.")
               )
             )
           );
@@ -160,9 +158,7 @@ _get_or_create_some_ty_for_trait :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_expr),
-            String.from("Expected type for left-hand side of where clause constraint."),
-            false,
-            .None
+            String.from("Expected type for left-hand side of where clause constraint.")
           )
         )
       );
@@ -208,9 +204,7 @@ _get_or_create_some_ty_for_trait :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_expr),
-            String.from("Expected type for left-hand side of where clause constraint."),
-            false,
-            .None
+            String.from("Expected type for left-hand side of where clause constraint.")
           )
         )
       );
@@ -222,9 +216,7 @@ _get_or_create_some_ty_for_trait :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs_expr),
-          String.from("Expected type for left-hand side of where clause constraint."),
-          false,
-          .None
+          String.from("Expected type for left-hand side of where clause constraint.")
         )
       )
     );
@@ -243,9 +235,7 @@ _get_or_create_some_ty_for_trait :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs_expr),
-          `Expected SomeType for left-hand side of where clause constraint, got ${type_to_string(lhs_tv)}`,
-          false,
-          .None
+          `Expected SomeType for left-hand side of where clause constraint, got ${type_to_string(lhs_tv)}`
         )
       )
     );
@@ -397,9 +387,7 @@ _parse_trait_where_clauses :: (
         dyn(
           format_error_message(
             ast_expr_token(constraint_expr),
-            `Expected constraint in the form "T <: Trait" or "T <: (Trait1, Trait2)", got: ${ast_expr_to_string(constraint_expr)}`,
-            false,
-            .None
+            `Expected constraint in the form "T <: Trait" or "T <: (Trait1, Trait2)", got: ${ast_expr_to_string(constraint_expr)}`
           )
         )
       );
@@ -476,9 +464,7 @@ _parse_trait_where_clauses :: (
               dyn(
                 format_error_message(
                   ast_expr_token(unwrapped_te),
-                  String.from("Expected trait type for right-hand side of where clause constraint."),
-                  false,
-                  .None
+                  String.from("Expected trait type for right-hand side of where clause constraint.")
                 )
               )
             );
@@ -495,9 +481,7 @@ _parse_trait_where_clauses :: (
             dyn(
               format_error_message(
                 ast_expr_token(unwrapped_te),
-                String.from("Expected trait type for right-hand side of where clause constraint."),
-                false,
-                .None
+                String.from("Expected trait type for right-hand side of where clause constraint.")
               )
             )
           );
@@ -517,9 +501,7 @@ _parse_trait_where_clauses :: (
           dyn(
             format_error_message(
               ast_expr_token(unwrapped_te),
-              `Expected trait type for right-hand side of where clause constraint, got: ${type_to_string(trait_ty2)}`,
-              false,
-              .None
+              `Expected trait type for right-hand side of where clause constraint, got: ${type_to_string(trait_ty2)}`
             )
           )
         );
@@ -529,9 +511,7 @@ _parse_trait_where_clauses :: (
           dyn(
             format_error_message(
               ast_expr_token(unwrapped_te),
-              String.from("Trait type in where clause already has a receiver type assigned."),
-              false,
-              .None
+              String.from("Trait type in where clause already has a receiver type assigned.")
             )
           )
         );
@@ -628,9 +608,7 @@ _evaluate_trait_field :: (
         dyn(
           format_error_message(
             ast_expr_token(expr_inner),
-            String.from("Cannot use \"::\" for trait field. Use \":=\" instead.\nAll trait fields are compile-time only by default."),
-            false,
-            .None
+            String.from("Cannot use \"::\" for trait field. Use \":=\" instead.\nAll trait fields are compile-time only by default.")
           )
         )
       );
@@ -645,9 +623,7 @@ _evaluate_trait_field :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Cannot have both default value and required value for trait field."),
-          false,
-          .None
+          String.from("Cannot have both default value and required value for trait field.")
         )
       )
     );
@@ -667,9 +643,7 @@ _evaluate_trait_field :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_label_expr),
-            String.from("No need to use \"comptime\" modifier. All trait fields are compile-time only by default."),
-            false,
-            .None
+            String.from("No need to use \"comptime\" modifier. All trait fields are compile-time only by default.")
           )
         )
       );
@@ -679,9 +653,7 @@ _evaluate_trait_field :: (
         dyn(
           format_error_message(
             ast_expr_token(lhs_label_expr),
-            `Expected identifier for trait field label, got ${ast_expr_to_string(lhs_label_expr)}`,
-            false,
-            .None
+            `Expected identifier for trait field label, got ${ast_expr_to_string(lhs_label_expr)}`
           )
         )
       );
@@ -696,9 +668,7 @@ _evaluate_trait_field :: (
         dyn(
           format_error_message(
             ast_expr_token(expr_inner),
-            String.from("No need to use \"comptime\" modifier. All trait fields are compile-time only by default."),
-            false,
-            .None
+            String.from("No need to use \"comptime\" modifier. All trait fields are compile-time only by default.")
           )
         )
       );
@@ -709,9 +679,7 @@ _evaluate_trait_field :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Expected label for trait field, got ${ast_expr_to_string(expr_inner)}`,
-            false,
-            .None
+            `Expected label for trait field, got ${ast_expr_to_string(expr_inner)}`
           )
         )
       );
@@ -722,9 +690,7 @@ _evaluate_trait_field :: (
         dyn(
           format_error_message(
             ast_expr_token(expr_inner),
-            `Expected identifier for trait field label, got ${ast_expr_to_string(expr_inner)}`,
-            false,
-            .None
+            `Expected identifier for trait field label, got ${ast_expr_to_string(expr_inner)}`
           )
         )
       );
@@ -793,9 +759,7 @@ _evaluate_trait_field :: (
           dyn(
             format_error_message(
               ast_expr_token(type_expr),
-              `Expected type for trait field, got ${ast_expr_to_string(type_expr)}`,
-              false,
-              .None
+              `Expected type for trait field, got ${ast_expr_to_string(type_expr)}`
             )
           )
         );
@@ -846,9 +810,7 @@ _evaluate_trait_field :: (
             dyn(
               format_error_message(
                 ast_expr_token(av_expr),
-                `Failed to evaluate required value expression: ${ast_expr_to_string(av_expr)}`,
-                false,
-                .None
+                `Failed to evaluate required value expression: ${ast_expr_to_string(av_expr)}`
               )
             )
           );
@@ -867,9 +829,7 @@ _evaluate_trait_field :: (
             dyn(
               format_error_message(
                 ast_expr_token(av_expr),
-                `Expected compile-time known value for required value, got ${ast_expr_to_string(av_expr)}`,
-                false,
-                .None
+                `Expected compile-time known value for required value, got ${ast_expr_to_string(av_expr)}`
               )
             )
           );
@@ -886,9 +846,7 @@ _evaluate_trait_field :: (
               dyn(
                 format_error_message(
                   ast_expr_token(av_expr),
-                  `Assigned value type mismatch:\nExpected type: ${type_to_string(fet)}\nGiven type: ${type_to_string(av_ty)}`,
-                  false,
-                  .None
+                  `Assigned value type mismatch:\nExpected type: ${type_to_string(fet)}\nGiven type: ${type_to_string(av_ty)}`
                 )
               )
             );
@@ -940,9 +898,7 @@ _evaluate_trait_field :: (
             dyn(
               format_error_message(
                 ast_expr_token(dv_expr),
-                `Failed to evaluate default value expression: ${ast_expr_to_string(dv_expr)}`,
-                false,
-                .None
+                `Failed to evaluate default value expression: ${ast_expr_to_string(dv_expr)}`
               )
             )
           );
@@ -961,9 +917,7 @@ _evaluate_trait_field :: (
             dyn(
               format_error_message(
                 ast_expr_token(dv_expr),
-                `Expected compile-time known value for default value, got ${ast_expr_to_string(dv_expr)}`,
-                false,
-                .None
+                `Expected compile-time known value for default value, got ${ast_expr_to_string(dv_expr)}`
               )
             )
           );
@@ -980,9 +934,7 @@ _evaluate_trait_field :: (
               dyn(
                 format_error_message(
                   ast_expr_token(dv_expr),
-                  `Default value type mismatch:\nExpected type: ${type_to_string(fet)}\nGiven type: ${type_to_string(dv_ty)}`,
-                  false,
-                  .None
+                  `Default value type mismatch:\nExpected type: ${type_to_string(fet)}\nGiven type: ${type_to_string(dv_ty)}`
                 )
               )
             );
@@ -1006,9 +958,7 @@ _evaluate_trait_field :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            String.from("Failed to infer the field type"),
-            false,
-            .None
+            String.from("Failed to infer the field type")
           )
         )
       );
@@ -1095,9 +1045,7 @@ evaluate_trait_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "trait", got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "trait", got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -1146,9 +1094,7 @@ evaluate_trait_type :: (
           dyn(
             format_error_message(
               ast_expr_token(last_arg),
-              String.from("The where clause must have at least one constraint."),
-              false,
-              .None
+              String.from("The where clause must have at least one constraint.")
             )
           )
         );
@@ -1193,9 +1139,7 @@ evaluate_trait_type :: (
           dyn(
             format_error_message(
               ast_expr_token(arg),
-              String.from("The where clause must be the last argument in a trait definition."),
-              false,
-              .None
+              String.from("The where clause must be the last argument in a trait definition.")
             )
           )
         );
@@ -1249,9 +1193,7 @@ evaluate_trait_type :: (
         dyn(
           format_error_message(
             match(args.get(i - usize(1)), .Some(a) => ast_expr_token(a), .None => ast_expr_token(expr)),
-            `Duplicate label 3 "${field_result.label}" in trait`,
-            false,
-            .None
+            `Duplicate label 3 "${field_result.label}" in trait`
           )
         )
       );
@@ -1388,9 +1330,7 @@ evaluate_trait_type :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(expr),
-                      `Return type "${type_to_string(vf_ret)}" in trait field "${vf_label}" is used with "comptime" but type parameter "${type_to_string(vf_missing)}" does not implement the Comptime trait. Add "${vf_missing_name} <: Comptime" to the where clause.`,
-                      false,
-                      .None
+                      `Return type "${type_to_string(vf_ret)}" in trait field "${vf_label}" is used with "comptime" but type parameter "${type_to_string(vf_missing)}" does not implement the Comptime trait. Add "${vf_missing_name} <: Comptime" to the where clause.`
                     )
                   )
                 );

--- a/src/evaluator/types/tuple.yo
+++ b/src/evaluator/types/tuple.yo
@@ -83,9 +83,7 @@ evaluate_tuple_elements_type :: (
           dyn(
             format_error_message(
               err_tok,
-              `Duplicate label "${field.label}" in tuple`,
-              false,
-              .None
+              `Duplicate label "${field.label}" in tuple`
             )
           )
         );
@@ -156,9 +154,7 @@ evaluate_tuple_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            String.from("Tuple type cannot have default value."),
-            false,
-            .None
+            String.from("Tuple type cannot have default value.")
           )
         )
       );

--- a/src/evaluator/types/union.yo
+++ b/src/evaluator/types/union.yo
@@ -55,9 +55,7 @@ evaluate_union_type :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "union", got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected "union", got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -102,9 +100,7 @@ evaluate_union_type :: (
         dyn(
           format_error_message(
             err_tok,
-            `Duplicate label "${field.label}" in union field.`,
-            false,
-            .None
+            `Duplicate label "${field.label}" in union field.`
           )
         )
       );
@@ -115,9 +111,7 @@ evaluate_union_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            String.from("Union type cannot have default value for its fields."),
-            false,
-            .None
+            String.from("Union type cannot have default value for its fields.")
           )
         )
       );
@@ -128,9 +122,7 @@ evaluate_union_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            String.from("Union type fields must be runtime types."),
-            false,
-            .None
+            String.from("Union type fields must be runtime types.")
           )
         )
       );
@@ -141,9 +133,7 @@ evaluate_union_type :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            String.from("Union type cannot have field with garbage-collected type."),
-            false,
-            .None
+            String.from("Union type cannot have field with garbage-collected type.")
           )
         )
       );

--- a/src/evaluator/types/utils.yo
+++ b/src/evaluator/types/utils.yo
@@ -328,9 +328,7 @@ enforce_atomic_object_send :: (
         dyn(
           format_error_message(
             error_token,
-            `atomic object must implement Send (all fields must be Send), but ${type_to_string(struct_ty)} has non-Send fields:\n${non_send_fields}\nUse "object" instead if thread safety is not needed.`,
-            false,
-            .None
+            `atomic object must implement Send (all fields must be Send), but ${type_to_string(struct_ty)} has non-Send fields:\n${non_send_fields}\nUse "object" instead if thread safety is not needed.`
           )
         )
       );

--- a/src/evaluator/utils.yo
+++ b/src/evaluator/utils.yo
@@ -373,9 +373,7 @@ throw_expr_is_implicit_variable_error :: (
               dyn(
                 format_error_message(
                   ast_expr_token(rhs),
-                  `Cannot use implicit variable "${var_name}" in assignment. Implicit variables must be passed via  parameters.`,
-                  false,
-                  .None
+                  `Cannot use implicit variable "${var_name}" in assignment. Implicit variables must be passed via  parameters.`
                 )
               )
             );
@@ -418,7 +416,7 @@ require_expr_not_consumed :: (
             error_message : `Variable "${var_name}" is not defined.`
           )
         );
-        exn.throw(dyn(format_error_messages(entries, false, .None)));
+        exn.throw(dyn(format_error_messages(entries)));
       });
       v := match(vars.get(vars.len() - usize(1)), .Some(v) => v, .None => make_err_variable(env));
       match(
@@ -457,7 +455,7 @@ require_expr_not_consumed :: (
               error_message : String.from("value moved here")
             )
           );
-          exn.throw(dyn(format_error_messages(entries, false, .None)));
+          exn.throw(dyn(format_error_messages(entries)));
         }
       );
     }
@@ -500,7 +498,7 @@ expect_expr_to_have_been_evaluated :: (
       entries.push(
         TokenAndError(token : ast_expr_token(expr), error_message : msg)
       );
-      exn.throw(dyn(format_error_messages(entries, false, .None)));
+      exn.throw(dyn(format_error_messages(entries)));
       // Unreachable. Provide a placeholder so the type checker is
       // satisfied.
       new_expr_info_placeholder_for_unreachable_(expr)
@@ -556,7 +554,7 @@ set_expr_as_consumed :: (
                 error_message : `Variable "${name}" is not defined.`
               )
             );
-            exn.throw(dyn(format_error_messages(entries, false, .None)));
+            exn.throw(dyn(format_error_messages(entries)));
           });
           v := match(vars.get(vars.len() - usize(1)), .Some(x) => x, .None => make_err_variable(env));
           match(
@@ -589,7 +587,7 @@ set_expr_as_consumed :: (
                     error_message : String.from("value moved here")
                   )
                 );
-                exn.throw(dyn(format_error_messages(entries, false, .None)));
+                exn.throw(dyn(format_error_messages(entries)));
               }
             )
           );
@@ -1095,9 +1093,7 @@ merge_and_check_envs :: (
           dyn(
             format_error_message(
               ast_expr_token(body),
-              `Expected the body of the case to be evaluated, but it is not.`,
-              false,
-              .None
+              `Expected the body of the case to be evaluated, but it is not.`
             )
           )
         );
@@ -1158,9 +1154,7 @@ merge_and_check_envs :: (
         dyn(
           format_error_message(
             ast_expr_token(match(bodies.get(ci), .Some(b) => b, .None => make_err_expr())),
-            `Case env is missing outer frames (has ${case_env.frames.len().to_string()}, need ${required_depth.to_string()}).`,
-            false,
-            .None
+            `Case env is missing outer frames (has ${case_env.frames.len().to_string()}, need ${required_depth.to_string()}).`
           )
         )
       );
@@ -1255,9 +1249,7 @@ merge_and_check_envs :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(match(bodies.get(cj), .Some(b) => b, .None => make_err_expr())),
-                    `Frame level ${frame_i} has different variable names for different cases.`,
-                    false,
-                    .None
+                    `Frame level ${frame_i} has different variable names for different cases.`
                   )
                 )
               );
@@ -1401,7 +1393,7 @@ Impl(...) uses static dispatch and requires the same concrete type in all branch
 Consider using Dyn(...) for dynamic dispatch if different concrete types are needed.`
                           )
                         );
-                        exn.throw(dyn(format_error_messages(cb_entries, false, .None)));
+                        exn.throw(dyn(format_error_messages(cb_entries)));
                       });
                     },
                     .None => ()
@@ -1420,7 +1412,7 @@ First initialization: ${type_to_string(cb_first_ty)}
 Conflicting initialization: ${type_to_string(cb_cur_ty)}`
                     )
                   );
-                  exn.throw(dyn(format_error_messages(cb_entries2, false, .None)));
+                  exn.throw(dyn(format_error_messages(cb_entries2)));
                 });
                 cb_k = (cb_k + usize(1));
               });
@@ -1440,9 +1432,7 @@ Conflicting initialization: ${type_to_string(cb_cur_ty)}`
                       dyn(
                         format_error_message(
                           base_var.token,
-                          `Variable "${var_name}" might not be initialized in all cases.`,
-                          false,
-                          .None
+                          `Variable "${var_name}" might not be initialized in all cases.`
                         )
                       )
                     );
@@ -1499,7 +1489,7 @@ Conflicting initialization: ${type_to_string(cb_cur_ty)}`
                 };
                 ei = (ei + usize(1));
               });
-              exn.throw(dyn(format_error_messages(err_list, false, .None)));
+              exn.throw(dyn(format_error_messages(err_list)));
             });
           });
           // ---- Check consumed_at_token ----
@@ -1566,7 +1556,7 @@ Conflicting initialization: ${type_to_string(cb_cur_ty)}`
                 };
                 eci = (eci + usize(1));
               });
-              exn.throw(dyn(format_error_messages(err_list, false, .None)));
+              exn.throw(dyn(format_error_messages(err_list)));
             });
           });
           // ---- Check is_owning_the_rc_value ----
@@ -1609,7 +1599,7 @@ Conflicting initialization: ${type_to_string(cb_cur_ty)}`
               };
               oei = (oei + usize(1));
             });
-            exn.throw(dyn(format_error_messages(err_list, false, .None)));
+            exn.throw(dyn(format_error_messages(err_list)));
           });
           // ---- Handle variable ID reassignment across branches ----
           // If any branch has a different variable ID, generate a new one.

--- a/src/evaluator/values/anonymous_function.yo
+++ b/src/evaluator/values/anonymous_function.yo
@@ -560,9 +560,7 @@ Use a closure (=> syntax) instead, or refactor the handler to not reference oute
 If this is an effect handler (e.g. Exception.throw), the handler type only accepts -> functions:
 handlers are capture-free by design (docs/en-US/ALGEBRAIC_EFFECTS.md), so a handler body may use
 its own parameters and locals, comptime constants, and builtins (panic, unwind) — record the
-outcome after the guarded call instead (e.g. a result the handler unwinds past).`,
-            false,
-            .None
+outcome after the guarded call instead (e.g. a result the handler unwinds past).`
           )
         )
       );
@@ -598,9 +596,7 @@ outcome after the guarded call instead (e.g. a result the handler unwinds past).
                             dyn(
                               format_error_message(
                                 ci.token,
-                                `Cannot capture inout binding '${k}' in a closure. \`inout(${k}) : T\` is a second-class reference to the caller's storage; a closure that captures it could outlive the call frame. Pass the value through (e.g. read it into a local first, or restructure to take the closure as a callback parameter).`,
-                                false,
-                                .None
+                                `Cannot capture inout binding '${k}' in a closure. \`inout(${k}) : T\` is a second-class reference to the caller's storage; a closure that captures it could outlive the call frame. Pass the value through (e.g. read it into a local first, or restructure to take the closure as a callback parameter).`
                               )
                             )
                           );
@@ -612,9 +608,7 @@ outcome after the guarded call instead (e.g. a result the handler unwinds past).
                                 ci.token,
                                 `Closures cannot capture a value of control-bound type. The captured value \`${k}\` has type \`${type_to_string(v.ty)}\` which transitively contains a \`ctl(...) -> ret\` function. Closures can escape their enclosing frame, taking the captured control function with them — which would unwind to a dead install frame.
 
-Pass \`${k}\` as a regular function parameter instead of capturing it in a closure.`,
-                                false,
-                                .None
+Pass \`${k}\` as a regular function parameter instead of capturing it in a closure.`
                               )
                             )
                           );
@@ -656,9 +650,7 @@ evaluate_anonymous_function_implementation :: (
       dyn(
         format_error_message(
           tok,
-          `Anonymous function: expected 2 args, got ${n_expr_args}`,
-          false,
-          .None
+          `Anonymous function: expected 2 args, got ${n_expr_args}`
         )
       )
     );
@@ -690,9 +682,7 @@ evaluate_anonymous_function_implementation :: (
         dyn(
           format_error_message(
             tok,
-            `Expected a function type, got:\n${ast_expr_to_string(expr)}`,
-            false,
-            .None
+            `Expected a function type, got:\n${ast_expr_to_string(expr)}`
           )
         )
       );
@@ -746,9 +736,7 @@ evaluate_anonymous_function_implementation :: (
         dyn(
           format_error_message(
             tok,
-            String.from("Anonymous function: expected a Func or Impl(Fn(...)) type"),
-            false,
-            .None
+            String.from("Anonymous function: expected a Func or Impl(Fn(...)) type")
           )
         )
       );
@@ -875,9 +863,7 @@ evaluate_anonymous_function_implementation :: (
       dyn(
         format_error_message(
           tok,
-          `Anonymous function: expected ${n_expected} regular parameters, got ${n_regular}`,
-          false,
-          .None
+          `Anonymous function: expected ${n_expected} regular parameters, got ${n_regular}`
         )
       )
     );
@@ -1468,9 +1454,7 @@ evaluate_anonymous_function_implementation :: (
             tok,
             `A function's result type cannot be control-bound (transitively contain a \`ctl(...) -> ret\` function type). A \`ctl\` handler unwinds the frame it is installed in at the throw site; returning one out of its defining function would let it be invoked after that frame is gone. Pass the handler (or the record holding it) downward as a parameter instead.
 
-Result type: ${type_to_string(decl_result_ty)}`,
-            false,
-            .None
+Result type: ${type_to_string(decl_result_ty)}`
           )
         )
       );
@@ -1545,7 +1529,7 @@ Result type: ${type_to_string(decl_result_ty)}`,
         hard_swallow_diagnostic(_anon_swallow_message()),
         .Some(anon_fwd_msg) => {
           _clear_anon_swallow();
-          exn.throw(dyn(format_error_message(tok, anon_fwd_msg, false, .None)));
+          exn.throw(dyn(format_error_message(tok, anon_fwd_msg)));
         },
         .None => ()
       );
@@ -1556,7 +1540,7 @@ Result type: ${type_to_string(decl_result_ty)}`,
     if(flow_violation_pending(), {
       anon_viol_msg := flow_violation_message();
       clear_flow_violation();
-      exn.throw(dyn(format_error_message(tok, anon_viol_msg, false, .None)));
+      exn.throw(dyn(format_error_message(tok, anon_viol_msg)));
     });
     // Channel 2: comptime_expect_error observation — when the body eval
     // THREW (empty `out`) and propagate mode is on, re-raise so the
@@ -1566,9 +1550,7 @@ Result type: ${type_to_string(decl_result_ty)}`,
         dyn(
           format_error_message(
             tok,
-            String.from("Anonymous function body raised a compile-time error during definition-time evaluation."),
-            false,
-            .None
+            String.from("Anonymous function body raised a compile-time error during definition-time evaluation.")
           )
         )
       );
@@ -1589,9 +1571,7 @@ Result type: ${type_to_string(decl_result_ty)}`,
             dyn(
               format_error_message(
                 tok,
-                String.from("`unwind` is only valid inside a control-function body. This function is declared with `fn(...) -> ret`; change the declared type to `ctl(...) -> ret` if the body needs to unwind."),
-                false,
-                .None
+                String.from("`unwind` is only valid inside a control-function body. This function is declared with `fn(...) -> ret`; change the declared type to `ctl(...) -> ret` if the body needs to unwind.")
               )
             )
           );
@@ -1844,7 +1824,7 @@ Result type: ${type_to_string(decl_result_ty)}`,
           hard_swallow_diagnostic(_anon_swallow_message()),
           .Some(dgc_fwd_msg) => {
             _clear_anon_swallow();
-            exn.throw(dyn(format_error_message(tok, dgc_fwd_msg, false, .None)));
+            exn.throw(dyn(format_error_message(tok, dgc_fwd_msg)));
           },
           .None => ()
         );
@@ -1909,9 +1889,7 @@ Result type: ${type_to_string(decl_result_ty)}`,
                 dyn(
                   format_error_message(
                     tok,
-                    `Incompatible function return type for:\n- Expected: ${dgc_exp_str}\n- Given  : ${dgc_got_str}`,
-                    false,
-                    .None
+                    `Incompatible function return type for:\n- Expected: ${dgc_exp_str}\n- Given  : ${dgc_got_str}`
                   )
                 )
               );

--- a/src/evaluator/values/anonymous_module.yo
+++ b/src/evaluator/values/anonymous_module.yo
@@ -185,9 +185,7 @@ evaluate_anonymous_module_begin_exprs :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(ext_mod_expr),
-                            String.from("Failed to evaluate the extended struct expression"),
-                            false,
-                            .None
+                            String.from("Failed to evaluate the extended struct expression")
                           )
                         )
                       );
@@ -203,9 +201,7 @@ evaluate_anonymous_module_begin_exprs :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(ext_mod_expr),
-                            `Expected struct type for export, got:\n${type_to_string(ext_mod_type)}`,
-                            false,
-                            .None
+                            `Expected struct type for export, got:\n${type_to_string(ext_mod_type)}`
                           )
                         )
                       );
@@ -258,9 +254,7 @@ evaluate_anonymous_module_begin_exprs :: (
                                     dyn(
                                       format_error_message(
                                         ast_expr_token(exclude_expr),
-                                        `Label "${lbl}" is not found in the extended module type.`,
-                                        false,
-                                        .None
+                                        `Label "${lbl}" is not found in the extended module type.`
                                       )
                                     )
                                   );
@@ -290,9 +284,7 @@ evaluate_anonymous_module_begin_exprs :: (
                                       dyn(
                                         format_error_message(
                                           ast_expr_token(member_expr),
-                                          `Expected identifier for excluded label, got:\n${ast_expr_to_string(member_expr)}`,
-                                          false,
-                                          .None
+                                          `Expected identifier for excluded label, got:\n${ast_expr_to_string(member_expr)}`
                                         )
                                       )
                                     );
@@ -306,9 +298,7 @@ evaluate_anonymous_module_begin_exprs :: (
                                           dyn(
                                             format_error_message(
                                               ast_expr_token(member_expr),
-                                              `Label "${lbl}" is not found in the extended module type.`,
-                                              false,
-                                              .None
+                                              `Label "${lbl}" is not found in the extended module type.`
                                             )
                                           )
                                         );
@@ -327,9 +317,7 @@ evaluate_anonymous_module_begin_exprs :: (
                               dyn(
                                 format_error_message(
                                   ast_expr_token(exclude_expr),
-                                  `Expected identifier or tuple for excluded labels, got:\n${ast_expr_to_string(exclude_expr)}`,
-                                  false,
-                                  .None
+                                  `Expected identifier or tuple for excluded labels, got:\n${ast_expr_to_string(exclude_expr)}`
                                 )
                               )
                             );
@@ -353,9 +341,7 @@ evaluate_anonymous_module_begin_exprs :: (
                                 dyn(
                                   format_error_message(
                                     ast_expr_token(export_expr),
-                                    `Element "${ext_label}" is already exported in the module.`,
-                                    false,
-                                    .None
+                                    `Element "${ext_label}" is already exported in the module.`
                                   )
                                 )
                               );
@@ -396,9 +382,7 @@ evaluate_anonymous_module_begin_exprs :: (
                             dyn(
                               format_error_message(
                                 ast_expr_token(export_expr),
-                                `Expected identifier for export, got:\n${ast_expr_to_string(export_expr)}`,
-                                false,
-                                .None
+                                `Expected identifier for export, got:\n${ast_expr_to_string(export_expr)}`
                               )
                             )
                           );
@@ -419,9 +403,7 @@ evaluate_anonymous_module_begin_exprs :: (
                             dyn(
                               format_error_message(
                                 ast_expr_token(label_expr),
-                                `Expected identifier for export, got:\n${ast_expr_to_string(label_expr)}`,
-                                false,
-                                .None
+                                `Expected identifier for export, got:\n${ast_expr_to_string(label_expr)}`
                               )
                             )
                           );
@@ -431,9 +413,7 @@ evaluate_anonymous_module_begin_exprs :: (
                             dyn(
                               format_error_message(
                                 ast_expr_token(label_expr),
-                                `Expected identifier for export, got:\n${ast_expr_to_string(label_expr)}`,
-                                false,
-                                .None
+                                `Expected identifier for export, got:\n${ast_expr_to_string(label_expr)}`
                               )
                             )
                           );
@@ -444,9 +424,7 @@ evaluate_anonymous_module_begin_exprs :: (
                             dyn(
                               format_error_message(
                                 ast_expr_token(name_expr),
-                                `Expected identifier for export, got:\n${ast_expr_to_string(name_expr)}`,
-                                false,
-                                .None
+                                `Expected identifier for export, got:\n${ast_expr_to_string(name_expr)}`
                               )
                             )
                           );
@@ -456,9 +434,7 @@ evaluate_anonymous_module_begin_exprs :: (
                             dyn(
                               format_error_message(
                                 ast_expr_token(name_expr),
-                                `Expected identifier for export, got:\n${ast_expr_to_string(name_expr)}`,
-                                false,
-                                .None
+                                `Expected identifier for export, got:\n${ast_expr_to_string(name_expr)}`
                               )
                             )
                           );
@@ -474,9 +450,7 @@ evaluate_anonymous_module_begin_exprs :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(export_expr),
-                            `Variable "${given_var_name}" is not defined in the module.`,
-                            false,
-                            .None
+                            `Variable "${given_var_name}" is not defined in the module.`
                           )
                         )
                       );
@@ -502,9 +476,7 @@ evaluate_anonymous_module_begin_exprs :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(export_expr),
-                            `Variable "${variable_name}" is already exported in the module.`,
-                            false,
-                            .None
+                            `Variable "${variable_name}" is already exported in the module.`
                           )
                         )
                       );
@@ -515,9 +487,7 @@ evaluate_anonymous_module_begin_exprs :: (
                         dyn(
                           format_error_message(
                             ast_expr_token(export_expr),
-                            `Variable "${given_var_name}" is not a compile-time variable and cannot be exported.`,
-                            false,
-                            .None
+                            `Variable "${given_var_name}" is not a compile-time variable and cannot be exported.`
                           )
                         )
                       );
@@ -546,9 +516,7 @@ evaluate_anonymous_module_begin_exprs :: (
                               dyn(
                                 format_error_message(
                                   ast_expr_token(export_expr),
-                                  `Function overloading is not supported: "Call" here is a tuple of ${cand_fns.len()} candidates. Bind exactly one function to "Call" (the runtime/comptime operator pairs in std/prelude.yo are the only sanctioned overload sets — plans/FUNCTION_OVERLOADING_POLICY.md).`,
-                                  false,
-                                  .None
+                                  `Function overloading is not supported: "Call" here is a tuple of ${cand_fns.len()} candidates. Bind exactly one function to "Call" (the runtime/comptime operator pairs in std/prelude.yo are the only sanctioned overload sets — plans/FUNCTION_OVERLOADING_POLICY.md).`
                                 )
                               )
                             );

--- a/src/evaluator/values/anonymous_struct.yo
+++ b/src/evaluator/values/anonymous_struct.yo
@@ -59,7 +59,7 @@ evaluate_anonymous_struct_value :: (
     expr,
     .FnCall(_, fb, _, _, _) => fb,
     .Atom(_, _) => {
-      exn.throw(dyn(format_error_message(tok, String.from("evaluate_anonymous_struct_value: expected FnCall"), false, .None)));
+      exn.throw(dyn(format_error_message(tok, String.from("evaluate_anonymous_struct_value: expected FnCall"))));
       make_err_expr()
     }
   );
@@ -75,9 +75,7 @@ evaluate_anonymous_struct_value :: (
       dyn(
         format_error_message(
           ast_expr_token(func_expr),
-          `Expected "_" for anonymous struct, got: ${ast_expr_to_string(func_expr)}`,
-          false,
-          .None
+          `Expected "_" for anonymous struct, got: ${ast_expr_to_string(func_expr)}`
         )
       )
     );
@@ -127,9 +125,7 @@ evaluate_anonymous_struct_value :: (
           dyn(
             format_error_message(
               ast_expr_token(lae),
-              `Expected identifier for anonymous struct field label, got: ${ast_expr_to_string(lae)}`,
-              false,
-              .None
+              `Expected identifier for anonymous struct field label, got: ${ast_expr_to_string(lae)}`
             )
           )
         );
@@ -152,9 +148,7 @@ evaluate_anonymous_struct_value :: (
           dyn(
             format_error_message(
               ast_expr_token(value_expr),
-              String.from("Failed to evaluate anonymous struct field expression"),
-              false,
-              .None
+              String.from("Failed to evaluate anonymous struct field expression")
             )
           )
         );

--- a/src/evaluator/values/array.yo
+++ b/src/evaluator/values/array.yo
@@ -57,9 +57,7 @@ evaluate_array_value :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected at least one element in array, got ${array_len}`,
-          false,
-          .None
+          `Expected at least one element in array, got ${array_len}`
         )
       )
     );
@@ -101,9 +99,7 @@ evaluate_array_value :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `Failed to evaluate array element`,
-            false,
-            .None
+            `Failed to evaluate array element`
           )
         )
       );
@@ -146,9 +142,7 @@ evaluate_array_value :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(arg),
-                      `Array element type mismatch:\nExpected type: ${inferred_str}\nGiven type: ${elem_str}`,
-                      false,
-                      .None
+                      `Array element type mismatch:\nExpected type: ${inferred_str}\nGiven type: ${elem_str}`
                     )
                   )
                 );
@@ -170,9 +164,7 @@ evaluate_array_value :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Failed to infer array element type`,
-            false,
-            .None
+            `Failed to infer array element type`
           )
         )
       );

--- a/src/evaluator/values/boolean.yo
+++ b/src/evaluator/values/boolean.yo
@@ -26,9 +26,7 @@ evaluate_boolean_literal :: (
       dyn(
         format_error_message(
           tok,
-          `Expected bool literal, got ${tok.value}`,
-          false,
-          .None
+          `Expected bool literal, got ${tok.value}`
         )
       )
     );

--- a/src/evaluator/values/char.yo
+++ b/src/evaluator/values/char.yo
@@ -65,9 +65,7 @@ parse_char_literal :: (fn(tok_value : String, tok : Token, exn : Exception) -> u
             dyn(
               format_error_message(
                 tok,
-                `Unknown escape sequence: \\${esc_str}`,
-                false,
-                .None
+                `Unknown escape sequence: \\${esc_str}`
               )
             )
           );
@@ -93,9 +91,7 @@ evaluate_char_literal :: (
       dyn(
         format_error_message(
           tok,
-          `Expected char literal, got ${tok.value}`,
-          false,
-          .None
+          `Expected char literal, got ${tok.value}`
         )
       )
     );

--- a/src/evaluator/values/comptime_list.yo
+++ b/src/evaluator/values/comptime_list.yo
@@ -47,9 +47,7 @@ evaluate_comptime_list_value :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected at least one element in comptime_list, got ${n_args}`,
-          false,
-          .None
+          `Expected at least one element in comptime_list, got ${n_args}`
         )
       )
     );
@@ -85,9 +83,7 @@ evaluate_comptime_list_value :: (
         dyn(
           format_error_message(
             ast_expr_token(arg),
-            `Failed to evaluate expr_list element. Expected compile-time known value`,
-            false,
-            .None
+            `Failed to evaluate expr_list element. Expected compile-time known value`
           )
         )
       );
@@ -106,9 +102,7 @@ evaluate_comptime_list_value :: (
           dyn(
             format_error_message(
               ast_expr_token(arg),
-              `comptime_list element has no compile-time value`,
-              false,
-              .None
+              `comptime_list element has no compile-time value`
             )
           )
         );
@@ -130,9 +124,7 @@ evaluate_comptime_list_value :: (
             dyn(
               format_error_message(
                 ast_expr_token(arg),
-                `Mismatched element types in comptime_list. Expected element of type ${ct_str}, got ${arg_str}`,
-                false,
-                .None
+                `Mismatched element types in comptime_list. Expected element of type ${ct_str}, got ${arg_str}`
               )
             )
           );
@@ -150,9 +142,7 @@ evaluate_comptime_list_value :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Failed to infer comptime_list element type`,
-            false,
-            .None
+            `Failed to infer comptime_list element type`
           )
         )
       );

--- a/src/evaluator/values/dyn.yo
+++ b/src/evaluator/values/dyn.yo
@@ -297,9 +297,7 @@ evaluate_dyn_value :: (
         dyn(
           format_error_message(
             expr_tok,
-            String.from("evaluate_dyn_value: expected a FnCall expression"),
-            false,
-            .None
+            String.from("evaluate_dyn_value: expected a FnCall expression")
           )
         )
       );
@@ -314,9 +312,7 @@ evaluate_dyn_value :: (
         dyn(
           format_error_message(
             expr_tok,
-            String.from("'dyn' requires exactly one argument"),
-            false,
-            .None
+            String.from("'dyn' requires exactly one argument")
           )
         )
       );
@@ -544,9 +540,7 @@ evaluate_dyn_value :: (
         dyn(
           format_error_message(
             expr_tok,
-            String.from("evaluate_dyn_value: failed to evaluate inner expression"),
-            false,
-            .None
+            String.from("evaluate_dyn_value: failed to evaluate inner expression")
           )
         )
       );
@@ -583,9 +577,7 @@ evaluate_dyn_value :: (
           dyn(
             format_error_message(
               expr_tok,
-              String.from("evaluate_dyn_value: failed to auto-box value for 'dyn'"),
-              false,
-              .None
+              String.from("evaluate_dyn_value: failed to auto-box value for 'dyn'")
             )
           )
         );
@@ -656,9 +648,7 @@ evaluate_dyn_value :: (
           dyn(
             format_error_message(
               expr_tok,
-              String.from("'dyn' requires a SomeType (Impl), DynType, or an expected Dyn type context. Concrete types without trait fields are not supported in Phase 3."),
-              false,
-              .None
+              String.from("'dyn' requires a SomeType (Impl), DynType, or an expected Dyn type context. Concrete types without trait fields are not supported in Phase 3.")
             )
           )
         );

--- a/src/evaluator/values/float.yo
+++ b/src/evaluator/values/float.yo
@@ -32,9 +32,7 @@ evaluate_float_literal :: (
       dyn(
         format_error_message(
           tok,
-          `Expected float literal, got ${tok.value}`,
-          false,
-          .None
+          `Expected float literal, got ${tok.value}`
         )
       )
     );
@@ -48,9 +46,7 @@ evaluate_float_literal :: (
         dyn(
           format_error_message(
             tok,
-            `Failed to parse float literal: ${tok.value}`,
-            false,
-            .None
+            `Failed to parse float literal: ${tok.value}`
           )
         )
       );

--- a/src/evaluator/values/impl.yo
+++ b/src/evaluator/values/impl.yo
@@ -2930,9 +2930,7 @@ evaluate_module_value :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected "impl", got: ${ast_expr_token(expr).value}`,
-          false,
-          .None
+          `Expected "impl", got: ${ast_expr_token(expr).value}`
         )
       )
     );
@@ -3589,9 +3587,7 @@ evaluate_module_value :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("impl requires a receiver type and at least one field."),
-          false,
-          .None
+          String.from("impl requires a receiver type and at least one field.")
         )
       )
     );
@@ -3767,9 +3763,7 @@ evaluate_module_value :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(field_expr),
-                      `Cannot use '!(...)' — negative impls are only allowed for marker traits (traits without methods).`,
-                      false,
-                      .None
+                      `Cannot use '!(...)' — negative impls are only allowed for marker traits (traits without methods).`
                     )
                   )
                 );
@@ -3796,9 +3790,7 @@ evaluate_module_value :: (
                 dyn(
                   format_error_message(
                     ast_expr_token(field_expr),
-                    `Manual 'impl(..., ${pos_trait_name}())' requires pragma(Pragma.AllowUnsafe). Add a '// SAFETY:' comment explaining why the type is safe to ${suffix}.`,
-                    false,
-                    .None
+                    `Manual 'impl(..., ${pos_trait_name}())' requires pragma(Pragma.AllowUnsafe). Add a '// SAFETY:' comment explaining why the type is safe to ${suffix}.`
                   )
                 )
               );
@@ -3848,7 +3840,7 @@ evaluate_module_value :: (
                   cf(receiver_ty, ctt, local_env),
                   .Some(sc_msg) => {
                     exn.throw(
-                      dyn(format_error_message(ast_expr_token(expr), sc_msg, false, .None))
+                      dyn(format_error_message(ast_expr_token(expr), sc_msg))
                     );
                   },
                   .None => ()
@@ -3976,9 +3968,7 @@ evaluate_module_value :: (
                       dyn(
                         format_error_message(
                           name_tok,
-                          `Method "${method_name}" is already defined for this type (first definition: ${__prev_site}). Duplicate inherent method impls are not allowed — use a distinct name (e.g. a comptime_ prefix), or provide the second signature via a trait (plans/FUNCTION_OVERLOADING_POLICY.md).`,
-                          false,
-                          .None
+                          `Method "${method_name}" is already defined for this type (first definition: ${__prev_site}). Duplicate inherent method impls are not allowed — use a distinct name (e.g. a comptime_ prefix), or provide the second signature via a trait (plans/FUNCTION_OVERLOADING_POLICY.md).`
                         )
                       )
                     );

--- a/src/evaluator/values/integer.yo
+++ b/src/evaluator/values/integer.yo
@@ -44,9 +44,7 @@ evaluate_integer_literal :: (
       dyn(
         format_error_message(
           tok,
-          `Expected integer literal, got ${tok.value}`,
-          false,
-          .None
+          `Expected integer literal, got ${tok.value}`
         )
       )
     );
@@ -60,9 +58,7 @@ evaluate_integer_literal :: (
         dyn(
           format_error_message(
             tok,
-            `Failed to parse integer literal: ${tok.value}`,
-            false,
-            .None
+            `Failed to parse integer literal: ${tok.value}`
           )
         )
       );

--- a/src/evaluator/values/string.yo
+++ b/src/evaluator/values/string.yo
@@ -175,9 +175,7 @@ evaluate_string_literal :: (
       dyn(
         format_error_message(
           tok,
-          `Expected string literal, got ${tok.value}`,
-          false,
-          .None
+          `Expected string literal, got ${tok.value}`
         )
       )
     );

--- a/src/evaluator/values/tuple.yo
+++ b/src/evaluator/values/tuple.yo
@@ -99,9 +99,7 @@ evaluate_tuple_element_value :: (
       dyn(
         format_error_message(
           ast_expr_token(lhs_expr),
-          String.from("Labelled field is not allowed in tuple value."),
-          false,
-          .None
+          String.from("Labelled field is not allowed in tuple value.")
         )
       )
     );
@@ -126,9 +124,7 @@ evaluate_tuple_element_value :: (
                   dyn(
                     format_error_message(
                       ast_expr_token(expr),
-                      `Failed to get the tuple field at index ${tuple_field_index}`,
-                      false,
-                      .None
+                      `Failed to get the tuple field at index ${tuple_field_index}`
                     )
                   )
                 );
@@ -146,9 +142,7 @@ evaluate_tuple_element_value :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `(2) Failed to evaluate the tuple fields. Expected type to be:\n${ty_str}`,
-              false,
-              .None
+              `(2) Failed to evaluate the tuple fields. Expected type to be:\n${ty_str}`
             )
           )
         );
@@ -180,9 +174,7 @@ evaluate_tuple_element_value :: (
         dyn(
           format_error_message(
             ast_expr_token(expr),
-            `Failed to evaluate the tuple field: ${ast_expr_to_string(expr)}`,
-            false,
-            .None
+            `Failed to evaluate the tuple field: ${ast_expr_to_string(expr)}`
           )
         )
       );
@@ -199,9 +191,7 @@ evaluate_tuple_element_value :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Cannot store a type value in tuple, please use module instead:\n  ${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Cannot store a type value in tuple, please use module instead:\n  ${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -283,9 +273,7 @@ evaluate_tuple_value :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          String.from("Expected tuple, got non-tuple expression"),
-          false,
-          .None
+          String.from("Expected tuple, got non-tuple expression")
         )
       )
     );

--- a/src/expr.yo
+++ b/src/expr.yo
@@ -776,9 +776,7 @@ expect_expr_to_be_fn_call_of :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected function call, got atom:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected function call, got atom:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -788,9 +786,7 @@ expect_expr_to_be_fn_call_of :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected function call of "${String.from(func_name)}", got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected function call of "${String.from(func_name)}", got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -808,9 +804,7 @@ expect_expr_to_be_fn_call_of :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Expected ${n.to_string()} arguments, got ${actual.to_string()}:\n${ast_expr_to_string(expr)}`,
-              false,
-              .None
+              `Expected ${n.to_string()} arguments, got ${actual.to_string()}:\n${ast_expr_to_string(expr)}`
             )
           )
         );
@@ -834,9 +828,7 @@ expect_expr_to_be_fn_call_of_any :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected function call, got atom:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected function call, got atom:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -846,9 +838,7 @@ expect_expr_to_be_fn_call_of_any :: (
       dyn(
         format_error_message(
           ast_expr_token(expr),
-          `Expected function call of one of the expected names, got:\n${ast_expr_to_string(expr)}`,
-          false,
-          .None
+          `Expected function call of one of the expected names, got:\n${ast_expr_to_string(expr)}`
         )
       )
     );
@@ -866,9 +856,7 @@ expect_expr_to_be_fn_call_of_any :: (
           dyn(
             format_error_message(
               ast_expr_token(expr),
-              `Expected ${n.to_string()} arguments, got ${actual.to_string()}:\n${ast_expr_to_string(expr)}`,
-              false,
-              .None
+              `Expected ${n.to_string()} arguments, got ${actual.to_string()}:\n${ast_expr_to_string(expr)}`
             )
           )
         );

--- a/src/lexer.yo
+++ b/src/lexer.yo
@@ -5,6 +5,7 @@ open(import("std/error"));
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 { TokenKind, Token, is_operator_char, is_identifier_start, is_identifier_continue } :: import("./token.yo");
+{ format_lexer_error } :: import("./error.yo");
 // Identifier/operator INTERN table: one canonical String instance per
 // distinct token text, so every same-named token shares one buffer and
 // downstream `String ==` hits the interned ptr+len fast path
@@ -44,30 +45,18 @@ _is_two_char_operator :: (fn(s : String) -> bool)(
 _is_one_char_operator :: (fn(s : String) -> bool)(
   (s == "!") || ((s == "#") || ((s == "%") || ((s == "&") || ((s == "*") || ((s == "+") || ((s == "-") || ((s == "/") || ((s == ":") || ((s == "<") || ((s == "=") || ((s == ">") || ((s == "?") || ((s == "^") || ((s == "|") || (s == "~")))))))))))))))
 );
-/// An error produced by the lexer during tokenization.
-LexerError :: ref(
-  struct(
-    message : String,
-    row : usize,
-    column : usize,
-    character : usize
-  )
-);
-impl(
-  LexerError,
-  ToString(
-    to_string : (fn(inout(self) : Self) -> String)(
-      `lexer error at ${self.row}:${self.column}: ${self.message}`
-    )
-  )
-);
-impl(LexerError, Error());
+/// An error produced by the lexer during tokenization. Deleted in P1 of
+/// plans/ERROR_DIAGNOSTICS_OVERHAUL.md: the lexer now throws the same
+/// structured `YoError` diagnostic as every other stage (`format_lexer_error`
+/// in src/error.yo), so its errors carry the module path, the source line
+/// and a 1-based anchor like the parser's and evaluator's do.
 /// Tokenizes `input` into a list of `Token`s.
 ///
 /// `module_path` is the source file path included in each token for error reporting.
 /// A leading UTF-8 BOM (U+FEFF) is skipped: rows, columns and `character` are as
 /// if the file had none (`byte_offset` still counts the 3 BOM bytes in `input`).
-/// Throws a `LexerError` (as `AnyError`) via `exn` on invalid input.
+/// Throws a structured `YoError` diagnostic (`format_lexer_error`) via `exn`
+/// on invalid input.
 tokenize :: (
   fn(
     input : String,
@@ -193,11 +182,12 @@ tokenize :: (
           if(tok_len == usize(0), {
             exn.throw(
               dyn(
-                LexerError(
-                  message : `unknown operator in '${op_str}': Yo has a closed operator set (plans/OPERATOR_SET_AND_PRECEDENCE.md); separate the operators with spaces or parentheses`,
-                  row : line,
-                  column : (col + k),
-                  character : (char_idx + k)
+                format_lexer_error(
+                  module_path,
+                  input,
+                  line,
+                  col + k,
+                  `unknown operator in '${op_str}': Yo has a closed operator set (plans/OPERATOR_SET_AND_PRECEDENCE.md); separate the operators with spaces or parentheses`
                 )
               )
             );
@@ -297,7 +287,7 @@ tokenize :: (
           );
         });
         if(nesting > usize(0), {
-          exn.throw(dyn(LexerError(message : `unterminated block comment`, row : bc_start_ln, column : col, character : char_idx)));
+          exn.throw(dyn(format_lexer_error(module_path, input, bc_start_ln, col, `unterminated block comment`)));
         });
         cm_str := cm_sb.to_string();
         tokens.push(Token(kind : block_kind, value : cm_str, row : bc_start_ln, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
@@ -377,7 +367,7 @@ tokenize :: (
         });
         char_is_valid := ((utf16_len == usize(1)) || ((utf16_len == usize(2)) && first_is_backslash));
         if(!char_is_valid, {
-          exn.throw(dyn(LexerError(message : `invalid char literal: expected char to have length 1`, row : line, column : col, character : char_idx)));
+          exn.throw(dyn(format_lexer_error(module_path, input, line, col, `invalid char literal: expected char to have length 1`)));
         });
         val_sb.write_byte(u8(0x27));
         tok_val := val_sb.to_string();
@@ -531,7 +521,7 @@ tokenize :: (
           );
         });
         if(!template_closed, {
-          exn.throw(dyn(LexerError(message : `unterminated template string`, row : line, column : col, character : char_idx)));
+          exn.throw(dyn(format_lexer_error(module_path, input, line, col, `unterminated template string`)));
         });
         ts_val := ts_sb.to_string();
         tokens.push(Token(kind : TokenKind.TemplateString, value : ts_val, row : line, column : col, character : char_idx, byte_offset : byte_idx, module_path : module_path, input : input));
@@ -723,11 +713,12 @@ tokenize :: (
         if((id_str == `forall`) || (id_str == `∀`), {
           exn.throw(
             dyn(
-              LexerError(
-                message : `\`${id_str}\` is reserved for verification quantifiers. Use \`generic(T : Type)\` to declare type parameters.`,
-                row : line,
-                column : col,
-                character : char_idx
+              format_lexer_error(
+                module_path,
+                input,
+                line,
+                col,
+                `\`${id_str}\` is reserved for verification quantifiers. Use \`generic(T : Type)\` to declare type parameters.`
               )
             )
           );
@@ -742,7 +733,7 @@ tokenize :: (
       },
       // Unknown character: error
       true => {
-        exn.throw(dyn(LexerError(message : `unexpected character`, row : line, column : col, character : char_idx)));
+        exn.throw(dyn(format_lexer_error(module_path, input, line, col, `unexpected character`)));
         i = (i + usize(1));
       }
     );
@@ -754,4 +745,4 @@ tokenize :: (
 // their concatenation is in this table, so the formatter's prefix-chain
 // tightening (`?*i32`, `**i32`) consults it instead of assuming every
 // operator pair would merge (the retired maximal-munch behavior).
-export(LexerError, tokenize, _is_two_char_operator);
+export(tokenize, _is_two_char_operator);

--- a/src/lsp/diagnostics.yo
+++ b/src/lsp/diagnostics.yo
@@ -4,12 +4,13 @@
 //! Analysis rides the same module_manager service `check` uses: the prelude
 //! env is process-cached, imports demand-load and cache, and the document
 //! itself is evaluated FRESH per call from its in-editor text (never from
-//! disk, never registered in the module cache). Errors arrive as
-//! `YoError.to_string()` text — a structured (token, message) channel is
-//! slice 0 of plans/P4_LSP.md; until then the stable
-//! `<path>:<row>:<col>:` anchors in the formatted text are parsed back out,
-//! and the underline length is recovered from the document text by
-//! extending over identifier characters.
+//! disk, never registered in the module cache). Errors arrive as rendered
+//! `YoError` strings (the P1 human format of src/diagnostics.yo) and
+//! `parse_error_text` parses that EXACT renderer shape — `severity:` header
+//! lines, `--> path:row:col` anchors, and the caret run itself as the
+//! underline length, so ranges are exact. A structured (token, message)
+//! channel that makes the parsing unnecessary is P3 of
+//! plans/ERROR_DIAGNOSTICS_OVERHAUL.md.
 //!
 //! KNOWN MVP LIMITS (plans/P4_LSP.md kickoff notes):
 //!   - Imports are cached for the process lifetime: an edit to an imported
@@ -24,7 +25,6 @@ open(import("std/error"));
 { parse } :: import("../parser.yo");
 { AstExpr } :: import("../expr.yo");
 { ExprInfoTable, expr_info_table_new } :: import("../expr_info.yo");
-{ rune_col_to_byte_offset } :: import("./protocol.yo");
 {
   mm_resolve_entry_abs,
   mm_eval_entry_exprs,
@@ -59,90 +59,208 @@ _take_parse_error :: (fn() -> Option(String))({
   taken
 });
 
-/// True iff byte `b` continues an identifier (the underline-length
-/// heuristic used when recovering a range from formatted error text).
-_is_ident_byte :: (fn(b : u8) -> bool)(
-  ((b >= u8(97)) && (b <= u8(122))) ||
-    (
-      ((b >= u8(65)) && (b <= u8(90))) ||
-        (((b >= u8(48)) && (b <= u8(57))) || (b == u8(95)))
-    )
+/// True iff byte `b` is an ASCII digit.
+_is_digit_byte :: (fn(b : u8) -> bool)(
+  (b >= u8(48)) && (b <= u8(57))
 );
 
-/// Length of the identifier starting at RUNE column `col` of row `row` in
-/// `text`, minimum 1. The answer is a RUNE count, because the caller adds it
-/// to `col` to build an LSP range.
-///
-/// `col` is a rune column (the formatted error text prints `token.column + 1`,
-/// and `Token.column` is a rune column) while `line.as_bytes()` is byte
-/// indexed — indexing one with the other put the underline in the wrong place
-/// on any line containing a multibyte character before the identifier
-/// (plans/STD_API_AUDIT_D4_PLAN.md §5.1, the `_ident_len_at` row). The count
-/// itself needs no conversion back: `_is_ident_byte` matches only ASCII, so
-/// every byte counted is exactly one rune.
-_ident_len_at :: (fn(text : String, row : usize, col : usize) -> usize)({
-  lines := text.split(String.from("\n"));
-  line := match(lines.get(row), .Some(l) => l, .None => return(usize(1)));
-  bytes := line.as_bytes();
-  start := rune_col_to_byte_offset(line, col);
-  if(start >= bytes.len(), {
-    return(usize(1));
-  });
+/// The number of `^` bytes in `s` — the underline length the renderer drew
+/// (the caret is ASCII, so bytes == runes).
+_count_carets :: (fn(s : String) -> usize)({
+  bytes := s.as_bytes();
   (n : usize) = usize(0);
-  (i : usize) = start;
+  (i : usize) = usize(0);
   while(i < bytes.len(), {
-    b := match(bytes.get(i), .Some(x) => x, .None => u8(0));
-    if(_is_ident_byte(b), {
-      n = (n + usize(1));
-      i = (i + usize(1));
-    }, {
-      i = bytes.len();
-    });
+    match(
+      bytes.get(i),
+      .Some(b) => {
+        if(b == u8(94), {
+          n = (n + usize(1));
+        });
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
   });
-  cond((n == usize(0)) => usize(1), true => n)
+  n
 });
 
-/// Extract `<path>:<row>:<col>:`-anchored diagnostics from a formatted
-/// YoError string. Entries whose path is the analyzed document map to
-/// precise ranges; entries in OTHER files (a broken import) surface at
-/// 0:0 with the full message so the user still sees them. Duplicate
-/// (row, col, message-head) anchors — the formatter prints the location
-/// twice per entry — collapse to one diagnostic.
+/// True iff `l` is the renderer's row line (`NN | source`, `NN` optionally
+/// space-padded to the group's gutter width).
+_is_row_line :: (fn(l : String) -> bool)({
+  t := l.trim();
+  bytes := t.as_bytes();
+  (i : usize) = usize(0);
+  (digits : usize) = usize(0);
+  (scanning : bool) = true;
+  while((i < bytes.len()) && scanning, {
+    b := match(
+      bytes.get(i),
+      .Some(x) => x,
+      .None => u8(0)
+    );
+    if(_is_digit_byte(b), {
+      digits = (digits + usize(1));
+      i = (i + usize(1));
+    }, {
+      scanning = false;
+    });
+  });
+  if((digits == usize(0)) || ((i + usize(2)) > bytes.len()), {
+    return(false);
+  });
+  b0 := match(
+    bytes.get(i),
+    .Some(x) => x,
+    .None => u8(0)
+  );
+  b1 := match(
+    bytes.get(i + usize(1)),
+    .Some(x) => x,
+    .None => u8(0)
+  );
+  (b0 == u8(32)) && (b1 == u8(124))
+});
+
+/// Strip one severity header prefix (`error: `, `warning: `, `note: `,
+/// `help: `) off a rendered block's message.
+_strip_severity_prefix :: (fn(message : String) -> String)({
+  if(message.starts_with(String.from("error: ")), {
+    return(message.substring(usize(7), message.len()));
+  });
+  if(message.starts_with(String.from("warning: ")), {
+    return(message.substring(usize(9), message.len()));
+  });
+  if(message.starts_with(String.from("note: ")), {
+    return(message.substring(usize(6), message.len()));
+  });
+  if(message.starts_with(String.from("help: ")), {
+    return(message.substring(usize(6), message.len()));
+  });
+  message
+});
+
+/// Extract diagnostics from a rendered diagnostic-group string (the P1
+/// human format of src/diagnostics.yo): blocks of `severity[code]: message`
+/// lines followed by `<indent>--> <path>:<row+1>:<col+1>`, `<indent>|`,
+/// `NN | source`, `<indent>| <spaces>^^^^`. The underline length is read
+/// from the caret run itself, so end columns are exact — no identifier
+/// guessing. Entries whose path is the analyzed document map to precise
+/// ranges; entries in OTHER files (a broken import) surface at 0:0 with the
+/// full message so the user still sees them.
 parse_error_text :: (
   fn(err_text : String, doc_abs : String, doc_text : String) -> ArrayList(LspDiag)
 )({
   out := ArrayList(LspDiag).new();
   lines := err_text.split(String.from("\n"));
-  // Message accumulator: lines since the last caret/location group.
+  // Message accumulator: lines since the last anchor group.
   msg_parts := ArrayList(String).new();
   (li : usize) = usize(0);
   n := lines.len();
   while(li < n, {
-    line := match(lines.get(li), .Some(l) => l, .None => String.new());
-    // A location anchor is `<path>:<digits>:<digits>:` — split from the
-    // RIGHT so paths containing ':' cannot confuse it.
-    (is_anchor : bool) = false;
-    (a_row : usize) = usize(0);
-    (a_col : usize) = usize(0);
-    (a_path : String) = String.new();
-    if(line.ends_with(String.from(":")), {
-      body := line.substring(usize(0), line.len() - usize(1));
+    line := match(
+      lines.get(li),
+      .Some(l) => l,
+      .None => String.new()
+    );
+    trimmed := line.trim();
+    (handled : bool) = false;
+    if(trimmed.starts_with(String.from("--> ")), {
+      body := trimmed.substring(usize(4), trimmed.len());
       segs := body.split(String.from(":"));
       if(segs.len() >= usize(3), {
-        col_s := match(segs.get(segs.len() - usize(1)), .Some(s) => s, .None => String.new());
-        row_s := match(segs.get(segs.len() - usize(2)), .Some(s) => s, .None => String.new());
+        col_s := match(
+          segs.get(segs.len() - usize(1)),
+          .Some(s) => s,
+          .None => String.new()
+        );
+        row_s := match(
+          segs.get(segs.len() - usize(2)),
+          .Some(s) => s,
+          .None => String.new()
+        );
         match(
           row_s.parse_u64(),
           .Some(r1) => match(
             col_s.parse_u64(),
             .Some(c1) => {
               if((r1 >= u64(1)) && (c1 >= u64(1)), {
-                is_anchor = true;
-                a_row = (usize(r1) - usize(1));
-                a_col = (usize(c1) - usize(1));
-                // path = body minus ":row:col"
+                handled = true;
+                a_row := (usize(r1) - usize(1));
+                a_col := (usize(c1) - usize(1));
+                // path = body minus ":row:col" (split from the right, so a
+                // path containing ':' cannot confuse it)
                 tail_len := (row_s.len() + col_s.len() + usize(2));
-                a_path = body.substring(usize(0), body.len() - tail_len);
+                a_path := body.substring(usize(0), body.len() - tail_len);
+                message := _strip_severity_prefix(
+                  String.from("\n").join(msg_parts).trim()
+                );
+                if(message.len() > usize(0), {
+                  same_file := ((a_path == doc_abs) || a_path.ends_with(doc_abs.clone()));
+                  cond(
+                    same_file => {
+                      // The renderer emits up to three snippet lines after
+                      // the anchor; consume exactly that shape and read the
+                      // underline length off the caret run.
+                      caret_len := usize(1);
+                      (k : usize) = (li + usize(1));
+                      (consumed : usize) = usize(0);
+                      if(k < n, {
+                        t0 := match(
+                          lines.get(k),
+                          .Some(x) => x,
+                          .None => String.new()
+                        );
+                        if(t0.trim() == String.from("|"), {
+                          k = (k + usize(1));
+                          consumed = (consumed + usize(1));
+                        });
+                      });
+                      if(k < n, {
+                        t1 := match(
+                          lines.get(k),
+                          .Some(x) => x,
+                          .None => String.new()
+                        );
+                        if(_is_row_line(t1), {
+                          k = (k + usize(1));
+                          consumed = (consumed + usize(1));
+                        });
+                      });
+                      if(k < n, {
+                        t2 := match(
+                          lines.get(k),
+                          .Some(x) => x,
+                          .None => String.new()
+                        );
+                        t2t := t2.trim();
+                        if(t2t.starts_with(String.from("| ")), {
+                          cnt := _count_carets(t2t);
+                          if(cnt > usize(0), {
+                            caret_len = cnt;
+                            consumed = (consumed + usize(1));
+                          });
+                        });
+                      });
+                      li = (li + consumed);
+                      end_col := (a_col + caret_len);
+                      out.push(
+                        LspDiag(row : a_row, col : a_col, end_col : end_col, message : message)
+                      );
+                    },
+                    true => {
+                      out.push(
+                        LspDiag(
+                          row : usize(0),
+                          col : usize(0),
+                          end_col : usize(1),
+                          message : `${message} (in ${a_path}:${(a_row + usize(1))}:${(a_col + usize(1))})`
+                        )
+                      );
+                    }
+                  );
+                });
+                msg_parts = ArrayList(String).new();
               });
             },
             .None => ()
@@ -151,59 +269,13 @@ parse_error_text :: (
         );
       });
     });
-    if(is_anchor, {
-      message := String.from("\n").join(msg_parts).trim();
-      if(message.starts_with(String.from("Error:")), {
-        message = message.substring(usize(6), message.len()).trim();
-      });
-      if(message.len() > usize(0), {
-        same_file := ((a_path == doc_abs) || a_path.ends_with(doc_abs.clone()));
-        cond(
-          same_file => {
-            end_col := (a_col + _ident_len_at(doc_text, a_row, a_col));
-            // Dedup: the formatter prints each entry's location twice.
-            (dup : bool) = false;
-            (di : usize) = usize(0);
-            while(di < out.len(), {
-              d := match(
-                out.get(di),
-                .Some(x) => x,
-                .None => {
-                  di = out.len();
-                  return(out);
-                }
-              );
-              if((d.row == a_row) && (d.col == a_col) && (d.message == message), {
-                dup = true;
-              });
-              di = (di + usize(1));
-            });
-            if(!dup, {
-              out.push(LspDiag(row : a_row, col : a_col, end_col : end_col, message : message));
-            });
-          },
-          true => {
-            out.push(
-              LspDiag(
-                row : usize(0),
-                col : usize(0),
-                end_col : usize(1),
-                message : `${message} (in ${a_path}:${(a_row + usize(1))}:${(a_col + usize(1))})`
-              )
-            );
-          }
-        );
-      });
-      // Skip the source line + caret line that follow an anchor.
-      msg_parts = ArrayList(String).new();
-      li = (li + usize(3));
-    }, {
+    if(!handled, {
       msg_parts.push(line);
-      li = (li + usize(1));
     });
+    li = (li + usize(1));
   });
-  // Nothing anchored (a LexerError or a bare string throw): one
-  // whole-message diagnostic at 0:0.
+  // Nothing anchored (a bare string throw): one whole-message diagnostic at
+  // 0:0.
   if((out.len() == usize(0)) && (err_text.trim().len() > usize(0)), {
     out.push(
       LspDiag(

--- a/src/main.yo
+++ b/src/main.yo
@@ -69,8 +69,10 @@ _(env : proc_env) :: import("std/env");
   mm_resolve_entry_abs,
   mm_eval_entry_exprs,
   mm_load_file,
-  mm_preload_prelude
+  mm_preload_prelude,
+  _take_load_error
 } :: import("./module_manager.yo");
+{ YoError } :: import("./error.yo");
 { eval_context_new } :: import("./evaluator/context.yo");
 { register_evaluate_expression, set_evaluator_deadline } :: import("./evaluator/exprs/_expr.yo");
 { evaluate_anonymous_module_begin_exprs } :: import("./evaluator/values/anonymous_module.yo");
@@ -616,9 +618,20 @@ check_single_file :: (
     io : Io,
     exn : Exception
   ) -> bool
-)(
-  mm_load_file(input_path, std_path, true, io, exn).ok
-);
+)({
+  outcome := mm_load_file(input_path, std_path, true, io, exn);
+  if(!(outcome.ok), {
+    // The loader's handlers only stash the rendered diagnostic (the P1
+    // single-print rule, plans/ERROR_DIAGNOSTICS_OVERHAUL.md D2) — check's
+    // own edge prints it here, exactly once, anchored at the failing file.
+    match(
+      _take_load_error(),
+      .Some(rendered) => eprintln(rendered),
+      .None => eprintln(`check: error in: ${input_path} (no diagnostic recorded)`)
+    );
+  });
+  outcome.ok
+});
 /// The argv entry following index `i` (the value of a `--flag value` pair), or
 /// "" if `i` is the last argument. Used by the `compile` flag parser.
 _arg_val :: (fn(argv : ArrayList(String), i : usize) -> String)(
@@ -1769,7 +1782,15 @@ run_compile :: (
     entry_abs := mm_resolve_entry_abs(input_path.clone(), std_path.clone());
     outcome := mm_eval_entry_exprs(entry_abs, std_path.clone(), exprs, exn);
     if(!(outcome.ok), {
-      exn.throw(dyn(`compile: failed to evaluate module "${input_path}"`));
+      // The eval failure's rendered diagnostic is in the loader's stash (its
+      // handlers no longer print — the P1 single-print rule). Rethrow it so
+      // the top-level handler prints it once, WITH the underlying text (the
+      // old wrapper dropped it, D2).
+      match(
+        _take_load_error(),
+        .Some(rendered) => exn.throw(dyn(rendered)),
+        .None => exn.throw(dyn(`compile: failed to evaluate module "${input_path}"`))
+      );
       return(());
     });
     module_value := outcome.module_value;
@@ -4107,7 +4128,24 @@ main :: (fn(io : Io) -> unit)({
   exn := Exception(
     throw : (
       (err) -> {
-        eprintln(`yo: error: ${err.to_string()}`);
+        // A structured YoError renders itself (severity header + --> anchor)
+        // — print it bare. Anything else keeps the yo: error: wrapper,
+        // unless it is a rendered diagnostic rethrown as a string (compile's
+        // eval-failure rethrow) — no doubled prefixes (P1, D4).
+        match(
+          downcast(err, YoError),
+          .Some(ye) => {
+            eprintln(ye.to_string());
+          },
+          .None => {
+            text := err.to_string();
+            if(text.starts_with(String.from("error: ")), {
+              eprintln(text);
+            }, {
+              eprintln(`yo: error: ${text}`);
+            });
+          }
+        );
         unsafe(exit(int(1)));
         unwind();
       }

--- a/src/module_manager.yo
+++ b/src/module_manager.yo
@@ -403,11 +403,13 @@ _take_load_error :: (fn() -> Option(String))({
 });
 /// Evaluate a module's top-level exprs, catching any evaluator error locally so
 /// the caller can unregister the currently-loading entry before re-throwing.
-/// Success: pushes the module value to `out`. Failure: the handler PRINTS the
-/// error (handlers cannot capture outer runtime vars, and an unwound String
-/// loses its Rc storage) and unwinds — `out` stays empty, which is the caller's
-/// signal. The message is also stashed via `_stash_load_error` (a fn call —
-/// legal in handlers) so the loader can return it as `module_error`.
+/// Success: pushes the module value to `out`. Failure: the handler STASHES the
+/// rendered diagnostic (handlers cannot capture outer runtime vars, so a module
+/// global is the channel) and unwinds — `out` stays empty, which is the
+/// caller's signal. The owning CLI edge then prints it exactly once (the P1
+/// single-print rule, plans/ERROR_DIAGNOSTICS_OVERHAUL.md D2): `check` via
+/// `check_single_file`, watch rounds in `check_watch.yo`, `compile` by
+/// re-throwing the stash, the LSP by parsing it into diagnostics.
 _eval_module_exprs_capturing_error :: (
   fn(
     mod_exprs : ArrayList(AstExpr),
@@ -421,7 +423,6 @@ _eval_module_exprs_capturing_error :: (
     throw : (
       err -> {
         _stash_load_error(err.to_string());
-        eprintln(`check: error in: ${err.to_string()}`);
         unwind(false)
       }
     )
@@ -673,10 +674,12 @@ mm_load_file :: (
   // Local exception handler escapes the function body with a failed outcome.
   // Effect-handler bodies cannot capture outer runtime vars (per Yo's `->`
   // rule), so we can't name the file here — the caller logs that from `ok`.
+  // The rendered diagnostic is STASHED, not printed (the P1 single-print
+  // rule, plans/ERROR_DIAGNOSTICS_OVERHAUL.md D2): the owning edge prints.
   local_exn := Exception(
     throw : (
       err -> {
-        eprintln(`check: error in: ${err.to_string()}`);
+        _stash_load_error(err.to_string());
         unwind(_failed_outcome())
       }
     )
@@ -787,7 +790,17 @@ mm_preload_prelude :: (
   ) -> unit
 )({
   if(g_cached_prelude_env.is_none(), {
-    _pre := mm_load_file(`${std_path}/prelude.yo`, std_path.clone(), verbose, io, exn);
+    pre_outcome := mm_load_file(`${std_path}/prelude.yo`, std_path.clone(), verbose, io, exn);
+    // A prelude that fails to evaluate is the ROOT cause of everything that
+    // follows — print its diagnostic here, once, at this edge (the P1
+    // single-print rule; the loader's handlers only stash).
+    if(!pre_outcome.ok, {
+      match(
+        _take_load_error(),
+        .Some(rendered) => eprintln(rendered),
+        .None => eprintln(`check: error in: ${std_path}/prelude.yo`)
+      );
+    });
     // Build the O(1) prelude variable cache here rather than inside
     // `mm_load_file`, to avoid interference with the compile path.
     match(g_cached_prelude_env, .Some(pe) => build_prelude_var_cache(pe), .None => ());

--- a/src/parser.yo
+++ b/src/parser.yo
@@ -9,6 +9,7 @@ open(import("std/error"));
 { ArrayList, array_list } :: import("std/collections/array_list");
 { TokenKind, Token, find_matching_bracket } :: import("./token.yo");
 { tokenize } :: import("./lexer.yo");
+{ YoError, format_error_message, format_raw_error } :: import("./error.yo");
 {
   AstExpr,
   ExprId,
@@ -40,48 +41,12 @@ FnArgsResult :: struct(
   args : ArrayList(AstExpr),
   index : usize
 );
-/// An error produced by the parser.
-ParseError :: ref(
-  struct(
-    message : String,
-    row : usize,
-    column : usize,
-    module_path : String,
-    source_line : String
-  )
-);
-impl(
-  ParseError,
-  ToString(
-    to_string : (fn(inout(self) : Self) -> String)({
-      sb := StringBuilder.new();
-      sb.write_str("error: ");
-      sb.write_string(self.message);
-      sb.write_str("\n --> ");
-      sb.write_string(self.module_path);
-      sb.write_str(":");
-      sb.write_string(`${(self.row + usize(1))}`);
-      sb.write_str(":");
-      sb.write_string(`${self.column}`);
-      if(self.source_line.len() > usize(0), {
-        sb.write_str("\n  |\n");
-        sb.write_string(`${(self.row + usize(1))}`);
-        sb.write_str(" | ");
-        sb.write_string(self.source_line);
-        sb.write_str("\n  |");
-        (k : usize) = usize(0);
-        // pad column + 3 spaces (to align under first non-space char of source line)
-        while(k < self.column, {
-          sb.write_byte(u8(32));
-          k = (k + usize(1));
-        });
-        sb.write_byte(u8(94));
-      });
-      sb.to_string()
-    })
-  )
-);
-impl(ParseError, Error());
+/// Parse errors used to be a local `ParseError` struct rendered by its own
+/// `ToString` — the only rustc-shaped renderer in the tree while every other
+/// stage printed plain blocks. P1 of plans/ERROR_DIAGNOSTICS_OVERHAUL.md
+/// deleted it: `make_parse_error`/`make_parse_error_raw` now build the same
+/// structured `YoError` the evaluator and lexer throw, so one renderer (src/
+/// diagnostics.yo) and one CLI-edge prefix rule serve every stage.
 /// Extract the Nth source line (0-indexed) from the input string.
 /// Returns an empty string if the row is out of range.
 extract_source_line :: (fn(input : String, row : usize) -> String)({
@@ -92,25 +57,15 @@ extract_source_line :: (fn(input : String, row : usize) -> String)({
     .Some(line) => line
   )
 });
-/// Build a `ParseError` from a token, automatically extracting the source line.
-make_parse_error :: (fn(tok : Token, message : String) -> ParseError)(
-  ParseError(
-    message : message,
-    row : tok.row,
-    column : tok.column,
-    module_path : tok.module_path,
-    source_line : extract_source_line(tok.input, tok.row)
-  )
+/// Build a parse-error `YoError` from a token (message + full span + source
+/// line, rendered by the shared renderer).
+make_parse_error :: (fn(tok : Token, message : String) -> YoError)(
+  format_error_message(tok, message)
 );
-/// Build a `ParseError` without source context (for end-of-input or internal errors).
-make_parse_error_raw :: (fn(module_path : String, message : String) -> ParseError)(
-  ParseError(
-    message : message,
-    row : usize(0),
-    column : usize(0),
-    module_path : module_path,
-    source_line : String.from("")
-  )
+/// Build a parse-error `YoError` without source context (end-of-input and
+/// internal errors): path-anchored, no snippet.
+make_parse_error_raw :: (fn(module_path : String, message : String) -> YoError)(
+  format_raw_error(module_path, message)
 );
 // Per-process monotonic counter for AstExpr ids. Each Parser instance
 // pulls from this so ids are unique across files in multi-file `check`
@@ -1729,6 +1684,6 @@ generate_exprs_from_code :: (
   module_path := `auto-generated://\n// === START auto-generated code ===\n${code}\n// === END auto-generated code ===\n`;
   parse(code.clone(), module_path, exn)
 });
-export(ParseResult, FnArgsResult, ParseError, Parser, parse);
+export(ParseResult, FnArgsResult, Parser, parse);
 export(extract_source_line, make_parse_error, make_parse_error_raw);
 export(generate_expr_from_code, generate_exprs_from_code);

--- a/src/types/flowability.yo
+++ b/src/types/flowability.yo
@@ -720,9 +720,7 @@ require_ref_own_argument_exclusivity :: (
                                 dyn(
                                   format_error_message(
                                     ast_expr_token(own_arg),
-                                    `Cannot pass "${own_var.name}" to the own parameter "${own_lbl}" in the same call where argument ${ref_idx + usize(1)} borrows from it (bound to the ref parameter "${ref_lbl}") — the callee takes ownership and may drop the object while the borrow is still in use. Copy the value out instead, or split the calls.`,
-                                    false,
-                                    .None
+                                    `Cannot pass "${own_var.name}" to the own parameter "${own_lbl}" in the same call where argument ${ref_idx + usize(1)} borrows from it (bound to the ref parameter "${ref_lbl}") — the callee takes ownership and may drop the object while the borrow is still in use. Copy the value out instead, or split the calls.`
                                   )
                                 )
                               ),
@@ -810,9 +808,7 @@ _reject_if_container_reachable :: (
       dyn(
         format_error_message(
           ast_expr_token(ref_arg),
-          `A 'ref' argument ("${ast_expr_to_string(ref_arg)}") borrows into the module-level container "${cname}" — any callee could reach it and free/reallocate the storage the reference points into. ${fix}`,
-          false,
-          .None
+          `A 'ref' argument ("${ast_expr_to_string(ref_arg)}") borrows into the module-level container "${cname}" — any callee could reach it and free/reallocate the storage the reference points into. ${fix}`
         )
       )
     );
@@ -849,9 +845,7 @@ _reject_if_container_reachable :: (
           dyn(
             format_error_message(
               ast_expr_token(ref_arg),
-              `A 'ref' argument ("${ast_expr_to_string(ref_arg)}") borrows into the container "${cname}", but argument ${(j + usize(1)).to_string()} of the same call could hold a handle to "${cname}" and grow it, reallocating the buffer the reference points into. ${fix}`,
-              false,
-              .None
+              `A 'ref' argument ("${ast_expr_to_string(ref_arg)}") borrows into the container "${cname}", but argument ${(j + usize(1)).to_string()} of the same call could hold a handle to "${cname}" and grow it, reallocating the buffer the reference points into. ${fix}`
             )
           )
         );
@@ -968,9 +962,7 @@ require_valid_ref_argument_places :: (
                           dyn(
                             format_error_message(
                               arg_tok,
-                              `A 'ref' argument cannot borrow a field of the module-level object "${ast_expr_token(cur).value}" — a callee could reassign it and free the borrowed storage. Bind it to a local first:\n  h := ${ast_expr_token(cur).value};\nand pass the field of "h" instead.`,
-                              false,
-                              .None
+                              `A 'ref' argument cannot borrow a field of the module-level object "${ast_expr_token(cur).value}" — a callee could reassign it and free the borrowed storage. Bind it to a local first:\n  h := ${ast_expr_token(cur).value};\nand pass the field of "h" instead.`
                             )
                           )
                         );

--- a/src/types/utils.yo
+++ b/src/types/utils.yo
@@ -157,9 +157,7 @@ prohibit_void_type :: (fn(ty : TypeValue, token : Token, exn : Exception) -> uni
         dyn(
           format_error_message(
             token,
-            `Void type is not allowed here. Void is only usable as a function return type.`,
-            false,
-            .None
+            `Void type is not allowed here. Void is only usable as a function return type.`
           )
         )
       );

--- a/tests/cli-cases/lsp-handshake/expected_stdout
+++ b/tests/cli-cases/lsp-handshake/expected_stdout
@@ -1,15 +1,7 @@
 $ yo lsp
 Content-Length: 405
 
-{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"definitionProvider":true,"documentSymbolProvider":true,"referencesProvider":true,"foldingRangeProvider":true,"renameProvider":true,"documentFormattingProvider":true,"signatureHelpProvider":{"triggerCharacters":["(",","]},"completionProvider":{"triggerCharacters":[".","\"","/"]}},"serverInfo":{"name":"yo-lsp"}}}check: error in: Error: Variable "undefined_fn_xyz" not found.
-
-file:///virtual/doc.yo:2:3:
-  undefined_fn_xyz();
-          ^
-file:///virtual/doc.yo:2:3:
-  undefined_fn_xyz();
-          ^
-Content-Length: 275
+{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"textDocumentSync":1,"hoverProvider":true,"definitionProvider":true,"documentSymbolProvider":true,"referencesProvider":true,"foldingRangeProvider":true,"renameProvider":true,"documentFormattingProvider":true,"signatureHelpProvider":{"triggerCharacters":["(",","]},"completionProvider":{"triggerCharacters":[".","\"","/"]}},"serverInfo":{"name":"yo-lsp"}}}Content-Length: 275
 
 {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///virtual/doc.yo","diagnostics":[{"range":{"start":{"line":1,"character":2},"end":{"line":1,"character":18}},"severity":1,"source":"yo","message":"Variable \"undefined_fn_xyz\" not found."}]}}Content-Length: 119
 

--- a/tests/internal/error.test.yo
+++ b/tests/internal/error.test.yo
@@ -1,21 +1,31 @@
-//! Tests for src/error.yo — mirrors src/error.ts
+//! Tests for src/error.yo + src/diagnostics.yo — the P1 structured
+//! diagnostic model (plans/ERROR_DIAGNOSTICS_OVERHAUL.md). These are the
+//! golden tests for the human/short renderers: exact-string pins of the
+//! rustc-shaped output.
 open(import("std/string"));
 open(import("std/fmt"));
 { ArrayList } :: import("std/collections/array_list");
 { TokenKind, Token } :: import("../../src/token.yo");
 { assert, panic } :: import("std/assert");
 {
-  ErrorKind,
   TokenAndError,
   TokenAndWarning,
-  YoLexerError,
   YoError,
   get_line_at_token,
   get_line_at_position,
   format_error_message,
   format_error_messages,
+  format_lexer_error,
+  format_raw_error,
   format_warning_messages
 } :: import("../../src/error.yo");
+{
+  Severity,
+  Span,
+  Diagnostic,
+  render_diagnostics_human,
+  render_diagnostics_short
+} :: import("../../src/diagnostics.yo");
 // Build a dummy token for testing.
 make_token :: (fn(module_path : String, input : String, row : usize, column : usize, value : String) -> Token)(
   Token(
@@ -28,29 +38,99 @@ make_token :: (fn(module_path : String, input : String, row : usize, column : us
     input : input
   )
 );
-// ─── YoLexerError ────────────────────────────────────────────────────────────
-test("YoLexerError to_string", {
-  err := YoLexerError(
-    character_index : usize(5),
-    message : `unexpected character`,
-    row : usize(2)
-  );
-  assert(err.to_string() == `Lexer Error at row 3: unexpected character`, "lexer error message");
+// ─── format_error_message: the human render (exact) ──────────────────────────
+test("format_error_message renders the full block exactly once", {
+  tok := make_token(`test.yo`, `let x = 1;`, usize(0), usize(4), `x`);
+  err := format_error_message(tok, `undefined variable x`);
+  s := err.to_string();
+  expected := `error: undefined variable x\n  --> test.yo:1:5\n  |\n1 | let x = 1;\n  |     ^`;
+  assert(s == expected, `exact render, got:\n${s}`);
 });
-test("YoLexerError to_string row 0", {
-  err := YoLexerError(
-    character_index : usize(0),
-    message : `bad token`,
-    row : usize(0)
-  );
-  assert(err.to_string() == `Lexer Error at row 1: bad token`, "row 0 becomes row 1");
+test("format_error_message multi-line message keeps continuation lines", {
+  tok := make_token(`test.yo`, `x := "s";`, usize(0), usize(0), `x`);
+  err := format_error_message(tok, `Incompatible types:\n- Expected: i32\n- Given   : String`);
+  s := err.to_string();
+  expected := `error: Incompatible types:\n- Expected: i32\n- Given   : String\n  --> test.yo:1:1\n  |\n1 | x := "s";\n  | ^`;
+  assert(s == expected, `multi-line render, got:\n${s}`);
 });
-// ─── get_line_at_token ───────────────────────────────────────────────────────
+test("format_error_message underlines the whole token (D5)", {
+  tok := make_token(`t.yo`, `aa bb`, usize(0), usize(3), `bb`);
+  s := format_error_message(tok, `msg`).to_string();
+  assert(s.contains(`  |    ^^`), `two carets under "bb", got:\n${s}`);
+});
+test("format_error_message gutter widens for multi-digit rows", {
+  input := `one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten xx`;
+  tok := make_token(`g.yo`, input, usize(9), usize(4), `xx`);
+  s := format_error_message(tok, `msg`).to_string();
+  assert(s.contains(`   --> g.yo:10:5`), `w=2 anchor, got:\n${s}`);
+  assert(s.contains(`   |`), `w=2 bar line, got:\n${s}`);
+  assert(s.contains(`10 | ten xx`), `padded row line, got:\n${s}`);
+  assert(s.contains(`   |     ^^`), `w=2 caret line, got:\n${s}`);
+});
+test("format_error_message multibyte before the token aligns by rune column", {
+  // `你` is one rune (3 bytes): the token `x` sits at RUNE column 1, and the
+  // caret padding counts runes, so it lands under `x` (D4 lesson).
+  tok := make_token(`m.yo`, `你x := 1;`, usize(0), usize(1), `x`);
+  s := format_error_message(tok, `msg`).to_string();
+  expected := `error: msg\n  --> m.yo:1:2\n  |\n1 | 你x := 1;\n  |  ^`;
+  assert(s == expected, `rune-column caret, got:\n${s}`);
+});
+// ─── format_error_messages: primary + note blocks ───────────────────────────
+test("format_error_messages: entry 0 is the error, later entries are notes (D6)", {
+  tok1 := make_token(`b.yo`, `x y`, usize(0), usize(0), `x`);
+  tok2 := make_token(`b.yo`, `x y`, usize(0), usize(2), `y`);
+  e1 := TokenAndError(token : tok1, error_message : `first error`);
+  e2 := TokenAndError(token : tok2, error_message : `second error`);
+  list := ArrayList(TokenAndError).new();
+  list.push(e1);
+  list.push(e2);
+  err := format_error_messages(list);
+  s := err.to_string();
+  expected := `error: first error\n  --> b.yo:1:1\n  |\n1 | x y\n  | ^\n\nnote: second error\n  --> b.yo:1:3\n  |\n1 | x y\n  |   ^`;
+  assert(s == expected, `error + note blocks, got:\n${s}`);
+});
+// ─── format_lexer_error (D3: lexer errors carry file + source line) ─────────
+test("format_lexer_error renders like every other stage", {
+  input := `a b\n@@ oops`;
+  err := format_lexer_error(`src.yo`, input, usize(1), usize(0), `unexpected character`);
+  s := err.to_string();
+  expected := `error: unexpected character\n  --> src.yo:2:1\n  |\n2 | @@ oops\n  | ^`;
+  assert(s == expected, `lexer diagnostic, got:\n${s}`);
+});
+// ─── format_raw_error (path anchor, no snippet) ──────────────────────────────
+test("format_raw_error anchors the path without a snippet", {
+  s := format_raw_error(`e.yo`, `unexpected end of input`).to_string();
+  expected := `error: unexpected end of input\n  --> e.yo:1:1`;
+  assert(s == expected, `raw diagnostic, got:\n${s}`);
+});
+// ─── the code field renders as [EXXXX] (filled by P2) ────────────────────────
+test("a coded diagnostic renders error[E0308] in both renderers", {
+  diags := ArrayList(Diagnostic).new();
+  diags.push(
+    Diagnostic(
+      code : Option(String).Some(String.from("E0308")),
+      severity : Severity.Error,
+      message : String.from("mismatched types"),
+      span : Span(path : String.from("a.yo"), row : usize(0), col : usize(0), len : usize(1)),
+      source_line : String.from("x")
+    )
+  );
+  h := render_diagnostics_human(diags);
+  assert(h == `error[E0308]: mismatched types\n  --> a.yo:1:1\n  |\n1 | x\n  | ^`, `coded human, got:\n${h}`);
+  sh := render_diagnostics_short(diags);
+  assert(sh == `a.yo:1:1: error[E0308]: mismatched types`, `coded short, got:\n${sh}`);
+});
+// ─── render_diagnostics_short ────────────────────────────────────────────────
+test("render_diagnostics_short is one line per entry", {
+  tok := make_token(`test.yo`, `let x = 1;`, usize(0), usize(4), `x`);
+  err := format_error_message(tok, `undefined variable x\nsecond line dropped in short`);
+  sh := render_diagnostics_short(err.diagnostics);
+  assert(sh == `test.yo:1:5: error: undefined variable x`, `short render, got:\n${sh}`);
+});
+// ─── get_line_at_token / get_line_at_position (legacy warnings-path helpers) ─
 test("get_line_at_token single line", {
   tok := make_token(`test.yo`, `hello world`, usize(0), usize(6), `world`);
   line := get_line_at_token(tok);
-  // Expect: "test.yo:1:7:\nhello world\n       ^"
-  // caret_col = column(6) + len("world")/2 = 6 + 2 = 8 spaces
   assert(line.contains(`test.yo:1:7:`), "header");
   assert(line.contains(`hello world`), "source line");
   assert(line.contains(`^`), "caret");
@@ -62,66 +142,13 @@ test("get_line_at_token multiline input selects correct row", {
   assert(line.contains(`src.yo:2:1:`), "row 1 shown as row 2");
   assert(line.contains(`line1`), "correct source line selected");
 });
-test("get_line_at_token missing row returns empty line", {
-  tok := make_token(`x.yo`, `only one line`, usize(5), usize(0), `x`);
-  line := get_line_at_token(tok);
-  assert(line.contains(`x.yo:6:1:`), "header still present");
-  assert(line.contains(`^`), "caret present even for missing row");
-});
-// ─── get_line_at_position ────────────────────────────────────────────────────
 test("get_line_at_position basic", {
   result := get_line_at_position(`mod.yo`, `abc\ndef`, usize(0), usize(2));
   assert(result.contains(`mod.yo:1:3:`), "header");
   assert(result.contains(`abc`), "source line");
   assert(result.contains(`^`), "caret");
 });
-// ─── format_error_message ────────────────────────────────────────────────────
-test("format_error_message creates YoError", {
-  tok := make_token(`test.yo`, `let x = 1;`, usize(0), usize(4), `x`);
-  err := format_error_message(tok, `undefined variable x`, false, .None);
-  s := err.to_string();
-  assert(s.contains(`Error:`), "has Error prefix");
-  assert(s.contains(`undefined variable x`), "contains error message");
-  assert(s.contains(`test.yo:1:5:`), "contains location");
-});
-test("format_error_message assertion error flag preserved", {
-  tok := make_token(`t.yo`, `assert(false)`, usize(0), usize(0), `assert`);
-  err := format_error_message(tok, `assertion failed`, true, .None);
-  assert(err.is_assertion_error, "is_assertion_error must be true");
-});
-test("format_error_message kind preserved", {
-  tok := make_token(`t.yo`, `999999`, usize(0), usize(0), `999999`);
-  err := format_error_message(tok, `integer overflow`, false, .Some(ErrorKind.Overflow));
-  match(
-    err.kind,
-    .Some(k) => assert(k == ErrorKind.Overflow, "kind must be Overflow"),
-    .None => assert(false, "kind must be Some")
-  );
-});
-// ─── format_error_messages ───────────────────────────────────────────────────
-test("format_error_messages with one entry", {
-  tok := make_token(`a.yo`, `foo`, usize(0), usize(0), `foo`);
-  entry := TokenAndError(token : tok, error_message : `missing semicolon`);
-  entries := ArrayList(TokenAndError).new();
-  entries.push(entry);
-  err := format_error_messages(entries, false, .None);
-  s := err.to_string();
-  assert(s.contains(`Error: missing semicolon`), "error message in output");
-});
-test("format_error_messages with two entries", {
-  tok1 := make_token(`b.yo`, `x y`, usize(0), usize(0), `x`);
-  tok2 := make_token(`b.yo`, `x y`, usize(0), usize(2), `y`);
-  e1 := TokenAndError(token : tok1, error_message : `first error`);
-  e2 := TokenAndError(token : tok2, error_message : `second error`);
-  list := ArrayList(TokenAndError).new();
-  list.push(e1);
-  list.push(e2);
-  err := format_error_messages(list, false, .None);
-  s := err.to_string();
-  assert(s.contains(`first error`), "first error present");
-  assert(s.contains(`second error`), "second error present");
-});
-// ─── format_warning_messages ─────────────────────────────────────────────────
+// ─── format_warning_messages (legacy pre-P1 block; the warnings channel is P4)
 test("format_warning_messages no prefix", {
   tok := make_token(`w.yo`, `foo`, usize(0), usize(0), `foo`);
   entry := TokenAndWarning(token : tok, warning_message : `unused variable`);
@@ -140,19 +167,16 @@ test("format_warning_messages with prefix", {
   assert(result.contains(`Warning: module warning`), "prefix warning present");
   assert(result.contains(`deprecated usage`), "per-token warning present");
 });
-test("format_warning_messages empty list with prefix", {
-  result := format_warning_messages(.Some(String.from("top warning")), ArrayList(TokenAndWarning).new());
-  assert(result.contains(`Warning: top warning`), "prefix only when list empty");
-});
 test("format_warning_messages empty list no prefix", {
   result := format_warning_messages(.None, ArrayList(TokenAndWarning).new());
   assert(result == ``, "empty result when no prefix and no warnings");
 });
-// ─── YoError.to_string ───────────────────────────────────────────────────────
-test("YoError to_string formats errors", {
+// ─── YoError round-trip ──────────────────────────────────────────────────────
+test("YoError.to_string is the shared human render", {
   tok := make_token(`main.yo`, `let`, usize(0), usize(0), `let`);
-  err := format_error_message(tok, `unexpected keyword`, false, .None);
+  err := format_error_message(tok, `unexpected keyword`);
   s := err.to_string();
-  assert(s.contains(`Error:`), "Error: prefix present");
-  assert(s.contains(`unexpected keyword`), "message present");
+  assert(s.starts_with(`error: unexpected keyword`), "severity header present");
+  assert(s.contains(`--> main.yo:1:1`), "anchor present");
+  assert(s.contains(`1 | let`), "source line present");
 });

--- a/tests/internal/lexer.test.yo
+++ b/tests/internal/lexer.test.yo
@@ -3,7 +3,8 @@ open(import("std/fmt"));
 open(import("std/error"));
 { ArrayList } :: import("std/collections/array_list");
 { Token, TokenKind, find_matching_bracket } :: import("../../src/token.yo");
-{ LexerError, tokenize } :: import("../../src/lexer.yo");
+{ tokenize } :: import("../../src/lexer.yo");
+{ YoError } :: import("../../src/error.yo");
 { assert, panic } :: import("std/assert");
 // Tokenize source, panicking on any lexer error.
 lex_or_panic :: (fn(source : String, exn : Exception) -> ArrayList(Token))(
@@ -661,14 +662,18 @@ test("Unterminated string auto-closes at EOF (TS parity)", {
     }
   );
 });
-test("Unterminated block comment raises LexerError", {
+test("Unterminated block comment raises a lexer diagnostic", {
   exn := Exception(
     throw : (
       err -> {
         match(
-          downcast(err, LexerError),
-          .Some(le) => assert(le.message == `unterminated block comment`, "wrong error message"),
-          .None => assert(false, "expected LexerError")
+          downcast(err, YoError),
+          .Some(ye) => {
+            s := ye.to_string();
+            assert(s.contains(`unterminated block comment`), "wrong error message");
+            assert(s.contains(`--> test.yo:`), "D3: lexer diagnostics carry the file");
+          },
+          .None => assert(false, "expected a YoError diagnostic")
         );
         unwind(());
       }
@@ -677,14 +682,14 @@ test("Unterminated block comment raises LexerError", {
   tokenize(`/* unterminated`, `test.yo`, exn);
   assert(false, "expected a lexer error to be raised");
 });
-test("Unterminated template string raises LexerError", {
+test("Unterminated template string raises a lexer diagnostic", {
   exn := Exception(
     throw : (
       err -> {
         match(
-          downcast(err, LexerError),
-          .Some(le) => assert(le.message == `unterminated template string`, "wrong error message"),
-          .None => assert(false, "expected LexerError")
+          downcast(err, YoError),
+          .Some(ye) => assert(ye.to_string().contains(`unterminated template string`), "wrong error message"),
+          .None => assert(false, "expected a YoError diagnostic")
         );
         unwind(());
       }
@@ -745,9 +750,9 @@ test("forall is reserved for verification quantifiers", {
     throw : (
       err -> {
         match(
-          downcast(err, LexerError),
-          .Some(le) => assert(le.message == `\`forall\` is reserved for verification quantifiers. Use \`generic(T : Type)\` to declare type parameters.`, "wrong error message"),
-          .None => assert(false, "expected LexerError")
+          downcast(err, YoError),
+          .Some(ye) => assert(ye.to_string().contains(`\`forall\` is reserved for verification quantifiers. Use \`generic(T : Type)\` to declare type parameters.`), "wrong error message"),
+          .None => assert(false, "expected a YoError diagnostic")
         );
         unwind(());
       }
@@ -761,9 +766,9 @@ test("∀ is reserved for verification quantifiers", {
     throw : (
       err -> {
         match(
-          downcast(err, LexerError),
-          .Some(le) => assert(le.message == `\`∀\` is reserved for verification quantifiers. Use \`generic(T : Type)\` to declare type parameters.`, "wrong error message"),
-          .None => assert(false, "expected LexerError")
+          downcast(err, YoError),
+          .Some(ye) => assert(ye.to_string().contains(`\`∀\` is reserved for verification quantifiers. Use \`generic(T : Type)\` to declare type parameters.`), "wrong error message"),
+          .None => assert(false, "expected a YoError diagnostic")
         );
         unwind(());
       }

--- a/tests/internal/parser.test.yo
+++ b/tests/internal/parser.test.yo
@@ -4,7 +4,8 @@ open(import("std/error"));
 { ArrayList } :: import("std/collections/array_list");
 { StringBuilder } :: import("std/string/string_builder");
 { AstExpr, ast_expr_to_string, ast_expr_is_atom, ast_expr_is_fn_call, make_err_expr } :: import("../../src/expr.yo");
-{ ParseError, parse, extract_source_line, generate_expr_from_code } :: import("../../src/parser.yo");
+{ parse, extract_source_line, make_parse_error, generate_expr_from_code } :: import("../../src/parser.yo");
+{ Token, TokenKind } :: import("../../src/token.yo");
 { assert, panic } :: import("std/assert");
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 // Check that two String values are equal; fails with msg if not.
@@ -575,18 +576,21 @@ test("extract_source_line: out-of-range returns empty string", {
   result := extract_source_line(src, usize(99));
   assert_str_eq(result, String.from(""), "out-of-range row should return(empty string)");
 });
-test("ParseError.to_string: format with source line", {
-  err := ParseError(
-    message : String.from("unexpected token: }"),
+test("make_parse_error renders via the shared renderer", {
+  tok := Token(
+    kind : TokenKind.Identifier,
+    value : String.from("}"),
     row : usize(3),
     column : usize(0),
+    character : usize(0),
     module_path : String.from("test.yo"),
-    source_line : String.from("}")
+    input : String.from("a\nb\nc\n}")
   );
-  s := err.to_string();
+  s := make_parse_error(tok, String.from("unexpected token: }")).to_string();
   assert(s.contains(String.from("error: unexpected token: }")), "should contain error message");
-  assert(s.contains(String.from("--> test.yo:4:0")), "should show row+1=4 in location");
+  assert(s.contains(String.from("--> test.yo:4:1")), "should show row+1=4, col+1=1 in location");
   assert(s.contains(String.from("4 | }")), "should show source line with row+1");
+  assert(s.contains(String.from("4 | }")), "source line");
 });
 // ---------------------------------------------------------------------------
 // generate_expr_from_code


### PR DESCRIPTION
Phase 1 of plans/ERROR_DIAGNOSTICS_OVERHAUL.md (design + decisions in this PR; see the plan doc for the full audit).

## What changes

- **`src/diagnostics.yo` (new)** — the structured diagnostic value (`Severity`, `Span` with 0-based row/rune-column + span length, `Diagnostic` with the P2 `code` slot already rendering as `error[E0308]`) plus the human renderer (rustc-shaped: severity header, `-->` anchor, width-aligned gutter, **full-token underline**) and the one-line short renderer.
- **`src/error.yo`** — `YoError` rebased onto `ArrayList(Diagnostic)`; dead write-only `ErrorKind`/`is_assertion_error` and never-constructed `YoLexerError` deleted. `format_error_message(s)` keep their (token, message) shape — **1028 call sites across 111 files** mechanically trimmed of the dead trailing args — but the location block is no longer baked into the message string, so every error renders its location **exactly once** (D1).
- **Lexer + parser throw the same structured error** (`format_lexer_error`; `make_parse_error` via `format_error_message`): lexer errors now carry the module path, source line and a 1-based anchor (D3); the local `ParseError`/`LexerError` structs are gone, so there is one prefix rule at the CLI edge instead of `yo: error: error:` (D4).
- **Single-print edges (D2)**: module_manager's handlers stash the rendered diagnostic instead of printing; `check` prints per failed file at its own edge, watch rounds likewise, `compile` rethrows the stash so the wrapper carries the underlying text, and `mm_preload_prelude` surfaces a failing prelude. The `check: error in:` leak into compile/lsp/test output is gone.
- Caret underlines the whole token from its start (D5); batch entries after the first render as `note:` blocks (D6).
- **LSP** `parse_error_text` parses the exact renderer shape — end columns are read off the caret run (exact) instead of guessed by identifier heuristics; the doubled-location dedup is deleted with the doubling.
- `tests/internal/error.test.yo` rewritten as the renderer's golden suite (17 exact-string tests); lexer/parser pins updated; `lsp-handshake` golden re-recorded — it loses the leak + doubled location, and the `publishDiagnostics` frames are **byte-identical** to before.

## Verification

- `yo check ./src` — 264/264, rc=0
- `yo compile src/main.yo --skip-c-compiler` — rc=0
- internal suites: error 17/17, lexer 47/47, parser 50/52 — the 2 failures are **pre-existing on pristine origin/develop** under the local toolchain (documented: `issues/parser-multibyte-spec-tests-leak-under-linux-asan.md`; CI-green on the same commit)
- stage-1 built at CI's exact flag set; full CLI corpus: **54 PASS**, 3 `doc-*` diffs that are local git-version stderr text only (no yo output involved), 1 network skip
- live smoke of eval/parse/lex errors confirms the new block, single print, single prefix

## Follow-ups

P2 (codes + bilingual registry + `yo explain` + `--error-format short|json`) and P3 (did-you-mean, LSP typed channel, ICE wrapper, panic locations) land as stacked PRs on top of this one.