### PR TITLE
issues: two gaps found verifying PR #409's short-circuit drop fix

### DIFF
--- a/issues/comptime-str-passed-where-string-is-declared-emits-invalid-c.md
+++ b/issues/comptime-str-passed-where-string-is-declared-emits-invalid-c.md
@@ -1,0 +1,103 @@
+# A `comptime_str` passed where `String` is declared passes `check` and emits invalid C
+
+**Found**: 2026-09-05, while writing the regression tests for
+`issues/fixed/url-parse-validates-no-characters-so-a-crlf-url-splits-the-http-request.md` —
+a helper declared `label : String` was called with a plain `"..."` literal.
+**Status**: OPEN. Measured against `develop` at v0.2.24.
+
+**Class**: missing rejection / invalid codegen. Exactly the shape of **C19**
+(`issues/fixed/`, "reject a C int passed where i32 is declared"): the evaluator
+accepts a type it should reject, and the error surfaces as a C compiler
+diagnostic pointing at generated code the user never wrote.
+
+## Reproducer
+
+```rust
+open(import("std/string"));
+{ assert } :: import("std/assert");
+{ println } :: import("std/fmt");
+_helper :: (fn(src : String, at : usize, label : String) -> unit)({
+  assert(src.len() > at, label);
+});
+main :: (fn() -> unit)({
+  //                                              vvvvvvvvvvvvvvvvvvv  comptime_str, not String
+  _helper(String.from("http://exa mple.com/"), usize(10), "raw space in host");
+  println(`ok`);
+});
+export(main);
+```
+
+`yo check` is clean:
+
+```
+$ yo check castbad.yo --std-path ./std
+check: parsed 8 top-level exprs
+check: invoking evaluate_anonymous_module_begin_exprs
+check: castbad.yo — evaluator OK
+```
+
+`yo compile` then fails inside the C compiler:
+
+```
+$ yo compile castbad.yo --std-path ./std --optimize 2 -o castbad
+castbad.c:1551:69: error: used type '__yo_t8' (aka 'struct __yo_t9_struct')
+                          where arithmetic or pointer type is required
+1 error generated.
+```
+
+The emitted line casts a struct-typed value with a C cast expression:
+
+```c
+yo_id_10636((__yo_t9)(_file____User_temp_15804), (size_t)(10ULL),
+            (__yo_t9)((__yo_str){ .ptr = (const uint8_t*)"raw space in host", .len = 17 }));
+```
+
+`(__yo_t9)(...)` is a cast to a **struct** type, which C does not allow.
+
+Changing the argument to a backtick literal (which IS a `String`) compiles and
+runs:
+
+```rust
+_helper(String.from("http://exa mple.com/"), usize(10), `raw space in host`);
+```
+
+```
+$ ./castrepro
+ok
+```
+
+## Why it matters
+
+The two spellings look interchangeable and are not — `` `...` `` is `String`,
+`"..."` is `comptime_str` (`.github/skills/yo-syntax/syntax-cheatsheet.md:111`).
+The mistake is easy to make and common in test helpers, where messages are
+habitually written with double quotes because `assert`'s own message parameter
+accepts them. What the author gets is not a type error naming the argument but
+a clang error naming a generated identifier, hundreds of lines into a file they
+did not write — the diagnostic gives no path back to the call site.
+
+It also means `yo check ./std` and `yo check ./src` cannot be trusted to catch
+this class, so it survives until someone runs a full compile.
+
+## Where to look
+
+The parameter-binding compatibility check that C19 tightened —
+`src/evaluator/calls/` — accepts `comptime_str` for a declared `String`
+parameter. Either reject it at check time with a message naming the argument
+and both spellings (the C19 shape, and the one this issue asks for), or, if an
+implicit widening is intended, make codegen emit the real conversion
+(`String.from`'s lowering) instead of a C cast. It must not stay in the current
+state, where the evaluator says yes and codegen emits code that cannot compile.
+
+Note the reverse direction (a `String` where `str`/`comptime_str` is declared)
+should be checked at the same time — the cheatsheet records that a
+double-quoted literal does not concatenate with a `String` variable, so the two
+directions are already known to be distinct types with no implicit bridge.
+
+## Regression test
+
+A `tests/cli-cases/` golden is the right home, since the assertion is about a
+compile FAILING with a specific diagnostic: a `compile` case whose
+`expected_rc` is non-zero and whose `stdout_keep_match` names the argument and
+the two types. Plus an over-rejection canary — a call passing a backtick
+literal, and one passing `String.from("...")` — that must keep compiling.

--- a/issues/fixed/std-spec-experimental-banner-is-invisible-to-yo-doc-so-both-modules-render-as-stable.md
+++ b/issues/fixed/std-spec-experimental-banner-is-invisible-to-yo-doc-so-both-modules-render-as-stable.md
@@ -1,5 +1,7 @@
 # `std/spec`'s EXPERIMENTAL banner is prose, not a `## Stability` section — `yo doc` reports both modules as stable
 
+**Status: FIXED 2026-09-05** — Both modules gained a real `## Stability` section under the existing prose banner, so `yo doc` publishes a marker instead of `null`.
+
 **Found**: 2026-09-04, taking the inventory of stability markers across `std/` for
 the S5 freeze. **Severity:** MEDIUM (published API lie): `std/spec/refine` and
 `std/spec/numeric` are Phase 0 identity stubs whose own doc says "Expect ANY change

--- a/issues/fixed/std-term-stability-marker-says-new-in-this-release-instead-of-a-version.md
+++ b/issues/fixed/std-term-stability-marker-says-new-in-this-release-instead-of-a-version.md
@@ -1,5 +1,7 @@
 # `std/term`'s stability marker says "new in this release" — a floating reference that has been wrong in four shipped releases
 
+**Status: FIXED 2026-09-05** — Resolved by option (a) of the sibling issue: `std/term` is FROZEN and the section is gone, so there is no longer a version to get wrong. Recorded in `plans/STD_API_AUDIT.md` §9 S5.
+
 **Found**: 2026-09-04, taking the inventory of `## Stability` markers across `std/`
 for the S5 freeze (`plans/STD_API_AUDIT.md` §9). **Severity:** LOW-MEDIUM (published
 API lie, and it disables the policy's own expiry rule): the marker rendered on the

--- a/issues/fixed/std-term-unstable-marker-outlived-its-one-release-window.md
+++ b/issues/fixed/std-term-unstable-marker-outlived-its-one-release-window.md
@@ -1,8 +1,10 @@
 # `std/term`'s `unstable` marker is undatable, four releases past its window, and names an exit condition that never happened
 
+**Status: FIXED 2026-09-05** — Option (a) taken — `std/term` is FROZEN (section dropped). The same pass decided the three siblings: `std/encoding/csv` and `std/http/server` frozen, `std/fs/watch` restated with the real Windows blocker. Recorded in `plans/STD_API_AUDIT.md` §9 S5.
+
 **Found**: 2026-09-04, by the std-API-audit re-measurement of the `cli` row.
 **Severity**: LOW (papercut), but it is a published stability promise on a
-shipped module and it renders into `yo doc`. **Status**: OPEN.
+shipped module and it renders into `yo doc`.
 
 ## The marker
 

--- a/issues/fixed/url-parse-validates-no-characters-so-a-crlf-url-splits-the-http-request.md
+++ b/issues/fixed/url-parse-validates-no-characters-so-a-crlf-url-splits-the-http-request.md
@@ -1,8 +1,10 @@
 # `Url.parse` validates no characters — a URL with a raw CRLF splits the HTTP request it is fetched with
 
+**Status: FIXED 2026-09-05** — `Url.parse` now pre-scans the whole input against the RFC 3986 §2 byte set (`_is_uri_byte`) and throws `UrlError.InvalidCharacter(pos)` at the first offending byte — the producer the variant never had. Verified 0/12 → 12/12 rejections with the over-rejection canary at 10/10 both before and after.
+
 **Found**: 2026-09-04, by the std-API-audit re-measurement of the dead-public-surface
 row (`UrlError.InvalidCharacter` is declared, documented and formatted, but nothing
-in the tree ever produces it). **Status**: OPEN. Measured against `develop`
+in the tree ever produces it). Measured against `develop`
 (`8d471c7df`) with `yo` 0.2.24 and `YO_STD=./std`.
 
 **Class**: wrong-value / protocol corruption (a request-splitting sink), plus the

--- a/issues/fixed/url-scheme-character-guard-is-tautological-so-any-byte-passes.md
+++ b/issues/fixed/url-scheme-character-guard-is-tautological-so-any-byte-passes.md
@@ -1,9 +1,11 @@
 # `Url.parse`'s scheme-character guard tests the wrong byte, so it is always true and `"ht tp://x/"` parses
 
+**Status: FIXED 2026-09-05** — The scheme-byte guard tested `first` (already known to be ALPHA) instead of `ch`, so its disjunction was always true; it now tests `ch`. The whole-input pre-scan from the sibling issue catches `"ht tp://x/"` before the scheme scan is even reached, so both layers now reject it.
+
 **Found**: 2026-09-04, while verifying that `UrlError.InvalidCharacter` has no
 producer (std-API-audit re-measurement, dead-public-surface row) — the scheme scan
 is the *only* place in `std/url` that looks at individual characters, and it turns
-out not to reject anything. **Status**: OPEN. Measured against `develop`
+out not to reject anything. Measured against `develop`
 (`8d471c7df`) with `yo` 0.2.24 and `YO_STD=./std`.
 
 **Class**: wrong-value (a validation guard that can never fail; the `throw` it

--- a/issues/fixed/yo-doc-html-and-json-stability-rendering-is-exercised-by-no-test.md
+++ b/issues/fixed/yo-doc-html-and-json-stability-rendering-is-exercised-by-no-test.md
@@ -1,5 +1,7 @@
 # The `## Stability` marker's HTML badge and JSON key are exercised by no test — only the Markdown note is pinned
 
+**Status: FIXED 2026-09-05** — `tests/internal/doc_stability.test.yo` now pins the JSON `"stability"` key, the HTML badge (end to end through `render_doc_site`) and the Markdown note, plus the section-reading rules themselves.
+
 **Found**: 2026-09-04, auditing the S5 stability-freeze mechanics
 (`plans/STD_API_AUDIT.md` §9, recorded as DONE). **Severity:** LOW (coverage gap, no
 runtime symptom of its own) — but it is why

--- a/issues/fixed/yo-doc-truncates-a-multi-line-stability-marker-to-its-first-line.md
+++ b/issues/fixed/yo-doc-truncates-a-multi-line-stability-marker-to-its-first-line.md
@@ -1,5 +1,7 @@
 # `yo doc` truncates a multi-line `## Stability` marker to its first line — the badge renders a dangling half-sentence
 
+**Status: FIXED 2026-09-05** — `module_stability` (`src/doc/builder.yo`) now COLLAPSES the whole section — blank lines dropped, remaining lines joined with one space — instead of reading only the first. Pinned by `tests/internal/doc_stability.test.yo`.
+
 **Found**: 2026-09-04, during the std-API-audit re-measurement of the S5
 stability-freeze mechanics (`plans/STD_API_AUDIT.md` §9). **Severity:** MEDIUM
 (wrong value on a published surface): the freeze marker is the one machine-readable

--- a/issues/leak-regression-tests-cannot-fail-in-ci-leak-verdicts-are-off-everywhere.md
+++ b/issues/leak-regression-tests-cannot-fail-in-ci-leak-verdicts-are-off-everywhere.md
@@ -1,0 +1,109 @@
+# Leak regression tests cannot fail in CI — every job sets `YO_TEST_LEAK_VERDICT: "0"`
+
+**Found**: 2026-09-05, verifying PR #409's fix
+(`issues/fixed/short-circuit-bare-fn-body-operand-temps-leak.md`).
+**Status**: OPEN. **Severity: hollow gate** — the same class as
+`issues/fixed/comptime-assert-never-fires-inside-a-function-body.md`: not a
+wrong answer, an ABSENT one, over the whole RC/leak surface.
+
+## The measurement
+
+`tests/internal/short_circuit_drops.test.yo` was added by #409 as the
+regression net for a leak of 4 allocations per call. Run it against the
+compiler that HAS the bug (`yo` 0.2.24, which predates #409 — the fix merged
+2026-09-04 20:38 UTC, the tag is 16:18 UTC):
+
+```
+$ yo test ./tests/internal/short_circuit_drops.test.yo --parallel 1
+  ✓ whole-body || drops its literal temps (leak regression)
+  ✓ whole-body && drops its literal temps and short-circuits
+  ✓ statement-position || keeps parity with the whole-body shape
+3 passed
+```
+
+All three pass. They assert only VALUES, and short-circuit values were never
+wrong — the leak was the defect. The file's own header says *"Under the shard's
+LeakSanitizer build these leak-aborted before the fix"*, and #409's commit
+message says *"Verified fail-before (the two whole-body tests leak-abort under
+the develop-codegen control binary)"*. Neither is reachable as CI is configured.
+
+## Why it cannot fail
+
+**1. CI turns leak verdicts off in every job that could apply one.**
+
+```
+$ grep -n 'YO_TEST_LEAK_VERDICT' .github/workflows/test.yml
+350:      YO_TEST_LEAK_VERDICT: "0"     # test
+861:      YO_TEST_LEAK_VERDICT: "0"     # test-native
+1271:          YO_TEST_LEAK_VERDICT: "0"
+1403:          YO_TEST_LEAK_VERDICT: "0"   # tests/internal differential shard
+1662:          YO_TEST_LEAK_VERDICT: "0"
+1900:          YO_TEST_LEAK_VERDICT: "0"
+```
+
+`src/main.yo:2882` turns that straight into `detect_leaks=0`:
+
+```rust
+leak_verdict := match(
+  proc_env.get(`YO_TEST_LEAK_VERDICT`),
+  .Some(lv) => (lv != "0"),
+  .None => true
+);
+...
+_sv_asan := proc_env.set(String.from("ASAN_OPTIONS"),
+  if(leak_verdict, String.from("detect_leaks=1"), String.from("detect_leaks=0")));
+```
+
+The only two suite runs that do NOT set it are the wasm32 legs, and
+`use_asan` excludes `emcc`/WASI explicitly — so they could not apply a verdict
+either. **No CI job applies a leak verdict.**
+
+The flag is a deliberate staging ratchet for pre-existing self-hosted-emit leak
+debt (`issues/self-hosted-emit-leaks-remaining-classes.md`) and the comments
+say so. The problem is not the ratchet — it is that a leak REGRESSION TEST was
+written as if the ratchet were not there.
+
+**2. On macOS, `--sanitize address` does not instrument at all.**
+
+```
+$ yo compile probe.yo --sanitize address --allocator system --optimize 2 -o probe
+$ nm probe | grep -c __asan
+0
+```
+
+Zero ASan symbols. So a developer cannot get the verdict locally either.
+
+## What DOES work locally
+
+macOS `leaks --atExit` measures it exactly, with no sanitizer:
+
+```
+$ leaks --atExit -- ./whole_body_or_probe     # 1000 calls
+Process: 4000 leaks for 128000 total leaked bytes     # pre-#409
+Process: 0 leaks for 0 total leaked bytes             # post-#409
+```
+
+That is how #409's fix was independently confirmed (per-shape table in the
+verification: two-operand `||` 4/call → 0, `&&` 2/call → 0, `||` in a match arm
+4/call → 0, chains halved 6→2 and 8→4).
+
+## Fix
+
+Two independent things, both needed:
+
+1. **Give leak regression tests a gate that works under the ratchet.** The
+   assertion "this construct emits its drops" does not need a leak verdict — it
+   is an EMIT-SHAPE property. A `tests/cli-cases/` golden that compiles a
+   whole-body `||` with `--emit-c --skip-c-compiler` and matches the two
+   `__yo_decr_rc` lines would fail the moment the drops disappear, on every
+   platform, with the ratchet on. That is the shape this class of fix should
+   use from now on.
+2. **Make the hollowness visible.** A test whose only failure mode is a leak
+   verdict should say so and be SKIPPED (not silently passed) when
+   `YO_TEST_LEAK_VERDICT=0` — otherwise "3 passed" is a lie about coverage.
+   Alternatively add one narrow CI leg that runs a small allowlisted set of
+   leak-sensitive tests with `detect_leaks=1`, so the ratchet stays for the
+   compiler-sized batches and real leak tests still have a gate.
+
+Until then, treat every leak-shaped regression test in `tests/` as unverified
+and re-measure with `leaks --atExit` before trusting it.

--- a/issues/short-circuit-chain-inner-operand-temps-still-leak.md
+++ b/issues/short-circuit-chain-inner-operand-temps-still-leak.md
@@ -1,0 +1,82 @@
+# A short-circuit CHAIN's inner operand still leaks its temps (the #409 remainder)
+
+**Found**: 2026-09-05, measuring PR #409's fix. **Status**: OPEN. Split out of
+`issues/fixed/short-circuit-bare-fn-body-operand-temps-leak.md`, whose
+"Remaining work" section describes it — this file exists so the remaining work
+is discoverable in `issues/` root rather than only inside a `fixed/` doc.
+
+## Measurement
+
+Per-shape, 1000 calls each, `leaks --atExit`, `--allocator system --optimize 2`.
+BEFORE = `yo` 0.2.24 (predates #409), AFTER = develop at `ca13e3c82`.
+
+| shape (whole fn body) | before | after | verdict |
+| --- | --- | --- | --- |
+| `(id == \`a\`) \|\| (id == \`b\`)` | 4/call | **0** | fixed |
+| `(a == \`x\`) && (b == \`y\`)` | 2/call | **0** | fixed |
+| `\|\|` inside a match arm | 4/call | **0** | fixed |
+| `((a) \|\| (b)) && ((c) \|\| (d))` | 4/call | 2/call | **halved** |
+| `((a) \|\| (b)) \|\| (c)` | 6/call | 2/call | **halved** |
+| `(((a) \|\| (b)) \|\| (c)) \|\| (d)` | 8/call | 4/call | **halved** |
+| statement-position `\|\|` (begin-opened) | 0 | 0 | never affected |
+| `\|\|` in a while body | 0 | 0 | never affected |
+| `\|\|` in a closure body | 0 | 0 | never affected |
+
+A chain parses as NESTED binaries, so the outermost node's list carries the
+outer operands' drops (now emitted) while each INNER `||`'s own list is empty —
+its operand temps' drops were scheduled onto the outermost/body node.
+
+## Reproducer
+
+```rust
+open(import("std/string"));
+{ println } :: import("std/fmt");
+probe :: (fn(id : String) -> bool)(
+  ((id == `a`) || (id == `bb`)) || (id == `ccc`)
+);
+main :: (fn() -> unit)({
+  (i : usize) = usize(0);
+  (a : usize) = usize(0);
+  while(i < usize(1000), {
+    if(probe(String.from("zz")), { a = (a + usize(1)); });
+    i = (i + usize(1));
+  });
+  println(`done ${a.to_string()}`);
+});
+export(main);
+```
+
+```
+$ yo compile chain3.yo --allocator system --optimize 2 -o chain3
+$ leaks --atExit -- ./chain3
+Process: 2000 leaks for 64000 total leaked bytes
+```
+
+(Do NOT try to measure this with `--sanitize address` — on macOS it produces a
+binary with zero `__asan` symbols, and CI has leak verdicts off everywhere:
+`issues/leak-regression-tests-cannot-fail-in-ci-leak-verdicts-are-off-everywhere.md`.)
+
+## Where to look
+
+`issues/fixed/short-circuit-bare-fn-body-operand-temps-leak.md` §"Remaining
+work" carries the full design record: threading the OUTERMOST short-circuit
+node (a `short_circuit_root_node` context field, set when unset and restored on
+exit) so an inner `||`'s emission points read the root's list. It was built and
+locally validated twice and BOTH times double-dropped operand `a`'s temp at the
+fall-through, with both dedup signals reading empty at the second consideration
+of the same drop expr — evidence of an uninstrumented fourth emitter placing
+fall-through drops.
+
+The named next step is to instrument the remaining direct
+`_call_generate_expr(drop_expr)` sites before re-landing the threading:
+`return.yo:376/468/522`, `atom.yo:53/388/554`, `while_loop.yo:214`,
+`begin.yo:153`.
+
+**Structural note found while verifying #409**: `while_loop.yo:201` consults
+ONLY the name-keyed `short_circuit_handled_drop_var_names`, and every consumer
+of that set REMOVES the entry on hit (`begin.yo:145`, `while_loop.yo:206`,
+`drop_dup.yo:885`), so it is a consume-once signal. Unlike `begin.yo:121` and
+`drop_dup.yo:861`, `while_loop.yo` never consults `emitted_deferred_drop_ids`
+and never inserts into it. That asymmetry is not tripped by #409 as it stands
+(measured: the while-body shape is unchanged at 0 leaks and 26 emitted drops
+before and after), but it is the shape the re-landing attempt keeps hitting.

--- a/issues/stringerror-indexoutofbounds-is-declared-but-no-string-api-can-return-it.md
+++ b/issues/stringerror-indexoutofbounds-is-declared-but-no-string-api-can-return-it.md
@@ -7,7 +7,7 @@ scoped to the declaring module). **Status**: OPEN. Measured against `develop`
 
 **Class**: api-lie. Lower stakes than its two siblings in the same sweep
 (`crypto-random-reports-every-failure-as-unavailable-and-discards-the-errno.md`,
-`url-parse-validates-no-characters-so-a-crlf-url-splits-the-http-request.md`):
+`issues/fixed/url-parse-validates-no-characters-so-a-crlf-url-splits-the-http-request.md`):
 there is no missing safety check and no wrong value — the panic semantics are a
 DECIDED design (D4). The defect is that a public enum publishes a *recoverable*
 bounds error that no entry point offers, and the freeze would lock it in.

