### PR TITLE
fix: truncate an HTTP body to its Content-Length (response/request smuggling)

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -124,6 +124,44 @@ payload-free variant as an over-drop canary, and re-run the fixed binary under
 `MallocScribble=1 MallocPreScribble=1` — recycled values in the output mean the
 fix over-dropped and introduced a use-after-free.
 
+## A network test whose oracle depends on TCP segmentation is probabilistic
+
+A test that has the peer `write` twice and then asserts on what one `read`
+produced is **not** deterministic: whether two writes arrive as one read is the
+platform's coalescing decision. Such a test passes on five CI legs and fails on
+the sixth, which reads as a flake and is not one — 2026-09-06 that shape hid a
+real body-framing over-read in `std/http/wire.yo` for as long as the tests
+existed (`issues/http-body-is-not-truncated-to-content-length.md`).
+
+**Write the whole payload — the framed message AND the bytes after it — in ONE
+`write_string`.** The coalesced case is the harder one, so the assertion gets
+stronger as well as deterministic, and it goes red on every platform without the
+fix.
+
+Corollary for reading CI: **one leg failing out of six on the same commit is a
+diagnosis, not a retry button.** Check the other legs before blaming the PR, and
+check whether that leg has failed before:
+
+```bash
+for r in $(gh run list --workflow "<name>" --limit 15 --json databaseId -q '.[].databaseId'); do
+  gh api repos/<owner>/<repo>/actions/runs/$r/jobs --paginate \
+    -q '.jobs[]|select(.name=="test (macos-26-intel)")|.conclusion'
+done | sort | uniq -c
+```
+
+## A failing test's own `println` output needs `--verbose`
+
+Without `-v` the runner captures the child's stdout and shows it only for a
+PASSING test; a failing test loses both its `println` lines and its assert
+message, leaving just `Test failed with exit code 6`. With `-v` both appear
+under the `✗` line.
+
+CI already passes `--verbose` (`.github/workflows/test.yml`), which makes the
+**absence** of an expected diagnostic line into evidence: if a test's error
+handler prints before it unwinds and that line is not in the log, the handler
+never ran — so the test failed on a value, not on a throw. Locally, always add
+`-v` before theorizing about a failure.
+
 ## Windows: failing tests report a SIGNAL status, and a runtime-template edit needs TWO builds
 
 `yo test` on Windows used to die with `yo: error: unknown I/O error` at the

