### PR TITLE
fix: the trait predicate must honour a generic impl's marker where-clause (Type.impls(*NonSend, Send) said true)

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -546,7 +546,7 @@ test("Async test", {
 ## Assertion builtins for Yo tests
 
 - `assert(condition, "message")` — runtime assertion (evaluates at runtime in the compiled C code); requires `{ assert } :: import("std/assert");`. The message accepts any `ToString` type; `assert(condition)` uses the default message.
-- `comptime_assert(condition, "message")` — compile-time assertion (evaluates during compilation). Use this for testing comptime behavior.
+- `comptime_assert(condition, "message")` — compile-time assertion (evaluates during compilation). Use this for testing comptime behavior. **It only FIRES at MODULE level** — inside any function body, and therefore inside a `test("…", { … })` block, `comptime_assert(false)` is silently accepted and the test verifies NOTHING (`issues/comptime-assert-never-fires-inside-a-function-body.md`). Until that is fixed, pin the comptime result in a module-level `::` binding and observe it with a runtime `assert` inside the test.
 - `comptime_expect_error(expr)` — expects the expression to produce a compile-time error. Use this to test that invalid code is properly rejected.
 
 `assert(condition, msg)` accepts any `msg` implementing `ToString` — plain
@@ -578,7 +578,7 @@ This is the standard pattern from `tests/internal/parser.test.yo`. The struct
 constructor `Exception(...)` pins the binding's type, so no annotation is needed
 on the LHS.
 
-Prefer `comptime_assert` over `assert` when the value being tested is compile-time known.
+Prefer `comptime_assert` over `assert` when the value being tested is compile-time known — but only at MODULE level. Inside a `test(...)` body it is inert (see the assertion-builtins section above), so pin the value in a module-level `::` binding and `assert` on that binding instead.
 
 ## Partial application (`_`) tests
 

--- a/issues/fixed/type-impls-reports-true-for-a-blanket-impl-whose-where-clause-fails.md
+++ b/issues/fixed/type-impls-reports-true-for-a-blanket-impl-whose-where-clause-fails.md
@@ -1,0 +1,185 @@
+# `Type.impls` reports `true` for a generic impl whose `where` clause fails (FIXED 2026-09-05)
+
+**Status:** FIXED — `src/evaluator/values/impl.yo`, `try_match_generic_impl`
+now enforces a failed MARKER `where` clause for CONSTRUCTED receiver patterns
+when it is answering the trait predicate. Regression tests + over-rejection
+canaries in `tests/basic.test.yo`.
+
+**Severity:** soundness. `Send` is the gate on what may cross a thread
+boundary, and the predicate answered `true` for `*(NonSend)`.
+
+## Symptom
+
+```
+*NonSend          Send == true   (want false)
+Array(NonSend, 4) Send == true   (want false)
+?*NonSend         Send == true   (want false)
+```
+
+The prelude declares these three conditionally (`std/prelude.yo`):
+
+```rust
+impl(generic(T : Type), where(T <: Send), *(T), Send());
+impl(generic(T : Type, U : usize), where(T <: Send), Array(T, U), Send());
+```
+
+`?*(T)` is `Option(*(T))`, whose Send is derived from its flattened variant
+field `*(T)` — so it inherits the same wrong answer.
+
+The `where(T <: Send)` bound was simply not consulted, so any `T` at all
+satisfied the impl.
+
+## Reproducer
+
+```rust
+pragma(Pragma.AllowUnsafe);
+{ println } :: import("std/fmt");
+NonSend :: ref(struct(v : i32));
+PTR_NONSEND :: Type.impls(*NonSend, Send);
+ARR_NONSEND :: Type.impls(Array(NonSend, 4), Send);
+OPT_PTR_NONSEND :: Type.impls(?*NonSend, Send);
+PTR_I32 :: Type.impls(*i32, Send);
+report :: (fn(label : str, got : bool, want : bool) -> unit)({
+  cond(
+    (got == want) => println(`ok     ${label} : ${got.to_string()}`),
+    true => println(`WRONG  ${label} : ${got.to_string()} (want ${want.to_string()})`)
+  );
+});
+main :: (fn() -> unit)({
+  report("*NonSend         ", PTR_NONSEND, false);
+  report("Array(NonSend, 4)", ARR_NONSEND, false);
+  report("?*NonSend        ", OPT_PTR_NONSEND, false);
+  report("*i32             ", PTR_I32, true);
+});
+export(main);
+```
+
+`yo compile tmp/send_where.yo --std-path ./std --optimize 2 -o tmp/send_where.out`
+then `./tmp/send_where.out` — three `WRONG` lines before the fix, zero after.
+
+Note the reproducer must observe the answers through **module-level `::`
+bindings + a runtime `assert`/`println`**: `comptime_assert` is inert inside a
+function body (`issues/comptime-assert-never-fires-inside-a-function-body.md`),
+which is exactly why the pre-existing `comptime_assert`-only test in
+`tests/basic.test.yo` ("Test Send on pointer-bearing types is conditional on the
+pointee") never caught this — it already contained the right assertions.
+
+## Root cause
+
+`src/evaluator/values/impl.yo`, `try_match_generic_impl`'s where-constraint
+pass. The clause was discharged, but the REJECTION was gated on the impl's
+receiver pattern being a bare blanket:
+
+```rust
+wcj_impl := wcj_f(wcj_bound, wcj_trait, match_env);
+if(!wcj_impl && is_some_type(entry.receiver_type_pattern), {
+  wc_ok = false;
+});
+```
+
+`is_some_type(entry.receiver_type_pattern)` is true only for
+`impl(generic(T), where(...), T, Trait())` — a bare-`SomeT` pattern. The
+pointer/array impls have a CONSTRUCTED pattern (`*(SomeT(T))`,
+`Array(SomeT(T), SomeT(U))`), so their clause was evaluated and then thrown
+away.
+
+The scoping was deliberate and its reasoning (recorded in the comment above the
+pass) is sound for **method dispatch**: enforcing a specific-pattern impl's
+clause there would DELETE a method wherever the trait-implements predicate has a
+load-order false negative (the comment names `String <: Hash` breaking
+`HashMap(String, _).new()`). What it missed is that the same function also feeds
+the **trait predicate** — `find_matching_generic_impl` is the sole feeder of
+`type_implements_trait` step 8 — where dropping the clause is not conservative
+at all, it is unsound.
+
+## Fix
+
+Two independent restrictions, both needed.
+
+**1. Split the two uses of `try_match_generic_impl`** instead of picking one
+policy for both. It takes an `enforce_all_where : bool`:
+
+- `false` — method dispatch (`find_methods_from_generic_impls`,
+  `find_associated_type_from_generic_impls`, `get_generic_impl_doc_entries`)
+  and `find_matching_negative_generic_impl`. Behaviour unchanged: only blanket
+  impls are rejected on a failed clause.
+- `true` — `find_matching_generic_impl`, the trait predicate. Constructed
+  patterns are enforced too.
+
+A load-order false negative on the predicate side costs a `false` from a
+PREDICATE (and the auto-derive / registry / builtin steps ahead of step 8
+already answer for the common types); it cannot silently delete a method the
+way the dispatch path can.
+
+**2. On the predicate side, enforce only a MARKER constraint**
+(`_is_marker_trait`: a `TraitT` whose member types and associated-type-
+constraint types mention no type variable — `Send`, `Comptime`, `Runtime`,
+`Acyclic`).
+
+This is not caution for its own sake — a non-marker constraint **cannot be
+answered from what is stored**. `entry.where_constraint_traits[i]` holds the
+trait as it was evaluated at IMPL-REGISTRATION time, so `where(T <: Eq(T))` is
+stored as `Eq(SomeT(T))`: a trait built for the impl's own type PARAMETER, with
+a `Rhs`-specialized id (`Eq` is a comptime fn returning a fresh `Trait` per
+`Rhs`). MEASURED: asked as-is, even `i32 <: Eq(SomeT(T))` is `false`, while
+`i32 <: Eq(i32)` is `true`. Enforcing the raw answer deleted the entire
+`Option(T)`/`Eq` and `Option(T)`/`Ord` family from the predicate — the
+over-rejection canary below caught exactly that, on the first build of the fix.
+
+`substitute()` cannot repair it either: its `TraitT` arm rewrites field types
+but KEEPS the trait id, which is what the registry is keyed on (verified by
+building that variant — the canary still failed). Closing the non-marker half
+would need the constraint's source EXPR re-evaluated against the match
+bindings, not a stored `TypeValue`; that is left as a known, documented gap.
+
+Unchanged in every mode: an **unbound** where-param is never a rejection.
+`_resolve_one_forall_binding` returning `.None` — the clause could not be
+discharged because the param never got a concrete binding, e.g. a def-time
+trial over an unresolved `SomeT` — still falls through. Only a param that IS
+bound and demonstrably fails its trait removes the impl.
+
+`find_matching_negative_generic_impl` is deliberately left on `false`: a
+negative impl REMOVES a trait, so tightening its match would LOOSEN the
+predicate — the opposite direction from this fix.
+
+## Known remaining gap
+
+A PARAMETRIC `where` bound on a constructed receiver pattern (`where(T <:
+Eq(T))`, `where(T <: Ord(T))`, `where(T <: Clone)`, `where(T <: Hash)`,
+`where(T <: Default)`) is still ignored by the trait predicate, for the reason
+above. So `Type.impls(Option(<a type with no Eq>), Eq(Option(...)))` still
+over-reports. That is a correctness wart, not a thread-safety hole: the marker
+traits — the ones that gate `Send` across a thread boundary and `Comptime` /
+`Runtime` / `Acyclic` across evaluation contexts — are now enforced.
+
+## Over-rejection canaries
+
+This change tightens trait resolution, which is the dangerous direction. The
+regression tests carry canaries that must KEEP answering `true`:
+
+- `*i32`, `Array(i32, 4)`, `?*i32` still report `Send == true` — the same three
+  impls, with a satisfied bound.
+- The `Option(T)` blanket family, also a constructed pattern with a `where`
+  clause, and the one that regressed before
+  (`issues/fixed/yo-self-option-eq-ref-enum-not-specialized.md`):
+  `Type.impls(Option(i32), Eq(Option(i32)))`,
+  `Type.impls(Option(<user struct with a manual Eq impl>), Eq(Option(...)))`,
+  `Type.impls(Option(i32), Acyclic)` — plus real `==` / `!=` dispatch on
+  `Option(<user struct>)`, so the canary covers dispatch and not just the
+  predicate.
+
+The `Option`/`Eq` canaries are what rejected the first two attempts at this fix
+(enforce every constraint; enforce with `substitute()`-repaired traits).
+
+## Tests
+
+`tests/basic.test.yo`, four new tests (each shape separately so one failure
+does not mask the others):
+
+- `Test *(T) Send honours the impl's where(T <: Send)`
+- `Test Array(T, N) Send honours the impl's where(T <: Send)`
+- `Test ?*(T) Send honours the impl's where(T <: Send)`
+- `Test where-clause enforcement does not over-reject a satisfied bound`
+
+Verified RED before the fix (the first three fail, the canary passes) and GREEN
+after.

--- a/src/evaluator/values/impl.yo
+++ b/src/evaluator/values/impl.yo
@@ -849,11 +849,50 @@ _bind_forall_from_type_args :: (
 /// module-level statement right after the finder's definition.
 FindAssocFromImplsFn :: (fn(t : TypeValue, label : String, env : Environment) -> Option(TypeValue));
 (g_find_assoc_from_impls_fn : Option(FindAssocFromImplsFn)) = Option(FindAssocFromImplsFn).None;
+/// True when any member of `tys` is, or structurally contains, a SomeT.
+_any_type_has_some_type :: (fn(tys : ArrayList(TypeValue)) -> bool)({
+  (ati : usize) = usize(0);
+  while(ati < tys.len(), {
+    at_ty := match(tys.get(ati), .Some(t) => t, .None => t_unit());
+    if(is_some_type(at_ty) || (get_all_some_types(at_ty).len() > usize(0)), {
+      return(true);
+    });
+    ati = (ati + usize(1));
+  });
+  false
+});
+/// A MARKER trait — its member and associated-type-constraint types mention no
+/// type variable at all, so the stored TypeValue is INSTANTIATION-INDEPENDENT:
+/// it means the same thing wherever it is asked. `Send`, `Comptime`, `Runtime`
+/// and `Acyclic` qualify (their only member is the `id := "..."` tag, a
+/// `comptime_str`); anything with a METHOD does not, because a method signature
+/// mentions `Self` — and a PARAMETRIC trait's arguments (`Eq(T)`'s `rhs : T`)
+/// are baked in at evaluation time as well.
+///
+/// `try_match_generic_impl`'s where-constraint pass enforces a constructed
+/// receiver pattern's clause only for these; see the long comment there for
+/// why a non-marker bound cannot be decided from the stored TypeValue.
+_is_marker_trait :: (fn(ty : TypeValue) -> bool)(
+  match(
+    ty,
+    .TraitT({ field_types : mt_fts, assoc_constraint_types : mt_acts }) => (
+      !_any_type_has_some_type(mt_fts) && !_any_type_has_some_type(mt_acts)
+    ),
+    _ => false
+  )
+);
+/// `enforce_all_where` — see the where-constraint pass below. `false` (the
+/// METHOD-DISPATCH callers) enforces a failed where-clause only for BLANKET
+/// impls; `true` (the TRAIT-PREDICATE caller, `find_matching_generic_impl`)
+/// enforces a MARKER constraint on a constructed receiver pattern too, so
+/// `impl(generic(T), where(T <: Send), *(T), Send())` cannot answer
+/// "`*(NonSend)` is Send".
 try_match_generic_impl :: (
   fn(
     concrete_type : TypeValue,
     entry : GenericImplEntry,
-    env : Environment
+    env : Environment,
+    enforce_all_where : bool
   ) -> Option(ArrayList(TypeValue))
 )({
   // 1. Resolve SomeT — if still unresolved, cannot match.
@@ -995,15 +1034,56 @@ try_match_generic_impl :: (
   // no ExprInfo and codegen dropped the statement (issues/repros/v5_direct.yo,
   // the tests/iter_filter_closure + iterator_combinators family).
   //
-  // ENFORCEMENT stays scoped to BLANKET impls (bare-SomeT receiver pattern),
-  // exactly as before: a blanket matches every type, so its where-clause is
-  // the only thing keeping it off non-satisfying types; specific-pattern
-  // impls already constrain via their pattern, and enforcing their clauses
-  // would wrongly exclude them wherever the trait-implements predicate has a
-  // load-order false negative (e.g. `String <: Hash` breaking
-  // `HashMap(String, _).new()`). TS enforces all — its predicate is complete;
-  // this scoping is the safe yo-self adaptation. The BINDINGS, however, are
-  // taken for every impl.
+  // ENFORCEMENT is scoped by `enforce_all_where`:
+  //
+  //   false (METHOD DISPATCH — find_methods_from_generic_impls and friends):
+  //     only BLANKET impls (bare-SomeT receiver pattern) are rejected on a
+  //     failed clause. A blanket matches every type, so its where-clause is
+  //     the only thing keeping it off non-satisfying types; specific-pattern
+  //     impls already constrain via their pattern, and enforcing their
+  //     clauses HERE would drop a method wherever the trait-implements
+  //     predicate has a load-order false negative (e.g. `String <: Hash`
+  //     breaking `HashMap(String, _).new()`).
+  //
+  //   true (TRAIT PREDICATE — find_matching_generic_impl, the sole feeder of
+  //     `type_implements_trait` step 8): a constructed pattern is enforced
+  //     too, but ONLY for a MARKER constraint (`_is_marker_trait`).
+  //     `impl(generic(T : Type), where(T <: Send), *(T), Send())` says `*(T)`
+  //     is Send *iff* `T` is; ignoring the clause made
+  //     `Type.impls(*(NonSend), Send)` — and `Array(NonSend, 4)`, `?*NonSend`
+  //     — answer `true`, letting non-Send data cross a thread boundary. See
+  //     `issues/fixed/type-impls-reports-true-for-a-blanket-impl-whose-where-clause-fails.md`.
+  //     A load-order false negative here costs a `false` from a PREDICATE,
+  //     which the auto-derive / registry / builtin steps ahead of step 8
+  //     already answer for the common types; it cannot silently delete a
+  //     method the way the dispatch path can.
+  //
+  //     The marker restriction is NOT conservatism for its own sake — a
+  //     NON-marker constraint cannot be answered from what is stored here.
+  //     The trait was evaluated at IMPL-REGISTRATION time, so `where(T <:
+  //     Eq(T))` is stored as `Eq(SomeT(T))` — a trait built for the impl's
+  //     own type PARAMETER, with a `Rhs`-specialized id (`Eq` is a comptime
+  //     fn returning a fresh `Trait` per `Rhs`). MEASURED: asked as-is even
+  //     `i32 <: Eq(SomeT(T))` is false, so enforcing it would delete the
+  //     whole `Option(T)`/`Eq` and `Option(T)`/`Ord` family from the
+  //     predicate (the over-rejection canary in tests/basic.test.yo caught
+  //     exactly that). `substitute()` cannot repair it either — its TraitT
+  //     arm rewrites field types but KEEPS the trait id, which is what the
+  //     registry is keyed on. A MARKER (`Send`, `Comptime`, `Runtime`,
+  //     `Acyclic`) mentions no type variable anywhere in its members, so the
+  //     stored value IS the trait to ask about and the answer is exact.
+  //     Non-marker bounds therefore stay on the old ignore-the-clause
+  //     behaviour; closing that half needs the constraint's source EXPR
+  //     re-evaluated against the bindings, not a stored TypeValue.
+  //
+  // TS enforces all — its predicate is complete; this split is the safe
+  // yo-self adaptation. The BINDINGS, however, are taken for every impl.
+  //
+  // In every mode an UNBOUND where-param (`_resolve_one_forall_binding` →
+  // `.None`, i.e. the clause could not be discharged because the param never
+  // got a concrete binding — a def-time trial over an unresolved SomeT, say)
+  // is NOT a rejection: only a param that IS bound and demonstrably fails
+  // its trait removes the impl.
   (match_env : Environment) = synth_result.expected_env;
   (wc_ok : bool) = true;
   {
@@ -1021,7 +1101,10 @@ try_match_generic_impl :: (
             // The adapter writes the post-constraint bindings into match_env
             // IN PLACE (env.frames swap) — see the hook's doc above.
             wcj_impl := wcj_f(wcj_bound, wcj_trait, match_env);
-            if(!wcj_impl && is_some_type(entry.receiver_type_pattern), {
+            if(!wcj_impl && (
+              (enforce_all_where && _is_marker_trait(wcj_trait))
+              || is_some_type(entry.receiver_type_pattern)
+            ), {
               wc_ok = false;
             });
           },
@@ -1317,7 +1400,10 @@ find_matching_generic_impl :: (
         continue;
       }
     );
-    if(try_match_generic_impl(concrete_type, entry, env).is_some(), {
+    // `true`: this is the TRAIT PREDICATE (`type_implements_trait` step 8), so
+    // a constructed pattern's MARKER where-clause is enforced — see the pass
+    // in `try_match_generic_impl`.
+    if(try_match_generic_impl(concrete_type, entry, env, true).is_some(), {
       return(true);
     });
     ei = (ei + usize(1));
@@ -1358,7 +1444,9 @@ find_matching_negative_generic_impl :: (
       }
     );
     if(entry.trait_key == key, {
-      if(try_match_generic_impl(concrete_type, entry, env).is_some(), {
+      // `false`: a negative impl REMOVES a trait, so tightening its match
+      // would loosen the predicate — the opposite direction. Unchanged.
+      if(try_match_generic_impl(concrete_type, entry, env, false).is_some(), {
         found = true;
       });
     });
@@ -1608,7 +1696,7 @@ find_methods_from_generic_impls :: (
       if(!has_field_with_name, {
         ei = (ei + usize(1));
       }, {
-        mb_opt := try_match_generic_impl(resolved, entry, env);
+        mb_opt := try_match_generic_impl(resolved, entry, env, false);
         if(in_def_time_trial() && impl_dbg_env.get(`YO_DEBUG_DISPATCH`).is_some() && (method_name == "add"), {
           eprintln(`[fmg-try] name=${method_name} recv=${type_to_string(resolved)} pat=${type_to_string(entry.receiver_type_pattern)} matched=${mb_opt.is_some().to_string()}`);
         });
@@ -1812,7 +1900,7 @@ find_associated_type_from_generic_impls :: (
             pfi = (pfi + usize(1));
           });
           if(has_field, {
-            mb_opt := try_match_generic_impl(resolved, entry, env);
+            mb_opt := try_match_generic_impl(resolved, entry, env, false);
             match(
               mb_opt,
               .Some(match_bindings) => {
@@ -1994,7 +2082,7 @@ get_generic_impl_doc_entries :: (
       match(
         entry_list.get(ei),
         .Some(entry) => {
-          (matched : bool) = try_match_generic_impl(resolved, entry, env).is_some();
+          (matched : bool) = try_match_generic_impl(resolved, entry, env, false).is_some();
           if(!matched && (concrete_base_id.len() > usize(0)), {
             if(_receiver_base_type_id_for_doc(entry.receiver_type_pattern) == concrete_base_id, {
               matched = true;

--- a/tests/basic.test.yo
+++ b/tests/basic.test.yo
@@ -285,6 +285,75 @@ test("Test Send on pointer-bearing types is conditional on the pointee", {
   // Nullable pointer ?(*(T)): same as *(T) via Option(*(T)) desugar.
   comptime_assert(Type.impls(?*i32, Send) == true);
 });
+// --- `Type.impls` must honour a generic impl's `where` clause ---------------
+// `impl(generic(T : Type), where(T <: Send), *(T), Send())` says `*(T)` is Send
+// *iff* `T` is. The trait predicate used to ignore the clause whenever the
+// impl's receiver pattern was CONSTRUCTED (`*(T)`, `Array(T, U)`) rather than a
+// bare blanket `T`, so `Type.impls(*(NonSend), Send)` answered `true` and
+// non-Send data could cross a thread boundary. Enforcement is limited to MARKER
+// constraints — a parametric one (`where(T <: Eq(T))`) is stored as
+// `Eq(SomeT(T))` and cannot be decided from the stored value, which is what the
+// over-rejection canary below pins. See
+// `issues/fixed/type-impls-reports-true-for-a-blanket-impl-whose-where-clause-fails.md`.
+//
+// These live at MODULE level, observed by a RUNTIME `assert`, because
+// `comptime_assert` is INERT inside a `test(...)` body — it only fires at module
+// level (`issues/comptime-assert-never-fires-inside-a-function-body.md`), which
+// is why the comptime_assert-only test above never caught this.
+SendWhereNonSend :: ref(struct(v : i32));
+SEND_BARE_NONSEND :: Type.impls(SendWhereNonSend, Send);
+SEND_PTR_NONSEND :: Type.impls(*SendWhereNonSend, Send);
+SEND_ARRAY_NONSEND :: Type.impls(Array(SendWhereNonSend, 4), Send);
+SEND_OPT_PTR_NONSEND :: Type.impls(?*SendWhereNonSend, Send);
+SEND_PTR_I32 :: Type.impls(*i32, Send);
+SEND_ARRAY_I32 :: Type.impls(Array(i32, 4), Send);
+SEND_OPT_PTR_I32 :: Type.impls(?*i32, Send);
+// Over-rejection canaries for the `Option(T)` blanket family — also a
+// constructed pattern carrying a `where` clause, and the one that regressed
+// before (`issues/fixed/yo-self-option-eq-ref-enum-not-specialized.md`).
+SendWhereEqPoint :: struct(x : i32);
+impl(
+  SendWhereEqPoint,
+  Eq(SendWhereEqPoint)(
+    (==) : (fn(lhs : Self, rhs : SendWhereEqPoint) -> bool)(lhs.x == rhs.x),
+    (!=) : (fn(lhs : Self, rhs : SendWhereEqPoint) -> bool)(lhs.x != rhs.x)
+  )
+);
+SEND_WHERE_OPTION_EQ_I32 :: Type.impls(Option(i32), Eq(Option(i32)));
+SEND_WHERE_OPTION_EQ_USER :: Type.impls(
+  Option(SendWhereEqPoint),
+  Eq(Option(SendWhereEqPoint))
+);
+SEND_WHERE_OPTION_ACYCLIC :: Type.impls(Option(i32), Acyclic);
+test("Test *(T) Send honours the impl's where(T <: Send)", {
+  assert(SEND_BARE_NONSEND == false);
+  assert(SEND_PTR_NONSEND == false);
+});
+test("Test Array(T, N) Send honours the impl's where(T <: Send)", {
+  assert(SEND_ARRAY_NONSEND == false);
+});
+test("Test ?*(T) Send honours the impl's where(T <: Send)", {
+  assert(SEND_OPT_PTR_NONSEND == false);
+});
+test("Test where-clause enforcement does not over-reject a satisfied bound", {
+  // Positive canaries: the same three impls MUST still match a Send pointee.
+  assert(SEND_PTR_I32 == true);
+  assert(SEND_ARRAY_I32 == true);
+  assert(SEND_OPT_PTR_I32 == true);
+  // The `Option(T)` blanket family stays intact — both as a predicate and as
+  // real dispatch.
+  assert(SEND_WHERE_OPTION_EQ_I32 == true);
+  assert(SEND_WHERE_OPTION_EQ_USER == true);
+  assert(SEND_WHERE_OPTION_ACYCLIC == true);
+  assert(
+    Option(SendWhereEqPoint).Some(SendWhereEqPoint(x : 1))
+    == Option(SendWhereEqPoint).Some(SendWhereEqPoint(x : 1))
+  );
+  assert(
+    Option(SendWhereEqPoint).Some(SendWhereEqPoint(x : 1))
+    != Option(SendWhereEqPoint).Some(SendWhereEqPoint(x : 2))
+  );
+});
 test("Test type auto derive Acyclic", {
   // Primitive types are Acyclic
   // Compile-time only types


### PR DESCRIPTION
## The bug

`Type.impls(*(NonSend), Send)` answered **`true`** — and so did
`Type.impls(Array(NonSend, 4), Send)` and `Type.impls(?*NonSend, Send)`.

The prelude declares all three conditionally:

```rust
impl(generic(T : Type), where(T <: Send), *(T), Send());
impl(generic(T : Type, U : usize), where(T <: Send), Array(T, U), Send());
```

`Send` is the gate on what may cross a thread boundary, so ignoring the bound is
a real soundness hole, not a cosmetic reflection wart. (`?*(T)` is `Option(*(T))`
and derives its Send from the flattened variant field `*(T)`, so it inherited the
same wrong answer.)

## Root cause

`src/evaluator/values/impl.yo`, `try_match_generic_impl`'s where-constraint pass.
The clause **was** discharged; the *rejection* was gated on the impl's receiver
pattern being a bare blanket:

```rust
wcj_impl := wcj_f(wcj_bound, wcj_trait, match_env);
if(!wcj_impl && is_some_type(entry.receiver_type_pattern), {
  wc_ok = false;
});
```

`is_some_type(entry.receiver_type_pattern)` is true only for
`impl(generic(T), where(...), T, Trait())`. A **constructed** pattern —
`*(SomeT(T))`, `Array(SomeT(T), SomeT(U))` — evaluated its clause and threw the
answer away.

That scoping is *correct for method dispatch*, exactly as the comment above it
argued: enforcing a specific-pattern impl's clause there would DELETE a method
wherever the trait-implements predicate has a load-order false negative (the
comment names `String <: Hash` breaking `HashMap(String, _).new()`). What it
missed is that the same function **also feeds the trait predicate** —
`find_matching_generic_impl` is the sole feeder of `type_implements_trait`
step 8 — where dropping the clause is not conservative at all, it is unsound.

## The fix

Two independent restrictions, both needed.

**1. Split the two uses.** `try_match_generic_impl` takes
`enforce_all_where : bool`. Every method-dispatch caller
(`find_methods_from_generic_impls`, `find_associated_type_from_generic_impls`,
`get_generic_impl_doc_entries`) passes `false` and is behaviourally unchanged.
`find_matching_negative_generic_impl` also passes `false` — a negative impl
*removes* a trait, so tightening its match would *loosen* the predicate, the
opposite direction. Only `find_matching_generic_impl` passes `true`.

**2. On the predicate side, enforce only a MARKER constraint** — `_is_marker_trait`:
a `TraitT` whose member types and associated-type-constraint types mention no type
variable (`Send`, `Comptime`, `Runtime`, `Acyclic`; their only member is the
`id := "..."` tag).

This is not caution for its own sake — a non-marker bound **cannot be answered
from what is stored**. `entry.where_constraint_traits[i]` holds the trait as
evaluated at IMPL-REGISTRATION time, so `where(T <: Eq(T))` is stored as
`Eq(SomeT(T))`: built for the impl's own type *parameter*, with an
`Rhs`-specialized id (`Eq` is a comptime fn returning a fresh `Trait` per `Rhs`).
**Measured:** asked as-is, even `i32 <: Eq(SomeT(T))` is `false`, while
`i32 <: Eq(i32)` is `true`.

Unchanged in every mode: an **unbound** where-param is never a rejection.
`_resolve_one_forall_binding` → `.None` (a def-time trial over an unresolved
`SomeT`, say) still falls through; only a param that IS bound and demonstrably
fails its trait removes the impl.

## Over-rejection canaries — they earned their keep

This tightens trait resolution, the dangerous direction, so the tests carry
canaries that must keep answering `true`. **They rejected two earlier versions of
this fix, each caught on its first build:**

1. *Enforce every constraint on a constructed pattern* → `Type.impls(Option(i32),
   Eq(Option(i32)))` and the `Option(T)`/`Ord` family flipped to `false`. The
   whole family would have silently left the predicate.
2. *Repair it with `substitute()`* → still `false`. `substitute()`'s `TraitT` arm
   rewrites field types but **keeps the trait id**, which is what the registry is
   keyed on.

Only then did the marker restriction go in. The canaries are:

- `*i32`, `Array(i32, 4)`, `?*i32` still report `Send == true` — the same three
  impls with a satisfied bound.
- The `Option(T)` blanket family (a constructed pattern with a `where` clause, and
  the one that regressed in
  `issues/fixed/yo-self-option-eq-ref-enum-not-specialized.md`):
  `Type.impls(Option(i32), Eq(Option(i32)))`,
  `Type.impls(Option(<user struct with a manual Eq impl>), Eq(Option(...)))`,
  `Type.impls(Option(i32), Acyclic)` — **plus real `==` / `!=` dispatch** on
  `Option(<user struct>)`, so the canary covers dispatch and not only the
  predicate.

## Known remaining gap (documented, not hidden)

A **parametric** `where` bound on a constructed pattern (`Eq(T)`, `Ord(T)`,
`Clone`, `Hash`, `Default`) is still ignored by the trait predicate, for the
reason above. `Type.impls(Option(<a type with no Eq>), Eq(Option(...)))` still
over-reports. Closing that half needs the constraint's source **expr**
re-evaluated against the match bindings, not a stored `TypeValue` — written up in
the issue doc.

## Tests

`tests/basic.test.yo`, four new tests — one per shape so a failure cannot mask its
siblings, plus the canary test. They are **module-level `::` bindings observed by
a runtime `assert`**, because `comptime_assert` is inert inside a `test(...)` body
(`issues/comptime-assert-never-fires-inside-a-function-body.md`) — which is
precisely why the pre-existing comptime_assert-only test, already containing these
exact assertions, never caught the bug. Verified RED before the fix (the three
negative tests fail, the canary passes) and GREEN after.

`.github/instructions/testing.instructions.md` gained a warning about that
inertness; it previously said "prefer `comptime_assert`" with no caveat.

## Gates

All run with the compiler built from this branch (`yo build --std-path ./std`),
**after** the rebase onto `develop` @ `660859c67`:

| Gate | Result |
| --- | --- |
| Reproducer (`tmp/send_where.yo`) | 3 WRONG → **0** |
| Canary file (11 assertions incl. `Option`/`Eq`) | **11/11 ok** |
| `yo check ./std --std-path ./std` | **173/173**, 0 errors |
| `yo check ./src --std-path ./std` | **266/266**, 0 errors |
| `yo test ./tests/basic.test.yo` | **39/39** (was 36 passed + 3 failed) |
| `yo test ./tests/type_reflection.test.yo` | **35/35** |
| `yo compile src/main.yo --skip-c-compiler` | rc=0; 14 `Failed to transpile` matches, **identical to baseline** — all 14 are string literals in the compiler's own codegen source, not real failures |
| `yo test ./tests --exclude tests/internal --exclude tests/cli-cases --bail` | **3451 passed / 3451 total** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
