### PR TITLE
evaluator: comptime u64/usize above i64.MAX must divide, mod, shift and compare UNSIGNED

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -241,6 +241,31 @@ locally built one, since that is what CI runs:
 yo fmt --check ./src ./std ./tests
 ```
 
+## Editing ANY file under `.github/skills/` re-records two cli-cases
+
+`yo skills install` (restored in #412) copies the skill tree into a project, and
+the `skills-install` / `skills-install-zh` cases record the **content hash of
+every installed file** in their `expected_tree`. So a one-line edit to, say,
+`.github/skills/yo-syntax/syntax-cheatsheet.md` — the file this repo asks you to
+update whenever you learn a Yo lesson — turns the tier-1 CLI gate red with
+
+```
+── GOLDEN-DIFF  skills-install  (rc=0; tree)
+    content-differs (vs recorded golden hash): ./.agents/skills/yo-syntax/syntax-cheatsheet.md
+```
+
+roughly 25 minutes into a PR's `Self-hosted \`test\` subcommand` job. The fix is
+a re-record, not a revert:
+
+```bash
+YO_SELF_BIN=<your stage-1> bash scripts/cli-diff-test.sh --record skills-install skills-install-zh
+YO_SELF_BIN=<your stage-1> bash scripts/cli-diff-test.sh          # re-score, expect a clean card
+```
+
+Review the diff before committing: it should be exactly one changed hash line
+per case per edited skill file. Anything else means the install copied
+something you did not intend.
+
 ## A fixpoint run's stage-1 must live OUTSIDE the repo (`/tmp/yo-s1`)
 
 Type keys embed each declaring module's PATH SPELLING, and std resolution is