--- a/issues/http-body-is-not-truncated-to-content-length.md
+++ b/issues/http-body-is-not-truncated-to-content-length.md
@@ -1,0 +1,115 @@
+# `read_http_message` never truncates a body to its `Content-Length` — bytes after the frame are handed on AS body
+
+**Status: FIXED** (`std/http/wire.yo`, this branch).
+
+**Severity: correctness / smuggling.** A framed HTTP message ends where its
+framing says it ends. `read_http_message` **stopped reading** at that boundary
+but **returned the whole receive buffer**, so anything the peer had already sent
+after the body became part of the body — on both the client side (response
+smuggling) and the server side (request smuggling), RFC 9112 §11.2.
+
+## How it surfaced — and why it hid for so long
+
+It failed **one** CI leg (`test (macos-26-intel)`) of PR #434, while the other
+five — including both Windows legs and the other two macOS/Linux legs — passed
+on the same commit. That asymmetry is the whole story: whether the bug is
+observable depends on whether two of the peer's writes **coalesce into a single
+`read`**, which is a platform TCP decision, not a program one.
+
+The failing test was `tests/http/http.test.yo`'s
+`only a real Content-Length field line frames a kept-alive response`, whose
+server writes the response and then a `TRAILING-MUST-NOT-BE-READ` marker as two
+separate `write_string` calls. On five platforms those arrived as two reads and
+the loop returned after the first; on macos-26-intel they arrived as one.
+
+It was **not** caused by #434 — #434 only happened to be the PR whose runner
+coalesced. The defect is as old as the framing loop.
+
+## Reproducer
+
+Deterministic anywhere, by making the server write once:
+
+```rust
+_serve_one_write :: (fn(listener : TcpListener, payload : String, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async(e => {
+    s := e.io.await(listener.accept(e.io), e);
+    _req := e.io.await(_read_request(s, e.io), e);
+    _w := e.io.await(s.write_string(payload, e.io), e);
+    e.io.await(s.close(e.io), e);
+    return(());
+  })
+);
+// payload: `HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhelloTRAILING-MUST-NOT-BE-READ`
+```
+
+```
+body      = "helloTRAILING-MUST-NOT-BE-READ"
+body len  = 30   want 5
+```
+
+## Root cause
+
+`std/http/wire.yo`, `read_http_message`. The read loop is correct — it stops the
+moment the frame is satisfied:
+
+```rust
+.Length(cl) => {
+  body_len := (result.len() - body_start);
+  cond((body_len >= cl) => { done = true; }, true => ());
+},
+```
+
+but the value it hands back is the entire buffer:
+
+```rust
+true => String.from_bytes(result)
+```
+
+`body_len >= cl` — not `==`. One read can overshoot the frame by any amount, and
+every overshot byte was returned. `parse_response` / `parse_request` then take
+the body **verbatim** (`std/http/http.yo:310` says so explicitly, and correctly:
+framing is `read_http_message`'s job), so the overshoot lands in
+`HttpResponse.body` / `HttpRequest.body`.
+
+Both framing rules were affected:
+
+| framing | before | after |
+| --- | --- | --- |
+| `Content-Length: N` | body = every byte read past the headers | body = exactly N bytes |
+| absent, `is_request` | body = every byte read past the headers | body = empty (request ends at its headers) |
+| absent, response | delimited by close — every byte read is body | unchanged |
+| chunked | `dechunk` already returns exactly the decoded data | unchanged |
+
+The chunked path was never affected because `dechunk` rebuilds the buffer from
+the decoded chunks rather than slicing the raw one — which is why only the
+`Content-Length` and body-less-request paths needed fixing.
+
+## Fix
+
+Truncate to the frame boundary before returning (`_message_upto`). The bound is
+computed as `cl < avail` rather than `(body_start + cl) < result.len()` so a
+hostile `Content-Length` cannot overflow `usize` into a false "no truncation
+needed".
+
+## Regression tests
+
+Both write the framed message and the bytes after it in **one** `write_string`,
+so they do not depend on coalescing and fail on every platform without the fix
+(verified red-first):
+
+- `tests/http/http.test.yo` — *bytes after a Content-Length body are not part of
+  the body*: the trailing bytes are a whole second HTTP response, so a failure
+  reads as the smuggling it is.
+- `tests/http/server.test.yo` — *bytes pipelined after a body-less request are
+  not its body*: a second request pipelined into the same write must not reach
+  the handler.
+
+## Lesson
+
+A test whose oracle depends on **how the peer's bytes were segmented** is a test
+that will pass on five platforms and fail on the sixth. The two pre-existing
+keep-alive tests were written with two `write_string` calls precisely to model
+"trailing bytes on a kept-alive connection", and that shape made them
+*probabilistic*. Writing the whole payload in one call makes the same assertion
+deterministic — and strictly stronger, since coalesced delivery is the harder
+case.

--- a/std/http/wire.yo
+++ b/std/http/wire.yo
@@ -345,6 +345,27 @@ dechunk :: (fn(body : ArrayList(u8), body_start : usize) -> Dechunk)({
   });
   Dechunk.Incomplete
 });
+// A framed message ENDS where its framing says it ends. `read_http_message`
+// stops READING at that boundary, but the buffer can already hold more: one
+// `read` can deliver the framed body and whatever the peer sent after it in a
+// single call, and whether it does is the peer's write-coalescing decision, not
+// ours. Handing those bytes on as body is response smuggling (RFC 9112 §11.2)
+// — and it is a heisenbug, because the same server and the same client agree
+// on every platform where the writes happen not to coalesce.
+_message_upto :: (fn(data : ArrayList(u8), limit : usize) -> String)(
+  cond(
+    (limit >= data.len()) => String.from_bytes(data),
+    true => {
+      out := ArrayList(u8).with_capacity(limit);
+      i := usize(0);
+      while(runtime(i < limit), {
+        out.push(data(i));
+        i = (i + usize(1));
+      });
+      String.from_bytes(out)
+    }
+  )
+);
 // ============================================================================
 // Read one full HTTP message (status/request line, headers, body)
 // ============================================================================
