### PR TITLE
docs: post-landed audit of the error-diagnostics overhaul

### DIFF
--- a/issues/parser-multibyte-spec-tests-leak-under-linux-asan.md
+++ b/issues/parser-multibyte-spec-tests-leak-under-linux-asan.md
@@ -4,6 +4,15 @@
 **not a regression of it**: reproduced on pristine `origin/develop`
 `060acdc26` with the stock seed `v0.2.23`, before any of that work's edits).
 
+**NOT the Stage-0 shared-id leak — refuted 2026-09-04**: the balancing-drop
+leak fix (PR #403; `issues/fixed/
+ref-local-scope-drop-missing-after-value-call.md`) does NOT cover this. The
+branch-built fixed compiler (CI `suite-candidate` artifact from run
+33842210258, verified leak-free on the original `to_string` repro) still
+reports the identical `SUMMARY: AddressSanitizer: 1881 byte(s) leaked in
+32 allocation(s)` on these two tests — a separate mechanism, most likely in
+the per-rune temp handling of the multibyte peel path itself.
+
 ## Reproducer
 
 ```bash

--- a/issues/skip-c-compiler-still-requires-a-c-compiler.md
+++ b/issues/skip-c-compiler-still-requires-a-c-compiler.md
@@ -1,0 +1,48 @@
+# `yo compile --emit-c --skip-c-compiler` still requires a C compiler to be FOUND
+
+**Status: OPEN** (found 2026-09-04 during the error-diagnostics P3r-1 work;
+the flag's contract is "don't RUN a C compiler", but the command still
+refuses to start when none is on PATH).
+
+## Reproducer
+
+On a machine with no `cc`/`clang`/`gcc`/`zig` on PATH (this Steam Deck
+outside `nix-shell` — the toolchain lives only in `shell.nix`):
+
+```bash
+~/.local/bin/yo compile src/main.yo --emit-c --skip-c-compiler --optimize 2 -o /tmp/yo
+# yo: error: Error: No C compiler found. Please install a C compiler
+#      (cc, gcc, clang, or zig) or specify one using the -cc/--c-compiler flag.
+```
+
+Inside `nix-shell` (clang on PATH) the same command succeeds — the C
+compiler is never invoked, it is only DISCOVERED.
+
+## Root cause
+
+`src/main.yo` `run_compile`'s compiler-resolution block (~line 1645):
+
+```rust
+if(cc == "", {
+  match(
+    _find_available_compiler(io),
+    .Some(found_cc) => { cc = found_cc; },
+    .None => { exn.throw(dyn(String.from("Error: No C compiler found. ..."))); }
+  );
+});
+```
+
+The probe-and-throw runs unconditionally when `-cc` was not passed — it is
+not guarded by `skip_c_compiler`, even though a skipped C-compile step never
+needs `cc` (and `--emit-c` only PRINTS the C text). Note `-cc` itself is
+also rejected by this build's flag parser (`compile: unknown option '-cc'`)
+even though the error text advertises it — worth checking the same
+fix (`--c-compiler` presumably parses; `-cc` does not).
+
+## Fix direction
+
+Skip the discovery block when `skip_c_compiler` is set (defaulting `cc`
+harmlessly), and make `-cc` an accepted spelling if the error message is
+going to keep recommending it. Tiny change; the affected UX is
+emit-C-only workflows on toolchain-less machines (CI containers, minimal
+dev boxes) — exactly where `--skip-c-compiler` is meant to be used.

--- a/plans/ERROR_DIAGNOSTICS_OVERHAUL.md
+++ b/plans/ERROR_DIAGNOSTICS_OVERHAUL.md
@@ -1,14 +1,17 @@
 # Error diagnostics overhaul — structured, coded, LLM-first
 
-> **Status: PROPOSED 2026-09-03 — awaiting maintainer review. Nothing here is
-> implemented.** This doc is the detailed design for ROADMAP items
-> [Phase 2.3](ROADMAP.md) ("Error-message overhaul"), [Phase 4.2](ROADMAP.md)
-> ("Errors as few-shot repairs") and [Phase 4.5](ROADMAP.md)
-> ("`yo explain <error-id>` / machine-consumable diagnostics"), and it closes
-> the "structured-diagnostics return channel" remaining-quality item in
+> **Status: IMPLEMENTED 2026-09-03 → 2026-09-04 — all phases LANDED** (P1 PR
+> #399; P2 PR #400; P3 + P3r + the P3r-1 Stage-0 balancing-drop leak fix PR
+> #403, opened as #401 and superseded when #400's branch was deleted on
+> merge). Kept as the living reference for the shipped design. This doc was
+> the detailed design for ROADMAP items [Phase 2.3](ROADMAP.md)
+> ("Error-message overhaul"), [Phase 4.2](ROADMAP.md) ("Errors as few-shot
+> repairs") and [Phase 4.5](ROADMAP.md) ("`yo explain <error-id>` /
+> machine-consumable diagnostics"), and it closed the
+> "structured-diagnostics return channel" remaining-quality item in
 > [P4_LSP.md](P4_LSP.md) header. Sections 1–4 are a verified audit of the
-> current `src/` (all numbers re-runnable, commands given); sections 5+ are
-> the design and phasing proposed for approval.
+> pre-overhaul `src/` (numbers frozen at their writing); sections 5+ are the
+> design as approved and landed.
 >
 > **§11 decisions recorded 2026-09-03**: `yo explain` (no alias), numeric
 > `E0308`-style codes, a bilingual English + 简体中文 registry from day one,


### PR DESCRIPTION
Documentation follow-ups from the post-merge audit of P1–P3:

- The overhaul plan header still said `PROPOSED — nothing implemented` under four LANDED banners; now records the real landing status (P1 #399, P2 #400, P3 + P3r + the Stage-0 balancing-drop leak fix #403).
- The multibyte parser-leak issue's `likely the same mechanism as the Stage-0 leak` hypothesis is REFUTED with evidence: the branch-built fixed compiler (CI `suite-candidate`, itself verified leak-free on the original `to_string` repro) still leaks the identical 1881B/32allocs on those two tests. Separate mechanism, still open.
- New issue: `yo compile --emit-c --skip-c-compiler` still requires a C compiler to be FOUND (the discovery-and-throw in `run_compile` is not guarded by the flag; the advertised `-cc` spelling is also rejected by the flag parser).

Docs-only.