--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -550,7 +550,21 @@ test("Async test", {
   is not a valid main shape). Do NOT write `io :: __yo_builtin_io` inside a fn body; that form is an
   internal mechanism of the batched test runner's synthesized programs only.
 - `assert(condition, "message")` — runtime assertion; requires `{ assert } :: import("std/assert");` at the top of the test file
-- `comptime_assert(condition)` — compile-time assertion (builtin, no import)
+- `comptime_assert(condition)` — compile-time assertion (builtin, no import).
+  **It only FIRES at MODULE level.** Inside any function body — `main`, a
+  called fn, a `comptime` fn, and therefore inside a `test("…", { … })` block —
+  `comptime_assert(false)` is silently ACCEPTED
+  (issues/comptime-assert-never-fires-inside-a-function-body.md; all 1559
+  `comptime_assert`s under `tests/` are in that dead position). Until that is
+  fixed, pin a comptime result with a **module-level `::` binding observed by a
+  runtime `assert`** — the binding folds at comptime and the runtime assert
+  sees what the folder produced:
+  ```rust
+  _DIV :: (u64.MAX / u64(2));            // folded at comptime
+  test("…", { assert(_DIV == u64(9223372036854775807), `folded to ${_DIV}`); });
+  ```
+  Always verify such a test goes RED on a compiler without your fix; that is
+  the only way to know the gate is real.
 - `comptime_expect_error(expr)` — verify code produces a compile error
 
 ## Design-by-contract clauses

--- a/issues/comptime-assert-never-fires-inside-a-function-body.md
+++ b/issues/comptime-assert-never-fires-inside-a-function-body.md
@@ -1,0 +1,139 @@
+# `comptime_assert` never fires inside a function body — 1559 assertions in `tests/` assert nothing
+
+**Status: OPEN.**
+
+**Severity: hollow gate.** Not a wrong answer — an *absent* answer, over the
+entire compile-time-evaluation surface. `comptime_assert` is the only mechanism
+the suite has for pinning CTFE results, and it is inert everywhere the suite
+uses it.
+
+**Found** 2026-09-04, while writing a regression test for
+`issues/fixed/comptime-u64-div-mod-cmp-shr-are-signed.md`. The new test passed
+on the *unfixed* compiler, which is how the vacuity surfaced.
+
+## Reproducer
+
+```rust
+main :: (fn() -> unit)({
+  comptime_assert(false);
+});
+export(main);
+```
+
+```
+$ yo compile ca1.yo --optimize 2 -o ca1.out
+$ echo $?
+0
+```
+
+Accepted. At module level the same call is correctly rejected:
+
+```rust
+comptime_assert(false);
+main :: (fn() -> unit)({});
+export(main);
+```
+
+```
+error[E1101]: Assertion failed for "comptime_assert":
+false
+  --> ca2.yo:1:1
+  |
+1 | comptime_assert(false);
+```
+
+Measured on v0.2.24, `comptime_assert(false)` in each position:
+
+| position | result |
+| --- | --- |
+| module level | **REJECTED** (E1101) — correct |
+| inside `main`'s body | accepted, silently |
+| inside a plain `fn` that IS called from `main` | accepted, silently |
+| inside a plain `fn` that is never called | accepted, silently |
+| inside a `fn(...) -> comptime(T)` body | accepted, silently |
+
+`yo check` accepts it in every position including module level, but that is
+expected: `check` is evaluator-only and this diagnostic is raised on the
+compile path.
+
+## Scale
+
+A `test("name", { ... })` body **is** a function body, so every
+`comptime_assert` in the suite is in the inert position:
+
+```
+$ grep -rh 'comptime_assert' tests/ | wc -l
+1559
+$ grep -rc 'comptime_assert' tests/*.test.yo | sort -t: -k2 -rn | head -5
+tests/comptime.test.yo:1064
+tests/basic.test.yo:172
+tests/type_reflection.test.yo:103
+tests/index.test.yo:58
+tests/variadic_comptime.test.yo:34
+```
+
+`tests/comptime.test.yo` is the primary gate on constant folding, comptime
+strings, comptime collections and type reflection. It reports 31 passing tests
+and verifies none of their comptime claims.
+
+This is exactly how the u64 signed-arithmetic bug above survived: `Test
+comptime u64` contains `comptime_assert(quot == …)` lines that would have
+caught a mis-folded division if they had run.
+
+## Why this matters beyond the count
+
+Two of the audit's own conventions lean on `comptime_assert`:
+
+- the O7 `Acyclic` pins use `comptime_assert(Type.impls(payload, Send))` to
+  guarantee "the expected error can only be Acyclic's"
+  (`plans/STD_API_AUDIT.md` §8 O7) — an inert guard there means the
+  `comptime_expect_error` tests may be passing for the wrong reason;
+- `std/prelude.yo`'s own `for`-macro validation uses
+  `comptime_assert(args.len() == 2, …)` inside a macro body, which is a
+  function body.
+
+## Root cause — not yet established
+
+Not yet root-caused; this doc is the filing, not the fix. What is known:
+
+- the diagnostic is `E1101` and is reachable, so the check exists and the
+  message is wired;
+- position is what decides, not reachability — an uncalled function behaves the
+  same as `main`, which rules out "the body was never evaluated" as the whole
+  story;
+- the shape strongly resembles the **def-eval swallow** family already
+  documented in this repo, where a real error raised during a function's
+  definition-time trial evaluation is caught and discarded. C18 and C19 were
+  both this: *"the check FIRED but was SWALLOWED in async-closure/generic
+  def-eval, leaving codegen no ExprInfo"*, and the fix there was to flag the
+  flow-violation channel before throwing so the swallow re-raises it at check
+  time (`issues/fixed/struct-literal-missing-field-silently-accepted.md`,
+  `issues/fixed/int-vs-i32-mismatch-reaches-codegen-and-emits-malformed-c.md`).
+
+Start there: find where `comptime_assert` is evaluated (the builtin dispatch in
+`src/evaluator/builtins/`), and find which handler swallows its throw when the
+enclosing expression is a function body rather than a module-level statement.
+
+## Fix shape
+
+1. Make `comptime_assert` fire in a function body, by the same
+   flow-violation-channel route C18/C19 used, so the def-eval trial cannot
+   discard it.
+2. **Then triage the fallout.** Turning on 1559 dormant assertions will go red
+   in places, and every red one is either a real bug or a stale assertion. That
+   triage is the substance of this work, not a side effect — budget for it, and
+   do not weaken assertions to get green. Land the fix and the triage together
+   so the suite is never knowingly hollow on `develop`.
+3. Add a **vacuity guard** so this cannot regress: a test that asserts
+   `comptime_assert(false)` inside a function body is REJECTED. The natural
+   home is a `tests/cli-cases/` golden (a compile that must fail with E1101),
+   since the assertion is about a compile failing.
+
+## Interim guidance for test authors
+
+Until this is fixed, do not rely on `comptime_assert` inside a `test(...)`
+body. The shape that works today is a **module-level `::` binding observed by a
+runtime `assert`**: the binding is folded at comptime, and the runtime assert
+observes what the folder produced. `tests/comptime.test.yo`'s three new
+`UNSIGNED` tests are written that way and are verified to go red on a broken
+compiler.

--- a/issues/fixed/comptime-u64-div-mod-cmp-shr-are-signed.md
+++ b/issues/fixed/comptime-u64-div-mod-cmp-shr-are-signed.md
@@ -1,0 +1,125 @@
+# Comptime `u64`/`usize` above `i64.MAX`: `/`, `%`, `>>` and the ordering comparisons are computed SIGNED
+
+**Severity: silent wrong value at compile time.** Every `u64` or `usize`
+constant above `i64.MAX` — `u64.MAX`, `usize.MAX`, hash seeds, bit masks with
+the top bit set — divides, mods, right-shifts and compares wrongly when the
+expression is folded at comptime. The runtime path is correct, so the same
+expression gives two different answers depending on whether it happened to be
+constant-folded.
+
+**Found** 2026-09-04, while re-measuring the std-API audit queue: the
+compiler's own integer-literal path (`src/evaluator/calls/numeric_type.yo:134`
+calls `String.parse_u64`) started failing after `parse_u64` was made
+overflow-checked, because the overflow guard divides by the radix.
+
+## Reproducer
+
+```rust
+{ println } :: import("std/fmt");
+main :: (fn() -> unit)({
+  // Comptime-folded (both operands are constants):
+  println(`u64.MAX / 2   = ${(u64.MAX / u64(2))}`);
+  println(`u64.MAX % 10  = ${(u64.MAX % u64(10))}`);
+  println(`u64.MAX > 1   = ${(u64.MAX > u64(1))}`);
+  println(`u64.MAX >> 1  = ${(u64.MAX >> u64(1))}`);
+  println(`(1 << 63) / 2 = ${((u64(1) << u64(63)) / u64(2))}`);
+  println(`u64.MAX - 1   = ${(u64.MAX - u64(1))}`);
+  // The same operations with a RUNTIME operand:
+  m := u64.MAX;
+  println(`runtime MAX/2 = ${(m / u64(2))}`);
+  println(`runtime MAX>1 = ${(m > u64(1))}`);
+});
+export(main);
+```
+
+Observed on v0.2.24:
+
+| expression | comptime | correct | why (as signed `i64`) |
+| --- | --- | --- | --- |
+| `u64.MAX / 2` | **0** | 9223372036854775807 | `-1 / 2` = 0 |
+| `u64.MAX / 10` | **0** | 1844674407370955161 | `-1 / 10` = 0 |
+| `u64.MAX % 10` | **18446744073709551615** | 5 | `-1 % 10` = -1 |
+| `u64.MAX > 1` | **false** | true | `-1 > 1` is false |
+| `u64.MAX >> 1` | **18446744073709551615** | 9223372036854775807 | arithmetic shift of -1 is -1 |
+| `(1 << 63) / 2` | **13835058055282163712** | 4611686018427387904 | `i64.MIN / 2` = -4611686018427387904 |
+| `u64.MAX - 1` | 18446744073709551614 | same | correct — see below |
+
+The runtime forms print the correct values, which is what makes this so easy to
+miss: `(m / u64(2))` and `(u64.MAX / u64(2))` disagree.
+
+`usize` is affected identically — `is_unsigned_integer_type` covers `.Usize`
+and `get_integer_type_bits(.Usize)` reports the target pointer width — so a
+comptime bounds check written against `usize.MAX` reads a negative pattern.
+
+## Root cause
+
+`src/evaluator/builtins/comptime_numeric_fns.yo` carries comptime integers as
+`i64` (`lhs_n`, `rhs_n` are `Option(i64)` produced by `parse_raw_int`). A `u64`
+value above `i64.MAX` is therefore stored as a **negative bit pattern**, and
+the operations were applied with signed semantics:
+
+```rust
+result_val = make_int_val(a / b, numeric_type);   // signed division
+result_val = make_int_val(a % b, numeric_type);   // signed modulo
+b_result := cond( … (op_s == "gt") => (a > b), … ) // signed comparison
+n_result := cond( (op_s == "shl") => (a << b), true => (a >> b) ) // arithmetic shift
+```
+
+`add`, `sub`, `mul`, `eq`, `neq`, `shl` and the bitwise operators are
+**two's-complement identical** in both domains, which is why `u64.MAX - 1` is
+right and the bug looks selective.
+
+The file already knew about the hazard. The `check_int_overflow` path carries
+this comment and does exactly the right thing:
+
+> `u64 / usize: yo-self carries comptime integers as i64, so every value above
+> i64::MAX is a NEGATIVE i64 BIT PATTERN (usize.MAX, hash constants). Both
+> signed tests below are meaningless there … so redo the test in the UNSIGNED
+> domain on the patterns.`
+
+The fix had been applied to the **overflow check** and not to the
+**operations**.
+
+## Why it went unnoticed
+
+`tests/comptime.test.yo` has a `Test comptime u64` case — but its values are
+around `1e12`, comfortably inside `i64`, so the top of the range was never
+exercised. And its assertions could not have caught it anyway: all 1064
+`comptime_assert` calls in that file sit inside `test(...)` bodies, where
+`comptime_assert` **does not fire at all**
+(`issues/comptime-assert-never-fires-inside-a-function-body.md`).
+
+## Fix
+
+Compute `unsigned_64` once in the integer binary path
+(`is_unsigned_integer_type(numeric_type)` and a 64-bit width) and redo the four
+affected operation groups in the unsigned domain:
+
+```rust
+// division / modulo
+cond(unsigned_64 => i64(u64(a) / u64(b)), true => (a / b))
+cond(unsigned_64 => i64(u64(a) % u64(b)), true => (a % b))
+// ordering (eq/neq are bit comparisons and stay as they are)
+unsigned_64 => cond((op_s == "lt") => (u64(a) < u64(b)), …)
+// right shift becomes LOGICAL
+unsigned_64 => i64(u64(a) >> u64(b))
+```
+
+`apply_bounds` passes 64-bit values through unchanged (`true => n` for
+`.Int(64, _)`, `_ => n` for `.Usize`), so the bit pattern survives the round
+trip.
+
+## Regression test
+
+`tests/comptime.test.yo` gained three tests. They are shaped as **module-level
+`::` bindings observed by runtime `assert`s**, deliberately: a module-level
+binding is folded at comptime, and the runtime assert then observes what the
+folder produced. That makes the gate real, where a `comptime_assert` inside the
+test body would have been dead. The third test is the negative control — `i64`
+must keep signed semantics (`-1 / 10 == 0`, `-1 >> 1 == -1`,
+`i64.MIN / 2 == -4611686018427387904`).
+
+**Verified RED first**: both unsigned tests fail on the v0.2.24 binary
+(exit code 6), and pass after the fix.
+
+**FIXED 2026-09-04.**