@@ -492,6 +513,28 @@ read_http_message :: (
             e.exn.throw(dyn(HttpError.MalformedChunkedBody(msg)));
             String.new()
           }
+        )
+      },
+      (header_end > usize(0)) => {
+        body_start := (header_end + usize(4));
+        avail := (result.len() - body_start);
+        match(
+          find_content_length(result, header_end),
+          // `cl < avail`, not `(body_start + cl) < result.len()`: the sum can
+          // overflow usize on a hostile Content-Length.
+          .Length(cl) => cond(
+            (cl < avail) => _message_upto(result, body_start + cl),
+            true => String.from_bytes(result)
+          ),
+          // A REQUEST with no framing header ends with its headers; a RESPONSE
+          // with none is delimited by close, so every byte read is body.
+          .Absent => cond(
+            is_request => _message_upto(result, body_start),
+            true => String.from_bytes(result)
+          ),
+          // Unreachable: the read loop throws on `.Invalid` as soon as the
+          // header section is complete.
+          .Invalid(_) => String.from_bytes(result)
         )
       },
       true => String.from_bytes(result)

--- a/tests/http/http.test.yo
+++ b/tests/http/http.test.yo
@@ -558,6 +558,19 @@ test("fetch round-trips a binary body byte-for-byte", {
 // shape held the connection open and gave the client a timeout budget, so a
 // loaded runner could lose the race and abort the whole test binary
 // (measured on ubuntu-latest and macos-26-intel) without saying why.
+// Response AND trailing bytes in ONE write. `_serve_then_trailing` writes them
+// separately, so whether they reach the client in a single `read` is the
+// platform's write-coalescing decision — which is exactly how the over-read
+// below hid: it failed on one CI runner and passed on the other five.
+_serve_one_write :: (fn(listener : TcpListener, payload : String, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async(e => {
+    s := e.io.await(listener.accept(e.io), e);
+    _req := e.io.await(_read_request(s, e.io), e);
+    _w := e.io.await(s.write_string(payload, e.io), e);
+    e.io.await(s.close(e.io), e);
+    return(());
+  })
+);
 _serve_then_trailing :: (
   fn(listener : TcpListener, response : String, trailing : String, io : Io) ->
     Impl(Future(unit, IoExn))
@@ -656,6 +669,44 @@ test("only a real Content-Length field line frames a kept-alive response", {
     match(outcome, .Some(r) => (r.body == "hello"), .None => false),
     `X-Content-Length must not frame the message`
   );
+});
+// RFC 9112 §11.2: a framed message ends where its framing says it ends. The
+// read loop STOPPED at the boundary but returned the whole buffer, so bytes the
+// peer sent after the body were handed on AS body — response smuggling, and a
+// heisenbug, because it only shows when the two writes coalesce into one read.
+test("bytes after a Content-Length body are not part of the body", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  // Capture-free by design (handlers are frame-bound): prints, then unwinds.
+  report_exn := Exception(
+    throw : (
+      err -> {
+        println(`  [smuggle client] ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  addr := SocketAddr.loopback(u16(19982));
+  listener := io.await(TcpListener.bind(addr, io), IoExn(io : io, exn : exn));
+  server := io.spawn(
+    _serve_one_write(listener, `HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhelloHTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nbad`, io),
+    IoExn(io : io, exn : report_exn)
+  );
+  client := io.spawn(
+    fetch_with(`http://127.0.0.1:19982/smuggle`, FetchOptions.new(), io),
+    IoExn(io : io, exn : report_exn)
+  );
+  outcome := client.await(io);
+  server.await(io);
+  io.await(listener.close(io), IoExn(io : io, exn : exn));
+  body := match(outcome, .Some(r) => r.body, .None => `<client unwound>`);
+  assert(body == "hello", `body must stop at Content-Length, got [${body}]`);
 });
 // RFC 9112 §6.3: a Content-Length that is present but unreadable is an
 // unrecoverable framing error. It used to fall back to -1 — "no such header" —

--- a/tests/http/server.test.yo
+++ b/tests/http/server.test.yo
@@ -92,6 +92,30 @@ test("parse_request: request line, headers, body, and the error cases", {
   assert(match(parse_request(``), .Err(m) => m.contains(`Empty`), .Ok(_) => false), "empty");
   assert(match(HttpMethod.from_str(`OPTIONS`), .Some(m) => (m.to_string() == "OPTIONS"), .None => false), "OPTIONS round-trips");
 });
+// The request-side half of the same defect: `read_http_message(is_request=true)`
+// completes a body-less request at its headers, but returned the whole buffer —
+// so a second request pipelined into the SAME write became the first one's
+// body. That is request smuggling (RFC 9112 §11.2).
+test("bytes pipelined after a body-less request are not its body", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  server := io.await(HttpServer.bind(SocketAddr.loopback(u16(19983)), io), IoExn(io : io, exn : exn));
+  task := io.spawn(server.serve_once(_echo, io), IoExn(io : io, exn : exn));
+  raw := io.await(
+    _raw_exchange(u16(19983), `GET /first HTTP/1.1\r\nHost: h\r\n\r\nGET /smuggled HTTP/1.1\r\nHost: h\r\n\r\n`, io),
+    IoExn(io : io, exn : exn)
+  );
+  assert(raw.contains(`body=[]`), `the pipelined bytes leaked into the body: ${raw}`);
+  assert(!raw.contains(`/smuggled`), `the smuggled request line reached the handler: ${raw}`);
+  task.await(io);
+  io.await(server.close(io), IoExn(io : io, exn : exn));
+});
 test("HttpResponse.to_string adds Content-Length and keeps explicit headers", {
   s := HttpResponse.with_status(i32(404)).header(`X-A`, `1`).with_body(`nope`).to_string();
   assert(s == "HTTP/1.1 404 Not Found\r\nX-A: 1\r\nContent-Length: 4\r\n\r\nnope", `wire form: ${s}`);


### PR DESCRIPTION
## What

`std/http/wire.yo`'s `read_http_message` **stopped reading** at the frame boundary but **returned the whole receive buffer**. One `read` can deliver the framed body and whatever the peer sent after it together, so those bytes were handed on *as body* — response smuggling on the client side, request smuggling on the server side (RFC 9112 §11.2).

```
Content-Length: 5   ->   body = "helloTRAILING-MUST-NOT-BE-READ"  (30 bytes)
```

## Why it took this long to see

It failed **one of six** CI legs on #434 — `test (macos-26-intel)` — while both Windows legs, both Linux legs and macos-latest passed *on the same commit*. That asymmetry is the diagnosis: observability depends on whether the peer's two writes **coalesce into a single `read`**, which is a platform TCP decision.

**This is not #434's regression.** #434 merely drew the runner that coalesced; the defect is as old as the framing loop. #434 is unblocked by this.

## Fix

| framing | before | after |
| --- | --- | --- |
| `Content-Length: N` | every byte read past the headers | exactly N bytes |
| absent, request | every byte read past the headers | empty — a request ends at its headers |
| absent, response | delimited by close | unchanged |
| chunked | `dechunk` rebuilds from decoded chunks | unchanged |

The bound is `cl < avail`, not `(body_start + cl) < result.len()`, so a hostile `Content-Length` cannot overflow `usize` into a false "nothing to truncate".

## Tests

Both write the framed message and the bytes after it in **one** `write_string`, so they do not depend on coalescing and go red on **every** platform without the fix (verified red-first):

- `tests/http/http.test.yo` — *bytes after a Content-Length body are not part of the body*. The trailing bytes are a whole second HTTP response, so a failure reads as the smuggling it is.
- `tests/http/server.test.yo` — *bytes pipelined after a body-less request are not its body*.

Local: `tests/http/http.test.yo` 25/25, `tests/http/server.test.yo` 11/11, `yo check ./std` unchanged at 170/173 (the 3 are pre-existing macro-def / platform-field failures).

`issues/http-body-is-not-truncated-to-content-length.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)