### PR TITLE
issues: corrected verdicts — tail flush inconclusive (seed lottery), lottery characterized

### DIFF
--- a/issues/short-circuit-bare-fn-body-operand-temps-leak.md
+++ b/issues/short-circuit-bare-fn-body-operand-temps-leak.md
@@ -41,24 +41,25 @@ verified.)
    and removal-on-emit inverts the pending path's `already` contract.
 3. **broad ||-node list flush** (this branch, first try): same undeclared
    class plus a bool-target drop expr (`.tag` on bool) from inner-node lists.
-4. **gated tail flush** (this branch, second try — emitted-once guard +
-   `require_scope_stack` block-scope gate): the branch-built compiler
-   ABORTS with `mimalloc: corrupted free list entry` compiling even
-   trivial files — the wrongly-emitted drop is somewhere in the compiler's
-   own bare-tail fns, and the wasm32-wasi leg failed the same way
-   (tests/crypto SHA-1, exit 34304). Conclusion: the scheduler-produced
-   body list contains drops whose release is accounted for ANALYTICALLY
-   elsewhere (the `_optimize_dup_drop_pairs` cancellation family) — none of
-   the four gates (emitted-once, undeclared-temp, scope-stack,
-   closure/short-circuit) covers that class.
+4. **gated tail flush** (emitted-once guard + `require_scope_stack`
+   block-scope gate) — **verdict: INCONCLUSIVE, not disproven**. Its CI run
+   failed (wasm32-wasi SHA-1 abort; stage-3 byte-identity fail) and the
+   branch-built binary aborts even on eval-only `yo check` of hello world —
+   but a probe build with emission prints showed ZERO emissions firing
+   before the abort: the corruption is the **seed-build lottery**
+   (v0.2.23's latent self-miscompiles — the class documented in
+   `issues/fixed/seed-built-stage1-miscompiles-current-source.md`), which
+   lands on a tree's exact eval shapes and can strike ANY branch that
+   shifts them. A control binary from the identical tree minus the flush
+   compiles cleanly. The flush itself was never actually invalidated.
 
 ## Next direction
 
-Pinpoint the wrongly-emitted drop FIRST, then design the gate around the
-actual failure: build the compiler from a tail-flush branch with
-`--sanitize address` (an ASan compiler build points at the exact over-
-release), or add a debug env-gated print of every tail-flushed
-drop's target and module path, compile the tree, and read the first drop
-whose target is analytically cancelled. The likely missing gate is a
-consumption/cancellation check mirroring `_keep_pending_drop`'s
-`consumed_at_token` logic (return.yo) for the node-list channel.
+**Precondition: a seed that carries the #403/#405 fixes** (the emitted-once
+guard closed the seed's own double-emission class). After the next release
+bumps SEED_VERSION past v0.2.23, re-land attempt 4 verbatim and let the
+self-hosted CI chain judge it — the corruption noise that masked the
+verdict is the old seed's, not the change's. If it still corrupts, pinpoint
+with the YO_DEBUG_TAIL_FLUSH probe (read the env IN-FUNCTION — module-level
+reads fire before std/env is populated) and design a consumption gate
+mirroring `_keep_pending_drop`'s `consumed_at_token` check.

--- a/issues/v0.2.23-seed-build-lottery-corrupts-shifted-trees.md
+++ b/issues/v0.2.23-seed-build-lottery-corrupts-shifted-trees.md
@@ -1,0 +1,44 @@
+# The v0.2.23 seed build is a corruption lottery for any branch that shifts eval shapes
+
+**Status: OPEN** (characterized 2026-09-04 during the bare-body `||` leak
+investigation; the class is the same one documented in
+`issues/fixed/seed-built-stage1-miscompiles-current-source.md` from the
+v0.2.0 era — it recurred at v0.2.23 with current develop).
+
+## What happens
+
+CI's `suite-candidate` / fixpoint stage-1 is built by the **seed**
+(SEED_VERSION = v0.2.23). The seed predates the #403 codegen fixes (the
+emitted-once drop guard, the shared-id begin concat) and still carries
+latent self-miscompiles. Whether a seed-built binary of a given tree is
+clean or corrupts is a deterministic function of the tree's exact content —
+eval-shape shifts (new functions, changed temps) re-roll the dice.
+
+Evidence (all 2026-09-04, Linux x64):
+
+- A candidate built from clean develop + 4 commits compiles and checks
+  everything fine (that tree's PR went 26/26 green).
+- The SAME tree plus a codegen-only commit (a drop flush that never even
+  EXECUTES during `check`) produces a candidate that aborts with
+  `mimalloc: corrupted free list entry` on **eval-only `yo check` of hello
+  world** — before any of the new code runs (verified with emission
+  probes: zero firings before the abort).
+- That corrupt run's CI failed downstream wholesale (wasm32-wasi test
+  abort, stage-3 byte-identity fail at 45 s) — all seed-corruption
+  symptoms, none attributable to the branch's change.
+
+## Impact
+
+Any PR that shifts the tree's eval shapes can draw the corrupt ticket and
+be unmergeable for reasons unrelated to its diff. This will keep recurring
+until SEED_VERSION points at a release containing the #403/#405 codegen
+fixes.
+
+## Direction
+
+Bump SEED_VERSION to the first release built from post-#405 develop (the
+release pipeline's auto-bump handles this once a release ships). Until
+then, a red-fixpoint/stage-3 or a candidate that aborts on trivial
+`check` inputs should be suspected as the lottery before the PR's own diff
+is blamed — a quick control is rebuilding from the same tree minus the
+suspect commit.


### PR DESCRIPTION
Docs-only. Corrects the evidence trail from the bare-body leak investigation:

- The gated tail flush's CI failure was the v0.2.23 seed-build corruption lottery (probe: zero emissions fired before an eval-only check abort; control build clean) — its verdict moves to INCONCLUSIVE with a concrete retry precondition (SEED_VERSION bump past v0.2.23).
- New issue characterizing the lottery itself, so future red fixpoints/candidate aborts are checked against the class before blaming the PR diff.