--- a/src/evaluator/builtins/comptime_numeric_fns.yo
+++ b/src/evaluator/builtins/comptime_numeric_fns.yo
@@ -635,6 +635,23 @@ evaluate_yo_comptime_numeric_functions :: (
         ),
         .None => Option(i64).None
       );
+      // Comptime integers are carried as `i64`, so a `u64`/`usize` value above
+      // `i64.MAX` is a NEGATIVE bit pattern — `u64.MAX` is `-1`. This is the
+      // same hazard the overflow check above already redoes in the unsigned
+      // domain, and it applies to the OPERATIONS too.
+      //
+      // `add`/`sub`/`mul`, `eq`/`neq`, `shl` and the bitwise ops are
+      // two's-complement identical in both domains and need no split.
+      // DIVISION, MODULO, the ORDERING comparisons and the RIGHT SHIFT are
+      // not: signed `-1 / 10` is `0`, `-1 % 10` is `-1`, `-1 > 1` is false and
+      // `-1 >> 1` is `-1`, none of which are the `u64.MAX` answers.
+      unsigned_64 := (
+        is_unsigned_integer_type(numeric_type) && match(
+          get_integer_type_bits(numeric_type),
+          .Some(bw) => (bw == u32(64)),
+          .None => false
+        )
+      );
       cond(
         ((op_s == "add") || (op_s == "sub") || (op_s == "mul")) => {
           match(
@@ -678,7 +695,13 @@ evaluate_yo_comptime_numeric_functions :: (
                     )
                   );
                 });