--- a/plans/HANDOVER_STD_AUDIT_2026-08-30.md
+++ b/plans/HANDOVER_STD_AUDIT_2026-08-30.md
@@ -1,0 +1,302 @@
+# HANDOVER — std API audit campaign (2026-08-30)
+
+The goal being handed over: **«Finish everything in plans/STD_API_AUDIT.md.
+Make sure the std APIs are well designed and stable for the future. Document
+and fix any surfaced issue and bug. No workaround is allowed. Admin merges are
+authorized to save CI cycles.»**
+
+Read `plans/STD_API_AUDIT.md` §2 (compiler rows) and §9 (phasing) alongside
+this. Every claim below is recorded in an issue file or PR body.
+
+---
+
+## 1. Where the campaign stands
+
+**v0.2.20 is RELEASED** (2026-08-30, 13 assets) and `SEED_VERSION` is bumped
+to v0.2.20 on develop. The local seed bundle is at
+`/private/tmp/yo-seed-0220/bin/yo` (and v0.2.19 at `/private/tmp/yo-seed-0219/bin/yo`).
+
+**Merged this session** (all admin-squash, all with green local batteries):
+#350 (C58/C59 runtime), #351 (HTTP server + C27), #353 (C57 + the Windows
+parked-pipe-read runtime fix — Windows suite went 3305/3305), #354 (C56),
+#355 (C55), #356 (doc `#` sections), #357 (std/term), #358 (binary bodies),
+#359 (C17), #360 (C22 stub gate), #361 (C61 — ctl result-type escape rule),
+#362 (C60 — nested io.async bundle binding + C45 dedup), #363 (O7 residual —
+sync containers require Acyclic; also de-vacuoused the imm_vec Acyclic pin).
+
+**§2 has ONE genuinely open compiler row: C29** (per-argument type-var
+rebinding — a unification-architecture arc; two containments already tried
+and reverted, see issues/generic-type-var-rebinds-per-argument.md).
+
+---
+
+## 2. OPEN PRs and worktrees — exact state, what to do
+
+Worktrees in play (`git worktree list` from the main checkout; NEVER branch in
+`/Users/yiyiwang/Workspace/Yo` itself — it is shared with a peer session):
+
+### 2a. `s6/version-install-unbreak` — **COMPLETE: merged as #366 (admin-squash)**
+
+PR #366 (branch deleted after merge) carried: the five version_cache un-hollowing
+fixes (b42b7a5f3), the strict-clean build path (b783c4077 — comptime module
+loading now uses synchronous libc reads via `_read_file_sync`; the build-graph
+helpers are proper io.async futures using the Command.output spawned-task
+recipe), and the ASan root-cause issue updates. Verified: the strict golden
+PASSES; gates_fast 0/1/3/4/5/6 green; CLI corpus 45 PASS vs seed's 44 with
+zero new diffs; codegen-bootstrap corpus 156/156; FIXPOINT_HOLDS CLANG_RC=0;
+CI bootstrap-fixpoint + stage-3 + all four internal shards pass.
+
+**THE NEW CRITICAL PATH: develop CI is red from the ASan regression, which is
+now ROOT-CAUSED as C54's specialization split on the EFFECT type** — the same
+"second specialization clobbers the first via the global last-writer registry"
+mechanism as issues/future-wrapper-return-shared-across-specializations.md,
+clobbering `E` instead of `R`: the await site's future type says effect=Io
+(32-byte temp) while the child SM's set_effect was emitted under IoExn (40-byte
+copy). A codegen-side mitigation was built, tested on CI, and is NOT viable
+(neither side can see the other's type) — recorded in
+issues/asan-stack-overread-set-effect-batch-selftest.md so it is not retried.
+Repro assets: the `debug/asan-batch` branch (temporary workflow + the offending
+pre-emitted tests/debug-batch-linux.c; crash at batch index 85) — delete when
+C54 lands. **v0.2.21 remains gated on the E-class ASan red** (the spec-cache dispatch
+investigation — breadcrumb + repro assets in
+issues/asan-stack-overread-set-effect-batch-selftest.md: the body capture's
+type read Fn(i64)->R during the R=String spec's eval, so
+create_specialized_function_inline's cache key is serving cross-substituted
+signatures; check it FIRST). The R-class fix (#367) does not cover it.
+
+### 2b. PR #365 `s6/fs-watch-windows` — **COMPLETE: merged (admin-squash) 2026-08-30 evening**
+
+Develop was merged into the branch first (its CI legs carry only the
+C54-inherited ASan red, same as develop). Local battery after the merge:
+gates_fast real gates green (the 3 reported FAILs are the bash-3.2 harness
+bug), FIXPOINT_HOLDS with CLANG_RC=0 and stage2 hollow=0, CLI corpus
+45 PASS / the same pre-existing 9 diffs — zero new.
+
+**fs.watch on Windows is fixed and verified**: `__yo_io_poll`'s empty-IOCP
+early returns skipped `__yo_poll_and_fs_event_tick`; a yield-driven wait
+(`Watcher.next`) never reaches `__yo_io_wait`, so RDCW completions were never
+serviced. The early returns now tick (mirrors io_wait's failure path). Round-3
+debug run on windows-latest: **4/4 tests/fs/watch.test.yo pass, rc=0**;
+`SkipWindows` pragma removed; issue moved to issues/fixed/; audit §7 updated.
+All probes stripped; the temp workflow deleted; everything committed+pushed.
+
+TO DO: the local battery for this branch was started and then **corrupted by
+a stray pkill** (its PREP build died; the gates ran with a missing S1) —
+disregard `/tmp/fsw-battery.log`. Rerun:
+
+```bash
+cd /private/tmp/yo-fsw
+YO_STD=/private/tmp/yo-fsw/std /private/tmp/yo-seed-0220/bin/yo build \
+  && cp yo-out/aarch64-apple-darwin/bin/yo /tmp/yo-fsw-s1
+S1=/tmp/yo-fsw-s1 P=local bash scripts/bootstrap/gates_fast.sh
+S1=/tmp/yo-fsw-s1 P=local bash scripts/bootstrap/fixpoint_only.sh
+```
+
+On green (plus the PR's own suite legs), admin-merge #365.
+
+### 2c. PR #364 `s6/version-cache-std-http` (`/private/tmp/yo-d6`) — PARKED
+
+The D6 PR-3 curl→std/http swap. Seed-gated on v0.2.20 (now satisfied — the
+tree builds), and **live-verified**: `version list --remote` over std/http
+TLS, real 5 MB bundle download through the CDN redirect, binary body written
+and extracted. Its install fixes were split out to §2a (cherry-pick
+`0fef9ad67` was clean), so this PR should be REBASED onto develop after §2a
+merges (dropping the duplicated fix commit) leaving only the swap.
+
+Parked because it exhibits the SAME strict regression as §2a (same backtrace)
+— un-hollowing is the trigger there too, so §2a's strict fix should clear it.
+Two additional items to fold in before merge:
+
+- **Battery-script gap**: `scripts/bootstrap/fixpoint_only.sh:20` (and the
+  equivalent stage2-compile in gates_fast.sh) compiles stage2.c with a bare
+  `clang` line; with std/http in the compiler closure, stage2.c includes
+  OpenSSL headers → `fatal error: 'openssl/bio.h' file not found`. Add
+  pkg-config flags (`pkg-config --cflags --libs openssl` fallback
+  `$(brew --prefix openssl)`) to those clang invocations. NOTE: the d6
+  battery run printed FIXPOINT_HOLDS with CLANG_RC=1 — treat that verdict as
+  suspect until the clang step actually links (the memory rule: check rc +
+  stage-file mtimes before trusting a verdict).
+- The strict CLI golden must pass on the branch.
+
+### 2d. `s7/seed-gated-sweep` (`/private/tmp/yo-sweep`) — no PR yet, ~80% done
+
+Contains three seed-gated items (all unblocked by v0.2.20):
+
+1. `HashMapError.KeyNotFound` / `HashSetError.ElementNotFound` DELETED
+   (`check ./std` under the 0220 seed passes with the now-identical enum
+   shapes — the #343 gate held).
+2. Prelude `if` macro DELETED (the 0220 seed ships the parse-time desugar);
+   `.github/instructions/yo-syntax.instructions.md` updated.
+3. `Command.current_dir` **generation B**: `std/sys/externs.yo` +
+   `std/sys/process.yo` gained `__yo_async_spawn_start_cwd`/`spawn_cwd`
+   (the runtime symbol shipped in v0.2.20 — generation A, #338);
+   `std/process/command.yo` gained `_cwd : Option(String)`, the
+   `current_dir` builder, and `_spawn_with_fds` now calls `spawn_cwd`
+   (`.None` = inherit); a generation-B end-to-end test was added to
+   `tests/process/command.test.yo`.
+
+`check ./std` + `check ./src` + `yo build` were green under the 0220 seed
+BEFORE item 3's std changes; the audit rows (§9 dead variants, §4 prelude,
+§7 item 5 current_dir, the stale line-13 bufio note) are already updated.
+
+TO DO: rebuild (`YO_STD=... /private/tmp/yo-seed-0220/bin/yo build`), run
+tests: `tests/process/command.test.yo`, `tests/hash_map*.test.yo` /
+`tests/hash_set*.test.yo` (whatever covers the two collections),
+`tests/quote_macro_eval.test.yo` + `tests/macro_expansion.test.yo` +
+`tests/macro_helpers.test.yo` + `tests/macro_def_pragma.test.yo` (if-macro
+deletion fallout — a dynamically built `if` AST is now an error), then
+`check ./std ./src`, fmt, battery, PR, merge. Note `git status` may show my
+uncommitted work — everything described above is intentional; commit it all.
+
+---
+
+## 3. New compiler issues filed today (all need eventual fixes; none block std)
+
+| Issue | Summary | Suggested attack |
+|---|---|---|
+| issues/wrong-arity-call-silently-accepted-version-install-broken.md | Wrong-arity calls are swallowed at def-eval and ship as UB; broke `yo version install` in two releases | Validate argument count against the resolved callee OUTSIDE the trial swallow (same enforcement family as C61); `try_to_call_function_with_arguments` already produces the error inside the swallow — find which layer eats it for async-helper shapes |
+| (same issue, "gate gap" section) | A hollow ASYNC STATE MACHINE passes the C22 stub gate (completes/aborts instantly instead of poisoning the build) | Give the C22 attribute treatment an async-SM equivalent: an SM whose body ExprInfos were never stamped must poison its resume fn |
+| issues/builtin-name-shadows-user-definition.md (upgraded) | Builtin-first dispatch silently shadows user locals — now with a production casualty (`short`) | The audit decision is pending: reserve builtin names (option 1) or prefer user bindings (option 2); at minimum land the shadowing diagnostic (option 3) before the next release |
+| issues/module-level-control-bound-binding-not-rejected.md | Module-level `(g : Exception) = ...` accepted though escape boundary 2 should reject it; the rule only fires in comptime_expect_error propagate mode | Trace `rhs_info_opt` for annotated module bindings; add check-visible repros |
+| issues/command-stdin-windows-pipe-write-blocks-the-event-loop.md | Windows pipe WRITES still block the loop (reads fixed in #353) | Overlapped NAMED pipes for child stdin |
+| issues/future-wrapper-return-shared-across-specializations.md (C54, body half) | Second specialization's `R` clobbers the first's async body via the global last-writer registry | Stamp the call result concretely inside the spec body (resolve `R` through the spec env at stamping time) or stop keying the fallback by the shared forall id; repro: issues/repros/future-wrapper-return-two-r-specializations.yo; unblocks async `Mutex.with_lock` |
+| issues/generic-type-var-rebinds-per-argument.md (C29) | The last open §2 row; per-call unification state needed | Read the issue — two failed approaches are recorded so they are not retried |
+
+---
+
+### 2e. PR #334 (`fix/second-cond-await-target`) — RESOLVED 2026-08-30 (evening): CLOSED as superseded; test salvaged as #368
+
+Asked about during the evening session. The 2026-08-28 PR fixed a cond arm's
+second-await storage (the plain-HTTP crash) but was CONFLICTING with develop.
+Measured: the motivating crash no longer reproduces on develop (live
+`fetch("http://github.com")` clean), the PR's own test passes on develop
+unchanged, and merging its remaining delta REGRESSES tests/http 21→5 (its
+store-side machinery predates and double-handles develop's newer
+`_dispatch_branches` chained-arm dispatch; first as a `duplicate case value`,
+then as runtime failures after reconciling). Closed with the evidence
+comment; `tests/async/cond_multi_await.test.yo` salvaged as PR #368 so the
+behavior stays pinned. NOTE the branch was the peer session's main-checkout
+branch — if that session is still iterating on it locally, it should rebase
+onto develop or drop the superseded changes.
+
+## 4. Remaining audit tail beyond the PRs (rough priority order)
+
+> **1 Sep 2026 FINAL session state.** **#371 MERGED (2026-08-31 21:52)**:
+> the #370 revert + the **E-class fix** — the io.async closure's bundle-param
+> slot now renders the CALL's own recorded Future-trait effect
+> (`_io_async_call_effect_type`, src/codegen/exprs/async.yo; concrete-only)
+> instead of the shared forall E's global last-winner. That fix is the ONLY
+> change that ever made CI's tier-1 async_await + hollow sweep PASS — C54 is
+> CLOSED (docs PR #372 moved both issues to issues/fixed/). The earlier
+> belief that this render "breaks the smoke" was WRONG: **the smoke hang is
+> pre-existing and environment-triggered** — PRISTINE #369 (CI-green Aug 30
+> 19:48) hangs the smoke both natively-built locally and on today's CI
+> runners; something in the runner environment shifted after Aug 30.
+>
+> **The standing blocker for v0.2.21 is that smoke hang** — root-caused to
+> the same registry-divergence family but at DIFFERENT read-sites; the full
+> investigation state (verified against a `--debug-async-await` build of
+> #369) is in issues/build-smoke-hangs-registry-perturbation.md: the
+> synchronous `yield()` defect (fixed in the /private/tmp/yo-369 worktree —
+> park on a 1 ms timer — cures the spin, NOT the hang), the mistyped
+> `await_future_9 : __yo_io_future_t*` rendition in std/process output()
+> (continuation written at the wrong offsets; zombie children + re-cycling
+> SMs), the `_async_override_return_type` bare-SomeT gate (fixed in the same
+> worktree — ALSO not curative alone), and the unmerged order-stability
+> constraints. **The systematic fix** (per-ExprInfo reads at every
+> await-future typing site; evaluator-side concrete registration; intern
+> table order unobservable) is the next arc. Two worktree fixes await
+> order-stable rework: the yield park + the override gate (both in
+> /private/tmp/yo-369), and the dyn double-emission dedup. The E-class fix
+> attempted first (registry seeding) and the dyn fix are documented as
+> refuted in their issues so they are not retried.
+>
+> **TLS unblocked**: the OpenSSL interop moved from std's `c_include` into a
+> per-target runtime backend behind `g_uses_tls` (branch
+> `fix/tls-runtime-backend`, rebased on the #371 merge, T1-gates green, live
+> HTTPS verified) — D6 PR-3's Windows blocker is gone; it can PR once the
+> smoke blocker clears (its own CI would hang the same way).
+
+1. **Merge queue — RESOLVED 2026-08-30 (evening session)**: §2a #366 MERGED;
+   §2b #365 MERGED; **C54 body half #367 MERGED** (valueless-callee call
+   results resolve through the call's env — Mutex.with_lock RESTORED with
+   regression tests; the E-class variant is a different site, see below);
+   §2d #370 MERGED **then REVERTED by #371 (2026-08-31 — see addendum
+   above)**; #334 CLOSED as superseded (its crash fixed by develop's
+   dispatch; its delta regressed http 21→5) with the test salvaged as #368;
+   #369 (issue breadcrumb) MERGED. **§2c PR #364 rebased + verified
+   (remote list over std/http TLS, FIXPOINT_HOLDS with the
+   OpenSSL-pkgconfig'd battery/CI lines — all on the branch) and UNBLOCKED
+   2026-08-31 by the TLS runtime backend** (Windows gets ABI stubs +
+   `tls_available()` until Schannel).
+2. **C54 body half** (unblocks `Mutex.with_lock`, the last C54 item).
+3. **Arity-outside-swallow enforcement + async-SM gate** (§3 rows 1–2) — these
+   two would have caught every defect found today; highest bug-class value.
+4. **C29** — the big unification arc.
+5. **Windows cluster**: stdin pipe writes (overlapped named pipes);
+   issues/s3-fs-wrappers-windows-semantics-audit.md (Child/spawn + fs
+   wrappers have no Windows story; fs_convenience S3 sections skip on
+   Windows). The debug-workflow pattern (temp workflow on the branch,
+   cross-emit from a Linux stage-1, clang-compile and run one test file on
+   windows-latest, upload the log) is proven — see git history of
+   `debug-win-c57.yml` / `debug-win-fsw.yml` (both deleted after use).
+6. **Polish rows** (§7/§4 of the audit): regex extras; `std/cli` typed values
+   + std/term adoption; O5's Formatter routing for derive output; D5's
+   remaining `Dyn(Reader)` spelling (C17 is FIXED, so this is now unblocked)
+   and the deliberately-deferred async `lines()`.
+7. **Builtin-shadowing decision** (§3 row 3) — user-visible language decision;
+   propose option 2 (prefer user bindings) or 1 (reserve), write the plan.
+8. **Freeze prep** (§9 S5): after the tail lands, re-run the dead-surface and
+   test-coverage sweeps and declare the stability freeze.
+
+---
+
+## 5. Operational knowledge you will need (hard-won today)
+
+- **macOS host quirks (afternoon session)**: the system has NO `timeout`/`gtimeout`
+  (gates_fast.sh and the diff harnesses call a bare `timeout` — every gate
+  reported rc=127 until a shim was provided: a tiny bash wrapper in
+  /tmp/yo-bin/timeout prepended to PATH). `/bin/bash` is 3.2 and chokes on the
+  harnesses' `declare -A` ("PASS: unbound variable", scripts/cli-diff-test.sh:325,
+  scripts/diff-test.sh:201) — run BOTH harness scripts with
+  /opt/homebrew/bin/bash. The local clang's ASan runtime is BROKEN and the test
+  runner SILENTLY skips the sanitizer ("AddressSanitizer is not functional with
+  this compiler setup") — never trust a local "green" on ASan-gated paths.
+- **Builds**: `YO_STD=<worktree>/std /private/tmp/yo-seed-0220/bin/yo build`
+  (~10 min). Copy the product to `/tmp/yo-<name>-s1` BEFORE running gates
+  (S1 must live outside the repo).
+- **Batteries**: `S1=/tmp/... P=local bash scripts/bootstrap/gates_fast.sh`
+  then `fixpoint_only.sh`. **NEVER run two batteries concurrently** — they
+  share `/tmp/local_*` scratch and manufacture FIXPOINT_BROKEN (memory:
+  yo-gates-fixpoint-share-tmp-scratch). Also avoid a battery + a heavy build
+  concurrently (16 GB machine swaps; the user has complained).
+- **One battery verdict trap**: FIXPOINT_HOLDS with a nonzero CLANG_RC or
+  suspicious stage-file mtimes is not a verdict — check rcs first.
+- **The C22 gate**: value-returning hollow closures fail the C compile with
+  an `error` attribute; hollow ASYNC SMs do NOT (yet) — a silently-broken
+  async body presents as an instantly-completing/aborting future and a
+  SILENT early return in the caller (rc=0!). When something async "does
+  nothing", run `YO_DEBUG_SWALLOW=1 yo check <file>` and read the
+  `[anon-swallow]` lines — that is how all five §2a defects were found.
+- **A compiled program's runtime C comes from the COMPILING binary's
+  templates, not the tree** — editing `src/codegen/async/runtime_*.yo` only
+  affects what the NEW compiler emits (stage-2+ / user programs). To change
+  the compiler binary's own runtime behavior you need the seed to carry it.
+- **CLI goldens**: after anything touching CLI output, run
+  `scripts/cli-diff-test.sh`; the `async-blocking-await-inside-task` case
+  arms `YO_ASYNC_STRICT=1` and is the strict-cleanliness gate.
+- **Windows debug loop**: temp workflow per branch (see §4 item 5), ~50 min
+  round trip; always `upload-artifact` the log with `if: always()`.
+- The main checkout `/Users/yiyiwang/Workspace/Yo` is SHARED with a peer
+  session — never check out branches there; use `/private/tmp` worktrees
+  with `git -c protocol.file.allow=always submodule update --init`.
+- Admin merges are authorized; an unmergeable PR gets NO CI — merge develop
+  into the branch instead of close/reopen.
+
+## 6. Background state at handover
+
+All background monitors and builds from my session are stopped (or dead).
+Batteries needing (re)runs: yo-fsw (§2b), yo-vfix (§2a, after the strict
+fix), yo-sweep (§2d), yo-d6 (§2c, after rebase + script fix). The
+`/tmp/yo-*-s1` binaries and `/tmp/*-battery.log` files from today are
+disposable. `~/.cache/yo/versions` currently holds a test-installed 0.2.19.

--- a/plans/HANDOVER_STD_AUDIT_2026-09-01.md
+++ b/plans/HANDOVER_STD_AUDIT_2026-09-01.md
@@ -1,0 +1,321 @@
+# Handover — std API audit campaign, session ending 2026-09-01 (evening)
+
+Supersedes `plans/HANDOVER_STD_AUDIT_2026-08-30.md` (keep it — the deep
+background on C-numbered issues, the E-class arc, and the smoke-hang
+investigation lives there; THIS doc is the current state).
+
+The active /goal is unchanged: finish everything in `plans/STD_API_AUDIT.md`,
+well-designed stable std APIs, document + fix every surfaced bug, **no
+workarounds**, admin merges authorized to save CI cycles.
+
+---
+
+## 0a. ADDENDUM 2026-09-02 (morning — #364 pushed, riding CI)
+
+**State**: v0.2.21 is published (assets + notes done), SEED_VERSION is
+v0.2.21 on develop (`22ec5f6e2`, CI green). **PR #364 was force-pushed at
+`0f3b0ca3c`** (rebased on that develop) and is riding CI — **merge only on
+green, no admin merge** (standing user rule).
+
+**What the night session left**: the 0221-seeded stage-1 of the #364 tree
+(`/tmp/yo-d6-0221s1-bin`, emit/clang/check green, live `version list
+--remote` + `tls: true` probe) and a prepared `/tmp/rungates.sh` whose run
+FAILED only for environmental reasons — `timeout: command not found` under
+its bash/PATH, cascading into `PASS: unbound variable` in the scorecards.
+Not a tree problem.
+
+**Found + fixed this morning (commit `0f3b0ca3c`)**: the OpenSSL CI plumbing
+was incomplete. The compiler's own emitted C now carries OpenSSL includes on
+unix targets, so EVERY raw `clang`/`cc` that compiles compiler C needs the
+flags; six sites in test.yml (`test`-matrix stage-2, suite-candidate + its
+install step, test-native's macOS compile via the brew keg, bootstrap-fixpoint
+stage-2 + install, the Alpine musl static build, the wasm-emscripten stage-2)
+and the shared `.github/actions/build-stage1` (wasm32 emscripten + wasi jobs)
+were missed. An awk sweep over test.yml / release.yml / fixpoint-arm64.yml /
+the action now shows every compiler-C `-o` covered (Windows/wasm emits carry
+stubs). release.yml's sites are still NOT exercised by PR CI — watch the
+next release run.
+
+**Validation of the pushed tree (S1 = `/tmp/yo-d6-0221s1-bin`)**: tier-1
+gates all green (corpus 156/0, std 172/172, src 262/262, CLI 54/0; the one
+`comptime rc=1` was MY concurrent dyn canary deleting the battery's batch
+.bin.c in the same worktree — rerun under GATE 1's exact conditions 31/31
+hollow=0; memory-of-record written); fixpoint **FIXPOINT_HOLDS**, CLANG_RC=0
+via fixpoint_only.sh's new OpenSSL flags, stage-2 hollow=0; CLI scorecard
+`--network` **55/0/0**; dyn canary 9/9.
+
+**Next**: on #364 green → plain squash merge → the audit's curl-swap row
+closes → continue §4.4's audit tail. If a CI leg fails on an OpenSSL flag
+or a missing libssl-dev, it is one of the sites above — fix in place, do not
+revert the plumbing.
+
+---
+
+## 0b. ADDENDUM 2026-09-02 (late morning — audit tail + forward-ref plan)
+
+**In flight**
+- **#364** riding CI at `0f3b0ca3c` (see §0a) — merge on green, plain squash.
+- **D5/§5 closeout** on branch `s8/audit-tail-d5-http` (worktree
+  `/private/tmp/yo-tail`, commits `a451edd66` + `f8583c83a`, NOT yet pushed/PR'd —
+  battery running with S1 = `/tmp/yo-tail-s1`, the v0.2.21-seed build of that
+  tree; seed `check ./std` 172/172; tests green: io/async_traits 9 (new
+  `Dyn(Reader)` pin), io/bufio 13, fs/file 16, net/tcp 13, http/http 21,
+  http/server 8). Content: `Dyn(Reader)` pinned (vtable read, default through
+  it, `BufReader(Dyn(Reader))`); inherent `File.read_bytes`,
+  `File.read_to_string`, `TcpStream.read_bytes` DELETED in favour of the
+  `Reader` defaults (D2, one Rust name per operation); `HttpRequest`/
+  `HttpResponse` `to_string` → `ToString` impls; plan §5/D5 rows updated;
+  ArrayList remove/drain row MEASURED (~20 typed sites) and left as its own PR.
+  **Found en route**: `impl(File, IoTraits.Reader(...))` sat BELOW the free
+  functions that now call the trait defaults — def-time failure swallowed,
+  `check` green, hollow stubs caught only by the C22 gate. Impls moved above
+  the callers; rule recorded in the syntax skill + instruction files
+  ("trait impls are bindings too"). PR body draft:
+  `<scratchpad>/pr-tail-body.md` (fill the BUILD/BATTERY placeholders).
+- **`plans/LAZY_TOPLEVEL_BINDINGS.md`** (+ AGENTS.md row): the design for
+  lifting the no-forward-reference rule. Was PR #379 (docs-only, CI green) —
+  **CLOSED and folded into the closeout branch** because a docs-only PR is
+  structurally unmergeable under the no-admin rule: the "Classify the diff
+  (docs-only fast path)" job skips every test job, so the ruleset's required
+  contexts (`test (<os>)`, fixpoint, tier-1 gates) never report and the PR
+  stays BLOCKED. **User decision needed**: either allow `--admin` for
+  docs-only PRs, or teach the fast path to report the required contexts as
+  success (a `test.yml` change), or keep folding docs into code PRs. Its **P0** (a check-time "forward reference to X (defined at line N)"
+  diagnostic replacing the silent swallow) is the next compiler item worth
+  doing before the audit's remaining compiler holes (C29, arity-outside-the-
+  swallow); P1+ is a campaign, not a PR.
+
+**Queue after these**: ArrayList `remove`→`drain`/`remove(idx)->T` (own PR,
+compiler-as-oracle rename first); D7 `Thread.spawn` `join() -> T` (S4); C29;
+arity validation outside the def-eval swallow + async-SM C22 equivalent;
+Windows stdin pipe WRITES; `issues/s3-fs-wrappers-windows-semantics-audit.md`;
+polish rows (regex extras, cli typed values + std/term adoption, O5 Formatter
+routing).
+
+---
+
+## 0. LATE ADDENDUM 2026-09-01 (night session — supersedes §2/§4 ordering)
+
+**Constraint change from the user (standing)**: merge PRs only on fully
+green CI — **no admin merges**. #375 and #376 were merged this way.
+
+**Merged tonight**: #375 `a0c88eddf` (sleep(0) timerfd), #376 `938342f2b`
+(TLS runtime backend).
+
+**PR #378 (fix/release-musl-gen2, worktree /private/tmp/yo-relg2)**: the
+musl-bundle release leg emitted the SHIPPED C with the SEED — the shipped
+Linux bundle (and the next cycle's SEED_VERSION download) was gen-1, i.e.
+its own compiled-in `yo build`/`yo version` machinery carried the seed's
+codegen (the hang). The Linux portable yo.c arms were seed-emitted too.
+#378 makes it: seed → Alpine cc → static stage-1 → **stage-1 re-emits the
+shipped C** → Alpine cc; the portable arms are emitted by the shipped
+binary; the pre-release gate becomes a **stage-3 byte-identity fixpoint**;
+the glibc smoke gains `yo init` + `yo build run` (15-min step timeout);
+job timeout 180→240. Non-Linux cross bundles were already gen-2. **#378
+must merge before v0.2.21.** Its PR CI does NOT exercise release.yml —
+watch the actual release run.
+
+**#364 RESCHEDULED — the second-order bootstrap veil (found tonight)**:
+after rebasing on post-#376 develop, the v0.2.20 seed CANNOT build the
+compiler tree with std/http in its closure: #376's `extern("Yo")
+__yo_tls_*` ABI has its runtime emitted only by #376-codegen compilers,
+and the seed emits bare undeclared `__yo_tls_*` calls (stage-1 clang:
+`call to undeclared function '__yo_tls_available'`). So CI's seed-built
+stage-1 fails the moment the swap enters the tree. **Merge gate moved to
+SEED_VERSION v0.2.21** — cut v0.2.21 WITHOUT #364, let publish-release
+auto-bump the seed, then rebase #364 and ride CI. Local verification of
+the rebased #364 is DONE (all green, using /tmp/yo-tls-s1 — a #376-tree
+stage-1 — as the seed stand-in): emit→clang→check ./src+./std, tls probe
+`tls: true`, LIVE `version list --remote`, LIVE `version install 0.2.18`
+(download + pre-triple name fallback + cache). Branch state (worktree
+/private/tmp/yo-d6, NOT pushed — do not push before the seed bump): 5
+commits on predictive base develop+#376 (rebase --onto real develop when
+the time comes), including tonight's follow-up commit `3cae9af08`
+(weak-canary `__yo_tls_available`, version_cache `tls_available()` gating
+with clean errors, rewritten PR-3 note in plans/STD_API_AUDIT.md).
+
+**Still to fold into #364 when it rides (post-v0.2.21)**:
+release.yml OpenSSL sites — (a) seed-cross-emit apt `libssl-dev
+pkg-config` (candidate build is compiler-driven clang), (b)
+seed-bundles-cross macOS legs: pkg-config cflags +
+`-Wl,-weak_library,$(brew --prefix openssl)/lib/libssl.3.dylib` (and
+libcrypto) so the shipped macOS bundle launches without brew openssl
+(verified locally: weak canary pattern compiles, links weak, launches
+with the dylib ABSENT and reports false — /tmp/weakcanary*.c); (c)
+musl-bundle BOTH Alpine cc lines: `apk add openssl-dev` + assert
+/usr/lib/libssl.a + `-lssl -lcrypto`; (d) portable-c gate: apt libssl-dev
++ `$(pkg-config --cflags openssl)` on the `gcc -fsyntax-only yo.c`. Then
+the CLI golden scorecard WITH `--network` (version-install-pinned is
+substring-matched on `0\.2\.1`, unaffected), the battery, and push.
+
+**v0.2.21 release notes draft (edit into the DRAFT after the run creates
+it, before publish flips it — or after; it stays editable)**: hang fix +
+gen-2 bundles; sleep(0); dyn dedup; E-class ASan; TLS backend +
+tls_available contract; **`yo version install` / `list --remote` were
+broken in v0.2.19/v0.2.20 — the hollowing fix (#366) restores the curl
+path in v0.2.21; the curl→std/http swap (no curl dependency) is the next
+release, gated on the v0.2.21 seed**.
+
+---
+
+## 1. What landed today (develop timeline, oldest first)
+
+| commit | PR | what |
+| --- | --- | --- |
+| `fc6b6cb99` | #373 | async: `yield` parks on the event loop (1 ms timer park); `_async_override_return_type` no longer bails on a bare-SomeT registry result; join_handle test made race-free (bounded drive loop); **the wasm-emscripten smoke migrated to stage-2** (was the last stage-1 self-application in CI — the bootstrap veil hid seed codegen bugs there) |
+| `11c34a8b6` | #374 | **re-land of the #370 sweep** (dead `KeyNotFound`/`ElementNotFound` variants deleted, prelude `if`-macro deleted, `Command.current_dir` generation B) + re-recorded goldens (check-watch-once 1156→1154, lsp-completion yo_id −1) |
+| `95f81970a` | #377 | **fix: dedup on-demand type-body emission** — un-redded develop (see §3) |
+
+All three admin-merged per the goal. #373 was full-CI green first; #374 was
+validated locally (battery FIXPOINT_HOLDS, CLI 54/0, gen-2 smoke) — but see
+§3's lesson about what that validation did NOT cover.
+
+## 2. Open PRs — both expected green, merge on green
+
+- **#375 `fix/sleep-zero-timerfd`** (head `7e0ebfa70`, CI run 33506595533,
+  worktree `/private/tmp/yo-sleep0`): `sleep(0)` never completed on Linux —
+  POSIX defines a zero `it_value` to `timerfd_settime` as DISARMING the
+  timer. Fix: clamp the arm to 1 ns (`__yo_async_sleep_start`,
+  `src/codegen/async/runtime_io_common.yo`). Pinned by "Test zero-length
+  sleep completes" in `tests/sys/timer.test.yo` (plain-context + in-task
+  await). Verified: stage-1 timer test 2/2 on macOS; Linux cross-emit
+  carries the clamp. **The ubuntu CI legs are the real proof of the Linux
+  path** (stage-2 templates) — that's why this one rode full CI instead of
+  being admin-merged early. `issues/fixed/sleep-zero-disarms-linux-timerfd.md`.
+  On green: squash-merge (not workflow-touching, `--admin` fine).
+
+- **#376 `fix/tls-runtime-backend`** (head `9ca08e4a4`, CI run 33506618725,
+  worktree `/private/tmp/yo-tls`): the predecessor's TLS backend move
+  (std's OpenSSL `c_include` → per-target runtime emission behind
+  `g_uses_tls`, extern("Yo") `__yo_tls_*` ABI, Windows stubs) **plus a
+  gating fix found revalidating it**: the first version emitted the TLS
+  runtime from inside `generate_async_runtime` (gated on `uses_async`), so a
+  SYNC program calling only `tls_available()` got
+  `call to undeclared function '__yo_tls_available'`, and wasm could never
+  see the ABI. Now emitted as a sibling of the parallelism runtime in
+  `generate_all_functions`, gated only on `get_uses_tls()`; the C guard is
+  `#if !defined(_WIN32) && !defined(__wasm__)` so Windows AND wasm get
+  stubs. Pinned by `tests/crypto/tls_available_sync.test.yo` — an
+  **async-free batch** (one async test in the file would mask the gate),
+  which **runs on the Windows legs deliberately** (stub → `false` is the
+  contract; it is the only Windows TLS coverage).
+  `issues/fixed/tls-runtime-emission-gated-behind-uses-async.md`.
+  Local validation: check 262/262 + 172/172; gating matrix (plain program 0
+  TLS refs / sync TLS program links + prints `tls: true` / windows + wasm
+  emits carry guard + stubs); tls 2/2 (live HTTPS), http 34/34, async
+  24/24; gates_fast failures=0 CLI 54/0; **FIXPOINT_HOLDS CLANG_RC=0**.
+  On green: admin-merge. This unblocks #364's Windows story.
+
+Both PRs already contain the #377 merge (develop merged in at
+`7e0ebfa70` / `9ca08e4a4`). Their previous runs failed ONLY on the develop
+breakage (§3) — verified by log: the same `redefinition of '__yo_t60_struct'`
+in the dyn batch on both.
+
+## 3. The develop breakage and the dyn dedup fix (#377) — read this before touching prelude/yo_ids
+
+**What happened**: the moment #374 landed, every full-suite CI leg went red
+on `tests/dyn.test.yo`'s batch: `error: redefinition of '__yo_t60_struct'`
+("Generic Future interface for Future[Future](usize) IoExn"). #375's first
+run surfaced it (all 9 legs red).
+
+**Mechanism** (`issues/fixed/dyn-async-future-trait-body-emitted-twice.md`):
+a dyn method's async Future-trait return type is minted lazily WHILE the
+fifth declaration pass renders the dyn vtable; the on-demand hook
+(`_on_demand_collect_and_declare`, `src/codegen/codegen_c.yo`) emits its
+forward typedef + body, then the pass iteration reaches the same entry and
+emits the body again. The defect predates #370/#374 — the prelude shrink
+merely re-shifted collection order enough to make a Future-trait arrive
+lazily at pass time (the registry-perturbation family).
+
+**The fix shape matters**: the predecessor's shared-set fix was RETRACTED
+for renumbering the type table (~1.7k C lines) and flipping async_await +
+smoke legs. #377's set is **asymmetric**: `on_demand_body_cnames` is
+populated ONLY by the hook with the C names whose bodies IT emits (already
+rendered there — no new interning); the declaration passes
+(`src/codegen/types/generation.yo`: simple-enum, topological
+struct/enum/tuple, nullable-pointer-enum, fifth pass's union/future-trait
+arms — the dyn arm deliberately unguarded, the hook never emits dyn bodies)
+skip exactly those names. On a healthy tree the set is empty at pass time.
+
+**Proof**: pre-fix and post-fix compilers emit **hash-identical** stage-2 C
+for the same input tree (sha256 `b94924bd…`) — the perturbation class is
+structurally excluded, and the fixpoint argument is free. dyn 9/9,
+async_await 188/188, battery FIXPOINT_HOLDS CLANG_RC=0.
+
+**Lessons, hard-won today**:
+1. **`tests/dyn.test.yo` is the canary for any yo_id/prelude-shifting
+   change.** #374's local validation (targeted suites + battery + gen-2
+   smoke + CLI scorecard) did NOT include the full `tests/` sweep, and the
+   battery does not run it either — the dyn batch was only covered by the
+   full-suite CI legs. Run it (2 min) after ANY change that renumbers.
+2. When doing a byte-identity A/B, **do not edit sources while the baseline
+   emit runs** — the module loader reads files over several minutes and my
+   first "baseline" silently contained the edits (grep the emitted C for a
+   string unique to your edit to detect pollution).
+3. This machine killed harness-background builds twice today (cause
+   unknown; possibly the peer session or memory pressure). Long builds run
+   reliably as `nohup bash -c '... ; echo rc=$?' &> log & disown` + a
+   Monitor polling the log for the rc line.
+
+## 4. Immediate queue (in order)
+
+1. **Merge #375 and #376 on green** (runs 33506595533 / 33506618725 were
+   in flight when this session ended; both heads include the #377 heal).
+2. **#364 / D6 PR-3** (curl→std/http swap, branch `s6/version-cache-std-http`,
+   worktree `/private/tmp/yo-d6`): rebase onto post-#376 develop; drop the
+   duplicated install-fix commit (those landed via #366); fold in the
+   battery-script OpenSSL flags fix (`scripts/bootstrap/fixpoint_only.sh`
+   stage-2 clang line + gates_fast equivalent need `pkg-config openssl`
+   flags once the COMPILER's own closure carries `__yo_tls_*` — with the
+   #376 backend that happens exactly when version_cache starts using
+   std/http); verify the strict CLI golden. The wrong-arity compiler hole
+   it exposed stays open
+   (`issues/wrong-arity-call-silently-accepted-version-install-broken.md`).
+3. **v0.2.21**: after the queue lands and develop CI is green on HEAD,
+   `gh workflow run release.yml --ref develop -f bump=patch`. Release notes
+   MUST say `yo version install` / `yo version list --remote` were broken
+   in v0.2.19 and v0.2.20.
+4. **Audit tail** (unchanged from the previous handover §5, minus what
+   landed): C29 unification arc; arity-validation outside the swallow + the
+   async-SM C22-gate equivalent; builtin-shadowing decision; Windows stdin
+   pipe WRITES (overlapped named pipes; reads landed in #353);
+   `issues/s3-fs-wrappers-windows-semantics-audit.md`; module-level
+   control-bound binding hole; polish rows (regex extras, cli typed values
+   + std/term adoption, O5 Formatter routing, D5 Dyn(Reader)); the
+   systematic registry arc (per-ExprInfo reads at await-future typing
+   sites, order-stable intern table — #377 fixed the dyn double-emission
+   INSTANCE of that family, the systematic rework is still open).
+5. **Timer-free yield** stays seed-gated (new runtime extern to enqueue own
+   completion); the `sleep(0)` fix (#375) removes the Linux blocker for a
+   granularity-free park as an interim step if wanted.
+
+## 5. Worktrees & binaries inventory (this machine)
+
+| path | branch | state |
+| --- | --- | --- |
+| `/Users/yiyiwang/Workspace/Yo` | (shared with peer session) | **never checkout branches here**; this doc + the 08-30 handover are untracked files here |
+| `/private/tmp/yo-sleep0` | `fix/sleep-zero-timerfd` | = PR #375, pushed |
+| `/private/tmp/yo-tls` | `fix/tls-runtime-backend` | = PR #376, pushed |
+| `/private/tmp/yo-dedup` | `fix/dyn-on-demand-dedup` | = #377, MERGED — worktree removable |
+| `/private/tmp/yo-resweep` | `s7/seed-gated-sweep-reland` | = #374, MERGED — worktree removable |
+| `/private/tmp/yo-ecls` | `fix/smoke-yield-gate` | = #373, MERGED — worktree removable |
+| `/private/tmp/yo-d6` | `s6/version-cache-std-http` | #364, needs the §4.2 rebase |
+
+Binaries: `/private/tmp/yo-seed-0220/bin/yo` (the SEED, v0.2.20);
+`/tmp/yo-dedup2-s1` (develop+#377 stage-1 — the freshest post-heal compiler,
+good for local test runs); `/tmp/yo-tls-s1` (PR #376 tree stage-1);
+`/tmp/yo-sleep0-s1` (PR #375 tree stage-1). Older `/tmp/yo-*-s1/g1/g2` are
+stale — prefer rebuilding over trusting them.
+
+## 6. Standing constraints (unchanged)
+
+- Main checkout is SHARED with a peer Claude session — work in
+  `/private/tmp` worktrees, `git -c protocol.file.allow=always submodule
+  update --init` after creating one.
+- One battery at a time (shared `/tmp/local_*` scratch); one heavy build at
+  a time (16 GB machine); S1 must live OUTSIDE the repo.
+- `--release` is removed — `--optimize 2`. Always fmt twice then check.
+- `yo build` runs under the SEED: std/ + src/ source forms must be correct
+  under the seed's bugs; tests/ are not seed-gated.
+- CLI diff harness reads `YO_SELF_BIN` (not YO_BIN); after any golden
+  re-record, rerun the FULL scorecard.

--- a/plans/HANDOVER_STD_AUDIT_2026-09-02.md
+++ b/plans/HANDOVER_STD_AUDIT_2026-09-02.md
@@ -1,0 +1,742 @@
+# Handover — std API audit campaign, session ending 2026-09-02
+
+Supersedes `plans/HANDOVER_STD_AUDIT_2026-09-01.md` (whose §0/§0a/§0b addenda
+are the detailed log of 09-01 → 09-02 morning; keep it) and, for deep
+background, `plans/HANDOVER_STD_AUDIT_2026-08-30.md`. THIS doc is the current
+state and the queue.
+
+The /goal is unchanged: finish everything in `plans/STD_API_AUDIT.md`,
+well-designed stable std APIs, document + fix every surfaced bug, no
+workarounds. **Admin merges are ALLOWED again (user, 2026-09-02 midday)** —
+the 09-01 night ban was about coverage, not the button; the checklist that
+survives it is in §4.
+
+---
+
+## 0. LATE ADDENDUM 2026-09-02 (afternoon session — read §3 as DONE)
+
+**Landed since §1 was written**: #364 **MERGED** `e84def46b` (curl→std/http,
+the LAST D6 item); #381 `a7dcc7bd2` (develop un-red: apostrophes inside the
+single-quoted Alpine `sh -euc '...'` docker scripts terminated the quoting —
+the musl leg died on `syntax error near unexpected token )` BEFORE apk, so
+the openssl-libs-static package fix had never actually run; both workflows'
+blocks rephrased apostrophe-free, verified by scan. Develop run 33589885601
+on that head: SUCCESS — the package fix's first real exercise, musl green);
+#382 `7b8976438` (**ArrayList §5 breaking change**: `drain(range) ->
+ArrayList(T)` Rust-parity panics, `remove(idx) -> T` (Index contract),
+`iter()` non-consuming over the RC-shared handle; 21 two-arg sites migrated
+across std+src, channel pops simplified, tests rewritten, three yo_id
+goldens re-recorded; validation: check 172/172+262/262, seed build, 93/93,
+dyn 9/9, battery, CLI --network 55/0). Post-#382 develop run 33595076863 FAILED
+only the tier-1 goldens (the route lesson above); healed by #383. Post-#383
+run 33606554518 in flight at this writing.
+
+**Machine restart mid-session wiped /private/tmp**: all worktrees and
+/tmp binaries were rebuilt (worktree dirs come back via `git worktree add`
++ submodule update; the v0.2.21 seed re-downloads from the release).
+`/tmp/yo-bin/timeout` shim must be recreated (script in §8), and gates
+drivers need `PATH=/opt/homebrew/bin:/tmp/yo-bin:$PATH` — the child
+scripts (`diff-test.sh`, `cli-diff-test.sh`) use associative arrays →
+bash 5 via `env bash`, and `timeout` must resolve.
+
+**#383 MERGED `01176a511` — P0 (LAZY_TOPLEVEL_BINDINGS §4.6) LANDED.** The
+silent-hollow class now errors at check time:
+`forward reference to "X" (defined at line N) — Yo evaluates definitions in
+order; move the definition above this use`. Module-walk cell in context.yo
+(accessor-fn pattern), `forward_ref_diagnostic` scanning later `::`/`:`/`=`,
+`comptime(X)`, `impl(X,...)` heads; wired at the fn-body dg trial + the
+anon-closure concrete and dgc trials (new anon swallow cell); the bounded
+pending-def re-run site deliberately unwired (no exn in scope — noted in
+the plan). Pinned by `tests/cli-cases/check-forward-ref-async-body/` (a
+check-FAILURE cli case; a .test.yo pin cannot see module order — the batch
+runner hoists `::` defs). Two hard lessons en route: (1) plain module-level
+SELF-recursion fails check today (`Variable X not found` at the def trial)
+— the campaign's own §6 target, do not write recursive helpers in src/std;
+(2) **the macOS /tmp/yo-bin/timeout shim must be exec-based** — the
+post-restart recreation used a `"$@" &` background form, and
+non-interactive bash gives background jobs /dev/null STDIN: the lsp CLI
+cases ran vacuously (2-line goldens) while CI's GNU timeout forwards
+stdin and emits the framed transcripts — the REAL cause of the #382 and
+#383 tier-1 golden failures (the compile-vs-build route theory was wrong;
+both routes agree). #385 re-recorded with a fixed shim + yo-build S1.
+
+_(Earlier note, kept for the record:)_ the repro that started P0.
+The silent-hollow class is confirmed end-to-end: a forward-referenced call
+INSIDE an `io.async` body (deferred-generic trial) is swallowed by the dg
+site (`function_type.yo:~1543`, TS ts:112 catch parity) and the test passes
+VACUOUSLY. Red repro (as `tests/tmp_fwdref.test.yo`, passes 1/1 today):
+
+```rust
+open(import("std/libc/stdio"));
+open(import("std/string"));
+open(import("std/fmt"));
+do_it :: (fn(io : Io) -> Impl(Future(unit, Io)))(
+  io.async((io : Io) => { later(); })
+);
+later :: (fn() -> unit)(println(String.from("later")));
+test("forward ref inside async body", { io.await(do_it(io), io); });
+```
+
+Implementation shape (per plan §4.6): the swallow already lands in
+`g_trial_swallow_msg` (`_flag_trial_swallow`, function_type.yo:161). At the
+two SILENT sites — the dg trial (~1543) and the pending-def re-run (~799) —
+before discarding, match the message against the unbound-name text
+(`Variable "X" not found.`; the concrete path at ~1357 already re-raises),
+look for X bound LATER in the same module's begin_exprs, and re-raise
+`forward reference to "X" (defined at line N) — Yo evaluates definitions
+in order; move the definition above this use` through the real exn.
+Needs: module begin_exprs reachable at def-eval time (a global set by
+`evaluate_anonymous_module_begin_exprs` is the likely plumbing) + the
+binding-name/impl-receiver extraction. Acceptance: check ./std+./src
+unchanged, the repro above errors with the new text, battery green. NOTE
+the plain (non-async) forward call already errors loudly today — only the
+dg/re-run swallows are the target.
+
+**Queue after P0**: unchanged — §5 items 4-8 (D7 join, C29/arity, Windows,
+polish, next patch release whose notes must now ALSO say the ArrayList
+breaking change).
+
+---
+
+## 0a. EVENING ADDENDUM 2026-09-02 — v0.2.22 SHIPPED
+
+**#384** (docs sync en+zh), **#385** (the stdin-fixed LSP goldens — the
+real cause of the #382/#383 tier-1 reds was the recreated macOS timeout
+shim eating stdin, see the corrected lesson in §0) — then develop went
+fully green on `74e4410c1` and **v0.2.22 was cut** (run 33620216691, ALL
+jobs green — the first release with std/http in the compiler closure:
+both Alpine `cc` lines linked `openssl-libs-static` successfully, the
+macOS bundle legs weak-linked, the portable-C parse gate passed, the
+stage-3 byte-identity fixpoint held, `yo build run` smoked). Published
+with the prepared notes; **SEED_VERSION = v0.2.22** (`4851ff9c0`).
+Live-verified from the published tarball: `yo version list --remote`
+speaks TLS through the compiler itself, no curl.
+
+The v0.2.22 seed carries: the P0 forward-ref diagnostic, TLS-emitting
+codegen, the gen-2 machinery, the ArrayList API. **Unblocked by the new
+seed:** std/src may now USE the extern("Yo") TLS ABI freely; the
+LAZY_TOPLEVEL_BINDINGS campaign (P1+) can build on the recorded
+module-walk cell; the next seed-gated items in §5.
+
+## 0b. NIGHT ADDENDUM 2026-09-02 — #387 arity fix landed
+
+The wrong-arity compiler hole (the only audit class that broke two
+shipped releases) is FIXED: `hard_swallow_diagnostic` in context.yo
+extends the P0 re-raise to `Argument count mismatch` — the same three
+silent trial sites now surface arity errors at check time, pinned by
+`tests/cli-cases/check-wrong-arity-async-body/`. Acceptance: check
+./std 172/172 + ./src 262/262 under the REBUILT compiler (no spurious
+firing anywhere in the healthy tree); tier-1 gates failures=0; CLI
+scorecard 57/0. #388/#389 moved the issue to issues/fixed/ and repointed
+references. OPEN follow-up from that issue: the async-SM hollow POISON
+GATE (a state machine whose body ExprInfos were never stamped must
+poison its resume fn like C22 does for closures — catches every
+hollow-SM cause, not just arity).
+
+Also this evening: seed-bump develop run on 4851ff9c0 = SUCCESS (v0.2.22
+bootstraps cleanly).
+
+## 0c. NIGHT-2 ADDENDUM — poison-gate scoping (LANDED 2026-09-02 late; see §0d)
+
+The async-SM hollow poison gate needs a FRESH session. What was measured
+2026-09-02 night: a body whose def-time trial swallowed a TYPE error
+(`i32 && i32` — "Expected bool type for and argument") produces a
+FULLY-hollow async that never reaches the state machine AT ALL — with the
+await analysis absent, codegen falls back to the SYNC-FUTURE path (the
+C22 `_sync_fut_t` class, issues/closure-nested-inside-io-async-closure-
+body-emits-abort-stub.md family). Three segment-statement sites in
+state_machine.yo (branch arms ~2392, remaining ~2889, while-tail ~3009)
+only see PARTIALLY-evaluated bodies; the correct poison point for the
+fully-hollow case is the sync-future fallback emission in
+exprs/async.yo (and/or an entry check on `get_expr_info(body_expr)`).
+The `_sync_fut_t` stub's own resume is what "runs nothing and completes"
+— start there. Repro (passes vacuously today):
+
+```rust
+do_bad :: (fn(io : Io) -> Impl(Future(unit, Io)))(
+  io.async((io : Io) => { b := (i32(1) && i32(2)); println(b.to_string()); })
+);
+test("type error inside async body", { io.await(do_bad(io), io); });
+```
+
+## 0d. POISON GATE LANDED (2026-09-02 late)
+
+§0c's scoping was executed end-to-end. Gates at BOTH io.async emitters in
+`src/codegen/exprs/async.yo` — `generate_io_async_sync_call` (fully-hollow,
+sync-future) and `generate_async_block` (FSM path) — `codegen_fatal` when the
+closure's body block has no ExprInfo. Acceptance, all with the gen-2 rebuild
+(seed v0.2.22 → develop@19e4b3817 + gate): both repro shapes (type error
+before/after an await — both actually route SYNC) now fail with
+`... body was never fully evaluated ... sync-future future would run nothing`;
+the good twin prints `false`; a VALID DEAD (uncalled) io.async closure still
+compiles (the def-time trial of a valid body succeeds even when uncalled —
+no false positive there); nested io.async green; `compile src/main.yo
+--skip-c-compiler` green; async_await.test.yo 188/188; async_trait_default_
+await.test.yo 4/4; full CLI battery PASS 57 / GOLDEN-DIFF 0 / NO-GOLDEN 0.
+New golden case `tests/cli-cases/compile-async-body-type-error` (recorded
+with gen-2). Issue: `issues/async-body-type-error-compiles-vacuously.md`.
+Two facts learned while pinning the repro: (1) a compiled entry point needs
+`export(main);` and `main` may take ONLY `(io : Io)` — no `exn : Exception`
+(docs updated in the cheatsheet); (2) the trait-`?=`-default variant of a
+bad async body fails NOISILY at the C level (undeclared hollow type), so it
+is not part of the silent class. The FSM gate's fire branch has no repro
+(every failing body routes sync — await analysis is stamped only on full
+trial success); kept as the same invariant, exercised-silent by valid FSMs.
+Follow-up recorded in the issue: the trait-default shape deserves its own
+clean evaluator-level diagnostic someday.
+
+## 0e. POISON-GATE CI ROUND (same night) — the wasm "false positive" was a TRUE positive
+
+PR #390's wasm leg failed on `tests/async_unit_tail_await.test.yo` — and the
+chase (through two rejected fix designs: an enclosing-generic skip via
+`current_function_type`, which prints `void*` at that emission site, and a
+deferred-generic stamp machinery in context.yo, which chased a ghost) landed
+on the REAL root: the failing closure was `outer_unit`'s **bare-`e` param**
+(`io.async((e) => e.io.await(inner_unit(io), e.io))`). The def-time trial
+cannot resolve `e.io.await` there — the effect bundle `E` is only bound at
+call sites whose expected type carries a concrete effect, and
+`Impl(Future(unit))` does not — so the swallow was ALWAYS silent: pre-gate,
+the future compiled to a **runs-nothing sync stub** and the test's
+`assert(true, "completed")` could not tell. The gate exposed a latent
+vacuity, exactly its job. (The suspected generic shapes were innocent:
+`put_all_generic`'s closure body evaluates fine at def time via where-trait
+resolution; generic fn bodies need NO carve-out.)
+
+Shipped in #390's second commit (`0897c642e`): the test's closure params
+annotated (`(io2 : Io) => ...`, the form every other async test uses), and
+the class filed as `issues/io-async-bare-e-closure-body-never-evaluates.md`
+(open work: bind the bundle before the def-time trial from the enclosing
+signature — the Step-6b call-site binding already does this when the
+expected type is concrete). Re-verified with the gate binary: the file's
+2 tests pass and the FULL fast suite is green (rc=0).
+
+## 0g. FINAL STATE of the night (2026-09-02 ~21:45)
+
+- **#390 (async hollow-body poison gate) MERGED** after three CI rounds:
+  the wasm false-alarm (§0e, bare-`e`), the #386-formatter ordering trap
+  (§0f — fixed by reformatting `std/regex/index.yo`, which also un-redded
+  develop), and one macos-26-intel FLAKE ("Test spawn with multi-yield
+  futures", rc=6 — passed on `--failed` rerun). Issue moved to
+  `issues/fixed/` via #393.
+- **#391 (regex POLISH row) MERGED**; **#392 (cheatsheet facts) MERGED**.
+- Develop now carries: the poison gate + golden case, the regex row, the
+  bare-`e` issue (OPEN — next session's candidate: bind the effect bundle
+  before the def-time trial from the enclosing signature), three syntax
+  facts in the cheatsheet.
+- Worktrees: `/private/tmp/yo-al` (post-#390 develop + bookkeeping branch,
+  removable), `/private/tmp/yo-rg`, `/private/tmp/yo-docs` (removable).
+- **Develop VALIDATED**: the post-merge run on `487a5bd9b` (#393's head,
+  run 33687129459) finished **success** — all four merges green together,
+  intel leg included (the flake did not recur).
+
+## 0h. 2026-09-03 — the bare-`e` ROOT FIX landed (#394)
+
+`issues/io-async-bare-e-closure-body-never-evaluates.md` is FIXED (moved to
+`fixed/` in the PR): the `.io` projection is now TOTAL — on a receiver whose
+type is the bare `Io` effect struct, `X.io` is the IDENTITY (evaluator +
+codegen twins in the two `property_access.yo` files; keyed on the
+io-builtin side table so user structs with an `io` field are untouched;
+`.exn` on a bare Io stays a field-miss). `io.async((e) => e.io.await(f,
+e.io))` bodies now evaluate at def time AND run — repro's awaited inner
+value flows out (regression test in async_unit_tail_await, 3/3). Verified:
+`check ./std` 172/172, self-compile, FULL fast suite rc=0, CLI battery
+57/0/0, fmt gate; #390's repro still fails (gate intact). Mechanism
+discovered en route: Step 6b-nested already binds `E := Io` from the
+receiver for this shape — the failure was purely the bundle-projection
+`e.io` being partial. NEW orthogonal bug filed:
+`issues/module-global-referenced-inside-async-closure-undeclared.md` (a
+module-level global inside an async closure body emits
+`use of undeclared identifier` + a mangled capture-struct member; the
+ANNOTATED form fails identically; every existing async test works around it
+with fn-local Boxes).
+
+## 0i. 2026-09-03 (cont.) — the module-global capture fix (PR #396)
+
+The §0h-filed bug is FIXED the same day, and measured WIDER than filed: a
+plain inline anon closure referencing a module global broke identically
+(not async-specific). One guard in `trackVariableUsage`
+(src/evaluator/context.yo): bindings in the module-global registry
+(`is_module_level_global` — the same registry the C-name mangler keys on)
+are skipped from closure captures; a module global lowers to a
+process-global C symbol, so closures reference it directly. All four
+shapes compile AND run (named fn / inline anon / annotated async / the
+filed repro); closure.test.yo 12/12 (+2 arms), async_await 189/189 (+1
+arm), std 172/172, self-compile, FULL suite rc=0, CLI battery 57/0/0,
+fmt clean. Two process notes: (1) test arms must be SELF-CONTAINED — the
+batch runner does not persist module-global state across tests (an arm
+asserting a prior arm's mutation aborts rc=6 with no message); (2) one
+CLI-battery invocation reported 0/31/26 — a transient harness glitch,
+identical re-run 57/0/0; if the battery ever reports near-total failure,
+re-run before diagnosing.
+
+## 0f. Same-night misc
+
+- **WaitGroup**: the queue note ("waits on migration decision") was STALE —
+  the audit already records **DECIDED KEEP (2026-08-29)** twice (D7 + §6).
+  A migrate-and-delete attempt was prepared, then abandoned on reading the
+  recorded decision; worktree reverted. Do not re-litigate without the
+  user.
+- **Regex POLISH row CLOSED** — PR #391: `Regex.escape`, flags-free
+  `Regex.compile`, `replace_with`/`replace_all_with` (callback),
+  `find_iter` → `RegexMatchIter` (an `Iterator`), `end()`/`span()`/
+  `group_span(i)` byte spans; 182/182 regex tests, `check ./std` 172/172.
+  Yo-syntax notes refreshed en route: `{...}` in ARG position is a struct
+  literal (drop braces on single-expression closures); `=>` RHS with an
+  operator chain needs the WHOLE RHS parenthesized; `"str" + var` in an
+  assert is a `comptime_str`/`String` unification error — use
+  `String.from("...") + var`.
+- **develop run for #387 (#388/#389 head 19e4b3817) SUCCESS** — the arity
+  fix is validated on develop.
+- **Formatter-ordering trap (bit #391 → develop briefly RED on the T1 fmt
+  gate)**: #386's redundant-paren-elision formatter landed on develop
+  (8088de32d) AFTER this session's worktrees branched (19e4b3817), and the
+  regex PR's `std/regex/index.yo` was formatted with a PRE-#386 binary — so
+  #391 shipped old-style formatting that the new formatter flags, and
+  develop's own T1 fmt gate + ubuntu fmt --check went red (both fixed by
+  #390's follow-up reformat, bae863183). LESSON: before pushing any
+  `.yo`-carrying PR, re-run `yo fmt` with a binary built from CURRENT
+  develop — a stale worktree binary silently formats with stale rules, and
+  `fmt --check` locally passes while CI fails.
+
+## 1. Where develop stands
+
+| commit | PR | what |
+| --- | --- | --- |
+| `fc6b6cb99` | #373 | `yield` parks on the loop; wasm smoke to stage-2 |
+| `11c34a8b6` | #374 | re-land of the #370 prelude/std sweep |
+| `95f81970a` | #377 | dyn on-demand type-body dedup (un-redded develop) |
+| `a0c88eddf` | #375 | `sleep(0)` on Linux (timerfd disarm) |
+| `938342f2b` | #376 | TLS as a per-target runtime backend + `tls_available()` |
+| `d2a8e3f7f` | #378 | release: musl bundle ships gen-2; stage-3 byte-identity gate |
+| `adf0dc887` / `22ec5f6e2` | release | **v0.2.21 published**; `SEED_VERSION` = v0.2.21 |
+| `ec6650f14` | #380 | **D5/§5 closeout** (see §2) + `plans/LAZY_TOPLEVEL_BINDINGS.md` |
+| `e84def46b` | #364 | `yo version` curl→std/http (D6 PR-3) + OpenSSL CI plumbing + harness sed portability — **MERGED** |
+| `a7dcc7bd2` | #381 | ci: apostrophe fix (develop un-red; musl leg green) |
+| `7b8976438` | #382 | **ArrayList drain/remove/iter (§5 breaking change)** |
+
+`yo version install` / `list --remote` work again as of v0.2.21 (curl path);
+the std/http path lands with #364 and ships in the NEXT release.
+
+## 2. #380 — the D5/§5 closeout (LANDED)
+
+- `Dyn(Reader)` pinned (`tests/io/async_traits.test.yo`): vtable `read`, the
+  `read_to_end` default through it, `BufReader(Dyn(Reader))`.
+- One spelling per read operation (D2, Rust names): inherent
+  `File.read_bytes`, `File.read_to_string`, `TcpStream.read_bytes` DELETED;
+  the `Reader` defaults `read_to_end`/`read_to_string` are the API. The `fs`
+  free functions go through them. `write_string`/`write_bytes`/`write_str`
+  stay (no trait counterpart).
+- `HttpRequest`/`HttpResponse` wire `to_string` → `impl(..., ToString(...))`.
+- `str.join` row closed (already documented); ArrayList `remove`→`drain` row
+  MEASURED (~20 typed sites) and left as its own PR (§5).
+- **Found en route — a class `yo check` is blind to**: `impl(File,
+  IoTraits.Reader(...))` sat BELOW the free functions that call its defaults;
+  the def-time failure was swallowed, `check ./std` green, hollow stubs caught
+  only by the C22 gate. Impls moved above the callers; rule recorded in
+  `.github/skills/yo-syntax/syntax-cheatsheet.md` + `yo-syntax.instructions.md`
+  ("trait impls are bindings too"). This motivated the plan in §6.
+- Validation: seed (v0.2.21) `check ./std` 172/172 + seed `yo build` rc=0;
+  io/async_traits 9, io/bufio 13, fs/file 16, net/tcp 13, http/http 21,
+  http/server 8; gates failures=0, CLI 54/0; FIXPOINT_HOLDS; dyn canary 9/9.
+
+## 3. #364 — curl→std/http on the v0.2.21 seed
+
+**State at handover (pick this up FIRST):** the PR is OPEN at remote head
+`0f3b0ca3c`; its CI run **33575192179** was still finishing (only the macOS
+native legs, wasm-emscripten, ubuntu-24.04-arm, the Windows legs and fixpoint
+stage-3 outstanding; everything else green, ONE failure = the musl job, fixed
+below). Two commits are **committed locally but NOT pushed** in worktree
+`/private/tmp/yo-d6` (branch `s6/version-cache-std-http`): `44c126b05` (the
+musl fix) and `0a523d514` (merge of develop incl. #380 — clean). The merged
+tree is validated: seed `check ./src` 262/262, `check ./std` 172/172, seed
+`yo build` rc=0, `tests/dyn.test.yo` 9/9 (S1 = `/tmp/yo-d6m-s1`).
+
+**To land**: (1) `gh run view 33575192179` — confirm the macOS native legs
+and wasm-emscripten passed (they are the last two OpenSSL plumbing sites not
+yet exercised: the brew `-I/-L -lssl -lcrypto` compile and the stage-2 line);
+(2) `cd /private/tmp/yo-d6 && git push origin s6/version-cache-std-http`
+(fast-forward, no force needed); (3) `gh pr merge 364 --admin --squash` —
+the new run it triggers will still verify the musl fix on develop, and the
+local coverage checklist (§4.1) is complete. If a macOS or wasm leg FAILED,
+fix that site in the same push before merging (they are the lines in
+`test.yml` under `test-native`'s `else` branch and `test-wasm32_emscripten`'s
+"Build stage-2 for the smoke").
+
+Content: the swap (`_http_get`/`_download_file` via
+`fetch_with`), `tls_available()` gating with actionable errors, the weak
+OpenSSL canary in the emitted TLS runtime (`&SSL_CTX_new != NULL` so the
+weak-linked macOS bundle launches without the dylib), OpenSSL plumbing at
+EVERY raw compiler-C compile site (test.yml ×8 incl. the shared
+`.github/actions/build-stage1`, release.yml ×5, fixpoint-arm64, the
+`fixpoint_only.sh` brew fallback), the BSD-sed-portable harness word
+boundaries + re-recorded `version-install-pinned`.
+
+First CI run (33575192179) failed ONLY the Static musl Linux bundle: Alpine
+splits `libssl.a` out of `openssl-dev` into **`openssl-libs-static`**; the
+fix (`44c126b05`, all three Alpine blocks incl. release.yml's) was verified
+against pkgs.alpinelinux.org (no docker on this Mac). **release.yml's sites
+are NOT exercised by PR CI — watch the first release run after this merges**
+(the two Alpine `cc` lines, the macOS bundle weak-link flags, the portable-C
+parse gate).
+
+Local validation (S1 = `/tmp/yo-d6-0221s1-bin`, seed-built): emit/clang/
+check green, live `version list --remote`, `tls: true` probe, gates
+failures=0 (one `comptime rc=1` was my own concurrent test run in the same
+worktree — see §4), FIXPOINT_HOLDS, CLI `--network` 55/0/0, dyn 9/9.
+
+## 4. Rules learned this cycle (the ones not yet in AGENTS.md)
+
+1. **Run `tests/dyn.test.yo` after any change that renumbers** (prelude/std
+   edits). #374's validation skipped the full suite and this batch was the
+   only place the on-demand double emission showed. Now a fixed item of the
+   admin-merge checklist: seed `check`, affected tests, battery + fixpoint,
+   CLI scorecard, dyn canary.
+2. **Never run two `yo test` invocations in one worktree concurrently** — the
+   runner's `tests/.yo_selftest_batch_*` names are fixed; the other run
+   deletes your `.bin.c` mid-compile (`clang: no such file`, `hollow=NA`).
+3. **Byte-identity A/B: do not edit sources while the baseline emit runs**
+   (the module loader reads files for minutes; grep the emitted C for a
+   string unique to your edit to detect pollution).
+4. **Heavy builds/batteries: `nohup bash -c '...; echo rc=$?' &> log &
+   disown` + a Monitor on the rc line.** Harness background tasks were
+   killed twice; the other agent's `rungates.sh` failed only because its
+   PATH lacked GNU `timeout` (`PASS: unbound variable` cascades from that).
+5. **Docs-only PRs cannot merge without `--admin`**: the "Classify the diff
+   (docs-only fast path)" job skips every test job, so the ruleset's required
+   contexts never report (#379 stayed BLOCKED while green). Moot while admin
+   merges are allowed; otherwise fold docs into a code PR or fix the fast
+   path to report the contexts.
+6. **Trait impls are bindings too** (§2) — until §6 lands, register
+   `impl(T, ...)` before any same-module caller of its methods/defaults.
+
+## 5. Queue (in order)
+
+1. **Watch develop's post-merge run for #364** (test.yml musl job with the
+   package fix) and the **next release run** for release.yml's OpenSSL sites.
+2. **ArrayList `remove(start,count)` → `drain(range)` + `remove(idx) -> T` +
+   `iter()`** — own PR, compiler-as-oracle: rename first (`remove` → `drain` /
+   `remove_at`) so the compiler names every site, then re-spell. ~20 typed
+   sites (std: async/channel ×2 FIFO pops, btree_map, array_list's retain;
+   src: module_loader ×7, module_manager ×2, trait_checking ×3,
+   unsafe_report ×2, type_trait_methods ×2). Pre-freeze breaking change;
+   `plans/STD_API_AUDIT.md` §5 row has the measurement.
+3. **`plans/LAZY_TOPLEVEL_BINDINGS.md` P0** — the check-time "forward
+   reference to X (defined at line N)" diagnostic replacing the silent
+   swallow (small, independent; the rest of that plan is a campaign the user
+   has not scheduled).
+4. D7 `Thread.spawn` `join() -> T` result carry (S4 item; the compiler
+   blocker measured fixed 2026-08-28).
+5. Compiler holes tracked by the audit: C29 (generic type vars re-resolve per
+   argument); arity validation OUTSIDE the def-eval swallow + the async-SM
+   C22 equivalent (`issues/wrong-arity-call-silently-accepted-version-install-broken.md`).
+6. Windows: stdin pipe WRITES (overlapped named pipes; reads landed #353);
+   `issues/s3-fs-wrappers-windows-semantics-audit.md`; Schannel (D6 deferred).
+7. Polish rows: regex extras, cli typed values + std/term adoption, O5
+   Formatter routing; D4 LSP UTF-16 position encoding.
+8. Next patch release once #364 has soaked: notes must say the curl
+   dependency is gone and `yo version` speaks TLS via the compiler-emitted
+   backend (Windows: `tls_available()` false until Schannel).
+
+## 6. The forward-reference design (written, not scheduled)
+
+`plans/LAZY_TOPLEVEL_BINDINGS.md`: `::` / `comptime(x) :=` definitions and
+`impl` registrations become order-independent via pending bindings forced on
+first reference or module end; two-phase function forcing; pending impls by
+receiver head; cycles are errors with a chain; statements stay ordered.
+Acceptance = byte-identical C on today's corpus. P0 is the diagnostic (queue
+item 3); P1+ needs a go from the user.
+
+## 7. Worktrees & binaries
+
+| path | branch | state |
+| --- | --- | --- |
+| `/Users/yiyiwang/Workspace/Yo` | shared with the peer session | never checkout here; the three handover docs are untracked files here |
+| `/private/tmp/yo-d6` | `s6/version-cache-std-http` | #364 — 2 local commits NOT pushed (§3); remove after merge |
+| `/private/tmp/yo-relg2`, `yo-sweep`, `yo-vfix`, `yo-o7`, `yo-fsw`, `yo-s4`, `yo-369`, `yo-370`, `yo-asandbg` | the other agent's | check `git status` before removing |
+
+Seed: `/private/tmp/yo-seed-0221/yo-v0.2.21-aarch64-apple-darwin/bin/yo`.
+Fresh stage-1s: `/tmp/yo-tail-s1` (= #380 tree ≈ develop), `/tmp/yo-d6m-s1`
+(#364 ∪ develop, the tree to be pushed), `/tmp/yo-d6-0221s1-bin` (#364 before the merge). Build with `YO_STD=<wt>/std <seed> build` (~10 min, detached).
+
+## 8. Standing constraints
+
+Shared main checkout → `/private/tmp` worktrees + `git -c protocol.file.allow=always
+submodule update --init`; one battery at a time, one heavy build at a time,
+S1 outside the repo; `--optimize 2` (no `--release`); fmt twice then check;
+`yo build` runs under the SEED — std/src source forms must be legal under it
+(no forward refs in std/src until §6 ships and becomes the seed); CLI harness
+reads `YO_SELF_BIN`; after any golden re-record rerun the FULL scorecard.
+
+## 0j. 2026-09-03 (cont.) — the capture fix landed (#396) and v0.2.23 SHIPPED
+
+#396 took three CI rounds, two of them finds beyond the diff:
+(1) the windows runner images LOST libasan — every ASan-instrumented batch
+link failed `cannot find -lasan` (uniform, rerun-stable, while develop's
+windows legs were green minutes earlier) → the two windows full-suite
+invocations now pass `--disable-sanitize` via a `RUNNER_OS` conditional
+(`issues/windows-images-lost-libasan.md`, restore path documented);
+(2) with ASan out of the way the REAL cross-platform bug showed: `_mg_canon`
+canonicalized `file:///C:/a/b` → `/C:/a/b` but the CLI spelling prepended a
+raw backslashed cwd → the module-global registry keys disagreed on windows
+ONLY, the capture exclusion missed, and the batch C failed — fixed by
+normalizing separators + drive-letter absolutes in `_mg_canon` (POSIX
+inputs unchanged). #395's formatter landed mid-flight; the branch merged
+it and re-formatted `expr_info.yo` with the NEW binary (the §0f lesson,
+applied).
+
+**v0.2.23 published** (user-approved): dispatched after develop went green
+on the exact head (`8bfe53851`, run 33726602175); release run 33733863309
+SUCCESS — 13 assets, Latest, notes set. Live-verified from the published
+tarball: `yo --version` = 0.2.23, `yo version list --remote` speaks TLS
+(std/http). `SEED_VERSION=v0.2.23` auto-bumped on develop (`060acdc26`,
+no [skip ci]) — its develop run 33740596643 validates the new seed chain.
+Carries: #386/#395 formatter rounds, #387 arity, #390 poison gate, #391
+regex row, #392 docs, #394 bare-e identity, #396 capture fix + windows
+canonicalization.
+
+**Seed-bump validation COMPLETE**: develop run 33740596643 on `060acdc26`
+(`SEED_VERSION=v0.2.23`) finished **success** — the v0.2.23 seed chain
+holds end to end (bootstrap fixpoint, internal shards, hollow sweep, wasm,
+musl, all OS legs). The v0.2.23 release cycle is fully closed.
+
+## 0k. 2026-09-03 (cont.) — string row CLOSED (+ a codegen bug found & fixed en route)
+
+Two PRs, stacked:
+
+- **#397** `fix/match-arm-and-or-drop-scope` — pre-existing codegen bug the new
+  string tests exposed: a `&&` whose RHS creates an RC temp inside a NON-BEGIN
+  match arm leaked the temp's drop out of the arm's C scope ("use of
+  undeclared identifier `_…_temp_N`"). Reachable by ordinary user code on
+  develop (minimal repro: match on `index_of` + `assert((i > 0) && (String.from(...).len() > i))`).
+  Root cause: the non-begin arm path of `generate_case_body` never published
+  the arm value's `deferred_drop_expressions` as `pending_deferred_drops`, so
+  the short-circuit branch claim found nothing. Fix = the same push the begin
+  path / `generate_function_body` already do. Corpus 156/156 byte-identical.
+  Issue filed+fixed in the same PR.
+- **#398** `std-string-row-closure` (NOTE: no slash — a flat remote branch
+  `std` blocks the `std/` namespace) — the string row of the audit: Unicode
+  `to_lowercase`/`to_uppercase` (unicode.yo leaf-ified to
+  `to_lowercase_bytes`/`to_uppercase_bytes` to break the import cycle),
+  `to_ascii_*`, `Pattern.length_in` + rune/Regex impls, Pattern-generic
+  `replace`/`replace_all` (empty pattern now Rust semantics `-a-b-c-`), 
+  `split_once` (`Option((String; String))` — first tuple-returning std API),
+  `strip_prefix`/`strip_suffix`, `parse_f64` (Rust grammar + atof),
+  `parse_i64_radix`/`parse_u64_radix`; deleted `panic_dyn`/`assert_dyn`
+  (subsumed by generic `panic`/`assert` — 4 tests/internal callers migrated)
+  and `to_c_str` (`to_cstr().ptr()` covers the 2 callers).
+
+Validation: string 267/267, regex 186/186, coverage/imm_string/dyn green,
+check std 172/172 + src 262/262, gates battery green, corpus 156/156,
+CLI 57/57 (1 network skip), fmt --check clean (fmt TWICE for string.yo).
+
+**Rules learned (all in the cheatsheet now):** block bodies cannot START with
+`match(`/`cond(` (hoist the scrutinee); typed assigns need `(x : T) = …`;
+module-level fns need `::`; tuple TYPE is `(A; B)` semicolons, tuple VALUE
+`(a, b)` commas, fields `p.0`, NO destructuring patterns (parser.yo's comment
+states the mapping BACKWARDS — trust tests/internal/parser.test.yo); `1e-12`
+exponent float literals do not lex; `__yo_panic` comptime-evaluates its
+message (bind the pointer through a local, an `.unwrap()` chain has no
+ExprInfo); `println` comes from `std/fmt`, and `join` is
+`separator.join(list)`.
+
+**Tooling notes:** gates_fast on this Mac needs GNU `timeout`
+(`/tmp/gnubin/timeout` — brew coreutils symlink; a hand-rolled shim
+DEADLOCKS diff-test.sh's `wait -n`) AND homebrew bash first on PATH
+(`/bin/bash` 3.2 dies on `declare -A` with "PASS: unbound variable").
+Seed for this cycle: the **published v0.2.23 bundle**
+(`/tmp/yo-v0223-check/yo-v0.2.23-aarch64-apple-darwin/bin/yo`) — doubles as
+the current-develop fmt binary (release head + version bumps only after).
+Worktree `/private/tmp/yo-str` (branch std-string-row-closure) holds both
+commits; patched compiler at `/private/tmp/yo-str/yo-out/aarch64-apple-darwin/bin/yo`.
+
+### §0k addendum — #397 needed a round 2 (pending is unwind-owned)
+
+The v1 fix (publish arm drops into `pending_deferred_drops`, like the begin
+path) double-freed: the claim reached drops rolled up to the FUNCTION-BODY
+pending list, whose emission belongs to the effect-unwind path
+(`__yo_effect_escaped` → drop-locals-before-early-return) — an unconditional
+in-branch drop beside the escape-only one. CI caught it as
+`json_parse lone high surrogate` ASan heap-use-after-free (exit 256; exactly
+one extra `__yo_decr_rc` line vs develop in the emitted C — emit both and
+diff to find such things fast). Replacing pending with the arm-only list
+instead broke unwind propagation (same test, throw swallowed, exit 6).
+Landed design: new `arm_value_deferred_drops` context field — the claim
+source when set, removed IN PLACE (the publication is the same shared
+ArrayList the arm-tail flush reads; a filtered copy double-drops). The
+timeout shim note above is now moot: `/tmp/gnubin/timeout` is a symlink to
+brew coreutils' real GNU timeout (hand-rolled shims deadlock diff-test.sh's
+`wait -n`).
+
+### §0k final — #397 CLOSED, bug filed OPEN; #398 standalone
+
+Round 3 (separate arm-list field) still failed the STAGE-2 SELF-COMPILE: the
+claim's drop, emitted at `&&` chain close, can sit in a DIFFERENT C scope
+than the temp's declaration when the arm body itself nests blocks (compiler
+`declared_c_var_names` machinery: temp declared at stage2.c:1779890 inside a
+nested if, claimed drop at :1780190 outside). The general fix needs the
+emitter to track which C block each temp was declared in — architecture
+work. Decision: #397 closed with the full analysis (branch deleted; three
+attempted designs preserved in the issue text), bug filed OPEN at
+`issues/match-arm-and-or-rhs-temp-drop-leaks-arm-scope.md` with the author
+workaround (begin-form arm bodies). #398 was rebuilt standalone off develop
+(branch force-pushed as std-string-row-closure; NOT stacked): the three
+`&&`-in-non-begin-arm test asserts reshaped to `begin(...)` form — string
+267/267 and regex 186/186 verified with the UNPATCHED v0.2.23 seed (develop
+codegen). LESSON for future queues: run the stage-2 self-compile
+(`yo-out compile src/main.yo --optimize 2 -o x`) BEFORE pushing any codegen
+change — `yo build` (seed→stage-1) does not exercise it, and CI's "Build the
+suite candidate" does.
+
+### §0k final-final — the FromIterator regression (and the lesson)
+
+PR398's first CI round failed on the WASI leg: `collect(String)` — "Type
+String does not implement required trait FromIterator". Cause: the python
+span-deletion of `panic_dyn`/`assert_dyn` (cut from the panic_dyn doc line to
+`export(`) had also swallowed the `impl(String, FromIterator)` that sat
+between them and the export list. A/B against pristine std + a 6-line
+`collect(String)` probe found it in minutes; restored, and the whole file
+structure-audited against develop (`grep -oE '^impl(|^  name : (fn' | sort |
+uniq -c` diff — now exactly the intended additions/removals). LESSONS:
+(a) after ANY scripted span deletion in a big file, run that structure diff
+before trusting the edit; (b) `tests/iterator_combinators.test.yo` is the
+only FromIterator-on-String consumer — add it to the string.yo validation
+set; (c) the WASI leg failing while others pass is NOT wasi-specific — it
+just reports the batch eval error first (reproduced locally in seconds).
+
+### §0k CLOSED — #398 MERGED (a5a67d992), string + regex rows of the audit DONE
+
+PR398 merged (squash) into develop after 26/26 green checks (three CI rounds:
+round 1 = the staged codegen fix's json UAF; round 2 = the FromIterator
+regression; round 3 clean). #397 closed with analysis; the codegen bug is
+OPEN at issues/match-arm-and-or-rhs-temp-drop-leaks-arm-scope.md. The audit's
+string row and regex row are now CLOSED. Post-merge develop run to watch;
+next queue item unchanged (blocked set + polish rows: cli typed values, LSP
+UTF-16, D4 PR 9, fmt dedup, collections drain/HashSet/BTreeMap real tree,
+encoding D1/base32/toml, url, io wrappers, fs row, path row, env merge,
+process current_dir, net leftovers, http row, async combinators, gc.stats,
+testing bench, spec/ freeze banner).
+
+### Post-merge validation — develop run 33794393216 on a5a67d992: SUCCESS
+
+(The macos-26-intel leg was cancelled by the runner once — the known flaky
+leg — and its `--failed` rerun completed green.) The string+regex row merge
+is fully validated on develop. Worktree `/private/tmp/yo-str` is now
+removable; its yo-out binary and the v0.2.23 seed stay useful for the next
+polish row.
+
+## 0l. 2026-09-04 — fs+path rows advanced (#402 MERGED 907908e7e); windows ftruncate bug fixed
+
+PR402 (5 CI rounds): the fs row's "still:" list was STALE — copy/read_link/
+set_permissions/try_exists/watch/remove_dir_all had all landed unrecorded
+(audit row re-measured). Implemented the real gaps: `File.set_len`
+(ftruncate), `File.from_fd` (Rust from_raw_fd ownership), `DirEntry.path()`
+(+`parent : Path` field), and the path row's `Clone`/`Hash`/`Ord` (Path is
+now a legal HashMap key). Local: file 19/19, dir 15/15, path 70/70,
+walker 8/8, fetch 10/10, checks 172/263 — all with the v0.2.23 seed.
+
+CI rounds 1/2/4 failed ONLY on windows: `set_len extends` threw EINVAL
+(exit 22). The eprintln-in-handler diagnosis (see below) finally surfaced
+"invalid input": the runtime opens files FILE_FLAG_OVERLAPPED and UCRT's
+`_chsize_s` EXTEND path zero-fills via a plain CRT write → EINVAL on
+overlapped handles (shrink = seek+SetEndOfFile, which is why truncation
+passed). Fixed in runtime_io_windows.yo with
+`SetFileInformationByHandle(FileEndOfFileInfo)` — one call, no file
+pointer, legal on overlapped handles. Round 5: 26/26 green incl. windows.
+
+**Diagnostic technique lessons (0l):**
+- Buffered `println` inside an exception handler is LOST when the assert
+  panic aborts — stdout is block-buffered to CI logs. `std/fmt.eprintln`
+  (stderr, unbuffered) is the right tool; `panic(msg)` also works and
+  terminates. Don't hand-roll `unsafe(fprintf(stderr, ..., to_cstr()))` —
+  eprintln already wraps exactly that (user steer, adopted).
+- An uncaught IoError unwind exits the test child with the ERRNO as rc
+  (rc 22 = EINVAL) — rc encodes the failing errno.
+- `.Write` OpenMode is create-or-OVERWRITE (O_TRUNC): set_len tests must
+  open `.ReadWrite`; raw fd reads need a malloc'd `*u8` buffer (an
+  ArrayList's length never advances).
+- `Path` had NO Clone — `path.clone()` inside an io.async closure body was
+  a deferred eval error caught by the #390 poison gate at compile time
+  (nice gate!).
+
+Post-merge develop run to verify; worktree /private/tmp/yo-str (now on the
+merged branch) removable after that. Remaining fs row: OpenOptions builder,
+Metadata btime/permissions()/stop re-stat, walker lazy, AsPath trait;
+remaining path row: join(str), push, Windows separator in to_string,
+ancestors, PATH split/join, `..` normalization revisit.
+
+### §0l post-merge — develop run 33842520793 on 907908e7e: SUCCESS
+
+The macos-26-intel leg was CANCELLED BY ITS RUNNER twice before a third
+rerun completed green (25/26 green each time, only that leg). That is now
+THREE cancellations of this leg in two days (also once on a5a67d992) — the
+standing "macos-26-intel flake" queue item should probably be escalated to
+"runner pool is being preempted": consider dropping the leg or moving to a
+different intel label; a CI-policy call for the user. Everything else —
+including both windows legs — green.
+
+## 0m. 2026-09-04 — quick-wins sweep (#406 MERGED 16054559a); v0.2.24 cut from it
+
+One PR with every remaining quick-win row (3 CI rounds): env (`remove`,
+`vars()` with the three-way platform split — `_environ` / `_NSGetEnviron()`
+via new `std/libc/darwin.yo` (`<crt_externs.h>`; macOS headers do NOT export
+`environ`, the accessor returns `char ***` and is deref'd once) / `environ`;
+`get`/`set`/`remove` take any ToString key), path (`join` ToString-generic
+facade over private `_join_path`; `push`; `ancestors` Rust-parity; module-level
+`split_paths`/`join_paths` on `PATH_DELIMITER`), fmt row CLOSED (print bodies
+collapsed onto `_write_str`/`_write_newline`; 21 numeric ToString impls onto
+`_snprintf_to_string(comptime fmt, T, v)` — comptime `str` params forward into
+extern variadic calls as literals, probed before relying on it), spec/ FREEZE
+banner executed, error.yo re-export narrowed to `{ String }`+`{ ToString }`,
+gc/process rows corrected (CustomAllocator verified gone; `current_dir` stale
+— `env.cwd()` already exists; `gc.stats()` deferred with rationale).
+Local: env 18/18, path 74/74, fmt 7/7, checks 173/264, windows cross-emit rc=0.
+
+**THE lesson (0m): generic method bodies RE-SPECIALIZE PER CALL SITE, and
+relative imports inside them resolve against the CALLER's directory.** Making
+`env.get`/`set` ToString-generic made the in-arm `import("./libc/windows")`
+resolve to `<caller>/libc/windows.yo` when compiling src/main.yo (the CI
+windows cross-emit leg caught it; reproduced locally with
+`compile src/main.yo --std-path ./std --target x86_64-pc-windows-msvc`).
+Rule: any import reachable from a GENERIC body must be package-absolute
+(`import("std/libc/windows")`). Relative in-arm imports are fine in
+NON-generic module-level fns (evaluated once in the defining module's
+context). Also: platform-gated module loads (comptime cond arms) are what
+keep platform-only headers (`crt_externs.h`) out of other targets' C —
+`c_include(...)` (not extern blocks; those rely on system headers being
+emitted) is the mechanism that both includes AND binds.
+
+Other lessons: `export(print)` dropped during a body-collapse is caught by
+`check ./src` via the compiler's own comptime_print — always run it on
+fmt-adjacent changes; u8 does not implement Pattern (split on `rune(u32(n))`);
+delimiter-portable tests construct fixtures from `u8(PATH_DELIMITER)` and
+compare Path segment equality, never hardcoded `:` literals.
+
+Post-merge develop run 33887236877 on 16054559a; v0.2.24 dispatched from it
+(bump=patch). Release notes drafted at /tmp/v0.2.24-notes.md and set via
+`gh release edit` — BREAKING: `to_c_str` and `panic_dyn`/`assert_dyn` deleted,
+`replace_all` empty-pattern now Rust semantics, `DirEntry.parent` field added.
+
+### §0m post-merge — develop GREEN; v0.2.24 SHIPPED
+
+- develop run 33887236877 on 16054559a: SUCCESS, all legs incl. macos-26-intel
+  (no reruns needed this time).
+- release.yml bump=patch → run 33894332042 GREEN: version-bump commit
+  0e218fed7, draft created, notes set from /tmp/v0.2.24-notes.md while the
+  bundles built (publish only PATCHes draft=false — the body survives),
+  13 assets (6 tarballs + 6 portable-C .c.gz + vsix), published 17:23Z as
+  `latest`, tagged on the bump commit. Tarball verified: `yo 0.2.24`.
+- SEED_VERSION auto-bump: 78abb90ba on develop (no [skip ci] → its Test run
+  33900306095 validates the new seed).
+- Successor handover written: **plans/HANDOVER_STD_AUDIT_NEXT.md** (queue,
+  open bugs, decisions, process, pitfalls). The /private/tmp/yo-str worktree
+  is gone (removed/OS-swept — branch was merged, nothing lost).
+
+### §0m final CI note
+
+The first full v0.2.24-seed run (33902170762, on the maintainer's #410
+plans-reorg head — the seed-bump commit's own run was cancelled by that
+merge's concurrency group) failed ONE leg: macos-latest, "Test spawn with
+multi-yield futures" — the SAME flake that hit macos-26-intel during #390
+(§0g). `--failed` rerun: GREEN. That test has now flaked twice on two
+different mac legs; recorded in HANDOVER_STD_AUDIT_NEXT.md §5.3 — weaken it
+when next touched. All work stopped here per the maintainer's instruction.

--- a/plans/HANDOVER_STD_AUDIT_NEXT.md
+++ b/plans/HANDOVER_STD_AUDIT_NEXT.md
@@ -1,0 +1,464 @@
+# Handover — std API audit, the road to the freeze (post-v0.2.24, 2026-09-05)
+
+**For the next agent picking up the std campaign.** Written at the v0.2.24
+release point. Everything here was verified against `origin/develop` at
+`0e218fed7` (the v0.2.24 version-bump commit) unless marked otherwise.
+
+---
+
+## 0. The standing goal (verbatim, from the maintainer)
+
+> "Finish everything in plans/STD_API_AUDIT.md. Update related docs as you
+> progress. Document and fix any surfaced bugs and issues. No workaround is
+> allowed. Try to stabilize the std API and make it well designed. Feel free
+> to admin merge PRs to save CI cycles. Feel free to cut patch release when
+> needed."
+
+Consequences you should internalize:
+
+- **Bugs found along the way get FIXED, not routed around.** If a std task
+  trips a compiler bug: file `issues/<name>.md` with the verbatim error, a
+  minimal repro in `tmp/fixme.yo`, and root-cause analysis; fix the compiler;
+  add a regression test that was RED before the fix. Three past sessions each
+  closed a compiler bug *en route* to a std row (#398 → the match-arm drop
+  leak [filed open, see §4]; #402 → the Windows ftruncate runtime bug;
+  #406 → the generic-body import resolution rule in §6).
+- **Admin merges are pre-authorized** (`gh pr merge N --admin --squash
+  --delete-branch`) when CI is green — required checks take ~55 min otherwise.
+- **Patch releases are pre-authorized.** Breaking std changes ship in ordinary
+  v0.2.x patches (maintainer decision 2026-08-24 — "no minor release"), but
+  every breaking change must be CALLED OUT in the release notes.
+
+**Read first, in order:** `AGENTS.md` (root — the era table, commands,
+pitfalls), `plans/STD_API_AUDIT.md` (the whole campaign state),
+`.github/instructions/yo-design.instructions.md` + `yo-syntax.instructions.md`.
+The three untracked session diaries `plans/HANDOVER_STD_AUDIT_2026-{08-30,
+09-01,09-02}.md` carry the blow-by-blow history of the last two weeks
+(§0a–§0m) — skim their lesson paragraphs; the load-bearing ones are
+extracted into §6 below.
+
+---
+
+## 1. Where things stand right now
+
+- **v0.2.24 published** (2026-09-04/05) from develop `16054559a` (the #406
+  quick-wins merge), tagged on bump commit `0e218fed7`. It bundles: the
+  string/fmt/fs/path/env audit closures (#398, #402, #406), the entire
+  error-diagnostics overhaul P1–P3 (#399/#400/#403/#405 — rustc-shaped
+  rendering, E-codes, bilingual `yo explain`, `--error-format human|short|json`,
+  did-you-mean, panic locations, LSP typed channel), mimalloc v3.5.1 + the
+  Windows seed-build path fix (#181), the `&&`/`||` first-operand and the
+  Stage-0 balancing-drop leak fixes (#405/#403), and the unterminated-string
+  lexer error. Release notes live on the GitHub release (drafted from
+  `/tmp/v0.2.24-notes.md`).
+- **Breaking changes shipped in v0.2.24** (already announced in its notes):
+  `String.to_c_str` (malloc'd `*u8`) deleted → `to_cstr().ptr()`;
+  `panic_dyn`/`assert_dyn` deleted (ToString-generic `panic`/`assert`
+  subsume them); `replace_all` with an empty pattern now has Rust semantics
+  (`"abc".replace_all("", "-")` == `"-a-b-c-"`); `DirEntry` gained a
+  `parent : Path` field.
+- **SEED_VERSION auto-bumped to v0.2.24** by the release pipeline (commit
+  `78abb90ba`; the bump does NOT carry `[skip ci]`, so develop's Test run
+  immediately exercises the new seed — run 33900306095, verify green, rerun
+  the macos-26-intel leg if its runner cancels it; see §5.3). The shipped
+  bundle was verified: `bin/yo --version` → `yo 0.2.24`, 13 assets, notes
+  4.3 KB, `latest` pointer correct.
+- The campaign's S0–S3 are essentially done; **S4 items and the two S5
+  freeze inputs are what remain** (§2), plus a short list of OPEN compiler
+  bugs (§4) and maintainer decisions (§5.4).
+- Session worktree `/private/tmp/yo-str` was removed after the release (/tmp
+  also gets swept by the OS — never rely on it surviving); the main workspace
+  `/Users/yiyiwang/Workspace/Yo` was left on the long-merged branch
+  `fix/second-cond-await-target` with untracked handover docs — **checkout
+  develop there before working** (`git fetch && git checkout develop &&
+  git pull`, plus `git submodule update vendor/mimalloc` — its pointer moved
+  in #181 and drift shows as a dirty submodule).
+
+## 1.1 Local toolchain facts (macOS, this machine)
+
+- A `yo` must be on PATH for everything. The v0.2.24 bundle will be at
+  `~/.cache/yo/versions/…` once `yo version install 0.2.24` runs, or extract
+  the release tarball. Older verified seeds live under `/tmp/yo-v0223-check/`
+  (v0.2.23) — /tmp is wiped on reboot, re-extract from GitHub Releases then.
+- When using a bundle outside the repo: **`YO_STD=<bundle>/std` must be set**
+  (or `--std-path`, but YO_STD behaves more consistently for import
+  resolution; the test-runner/binary-tree interaction has its own issue doc,
+  `issues/test-runner-std-path-shadowed-by-binary-tree-std.md`).
+- Cross-emit smoke (no Windows box needed):
+  `yo compile src/main.yo --std-path ./std --target x86_64-pc-windows-msvc`
+  — this is the exact shape that caught #406's regression (§6, rule 1).
+- Gates battery needs GNU timeout + homebrew bash:
+  `S1=<built-binary> P=local bash scripts/bootstrap/gates_fast.sh`
+  (stock bash 3.2 dies on `declare -A`).
+
+---
+
+## 2. The queue — what remains, in suggested order
+
+> **The audit's own meta-rule: rows have repeatedly measured wrong.** Re-measure
+> (grep the tree, run the tests) before executing any row, and correct the row
+> in the same PR. Two rows are KNOWN stale right now: the §4 `io` row ("generic
+> wrappers + bufio move remain" — D5's closeout 2026-09-02 says they landed;
+> only buffered `lines()` remains, blocked on an async iterator protocol) and
+> §7 P0 item 3 (same text). Fix those two rows opportunistically.
+
+### Wave A — medium std rows, no blockers (each ≈ one PR)
+
+1. **error/assert row** — the last pure-API row of the original trio:
+   `AnyError` downcast (`is(T)`/`as(T)`), a `derive_rule(Error, …)` so error
+   enums stop hand-writing `ToString` + `Error()`, and `Error.source`
+   actually used for chaining (a `wrap`/`context` helper). The re-export
+   narrowing half already landed (#406).
+2. **testing `bench`** — `std/testing/bench.yo` currently returns
+   avg/min/max only. Wanted: auto-calibration (pick N from a time budget),
+   `black_box`, stddev/percentiles. (`assert_eq`/`assert_ne`/`assert_approx`
+   are DONE.)
+3. **url row** — percent-encode/decode integration (the codec EXISTS in
+   `std/encoding/percent.yo`; wire it in), `query_pairs`/`SearchParams`,
+   `join` (RFC 3986 §5), builder/setters. Note C33's http-redirect
+   resolution already hand-rolls path resolution — `Url.join` should replace
+   that and be the tested home for it.
+4. **net row** — `incoming()` on listeners, UDP `connect` + typed
+   `recv_from`, `parse_v6`, `SocketAddr.parse`, `Eq`/`Hash` on addr types,
+   RFC 5952 V6 formatting.
+5. **collections row** — `drain`; `HashSet` = `HashMap(T, unit)` to kill
+   ~500 duplicated SwissTable lines; hide pub `ctrl/data/…` fields (needs a
+   visibility decision — Yo's only mechanism is `export(...)`; see §5.4);
+   `BTreeMap` → real B-tree with `range()` (recommended verdict: real B-tree,
+   keep the name); add `BTreeSet`; `PriorityQueue` comparator ctor +
+   DOCUMENT that it is a min-heap.
+6. **cli row** — typed values, required enforcement, `--`, repeated opts,
+   help-not-an-error. `std/term` (is_terminal/size/supports_color/raw mode)
+   landed 2026-08-29; adopting it in std/cli's help coloring is part of this.
+   Verdict already decided: keep minimal-but-correct in std.
+7. **imm row** — iteration + `Index` where documented, dedupe the set pair,
+   and mark the family `unstable` via the Stability doc section (§3 of the
+   freeze, below) until it has real consumers.
+8. **async row** — `interval` (the only missing combinator; `join_all`/
+   `race`/`any`/`timeout`/channel/mutex all landed 2026-08-27).
+9. **encoding row** — TOML is the P1 gap: floats/arrays/dates, serializer,
+   derives; also give TOML a typed error per D1 (its `Result(_, String)` is
+   the last stringly error). base32 is P2. CSV is DONE.
+
+### Wave B — needs a decision or a small design first
+
+10. **fs leftovers** — `OpenOptions` builder; Metadata: real `btime`
+    (`STATX_BTIME`/`st_birthtime`/`CreationTime`), `permissions()`, stop
+    `metadata` re-stat by path; walker lazy option; collapse the
+    `_str`/`cstr` path-arg matrix behind an `AsPath`-style trait.
+11. **path leftovers** — Windows separator in `to_string` (Path is
+    POSIX-normalized today); revisit eager `..` normalization (symlink
+    semantics — Rust normalizes lazily for a reason); decide `Path.new`
+    fallibility (PathError was deleted in §6; `new` is currently infallible).
+12. **thread row** — `Thread.spawn` result carry (`join() -> T`) is now an
+    S4 item: its compiler blocker
+    (`issues/fixed/spawn-closure-generic-captures-erased-to-void-ptr.md`)
+    measured fixed-by-events 2026-08-28. **Panic propagation is NOT
+    implementable at any layer** (panic lowers to `fprintf`+`abort()`; no
+    unwinding) — do not fake a `join() -> Result(T, E)` that cannot observe
+    a panic.
+
+### Wave C — the S5 freeze inputs (§9 of the audit; the actual finish line)
+
+13. **Dead public surface** — remaining decisions from the enum sweep:
+    delete `HashMapError.KeyNotFound`/`HashSetError.ElementNotFound` (dead
+    by design; lookups return `Option`). **BLOCKED** by
+    `issues/structurally-identical-error-enums-in-two-generic-impls-collide.md`
+    (deleting them makes the two enums structurally identical → collision;
+    fix the compiler first). `std/allocator`'s `Layout`/`layout_of` were
+    DECIDED KEEP 2026-08-29. (`DateTime.nanosecond` measured fine.)
+14. **Coverage read** — ~183 exported names outside `std/sys`+`std/libc`
+    are never named under `tests/`. Freeze requires a real read of these;
+    `C34` (json_parse accepting `"<html>"` as `0`) is the cautionary tale.
+    A name-grep overstates the gap — structural uses score zero — triage,
+    don't grind.
+15. **Freeze mechanics are DONE** (2026-08-29): a module's inner doc may end
+    with `## Stability` (`unstable — new in vX.Y.Z; …`), carried by `yo doc`
+    as `DocModule.stability`. Everything without the section is stable +
+    additive-only. Use it for wave-A items that are genuinely new surface
+    (the rule: new modules enter `unstable` for one release before
+    freezing). `std/http/server` and `std/fs/watch` still need their marker
+    (their own PRs, per the §9 note).
+
+### Carried items sitting on branches / gates
+
+16. **`s6/version-cache-std-http`** (remote branch exists, `0a523d514`): the
+    P0+ curl→`std/http` swap for `src/version_cache.yo`, fully written. Its
+    old seed gate (v0.2.20) is long satisfied, but it is **now blocked on
+    Windows TLS**: the compiler must build on the windows legs, and OpenSSL
+    isn't there (`plans/D6_TLS_PLAN.md` item 3). Rebase + land it as part of
+    the Schannel work (17) or decide to platform-gate the import.
+17. **Windows Schannel TLS** (D6 remainder) — OpenSSL-first landed; Windows
+    has no TLS until a Schannel pass over `TlsStream`. Unblocks 16 and
+    closes D6 entirely. This is the biggest single chunk left.
+18. **D4 PR 9** — dedup the remaining hand-rolled UTF-8 decoders onto
+    `std/encoding/utf8.yo`, incl. `vendor/markdown_yo` (needs companion
+    upstream commits + submodule bump). **LSP UTF-16 position encoding**
+    (D4 §5.4) is the other dangling D4 end: protocol-visible, wants a
+    `positionEncoding` capability, builds on the rune↔byte helpers in
+    `src/lsp/protocol.yo`.
+
+### Explicitly blocked / deferred (do not grind on these)
+
+- **buffered `lines()`** on the D5 Reader — needs an async iterator protocol
+  (deliberately not faked). BufWriter's SYNC `Dispose` cannot await an async
+  `Writer.write` — a structural constraint, not a bug (C12 note).
+- **HTTP keep-alive** — deferred post-freeze (connection pooling).
+- **`process` hide `raw`** — needs module-private visibility, a LANGUAGE
+  feature (§5.4).
+- **`gc.stats()`** — the runtime only exposes `__yo_gc_collect`/
+  `__yo_gc_tracked_count`; real stats need new builtins. Deferred with
+  rationale in the gc row.
+- **`JsonValue.Object` index map** — only if profiling demands.
+- **log pluggable writer sink** — needs a Writer-trait object in module
+  state.
+- Panic propagation (see 12).
+
+---
+
+## 3. What "done" looks like per change (the validation battery)
+
+Copied from the working method of every landed PR; AGENTS.md has the full
+command reference.
+
+- Any `.yo` change: `yo fmt <file>` + `yo fmt --check` before commit (no
+  pre-commit hook exists — it's on you).
+- std change: `yo check ./std` (173/173 at #406) and `yo check ./src`
+  (264/264) — the latter catches std-surface breakage in the compiler's own
+  closure (e.g. the dropped `export(print)` was caught via comptime_print).
+- Then the targeted suite files (`yo test ./tests/<area>.test.yo
+  --parallel 1`), then the fast suite
+  `yo test ./tests --exclude tests/internal --exclude tests/cli-cases --bail`
+  (~30 min, M4) before pushing. tests/internal files are heavy (one at a
+  time; macro_expansion needs 6.5 GB).
+- Compiler/codegen change: ALSO `yo compile src/main.yo --skip-c-compiler`
+  (~3 min; `check` is evaluator-only and passes over codegen restrictions),
+  plus stage-2 self-compile (`yo-out compile src/main.yo --optimize 2`)
+  before pushing — this was the #397 lesson (three fix designs shipped and
+  broke the fixpoint because only stage-2 exercises a codegen change on the
+  compiler itself).
+- Windows-adjacent change: run the cross-emit smoke from §1.1.
+- Deletion/change of exported surface: the "method lesson" — four call-site
+  classes are structurally invisible to `check` (macro `quote` bodies,
+  generic trait-impl bodies, generic helpers in the defining module, async
+  closure bodies). Grep inside `quote(`, `impl(` and `io.async(` bodies by
+  hand; gate on the FULL suite + a standalone program that exercises the
+  changed declarations at runtime (a passing targeted test can be vacuous —
+  the enum-collision was caught only by a standalone compile+RUN).
+- Docs: user-visible surface gets both `docs/en-US/` and `docs/zh-CN/`.
+- Update the audit row + any instructions/skills files in the SAME PR
+  (`.github/skills/yo-syntax/syntax-cheatsheet.md`,
+  `yo-core-patterns/core-patterns-cheatsheet.md`,
+  `.github/instructions/*.instructions.md`) — the standing goal says
+  "update related docs as you progress".
+
+---
+
+## 4. OPEN compiler bugs you may meet (filed, with docs)
+
+Only C29 is still an OPEN row in the audit's §2; everything else here lives
+as standalone issue docs. All are on develop; read the doc before touching.
+
+- **C29 — generic call type variables re-resolve PER ARGUMENT**
+  (`issues/generic-type-var-rebinds-per-argument.md`):
+  `pair_same(generic(A), x : A, y : A)` accepts `(String, i32)`. Memory-safety
+  face closed by C28's gate; wrong-value faces remain.
+- **Match-arm `&&` RHS-temp drop leaks the arm's C scope**
+  (`issues/match-arm-and-or-rhs-temp-drop-leaks-arm-scope.md`): surfaced by
+  #398's own tests. Three fix designs were tried and rejected; the correct
+  fix needs emitter branch-scope tracking. Test authors work around it with
+  begin-form arm bodies — the standing goal's "no workaround" makes this a
+  real queue item, but budget it as a codegen project, not a std-row errand.
+- **Structurally identical error enums in two generic impls collide**
+  (`issues/structurally-identical-error-enums-in-two-generic-impls-collide.md`,
+  repro in `issues/repros/`): blocks freeze item 13. Fixing this unlocks the
+  KeyNotFound/ElementNotFound deletion.
+- **Async tail match/return hangs the state machine**
+  (`issues/async-tail-match-return-hangs-state-machine.md`): known hazard;
+  sync-helper workaround documented in the glob-filter landing.
+- **Iterator chain shared-stamp cross-Item pollution**
+  (`issues/iterator-chain-shared-stamp-cross-item-pollution.md`): `.map(f)`
+  chains at two Item types in one module.
+- **`Variable.is_ref` family** —
+  `issues/generic-trait-method-reads-primitive-inout-self-as-pointer.md`
+  was the D3.9 blocker; D3.9 Hasher landed anyway (2026-08-28), but the
+  underlying family bug is worth attacking as a group if it resurfaces.
+- The long tail lives in `issues/` (~85 open docs). The `yo-self-*` prefixed
+  ones are mostly older self-hosting-era filings — verify against current
+  develop before believing them.
+
+**Compiler-bug etiquette** (from AGENTS.md, proven repeatedly): document in
+`issues/<name>.md` (verbatim error + minimal repro in `tmp/fixme.yo` + root
+cause), fix in `src/`, verify repro compiles + full-tree error count drops,
+move the doc to `issues/fixed/`, update references
+(`grep -rn "issues/<name>.md"`). Always add the RED-first regression test to
+`tests/`.
+
+---
+
+## 5. Process knowledge
+
+### 5.1 CI shape
+
+`test.yml` on PRs: ~26 checks. The `test (…)` matrix runs in two waves
+(second wave starts when the first finishes — a "pending, 0s" check list is
+normal). Slowest legs: `test-wasm32_emscripten` (~52 min), internal shards
+(~45 min), `test (ubuntu-…)`. A docs-only diff takes the fast path (~4 min).
+`gh pr checks <N>` is the poll command; rerun a whole run's failures with
+`gh run rerun <id> --failed`.
+
+### 5.2 Merging
+
+Green PR → `gh pr merge N --admin --squash --delete-branch` (pre-authorized,
+§0). After every merge, watch develop's post-merge Test run to conclusion —
+required before any release (release.yml refuses to release a SHA whose Test
+run isn't `success`).
+
+### 5.3 The flaky mac legs (known, do not chase as regressions)
+
+Two distinct flakes:
+
+- **`test (macos-26-intel)` cancelled BY ITS RUNNER** (preemption, not test
+  failure) — repeatedly (4+ times across 2026-09-02→09-04). Handling:
+  `gh run rerun <run> --failed`; it has always passed on rerun. **Policy
+  decision still pending with the maintainer** (drop the leg / different
+  label / live with it) — see §5.4.
+- **"Test spawn with multi-yield futures"** (tests/async_await.test.yo ~57)
+  asserts STRICT round-robin interleaving of two spawned tasks; under runner
+  load the assumption breaks ~once per many runs. Flaked on macos-26-intel
+  2026-09-02 (#390's CI; passed on rerun, recorded in
+  HANDOVER_STD_AUDIT_2026-09-02.md §0g) and on macos-latest 2026-09-04
+  (run 33902170762, first full v0.2.24-seed run — passed on rerun). The test
+  wants weakening to "both tasks complete and the total is right" or a
+  documented scheduler-order guarantee; **file it properly when touched** —
+  it has now flaked twice on two different mac legs.
+
+### 5.4 Decisions to ask the maintainer about (do NOT decide alone)
+
+1. macos-26-intel leg policy (§5.3).
+2. Visibility for collections' pub `ctrl/data/…` fields and `process.raw`:
+   today the only visibility mechanism is `export(...)` — hiding from
+   importers needs either naming discipline or a real module-private
+   visibility LANGUAGE feature (a much bigger project; there is an audit
+   note that "go private has no language mechanism").
+3. Scheduling the match-arm drop-leak codegen fix (§4) — days of emitter
+  work, blocked on nothing but priority.
+4. Whether the enum-collision compiler fix (unblocks freeze item 13) rides
+  before the freeze or the deletion slips to post-freeze (deleting a public
+  variant post-freeze is breaking — decide consciously).
+
+### 5.5 Cutting a patch release (procedure, just executed for v0.2.24)
+
+1. Develop's Test run green on the exact head SHA you will release.
+2. `gh workflow run release.yml --ref develop -f bump=patch`.
+3. The workflow: verifies green → pushes `chore: bump version to X.Y.Z
+   [skip ci]` → builds seed bundles from the PREVIOUS release's compiler →
+   creates a DRAFT release (stub body = last commit message) → publish job
+   flips it public → pushes the SEED_VERSION bump (no `[skip ci]`).
+4. While bundles build, set the real notes on the DRAFT:
+   `gh release edit vX.Y.Z --notes-file <file>` — the publish job only
+   PATCHes `draft=false`, it never touches the body. Match the house style
+   of v0.2.23/v0.2.24 notes: sections Compiler fixes / Standard library /
+   Breaking changes called out loudly.
+5. Verify: release public + 13ish assets (5 bundle tarballs, portable-C
+   .c.gz set, .vsix, …), `yo --version` from an extracted tarball, and the
+   SEED_VERSION-bump commit's Test run green (rerun macos-26-intel if
+   preempted). If a run dies midway: re-dispatch with `bump=none` (it
+   resumes at the version already in src/version.yo).
+
+### 5.6 Seed discipline (the yo-seed-gates-source-forms rule)
+
+The seed (previous release's binary) must be able to compile the CURRENT
+tree. New source forms (new externs, new lowering shapes) can only enter
+`src/`/`std/` once a release CONTAINING the compiler support has become the
+seed — typically one release of lag. This gated: the bufio consumer move
+(v0.2.18), `sleep_blocking`'s body, the curl→std/http swap (v0.2.20 + the
+Windows-TLS twist). SEED_VERSION lives in THREE workflows and is bumped
+automatically at release (plans/backlog/SEED_VERSION_AUTOMATION.md). When a
+PR "mysteriously" fails only in seed-driven CI jobs, check this first.
+
+### 5.7 Worktrees & hygiene
+
+The last three sessions used `/private/tmp/yo-str` (worktree on develop; now
+removed — recreate one the same way when you want an isolated checkout).
+`git worktree remove` it when done; remember `git submodule update
+vendor/mimalloc` after checkouts (its pointer moved in #181 and drift shows
+as a dirty submodule). Never commit the mimalloc drift unintentionally.
+Keep `tmp/fixme.yo` for scratch (gitignored). After scripted file surgery,
+structure-diff against develop — a python span-deletion once silently
+swallowed String's FromIterator impl and only the WASI CI leg caught it.
+
+---
+
+## 6. Yo language facts that cost real time to learn (extracted)
+
+**Rules that bit us (each verified by repro):**
+
+1. **Generic method bodies re-specialize PER CALL SITE, and relative imports
+   inside them resolve against the CALLER's directory.** Any import reachable
+   from a generic body must be package-absolute (`import("std/libc/windows")`).
+   Relative in-arm imports are fine in NON-generic module-level fns. The CI
+   windows cross-emit leg catches violations; reproduce locally with
+   `yo compile src/main.yo --std-path ./std --target x86_64-pc-windows-msvc`.
+2. `extern("C")` declarations are NOT emitted — they rely on system headers
+   in the emitted preamble. `c_include("<header>", ...decls)` (see
+   `std/libc/stdio.yo`) both includes AND binds. Platform-gated module loads
+   (comptime cond arms) keep platform-only headers out of other targets' C
+   (e.g. `std/libc/darwin.yo`'s `<crt_externs.h>` is only imported from the
+   Platform.Macos arm). `environ` is not exported by macOS headers —
+   `_NSGetEnviron()` returns `char ***`, deref once.
+3. Block bodies cannot START with `match(` / `cond(` / `unsafe(` — hoist a
+   statement first. Typed assigns: `(x : T) = expr;`. Module-level fns:
+   `name :: (fn…)`. `{ () }` is not a valid else-arm (use `()`).
+   `comptime(T : Type)` doesn't parse — `comptime(T) : Type`. Trailing comma
+   before `);` is rejected.
+4. Tuples: TYPE `(A; B)` semicolons, VALUE `(a, b)` commas, access `p.0`.
+   NO destructuring in match patterns. Pairs in collections use
+   `IterPair(A, B)` (prelude struct `_0/_1`). Multi-generic where clauses:
+   `where(K <: ToString, V <: ToString)` — the tuple form does NOT work.
+5. `u8` does not implement `Pattern` — split on `rune(u32(n))`.
+   `1e-12` float literals do not lex — write `f64(0.000000000001)`.
+6. `__yo_panic` comptime-evaluates its message — an `.unwrap()` chain has no
+   ExprInfo and is rejected; bind through a local (std/assert does).
+7. `println`/`eprintln`/`print` come from `std/fmt` (no `io.println`).
+   `join` is `separator.join(list)` (receiver-as-separator, Python style —
+   documented KEEP).
+8. `.Write` OpenMode is O_TRUNC (create-or-overwrite) — tests that set_len
+   open `.ReadWrite`. Raw fd reads need a malloc'd `*u8` buffer (an
+   ArrayList's length never advances).
+9. Diagnostics: buffered `println` inside an exception handler is LOST when
+   the assert panic aborts — use `eprintln` (stderr, unbuffered) or
+   `panic(msg)`. An uncaught IoError unwind exits the test child with the
+   ERRNO as rc (22 = EINVAL).
+10. Windows runtime: files open FILE_FLAG_OVERLAPPED; UCRT `_chsize_s`'s
+    extend path EINVALs there (shrink works) — use
+    `SetFileInformationByHandle(FileEndOfFileInfo)` (see
+    `src/codegen/async/runtime_io_windows.yo`).
+11. comptime `str` parameters forward into extern variadic calls as C string
+    literals (that's what powers `_snprintf_to_string`); comptime TYPE
+    equality/dispatch (`T == i8`) is NOT supported.
+12. An `ExprInfo.value` of `.None` = runtime value; `UnknownVal` = type
+    known, value not. `yo compile` cannot run `*.test.yo` — extract to a
+    standalone file with `main` + `export(main);`.
+13. A "move" of a named local into a struct field is NOT a consumption in
+    the evaluator; dup/drop cancellation is the optimizer's job
+    (`_optimize_dup_drop_pairs`, `src/evaluator/exprs/begin.yo`) — missing
+    drops in emitted C are optimizer bugs, and tree walks there must follow
+    `ExprInfo.macro_expansion`.
+14. Deep CTFE recursion at `-O0` can exhaust the 1 GiB main-worker stack
+    (rc=139, no ASan output, deterministic depth threshold) — validate with
+    `--release` or `YO_MAIN_STACK_MB=4096`. Don't chase heap corruption.
+15. Export placement: an `export` referencing a label must come AFTER its
+   declaration in module order; duplicate labels collide across the module
+   (check `std/libc/unistd.yo` before declaring `environ` yourself).
+
+---
+
+## 7. Suggested first PR for the next agent
+
+The **error/assert row** (queue item 1): pure std, no blockers, finishes the
+original error/fmt/string trio, and its `derive(Error)` half exercises the
+derive machinery that just stabilized. Alternatively the **stale-row fix +
+testing bench** as a warm-up that teaches the release/merge loop. Start the
+Schannel read (item 17) early in the background of wave A — it's the long
+pole for closing D6 and landing the carried version_cache swap.

--- a/plans/STD_API_AUDIT.md
+++ b/plans/STD_API_AUDIT.md
@@ -832,6 +832,32 @@ mmap/file-lock/statfs wrappers; `gc.stats`; DNS SRV/TXT/reverse
    are in `.github/instructions/yo-design.instructions.md` ("API stability").
    `std/encoding/csv` is the first module carrying the marker (new in this
    release); `std/http/server` and `std/fs/watch` get it in their own PRs.
+
+   **Marker pass, 2026-09-05 (post-v0.2.24).** All four markers in the tree had
+   outlived the one-release window — `std/term`, `std/encoding/csv`,
+   `std/http/server` and `std/fs/watch` all shipped in v0.2.20 and were still
+   marked unstable at v0.2.24 — so the window was decided module by module
+   rather than left to drift:
+
+   | module | decision | why |
+   | --- | --- | --- |
+   | `std/term` | **FROZEN** (marker dropped) | small surface, exercised by its tests; the stated exit condition ("while `std/cli` adopts it") is unowned and turns out to need a NEW ANSI vocabulary in two modules, not a swap. A colour vocabulary added later is additive. |
+   | `std/encoding/csv` | **FROZEN** | five releases, 7 tests, no open defect. |
+   | `std/http/server` | **FROZEN** | exports exactly `HttpServer` + `DEFAULT_MAX_REQUEST_BYTES`, 8 tests; concurrency and routing are additive growth. |
+   | `std/fs/watch` | **stays unstable, restated** | the Windows backend is not delivered, and `ReadDirectoryChangesW`'s paired rename events are the one thing likely to move `Change`. Freezing follows Windows delivery, not a release count. |
+
+   `std/spec/refine` and `std/spec/numeric` GAINED a marker: their
+   "EXPERIMENTAL — not covered by the std stability promise" banner was prose
+   with no heading, so `yo doc` published `"stability": null` for both — the
+   same value it publishes for `std/string`
+   (issues/fixed/std-spec-experimental-banner-is-invisible-to-yo-doc-so-both-modules-render-as-stable.md).
+
+   Two mechanism defects fixed in the same pass: `module_stability` read only
+   the FIRST SOURCE LINE of the section, so every marker longer than one line
+   was published cut mid-clause in the JSON key, the HTML badge and the
+   Markdown note alike; and the JSON key and HTML badge were exercised by no
+   test at all (only the Markdown note was pinned). Both are now covered by
+   `tests/internal/doc_stability.test.yo`.
    Found en route: `yo doc` only recognised `## ` section headings while std
    wrote `# Examples` at 70 sites — **FIXED 2026-08-29**: `# <well-known name>`
    is accepted (fenced code ignored) and std normalised to `## `

--- a/src/doc/builder.yo
+++ b/src/doc/builder.yo
@@ -86,9 +86,16 @@ extract_doc_sections :: (fn(doc : Option(String)) -> DocSections)(
     }
   )
 );
-/// The module's stability marker: the first line of its `## Stability` doc
-/// section verbatim (`unstable — new in v0.2.20; …`), or `.None` when the
-/// module has none. Renderers key the badge on its first word.
+/// The module's stability marker: its whole `## Stability` doc section,
+/// collapsed to a single line (`unstable — new in v0.2.20; …`), or `.None`
+/// when the module has none. Renderers key the badge on its first word.
+///
+/// The section is COLLAPSED, not truncated. A marker is ordinary prose and
+/// wraps at the source file's line width, so reading only its first line cut
+/// every marker longer than one source line mid-clause — in the JSON
+/// `"stability"` key, the HTML badge and the Markdown note alike, with no
+/// warning. Blank lines are dropped and the remaining lines are joined with a
+/// single space, which is exactly the paragraph the author wrote.
 module_stability :: (fn(doc : Option(String)) -> Option(String))(
   match(
     doc,
@@ -97,8 +104,26 @@ module_stability :: (fn(doc : Option(String)) -> Option(String))(
       parse_doc_comment(text).sections.get(String.from("stability")),
       .None => Option(String).None,
       .Some(sec) => {
-        first := match(sec.split(`\n`).get(usize(0)), .Some(l) => l, .None => sec);
-        Option(String).Some(first.trim())
+        (collapsed : String) = String.from("");
+        lines := sec.split(`\n`);
+        (i : usize) = usize(0);
+        n := lines.len();
+        while(i < n, {
+          match(
+            lines.get(i),
+            .Some(line) => {
+              piece := line.trim();
+              if(piece.len() > usize(0), {
+                collapsed = if(collapsed.len() > usize(0), collapsed + String.from(" ") + piece, piece);
+              });
+            },
+            .None => ()
+          );
+          i = (i + usize(1));
+        });
+        // An empty or whitespace-only section is no marker at all; it used to
+        // render as an empty badge.
+        if(collapsed.len() == usize(0), Option(String).None, Option(String).Some(collapsed))
       }
     )
   )
@@ -3100,5 +3125,6 @@ export(
   build_cross_references,
   GenericImplInfo,
   build_doc_function,
-  build_doc_module
+  build_doc_module,
+  module_stability
 );

--- a/src/doc/render_html.yo
+++ b/src/doc/render_html.yo
@@ -1466,7 +1466,7 @@ _render_index_content :: (fn(model : DocModel) -> String)({
   html
 });
 // ── Module page ──────────────────────────────────────────────────────
-_render_module_content :: (
+render_module_content_html :: (
   fn(m : DocModule, links : HashMap(String, String)) -> String
 )({
   current_mod_file := Option(String).Some(_module_to_filename(m.name));
@@ -1667,11 +1667,11 @@ render_doc_site :: (
     );
     fname := _module_to_filename(m.name);
     mod_sidebar := _fix_sidebar_for_module_page(_render_sidebar(model, Option(String).Some(m.name.clone())));
-    mod_content := _render_module_content(m, symbol_links);
+    mod_content := render_module_content_html(m, symbol_links);
     mod_search := _fix_search_index_for_module_page(search_idx);
     mod_page := _wrap_page(`${m.name} — ${model.name}`, mod_content, mod_sidebar, _search_index_json(mod_search), css_text, js_text);
     io.await(write_string(Path.new(`${module_dir}/${fname}.html`), mod_page, io), ioexn);
     mi = (mi + usize(1));
   });
 });
-export(render_doc_site);
+export(render_doc_site, render_module_content_html);

--- a/std/encoding/csv.yo
+++ b/std/encoding/csv.yo
@@ -16,9 +16,6 @@
 //! rows := csv_parse(String.from("a,b\n1,\"x,y\"\n"));   // Result(ArrayList(ArrayList(String)), CsvError)
 //! text := csv_write(rows.unwrap());                      // `a,b\n1,"x,y"\n`
 //! ```
-//!
-//! ## Stability
-//! unstable — new in v0.2.20; the API may still change until the next release.
 open(import("../string"));
 { ArrayList } :: import("../collections/array_list");
 { Error } :: import("../error");

--- a/std/fs/watch.yo
+++ b/std/fs/watch.yo
@@ -26,7 +26,13 @@
 //! an exact journal.
 //!
 //! ## Stability
-//! unstable — new in v0.2.20; the API may still change until the next release (Windows delivery is an open issue).
+//!
+//! unstable — shipped in v0.2.20 and still unstable at v0.2.24. This is a
+//! deliberate extension of the one-release window, not drift: the Windows
+//! backend is not delivered, and the shape of Windows change delivery
+//! (`ReadDirectoryChangesW` batches renames as paired events) is the one
+//! thing most likely to move `Change`. macOS and Linux are usable today.
+//! Freezing follows Windows delivery, not a release count.
 pragma(Pragma.AllowUnsafe);
 open(import("../string"));
 { ArrayList } :: import("../collections/array_list");

--- a/std/http/server.yo
+++ b/std/http/server.yo
@@ -14,9 +14,6 @@
 //! `serve` runs until `stop()` is called (checked after each connection) —
 //! from another task, or from the handler itself. `serve_once` handles exactly
 //! one connection, which is what a test wants.
-//!
-//! ## Stability
-//! unstable — new in v0.2.20; the API may still change until the next release.
 open(import("../string"));
 { IoExn } :: import("../error");
 { TcpListener, TcpStream } :: import("../net/tcp");

--- a/std/spec/numeric.yo
+++ b/std/spec/numeric.yo
@@ -8,6 +8,14 @@
 //! verdict: FREEZE AS DOC). These are Phase 0 identity stubs from
 //! plans/backlog/FORMAL_VERIFICATION.md; refinement predicates arrive with the
 //! Phase 2+ verifier. Expect ANY change here, including removal.
+//!
+//! ## Stability
+//!
+//! unstable — Phase 0 identity stubs, outside the std stability promise
+//! entirely. Expect ANY change, including removal, when the Phase 2 verifier
+//! lands. The section exists so `yo doc` reports it: the warning above is
+//! prose, and a consumer keyed on the machine-readable stability channel read
+//! these two modules as frozen std surface.
 { Refine } :: import("./refine.yo");
 
 /// Even integer.

--- a/std/spec/refine.yo
+++ b/std/spec/refine.yo
@@ -21,6 +21,14 @@
 //! verdict: FREEZE AS DOC). These are Phase 0 identity stubs from
 //! plans/backlog/FORMAL_VERIFICATION.md; refinement predicates arrive with the
 //! Phase 2+ verifier. Expect ANY change here, including removal.
+//!
+//! ## Stability
+//!
+//! unstable — Phase 0 identity stubs, outside the std stability promise
+//! entirely. Expect ANY change, including removal, when the Phase 2 verifier
+//! lands. The section exists so `yo doc` reports it: the warning above is
+//! prose, and a consumer keyed on the machine-readable stability channel read
+//! these two modules as frozen std surface.
 Refine :: (fn(comptime(T) : Type) -> comptime(Type))(T);
 export(Refine);
 

--- a/std/term.yo
+++ b/std/term.yo
@@ -2,11 +2,6 @@
 //! raw mode for the standard streams — the typed, non-`sys` face of
 //! `std/sys/tty` (which stays fd- and errno-oriented). `std/cli` and
 //! interactive tools consume this module.
-//!
-//! ## Stability
-//!
-//! unstable — new in this release; the API may still change while `std/cli`
-//! adopts it. It becomes additive-only in the next release.
 open(import("./string"));
 { Exception } :: import("./error");
 { IoError } :: import("./sys/errors");

--- a/std/url/index.yo
+++ b/std/url/index.yo
@@ -1,4 +1,15 @@
 //! URL parsing and formatting per RFC 3986 (simplified).
+//!
+//! `Url.parse` is STRICT about the byte set: RFC 3986 §2 admits only
+//! unreserved, gen-delims, sub-delims and `%`, and every other byte —
+//! a raw space, a control byte, a CR or LF, a raw UTF-8 byte — is rejected
+//! with `UrlError.InvalidCharacter(pos)`. Callers with non-ASCII or
+//! space-bearing components percent-encode first, via
+//! `std/encoding/percent`'s `percent_encode`.
+//!
+//! This is a security boundary, not a tidiness rule: `Url.path()` flows into
+//! `HttpRequest`'s request line, so a URL carrying a raw CRLF would otherwise
+//! split one HTTP request into two.
 open(import("../string"));
 { ArrayList } :: import("../collections/array_list");
 { ToString } :: import("../fmt");
@@ -48,6 +59,45 @@ _UPPER_Z :: u8(90); // 'Z'
 _PLUS :: u8(43); // '+'
 _MINUS :: u8(45); // '-'
 _DOT :: u8(46); // '.'
+_UNDERSCORE :: u8(95); // '_'
+_TILDE :: u8(126); // '~'
+_PERCENT :: u8(37); // '%'
+// RFC 3986 §2 admits exactly these bytes in a URI, and nothing else:
+// unreserved (ALPHA / DIGIT / "-" / "." / "_" / "~"), gen-delims
+// (":" "/" "?" "#" "[" "]" "@"), sub-delims
+// ("!" "$" "&" "'" "(" ")" "*" "+" "," ";" "="), and "%", which introduces a
+// pct-encoded triplet.
+//
+// Everything else — a raw space, a control byte, a CR or an LF, a raw UTF-8
+// byte — must be percent-encoded by the caller before it reaches a URI. The
+// CR/LF case is why this is a security boundary and not a tidiness rule: a
+// raw CRLF in a path flows through `Url.path()` into `HttpRequest`'s request
+// line and splits one HTTP request into two.
+_is_uri_byte :: (fn(b : u8) -> bool)(
+  cond(
+    ((b >= _LOWER_A) && (b <= _LOWER_Z)) => true,
+    ((b >= _UPPER_A) && (b <= _UPPER_Z)) => true,
+    ((b >= _ZERO) && (b <= _NINE)) => true,
+    // unreserved punctuation
+    ((b == _MINUS) || (b == _DOT)) => true,
+    ((b == _UNDERSCORE) || (b == _TILDE)) => true,
+    // gen-delims
+    ((b == _COLON) || (b == _SLASH)) => true,
+    ((b == _QUESTION) || (b == _HASH)) => true,
+    ((b == _AT) || (b == _LBRACKET)) => true,
+    (b == _RBRACKET) => true,
+    // sub-delims: ! $ & ' ( ) * + , ; =
+    ((b == u8(33)) || (b == u8(36))) => true,
+    ((b == u8(38)) || (b == u8(39))) => true,
+    ((b == u8(40)) || (b == u8(41))) => true,
+    ((b == u8(42)) || (b == _PLUS)) => true,
+    ((b == u8(44)) || (b == u8(59))) => true,
+    (b == u8(61)) => true,
+    // pct-encoding introducer
+    (b == _PERCENT) => true,
+    true => false
+  )
+);
 // ============================================================================
 // Helper: parse port number from bytes
 // ============================================================================
@@ -106,6 +156,21 @@ impl(
     );
     pos := usize(0);
     src_len := s.len();
+    // Validate the WHOLE input before any section scan, so the reported `pos`
+    // is a byte offset into the caller's string and no forbidden byte can
+    // reach `path()` / `query()` — see `_is_uri_byte`. This is the producer
+    // for `UrlError.InvalidCharacter`, which the enum has always published and
+    // nothing ever threw.
+    (vi : usize) = usize(0);
+    while(runtime(vi < src_len), {
+      cond(
+        _is_uri_byte(s.byte_at(vi)) => (),
+        true => {
+          exn.throw(dyn(UrlError.InvalidCharacter(pos : vi)));
+        }
+      );
+      vi = (vi + usize(1));
+    });
     // --- Parse scheme ---
     // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     scheme_end := usize(0);
@@ -133,7 +198,7 @@ impl(
           found_colon = true;
           break;
         },
-        (((((first >= _LOWER_A) && (first <= _LOWER_Z)) || ((first >= _UPPER_A) && (first <= _UPPER_Z))) || (((ch >= _LOWER_A) && (ch <= _LOWER_Z)) || ((ch >= _UPPER_A) && (ch <= _UPPER_Z)))) || ((((ch >= _ZERO) && (ch <= _NINE)) || (ch == _PLUS)) || ((ch == _MINUS) || (ch == _DOT)))) => (),
+        (((ch >= _LOWER_A) && (ch <= _LOWER_Z)) || ((ch >= _UPPER_A) && (ch <= _UPPER_Z)) || (((ch >= _ZERO) && (ch <= _NINE)) || (ch == _PLUS) || ((ch == _MINUS) || (ch == _DOT)))) => (),
         true => {
           exn.throw(dyn(UrlError.MissingScheme));
         }
@@ -141,7 +206,7 @@ impl(
       i = (i + usize(1));
     });
     cond(
-      (!(found_colon)) => {
+      !found_colon => {
         exn.throw(dyn(UrlError.MissingScheme));
       },
       true => ()
@@ -182,7 +247,7 @@ impl(
         while(runtime(k < src_len), {
           ch := s.byte_at(k);
           cond(
-            (((ch == _SLASH) || (ch == _QUESTION)) || (ch == _HASH)) => {
+            ((ch == _SLASH) || (ch == _QUESTION) || (ch == _HASH)) => {
               auth_end = k;
               break;
             },
@@ -278,7 +343,7 @@ impl(
                 });
                 h := String.from_bytes(host_b);
                 cond(
-                  (!(h.is_empty())) => {
+                  !h.is_empty() => {
                     host = .Some(h);
                   },
                   true => ()
@@ -365,7 +430,7 @@ impl(
     );
     // Ensure authority-based URLs have a path starting with "/" or empty
     cond(
-      (has_authority && ((!(path_str.is_empty())) && (path_str.as_bytes()(usize(0)) != _SLASH))) => {
+      (has_authority && (!path_str.is_empty() && (path_str.as_bytes()(usize(0)) != _SLASH))) => {
         exn.throw(dyn(UrlError.Other(`authority path must start with '/'`)));
       },
       true => ()

--- a/tests/internal/doc_stability.test.yo
+++ b/tests/internal/doc_stability.test.yo
@@ -13,11 +13,8 @@ open(import("std/string"));
   import("../../src/doc/model.yo");
 { module_stability } :: import("../../src/doc/builder.yo");
 { render_doc_json_string } :: import("../../src/doc/render_json.yo");
-{ render_doc_site } :: import("../../src/doc/render_html.yo");
-{ TempDir } :: import("std/fs/temp");
-{ read_to_string } :: import("std/fs/file");
-{ Path } :: import("std/path");
-{ Exception, IoExn } :: import("std/error");
+{ render_module_content_html } :: import("../../src/doc/render_html.yo");
+{ HashMap } :: import("std/collections/hash_map");
 { render_module_md } :: import("../../src/doc/render_markdown.yo");
 // A module carrying nothing but a name, a path and whatever stability marker
 // the test wants to publish.
@@ -31,7 +28,7 @@ _module_with :: (fn(stability : Option(String)) -> DocModule)(
     types : ArrayList(DocType).new(),
     traits : ArrayList(DocTrait).new(),
     constants : ArrayList(DocConstant).new(),
-    submodules : ArrayList(String).new()
+    submodules : ArrayList(Box(DocModule)).new()
   )
 );
 _one_module_model :: (fn(stability : Option(String)) -> DocModel)({
@@ -106,22 +103,15 @@ test("render_module_md: the whole marker reaches the Markdown note", {
   md := render_module_md(_module_with(Option(String).Some(marker)));
   assert(md.contains(`**Stability: ${marker}**`), `the note carries the WHOLE marker, got: ${md}`);
 });
-test("render_doc_site: the whole marker reaches the HTML badge", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, `unexpected exception: ${err.to_string()}`);
-        unwind(());
-      }
-    )
-  );
-  e := IoExn(io : io, exn : exn);
+test("render_module_content_html: the whole marker reaches the HTML badge", {
   marker := `unstable — new in v0.2.24; the API may still change while std/cli adopts it.`;
-  dir := io.await(TempDir.new(io), e);
-  out := dir.path().to_string();
-  render_doc_site(_one_module_model(Option(String).Some(marker)), out, io, e);
-  html := io.await(read_to_string(Path.new(`${out}/module/term.html`), io), e);
-  assert(html.contains(`class="stability stability-unstable"`), "the badge is keyed on the marker's first word");
+  links := HashMap(String, String).new();
+  html := render_module_content_html(_module_with(Option(String).Some(marker)), links);
+  assert(
+    html.contains(`class="stability stability-unstable"`),
+    "the badge class is keyed on the marker's FIRST WORD, not the whole marker"
+  );
   assert(html.contains(marker), `the badge carries the WHOLE marker, got: ${html}`);
-  io.await(dir.remove(io), e);
+  stable := render_module_content_html(_module_with(Option(String).None), links);
+  assert(!stable.contains(`class="stability`), "a frozen module renders no badge");
 });

--- a/tests/internal/doc_stability.test.yo
+++ b/tests/internal/doc_stability.test.yo
@@ -1,0 +1,127 @@
+/// Tests for the `## Stability` module marker end to end: how `yo doc` reads
+/// the section out of a module doc comment, and how the three renderers
+/// publish it.
+///
+/// Before these existed, only the Markdown note was pinned
+/// (`doc_render_markdown.test.yo`), so two defects shipped unnoticed: the
+/// marker was truncated to its first source line, and the JSON key and HTML
+/// badge were exercised by nothing at all.
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ assert } :: import("std/assert");
+{ DocModule, DocModel, DocFunction, DocType, DocTrait, DocConstant } ::
+  import("../../src/doc/model.yo");
+{ module_stability } :: import("../../src/doc/builder.yo");
+{ render_doc_json_string } :: import("../../src/doc/render_json.yo");
+{ render_doc_site } :: import("../../src/doc/render_html.yo");
+{ TempDir } :: import("std/fs/temp");
+{ read_to_string } :: import("std/fs/file");
+{ Path } :: import("std/path");
+{ Exception, IoExn } :: import("std/error");
+{ render_module_md } :: import("../../src/doc/render_markdown.yo");
+// A module carrying nothing but a name, a path and whatever stability marker
+// the test wants to publish.
+_module_with :: (fn(stability : Option(String)) -> DocModule)(
+  DocModule(
+    name : `term`,
+    path : `std/term`,
+    doc : Option(String).Some(`Terminal facade.`),
+    stability : stability,
+    functions : ArrayList(DocFunction).new(),
+    types : ArrayList(DocType).new(),
+    traits : ArrayList(DocTrait).new(),
+    constants : ArrayList(DocConstant).new(),
+    submodules : ArrayList(String).new()
+  )
+);
+_one_module_model :: (fn(stability : Option(String)) -> DocModel)({
+  modules := ArrayList(DocModule).new();
+  modules.push(_module_with(stability));
+  DocModel(name : `proj`, modules : modules, version : Option(String).None)
+});
+// ── reading the section ────────────────────────────────────────────────────
+test("module_stability: a marker on one line is read verbatim", {
+  doc := `A module.\n\n## Stability\n\nunstable — new in v0.2.20; the API may still change.`;
+  match(
+    module_stability(Option(String).Some(doc)),
+    .Some(st) =>
+      assert(
+        st == `unstable — new in v0.2.20; the API may still change.`,
+        `single-line marker must round-trip, got: ${st}`
+      ),
+    .None => assert(false, "a module with a Stability section has a marker")
+  );
+});
+test("module_stability: a marker wrapped over source lines is COLLAPSED, not cut", {
+  // This is the regression. A marker is prose and wraps at the file's line
+  // width; reading only the first line published `unstable — new in v0.2.24;
+  // the API may still change while `std/cli`` — a dangling half-sentence.
+  doc :=
+    `A module.\n\n## Stability\n\nunstable — new in v0.2.24; the API may still change while std/cli\nadopts it. It becomes additive-only in the next release.`;
+  match(
+    module_stability(Option(String).Some(doc)),
+    .Some(st) => {
+      assert(
+        st ==
+          `unstable — new in v0.2.24; the API may still change while std/cli adopts it. It becomes additive-only in the next release.`,
+        `wrapped marker must collapse to one line, got: ${st}`
+      );
+      assert(!st.contains(`\n`), "the collapsed marker carries no newline");
+    },
+    .None => assert(false, "a wrapped marker is still a marker")
+  );
+});
+test("module_stability: blank lines inside the section are dropped, paragraphs joined", {
+  doc := `A module.\n\n## Stability\n\nunstable — new in v0.2.24.\n\nFreezing follows Windows delivery.`;
+  match(
+    module_stability(Option(String).Some(doc)),
+    .Some(st) =>
+      assert(
+        st == `unstable — new in v0.2.24. Freezing follows Windows delivery.`,
+        `paragraphs join with one space, got: ${st}`
+      ),
+    .None => assert(false, "a two-paragraph marker is still a marker")
+  );
+});
+test("module_stability: no section, no doc and an empty section all mean None", {
+  no_section := module_stability(Option(String).Some(`A module with no marker.`));
+  assert(match(no_section, .None => true, .Some(s) => false), "no Stability section → None");
+  no_doc := module_stability(Option(String).None);
+  assert(match(no_doc, .None => true, .Some(s) => false), "no doc at all → None");
+  // An empty section used to publish an empty badge.
+  empty := module_stability(Option(String).Some(`A module.\n\n## Stability\n\n`));
+  assert(match(empty, .None => true, .Some(s) => false), "an empty Stability section → None");
+});
+// ── publishing it ──────────────────────────────────────────────────────────
+test("render_doc_json_string: the whole marker reaches the stability key", {
+  marker := `unstable — new in v0.2.24; the API may still change while std/cli adopts it.`;
+  json := render_doc_json_string(_one_module_model(Option(String).Some(marker)), false);
+  assert(json.contains(`"stability"`), "the JSON carries a stability key");
+  assert(json.contains(marker), `the JSON carries the WHOLE marker, got: ${json}`);
+  stable := render_doc_json_string(_one_module_model(Option(String).None), false);
+  assert(!stable.contains(`"stability":"`), "a frozen module publishes no marker string");
+});
+test("render_module_md: the whole marker reaches the Markdown note", {
+  marker := `unstable — new in v0.2.24; the API may still change while std/cli adopts it.`;
+  md := render_module_md(_module_with(Option(String).Some(marker)));
+  assert(md.contains(`**Stability: ${marker}**`), `the note carries the WHOLE marker, got: ${md}`);
+});
+test("render_doc_site: the whole marker reaches the HTML badge", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  marker := `unstable — new in v0.2.24; the API may still change while std/cli adopts it.`;
+  dir := io.await(TempDir.new(io), e);
+  out := dir.path().to_string();
+  render_doc_site(_one_module_model(Option(String).Some(marker)), out, io, e);
+  html := io.await(read_to_string(Path.new(`${out}/module/term.html`), io), e);
+  assert(html.contains(`class="stability stability-unstable"`), "the badge is keyed on the marker's first word");
+  assert(html.contains(marker), `the badge carries the WHOLE marker, got: ${html}`);
+  io.await(dir.remove(io), e);
+});

--- a/tests/url/url.test.yo
+++ b/tests/url/url.test.yo
@@ -1,6 +1,7 @@
 { assert } :: import("std/assert");
 open(import("std/libc/stdio"));
 open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
 { Url, UrlError } :: import("std/url");
 { Error, AnyError, Exception } :: import("std/error");
 // ============================================================================
@@ -351,4 +352,96 @@ test("Url UrlError to_string", {
   assert(e2.to_string() == String.from("URL error: missing scheme"), "MissingScheme message");
   e3 := UrlError.InvalidPort;
   assert(e3.to_string() == String.from("URL error: invalid port"), "InvalidPort message");
+  // The two variants the file used to skip. `InvalidCharacter` went
+  // un-asserted AND un-produced, which is how the missing validation survived.
+  e4 := UrlError.InvalidCharacter(pos : usize(9));
+  assert(
+    e4.to_string() == String.from("URL error: invalid character at position 9"),
+    "InvalidCharacter message"
+  );
+  e5 := UrlError.Other(msg : `boom`);
+  assert(e5.to_string() == String.from("URL error: boom"), "Other message");
+});
+// ============================================================================
+// RFC 3986 §2 byte-set validation
+//
+// `Url.parse` used to validate nothing outside the scheme (and the scheme
+// guard tested the wrong operand, so it was always true). A raw CRLF in a
+// path therefore flowed through `Url.path()` into `HttpRequest`'s request
+// line and split one HTTP request into two — textbook request splitting,
+// reachable from any caller that interpolates untrusted text into a fetch URL
+// and, via `Location`, from a remote server.
+// ============================================================================
+// The parse error a URL produced, or `.None` if it parsed. Returning the
+// MESSAGE pins the variant AND the byte offset — the parser has four other
+// rejections, so "did it throw" would pass for the wrong reason.
+_parse_err :: (fn(src : String) -> Option(String))({
+  rec := Exception(
+    throw : (
+      err -> {
+        unwind(Option(String).Some(err.to_string()));
+      }
+    )
+  );
+  _u := Url.parse(src, rec);
+  Option(String).None
+});
+_assert_invalid_at :: (fn(src : String, at : usize, label : String) -> unit)({
+  want := (String.from("URL error: invalid character at position ") + at.to_string());
+  match(
+    _parse_err(src),
+    .Some(got) => assert(got == want, `${label}: want [${want}], got [${got}]`),
+    .None => assert(false, `${label}: parsed a URL that RFC 3986 forbids`)
+  );
+});
+test("Url parse rejects RFC 3986 forbidden characters at the exact offset", {
+  _assert_invalid_at(String.from("http://exa mple.com/"), usize(10), `raw space in host`);
+  _assert_invalid_at(String.from("http://x/a b"), usize(10), `raw space in path`);
+  // The scheme scan's own guard tested `first` instead of `ch`, so it could
+  // never fail; the pre-scan catches this one before the scheme scan runs.
+  _assert_invalid_at(String.from("ht tp://x/"), usize(2), `raw space in scheme`);
+  _assert_invalid_at(String.from("http://x/a\rb"), usize(10), `raw CR`);
+  _assert_invalid_at(String.from("http://x/a\nb"), usize(10), `raw LF`);
+  _assert_invalid_at(
+    String.from("http://x/a\r\nX: y\r\n\r\nGET /admin"),
+    usize(10),
+    `CRLF request-splitting payload`
+  );
+  _assert_invalid_at(String.from("http://x/a\"b"), usize(10), `double quote`);
+  _assert_invalid_at(String.from("http://x/a<b"), usize(10), `less-than`);
+  _assert_invalid_at(String.from("http://x/a>b"), usize(10), `greater-than`);
+  _assert_invalid_at(String.from("http://x/a\\b"), usize(10), `backslash`);
+  _assert_invalid_at(String.from("http://x/a{b"), usize(10), `open brace`);
+  _assert_invalid_at(String.from("http://x/a|b"), usize(10), `pipe`);
+  // A raw control byte, and a raw UTF-8 lead byte: RFC 3986 is ASCII-only, so
+  // non-ASCII components are percent-encoded by the caller.
+  _assert_invalid_at(String.from("http://x/a\x01b"), usize(10), `control byte 0x01`);
+  _assert_invalid_at(String.from("http://x/h\xc3\xa9llo"), usize(10), `raw UTF-8`);
+});
+test("Url parse still accepts every legal URI byte", {
+  // The over-rejection canary. Tightening a parser is the dangerous
+  // direction: this asserts the whole legal byte set still gets through, and
+  // it passed BEFORE the validation was added as well as after.
+  legal := ArrayList(String).new();
+  legal.push(String.from("http://x/p?a=1&b=2;c=3!"));
+  legal.push(String.from("http://u:p@x:8080/"));
+  legal.push(String.from("http://x/a~b-c.d_e"));
+  legal.push(String.from("http://[::1]:80/"));
+  legal.push(String.from("http://x/a%20b"));
+  legal.push(String.from("http://x/p?q=1#frag"));
+  legal.push(String.from("mailto:user@example.com"));
+  legal.push(String.from("a+b-c.d://x/"));
+  legal.push(String.from("http://x/$'()*,"));
+  legal.push(String.from("http://x/p?a+b=c"));
+  legal.push(String.from("data:text/plain;base64,SGVsbG8="));
+  i := usize(0);
+  while(runtime(i < legal.len()), {
+    src := legal(i);
+    match(
+      _parse_err(src),
+      .Some(got) => assert(false, `legal URI rejected: [${src}] -> ${got}`),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
 });


### PR DESCRIPTION
Verification of #409 against a from-source develop build, with `yo` 0.2.24 as the before-oracle (it predates the merge).

**The fix is correct and its scope claim is accurate.** Per-shape, 1000 calls, `leaks --atExit`:

| shape | before | after |
|---|---|---|
| whole-body `\|\|` | 4/call | **0** |
| whole-body `&&` | 2/call | **0** |
| `\|\|` in a match arm | 4/call | **0** |
| mixed `&&`/`\|\|` | 4/call | 2/call |
| chain of 3 | 6/call | 2/call |
| chain of 4 | 8/call | 4/call |
| statement-position / while / closure | 0 | 0 |

Whole probe: 112,000 → 28,000 leaks, values correct, rc=0. Emit-diff: drops go **up** (+2), never down; each new drop targets a distinct temp; no duplicate drop on any path.

Two gaps filed:

1. **`issues/leak-regression-tests-cannot-fail-in-ci-leak-verdicts-are-off-everywhere.md`** — the new regression test passes 3/3 under the *buggy* compiler. Leak verdicts are disabled in every CI job, and ASan doesn't instrument on macOS. Suggests an emit-shape cli-case golden instead, which works under the ratchet.
2. **`issues/short-circuit-chain-inner-operand-temps-still-leak.md`** — the acknowledged remainder, split out of the `fixed/` doc so it stays discoverable.