-                result_val = make_int_val(a / b, numeric_type);
+                result_val = make_int_val(
+                  cond(
+                    unsigned_64 => i64(u64(a) / u64(b)),
+                    true => (a / b)
+                  ),
+                  numeric_type
+                );
               },
               .None => {
                 result_val = create_unknown_val(numeric_type);
@@ -705,7 +728,13 @@ evaluate_yo_comptime_numeric_functions :: (
                     )
                   );
                 });
-                result_val = make_int_val(a % b, numeric_type);
+                result_val = make_int_val(
+                  cond(
+                    unsigned_64 => i64(u64(a) % u64(b)),
+                    true => (a % b)
+                  ),
+                  numeric_type
+                );
               },
               .None => {
                 result_val = create_unknown_val(numeric_type);
@@ -729,6 +758,12 @@ evaluate_yo_comptime_numeric_functions :: (
                 b_result := cond(
                   (op_s == "eq") => (a == b),
                   (op_s == "neq") => !(a == b),
+                  unsigned_64 => cond(
+                    (op_s == "lt") => (u64(a) < u64(b)),
+                    (op_s == "lte") => (u64(a) <= u64(b)),
+                    (op_s == "gt") => (u64(a) > u64(b)),
+                    true => (u64(a) >= u64(b))
+                  ),
                   (op_s == "lt") => (a < b),
                   (op_s == "lte") => (a <= b),
                   (op_s == "gt") => (a > b),
@@ -775,6 +810,7 @@ evaluate_yo_comptime_numeric_functions :: (
               .Some(b) => {
                 n_result := cond(
                   (op_s == "shl") => (a << b),
+                  unsigned_64 => i64(u64(a) >> u64(b)),
                   true => (a >> b)
                 );
                 result_val = make_int_val(n_result, numeric_type);

--- a/tests/cli-cases/skills-install-zh/expected_tree
+++ b/tests/cli-cases/skills-install-zh/expected_tree
@@ -5,6 +5,6 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	7cf33a0060dfd8ea1b863bcdcbc0f1155165c54feebcc40f4da5b7e32749835f
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	326dcbcb5e5d6a3ae466898aa1c1a2e27b7c8a33607410785a056d8bb7facb69
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	b40213459a1f804f16032117bf8281dd1af68ad9e18712d9ea8ec5dab45e8bb2
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	9acf7e5a24aebe0ab4267fff93668c28d034f2dca7d716f7a193b8471362ad1e

--- a/tests/cli-cases/skills-install/expected_tree
+++ b/tests/cli-cases/skills-install/expected_tree
@@ -5,6 +5,6 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	7cf33a0060dfd8ea1b863bcdcbc0f1155165c54feebcc40f4da5b7e32749835f
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	326dcbcb5e5d6a3ae466898aa1c1a2e27b7c8a33607410785a056d8bb7facb69
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	b40213459a1f804f16032117bf8281dd1af68ad9e18712d9ea8ec5dab45e8bb2
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	9acf7e5a24aebe0ab4267fff93668c28d034f2dca7d716f7a193b8471362ad1e

--- a/tests/comptime.test.yo
+++ b/tests/comptime.test.yo
@@ -3313,3 +3313,90 @@ test("comptime requires(...) on a satisfying call compiles cleanly", {
   v := ok;
   assert(v == i32(50), "abs(-50) folds to 50");
 });
+// ===========================================================================
+// u64 / usize above i64.MAX — comptime arithmetic must be UNSIGNED
+// ===========================================================================
+// Comptime integers are carried as `i64`, so every u64/usize value above
+// i64.MAX is a NEGATIVE bit pattern (`u64.MAX` is `-1`). Division, modulo, the
+// ordering comparisons and the right shift have to be redone in the unsigned
+// domain: signed `-1 / 10` is 0, `-1 % 10` is -1, `-1 > 1` is false and
+// `-1 >> 1` is -1, none of which are the u64 answers.
+// issues/fixed/comptime-u64-div-mod-cmp-shr-are-signed.md
+//
+// These are MODULE-LEVEL `::` bindings observed by RUNTIME asserts, and that
+// shape is deliberate: a `comptime_assert` inside a `test(...)` body does NOT
+// FIRE (issues/comptime-assert-never-fires-inside-a-function-body.md), so the
+// 1064 comptime_asserts already in this file assert nothing. A module-level
+// binding folds at comptime; the runtime assert below then observes the value
+// the folder produced, which makes the gate real.
+_MAX :: u64.MAX;
+_DIV2 :: (_MAX / u64(2));
+_DIV10 :: (_MAX / u64(10));
+_SUB5_DIV10 :: ((_MAX - u64(5)) / u64(10));
+_BIT63_DIV2 :: ((u64(1) << u64(63)) / u64(2));
+_MOD10 :: (_MAX % u64(10));
+_MOD2 :: (_MAX % u64(2));
+_GT1 :: (_MAX > u64(1));
+_GTE1 :: (_MAX >= u64(1));
+_LT1 :: (_MAX < u64(1));
+_LTE1 :: (_MAX <= u64(1));
+_ONE_LT_MAX :: (u64(1) < _MAX);
+_I64MAX_LT_MAX :: (u64(9223372036854775807) < _MAX);
+_MAX_GT_BIT63 :: (_MAX > u64(9223372036854775808));
+_SHR1 :: (_MAX >> u64(1));
+_SHR63 :: (_MAX >> u64(63));
+_SUB1 :: (_MAX - u64(1));
+_SHL63 :: (u64(1) << u64(63));
+test("comptime u64 above i64.MAX divides and compares UNSIGNED", {
+  assert(_DIV2 == u64(9223372036854775807), `u64.MAX / 2 folded to ${_DIV2}`);
+  assert(_DIV10 == u64(1844674407370955161), `u64.MAX / 10 folded to ${_DIV10}`);
+  assert(_SUB5_DIV10 == u64(1844674407370955161), `(u64.MAX - 5) / 10 folded to ${_SUB5_DIV10}`);
+  assert(_BIT63_DIV2 == u64(4611686018427387904), `(1 << 63) / 2 folded to ${_BIT63_DIV2}`);
+  assert(_MOD10 == u64(5), `u64.MAX % 10 folded to ${_MOD10}`);
+  assert(_MOD2 == u64(1), `u64.MAX % 2 folded to ${_MOD2}`);
+  assert(_GT1, "u64.MAX > 1");
+  assert(_GTE1, "u64.MAX >= 1");
+  assert(!_LT1, "!(u64.MAX < 1)");
+  assert(!_LTE1, "!(u64.MAX <= 1)");
+  assert(_ONE_LT_MAX, "1 < u64.MAX");
+  assert(_I64MAX_LT_MAX, "i64.MAX < u64.MAX");
+  assert(_MAX_GT_BIT63, "u64.MAX > 2^63");
+  assert(_SHR1 == u64(9223372036854775807), `u64.MAX >> 1 folded to ${_SHR1}`);
+  assert(_SHR63 == u64(1), `u64.MAX >> 63 folded to ${_SHR63}`);
+  // The two's-complement-identical operations were always right; pin them so
+  // a future change here cannot regress them.
+  assert(_SUB1 == u64(18446744073709551614), "u64.MAX - 1");
+  assert(_SHL63 == u64(9223372036854775808), "1 << 63");
+});
+_UMAX :: usize.MAX;
+_U_GT1 :: (_UMAX > usize(1));
+_U_LT1 :: (_UMAX < usize(1));
+_U_DIV2 :: (_UMAX / usize(2));
+_U_MOD10 :: (_UMAX % usize(10));
+_U_SHR1 :: (_UMAX >> usize(1));
+test("comptime usize above i64.MAX divides and compares UNSIGNED", {
+  // usize shares the hazard: is_unsigned_integer_type covers .Usize and
+  // get_integer_type_bits reports the target pointer width, so a comptime
+  // bounds check against usize.MAX was reading a negative pattern.
+  assert(_U_GT1, "usize.MAX > 1");
+  assert(!_U_LT1, "!(usize.MAX < 1)");
+  assert(_U_DIV2 == usize(9223372036854775807), `usize.MAX / 2 folded to ${_U_DIV2}`);
+  assert(_U_MOD10 == usize(5), `usize.MAX % 10 folded to ${_U_MOD10}`);
+  assert(_U_SHR1 == usize(9223372036854775807), `usize.MAX >> 1 folded to ${_U_SHR1}`);
+});
+_NEG :: i64(-1);
+_S_DIV10 :: (_NEG / i64(10));
+_S_LT1 :: (_NEG < i64(1));
+_S_GT1 :: (_NEG > i64(1));
+_S_SHR1 :: (_NEG >> i64(1));
+_S_MIN_DIV2 :: (i64.MIN / i64(2));
+_S_MIN_LT0 :: (i64.MIN < i64(0));
+test("comptime SIGNED integers stay signed", {
+  // The negative control: the unsigned split must not leak into i64.
+  assert(_S_DIV10 == i64(0), `-1 / 10 folded to ${_S_DIV10}`);
+  assert(_S_LT1, "-1 < 1");
+  assert(!_S_GT1, "!(-1 > 1)");
+  assert(_S_SHR1 == i64(-1), `-1 >> 1 folded to ${_S_SHR1}`);
+  assert(_S_MIN_DIV2 == i64(-4611686018427387904), `i64.MIN / 2 folded to ${_S_MIN_DIV2}`);
+  assert(_S_MIN_LT0, "i64.MIN < 0");
+});

--- a/tests/comptime.test.yo
+++ b/tests/comptime.test.yo
@@ -3376,13 +3376,21 @@ _U_MOD10 :: (_UMAX % usize(10));
 _U_SHR1 :: (_UMAX >> usize(1));
 test("comptime usize above i64.MAX divides and compares UNSIGNED", {
   // usize shares the hazard: is_unsigned_integer_type covers .Usize and
-  // get_integer_type_bits reports the target pointer width, so a comptime
+  // get_integer_type_bits reports the TARGET POINTER WIDTH, so a comptime
   // bounds check against usize.MAX was reading a negative pattern.
+  //
+  // These assertions are deliberately WIDTH-AGNOSTIC: usize is 32-bit on
+  // wasm32, where usize.MAX (4294967295) is a positive i64 and the unsigned
+  // split is not even taken. Hardcoding the 64-bit answers made this test fail
+  // on the wasm32-wasi leg while the fix itself was correct. For an N-bit
+  // unsigned maximum M = 2^N - 1, M/2 == M>>1 and M%10 == 5 hold at BOTH
+  // widths — and under the signed bug M/2 is 0 while M>>1 is M, so the
+  // equality still catches it.
   assert(_U_GT1, "usize.MAX > 1");
   assert(!_U_LT1, "!(usize.MAX < 1)");
-  assert(_U_DIV2 == usize(9223372036854775807), `usize.MAX / 2 folded to ${_U_DIV2}`);
+  assert(_U_DIV2 > usize(0), `usize.MAX / 2 folded to ${_U_DIV2} (signed gives 0)`);
+  assert(_U_DIV2 == _U_SHR1, `usize.MAX / 2 = ${_U_DIV2} but usize.MAX >> 1 = ${_U_SHR1}`);
   assert(_U_MOD10 == usize(5), `usize.MAX % 10 folded to ${_U_MOD10}`);
-  assert(_U_SHR1 == usize(9223372036854775807), `usize.MAX >> 1 folded to ${_U_SHR1}`);
 });
 _NEG :: i64(-1);
 _S_DIV10 :: (_NEG / i64(10));


### PR DESCRIPTION
## The bug

Comptime integers are carried as `i64`, so every `u64`/`usize` value above `i64.MAX` is a **negative bit pattern** — `u64.MAX` is `-1`. The operations were then applied with signed semantics:

| expression | comptime | correct | as signed `i64` |
| --- | --- | --- | --- |
| `u64.MAX / 2` | **0** | 9223372036854775807 | `-1 / 2` = 0 |
| `u64.MAX / 10` | **0** | 1844674407370955161 | `-1 / 10` = 0 |
| `u64.MAX % 10` | **18446744073709551615** | 5 | `-1 % 10` = -1 |
| `u64.MAX > 1` | **false** | true | `-1 > 1` is false |
| `u64.MAX >> 1` | **18446744073709551615** | 9223372036854775807 | arithmetic shift of -1 |
| `(1 << 63) / 2` | **13835058055282163712** | 4611686018427387904 | `i64.MIN / 2` |

The **runtime path is correct**, so the same expression gives two different answers depending on whether it was constant-folded — `(m / u64(2))` and `(u64.MAX / u64(2))` disagree. `usize` is affected identically (`is_unsigned_integer_type` covers `.Usize`; `get_integer_type_bits` reports the pointer width), so a comptime bounds check against `usize.MAX` was reading a negative pattern.

`add`/`sub`/`mul`, `eq`/`neq`, `shl` and the bitwise operators are two's-complement identical in both domains and were always right — which is why the bug looked selective (`u64.MAX - 1` is correct).

## Root cause

`src/evaluator/builtins/comptime_numeric_fns.yo` **already knew**. Its `check_int_overflow` path carries this comment:

> `u64 / usize: yo-self carries comptime integers as i64, so every value above i64::MAX is a NEGATIVE i64 BIT PATTERN (usize.MAX, hash constants). Both signed tests below are meaningless there … so redo the test in the UNSIGNED domain on the patterns.`

The fix had been applied to the overflow **check** and not to the **operations**. This PR finishes it: one `unsigned_64` flag in the integer binary path, and `div`, `mod`, the four ordering comparisons and the right shift redone through `u64`. `apply_bounds` already passes 64-bit values through unchanged, so the bit pattern survives the round trip.

## How it was found

Making `std/string`'s integer parsers overflow-checked (#414) put `_radix_magnitude` into the compiler's own closure for the first time. Its guard is `mag > (u64.MAX - d) / radix`, which folds to `mag > 0` under signed semantics — so the compiler's integer-literal path (`src/evaluator/calls/numeric_type.yo:134`) rejected **every large literal** and the prelude died at `impl(u64, Send())` with `Variable "Send" not found`. **This PR unblocks #414.**

## ⚠️ A second bug found on the way — filed, not fixed here

`issues/comptime-assert-never-fires-inside-a-function-body.md`

`comptime_assert(false)` is **silently accepted** inside `main`, inside a called `fn`, and inside a `comptime` fn. Only module level rejects it. A `test("…", { … })` body *is* a function body, so **all 1559 `comptime_assert` calls under `tests/`** — 1064 of them in `tests/comptime.test.yo` — assert nothing. That is precisely why the existing `Test comptime u64` could not have caught this bug.

Filed with the reproducer matrix, the fix shape (the C18/C19 flow-violation-channel route), and a warning that turning 1559 dormant assertions on will need real triage. It wants its own PR.

## Tests — verified RED first

Three tests in `tests/comptime.test.yo`, shaped as **module-level `::` bindings observed by runtime `assert`s**. That shape is deliberate and load-bearing given the above: a module-level binding folds at comptime, and the runtime assert then observes what the folder produced. The third test is the **negative control** — `i64` must keep signed semantics (`-1 / 10 == 0`, `-1 >> 1 == -1`, `i64.MIN / 2 == -4611686018427387904`).

Both unsigned tests fail on the v0.2.24 binary (exit code 6) and pass after the fix.

## Gates

`yo check ./src` 266/266, `yo check ./std` 173/173, `tests/comptime.test.yo` 34/34 (31 existing + 3 new), stage-1 self-build clean.

Also records the module-level-binding idiom in `.github/skills/yo-syntax/syntax-cheatsheet.md` so the next test author does not write a dead assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)