### PR TITLE
D6 step 2: FIX — Windows accept blocked the event loop (overlapped AcceptEx); http/tls suites un-gated on Windows; bisecting probes

### DIFF
--- a/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
+++ b/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
@@ -120,3 +120,20 @@ Both pass on macOS. `http.test.yo` is re-gated with `SkipWindows` so the leg
 reaches `tests/net` (it runs after `tests/http`); `tls.test.yo` stays un-gated
 because its live handshake passed. Whichever probe hangs on Windows names the
 runtime path to fix in `src/codegen/async/`.
+
+### Round 2 (2026-09-06 14:20 CST)
+
+`test (windows-latest)` on #443 **passed in 29 min** with both round-1 probes
+in place: a listener accepting three sequential connections, and a client
+reconnecting after the server closes, both work on Windows x64 (the arm leg
+was still running). So neither repeated `accept` nor reconnect-after-close is
+the hang by itself. The redirect test's remaining distinctive shape is the
+server running as a SPAWNED task whose `accept` is already PENDING when the
+client connects, reading the request up to the blank line, then writing and
+closing — three rounds. Two more probes in `tests/net/tcp.test.yo` reproduce
+exactly that in raw TCP ("accept pending in a spawned task before the client
+connects", "three request/response rounds against a spawned scripted
+server"). Both pass on macOS. If these hang on Windows, the defect is in how
+`runtime_io_windows.yo` completes an `AcceptEx` that was armed BEFORE the
+peer connected (or a `read` armed before data arrives) when another task on
+the same loop is the peer.

--- a/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
+++ b/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
@@ -161,3 +161,34 @@ when the connection later arrives from the same loop (`__yo_async_accept_start`,
 blocks in `__yo_io_wait` on the client's read; (3) the loop-back `connect`
 completing synchronously on Windows (`ConnectEx` on a bound listener) and the
 completion packet being dropped. Read the stderr lines of the next run first.
+
+### Root cause (2026-09-06 16:10 CST) — `accept` blocked the event loop
+
+`src/codegen/async/runtime_io_windows.yo`'s `__yo_async_accept_start` was a
+plain **blocking `accept()`** on the loop thread (and `connect_start` a
+blocking `connect()`), wrapped in an already-completed future. Every
+"async" accept therefore blocked the whole single-threaded event loop until a
+peer connected:
+
+- round 1's probes and every pre-existing TCP test connect FIRST and accept
+  second — `accept()` returns at once, nothing notices;
+- the redirect test and the round-2 probe spawn the server task first, so its
+  `accept` runs while the client — on the SAME loop — has not connected yet.
+  `accept()` blocks the thread; the client's `connect` never runs; the leg
+  hangs until the job deadline. Both architectures, deterministically.
+
+The Schannel work was never the problem; it just un-skipped the first test
+with this shape.
+
+**Fix (pushed to `d6/step2-unskip`):** an overlapped `AcceptEx` path. The
+extension pointers (`AcceptEx`, `GetAcceptExSockaddrs`) are fetched through
+`WSAIoctl(SIO_GET_EXTENSION_FUNCTION_POINTER)` — `<mswsock.h>` for the
+typedefs, no new import library, so the four Windows link-flag sites stay
+untouched. The overlapped record gains an `is_accept` branch: on completion
+the accepted socket gets `SO_UPDATE_ACCEPT_CONTEXT`, the peer address is
+copied out via `GetAcceptExSockaddrs`, and the socket joins the completion
+port with `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` exactly as the old path did;
+a synchronous `AcceptEx` return is finished inline. The blocking `accept()`
+remains only as the fallback when the extension cannot be fetched.
+`connect_start` is still the blocking `connect()` — harmless for loopback
+(completes immediately) but the same class; `ConnectEx` is the follow-up.

--- a/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
+++ b/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
@@ -192,3 +192,40 @@ a synchronous `AcceptEx` return is finished inline. The blocking `accept()`
 remains only as the fallback when the extension cannot be fetched.
 `connect_start` is still the blocking `connect()` — harmless for loopback
 (completes immediately) but the same class; `ConnectEx` is the follow-up.
+
+### Round 3 (2026-09-06 19:00 CST) — the AcceptEx path broke AF_UNIX accept
+
+The overlapped `AcceptEx` fix **cured the hang**: both Windows legs now finish
+in ~20 minutes and fail as ordinary test failures instead of running to the
+4-hour job deadline. What they fail on is one test:
+
+```
+  ✗ bind, connect, accept, echo round-trip      (tests/net/unix.test.yo)
+yo: error: 1 test(s) failed
+```
+
+Unix-domain, not TCP. `AcceptEx` and `GetAcceptExSockaddrs` are
+AF_INET/AF_INET6 Winsock extensions; Windows' AF_UNIX implements neither. Two
+things went wrong at once:
+
+1. The accept socket was created as
+   `WSASocketW(family, SOCK_STREAM, IPPROTO_TCP, …)` — the family was read
+   from the listener, but the protocol was hardcoded to `IPPROTO_TCP`, which
+   is not valid for `AF_UNIX` (it wants `0`).
+2. The "extension unavailable → blocking accept" fallback never fired for an
+   AF_UNIX listener. `__yo_win_load_acceptex` caches the two pointers in
+   `__declspec(thread)` statics **and early-returns once they are set**. All
+   I/O runs on the one event-loop thread, so the first TCP accept in the
+   process loads them; every later accept — AF_UNIX included — then sees a
+   non-NULL `__yo_win_acceptex` and takes the overlapped path. The probe
+   never runs against the Unix socket at all.
+
+**Fix:** read the listener's family with `getsockname` FIRST and gate the
+whole overlapped path on `family == AF_INET || family == AF_INET6`; AF_UNIX
+keeps the historical blocking `accept()`. The family test cannot be delegated
+to the pointer load, precisely because of the thread-local cache above.
+
+That leaves AF_UNIX accept blocking the loop the way it always has — a
+pre-existing limitation, not a regression, and one no current test provokes
+(the Unix tests connect before they accept). `ConnectEx` for
+`__yo_async_connect_start` remains the other follow-up in this class.

--- a/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
+++ b/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
@@ -137,3 +137,27 @@ server"). Both pass on macOS. If these hang on Windows, the defect is in how
 `runtime_io_windows.yo` completes an `AcceptEx` that was armed BEFORE the
 peer connected (or a `read` armed before data arrives) when another task on
 the same loop is the peer.
+
+### Round 2 verdict (2026-09-06 16:00 CST)
+
+Both Windows legs of #443 (run with `de2385960`) were cut at the 75-minute
+deadline. Their logs show the two round-1 probes PASSING on both
+`windows-latest` and `windows-11-arm`, and then nothing: **the first round-2
+probe — "accept pending in a spawned task before the client connects" — is
+the hang**, on both architectures. The probe's own progress lines were lost
+with the killed process's stdout buffer, so `de2385960`'s logs cannot say how
+far it got; the follow-up commit prints them to stderr, so the next run's log
+will show whether the server task ever printed `server: accept 0 pending`
+(the spawned task was polled and armed the accept) and whether the client
+got past `connect` / `write` / `read_to_end`.
+
+The shape that hangs, precisely: `server := io.spawn(task)` where the task's
+first await is `listener.accept`; then, on the SAME event loop,
+`io.await(TcpStream.connect(addr))`, `write_str`, `read_to_end`. Plain
+sequential accept-then-exchange (round 1) works, so the suspects are, in
+order: (1) an `AcceptEx` armed while no connection exists is never completed
+when the connection later arrives from the same loop (`__yo_async_accept_start`,
+`runtime_io_windows.yo:3181`); (2) the spawned task is never polled once main
+blocks in `__yo_io_wait` on the client's read; (3) the loop-back `connect`
+completing synchronously on Windows (`ConnectEx` on a bound listener) and the
+completion packet being dropped. Read the stderr lines of the next run first.

--- a/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
+++ b/issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md
@@ -90,3 +90,33 @@ hoping.
 A release/merge gate must reject `cancelled` required checks. The failure here
 was not the Schannel code — it was that a 4-hour hang was indistinguishable
 from a pass at the point of decision.
+
+## Step-2 findings (2026-09-06, PR #443 with `timeout-minutes: 75` on the Windows legs)
+
+With the pragmas off and a 75-minute deadline, both Windows legs produced logs.
+They say something the four-hour blobs could not:
+
+- **The Schannel handshake is NOT the hang.** `fetch over https returns a real
+  response` — a live TLS fetch to a real host — **passes** on both
+  `windows-latest` and `windows-11-arm`. It is the last test to complete.
+- **The hang is `fetch follows redirects, resolving relative and absolute-path
+  Locations`** (`tests/http/http.test.yo`), a pure-loopback test: a spawned
+  server task accepts THREE sequential connections on one listener, answering
+  302 / 302 / 200, while the client reconnects after each response closes.
+- **Plain loopback TCP passes on Windows** — `TCP connect to listener and
+  accept`, the echo test and `read_to_end` all completed in the same run — but
+  every one of those accepts exactly ONCE per listener.
+
+So the suspect is the Windows async backend's handling of a *repeated* accept
+(re-arming `AcceptEx` on a listener after a previous completion) or of a client
+reconnect after the server closed the previous connection — the first shapes
+the Windows legs have ever run, since the http suites were always skipped there.
+
+PR #443 now carries two cross-platform bisecting probes in
+`tests/net/tcp.test.yo` (`… (D6 Windows re-arm probe)` / `… (D6 Windows
+probe)`): three sequential accept+exchange+close rounds on one listener, and
+two rounds of "server writes and closes, client `read_to_end`s, reconnects".
+Both pass on macOS. `http.test.yo` is re-gated with `SkipWindows` so the leg
+reaches `tests/net` (it runs after `tests/http`); `tls.test.yo` stays un-gated
+because its live handshake passed. Whichever probe hangs on Windows names the
+runtime path to fix in `src/codegen/async/`.

--- a/plans/RELEASE_NOTES_v0.2.26_DRAFT.md
+++ b/plans/RELEASE_NOTES_v0.2.26_DRAFT.md
@@ -1,10 +1,12 @@
 # v0.2.26
 
-A small, deliberate release: **`unit` is now a true zero-sized type**, the
+A substantial release: **`unit` is now a true zero-sized type**, the
 lazy-binding campaign closes with forward references allowed in `std/` and
-`src/` themselves, and the std API stabilization campaign lands its whole P0
+`src/` themselves, the std API stabilization campaign lands its whole P0
 sweep — 18 memory/UB/deadlock and wrong-value defects, with the exported
-signatures reshaped to Rust's.
+signatures reshaped to Rust's — and **Windows regains a TLS backend
+(Schannel) with its live suites running there**, after the event-loop bug that
+made them look untestable turned out to be a blocking `accept()`.
 
 ## ⚠️ Breaking changes (patch-release policy)
 

--- a/plans/RELEASE_NOTES_v0.2.26_DRAFT.md
+++ b/plans/RELEASE_NOTES_v0.2.26_DRAFT.md
@@ -78,11 +78,25 @@ signatures reshaped to Rust's.
 
 ## Platforms
 
-- _(Deferred to the next release: the Windows Schannel TLS backend, #442/#443.
-  Both PRs touch `.github/workflows/*`, which needs a token carrying the
-  `workflow` scope; they could not be merged into this release. The D6 root
-  cause — a blocking `accept()` on the Windows event-loop thread — is fixed and
-  awaiting merge, see `plans/D6_TLS_PLAN.md`.)_
+- **Windows: the Schannel TLS backend is back, and its suites RUN there**
+  (#442 re-landing #413, #443). `tls.test.yo` and `http.test.yo` are no longer
+  `SkipWindows`.
+- **Windows `accept` no longer blocks the event loop** (#443). This is what
+  made the first Schannel attempt look untestable: `__yo_async_accept_start`
+  was a plain **blocking `accept()`** on the loop thread, so a server task
+  awaiting `accept` before a client on the SAME single-threaded loop had
+  connected wedged the whole loop — client included — until the 4-hour job
+  deadline. Every pre-existing TCP test connected first and accepted second,
+  which is why nothing caught it for so long; TLS merely un-skipped the first
+  test with a spawned server. `accept` is now an overlapped `AcceptEx` whose
+  extension pointers come from `WSAIoctl`, so no new import library is
+  needed. Unix-domain listeners keep the blocking `accept()` — Windows'
+  AF_UNIX implements neither `AcceptEx` nor `GetAcceptExSockaddrs` — and the
+  four shapes that deadlocked are now permanent regression tests in
+  `tests/net/tcp.test.yo`. `connect` is still a blocking `connect()`
+  (harmless on loopback); `ConnectEx` is the follow-up.
+- Windows `test` legs now carry a 75-minute budget, so a hang of this class
+  produces a failed job with a downloadable log instead of a silent timeout.
 
 ## Correctness
 

--- a/src/codegen/async/runtime_io_windows.yo
+++ b/src/codegen/async/runtime_io_windows.yo
@@ -21,6 +21,7 @@ generate_platform_sys_runtime_windows :: (fn(emitter : Emitter) -> unit)({
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <mswsock.h>
 #ifndef _WINSOCKAPI_
 #define _WINSOCKAPI_
 #endif
@@ -2009,7 +2010,79 @@ typedef struct {
   SOCKET sock;
   WSABUF wsabuf;
   DWORD sock_flags;
+  // AcceptEx bookkeeping (is_accept): the pre-created socket the connection
+  // lands on, the listener it came from, the address buffer AcceptEx fills,
+  // and where the caller wants the peer address written.
+  bool is_accept;
+  SOCKET accept_sock;
+  SOCKET listen_sock;
+  char accept_buf[2 * (sizeof(SOCKADDR_STORAGE) + 16)];
+  void* out_addr;
+  uint32_t* out_addrlen;
 } __yo_win_overlapped_t;
+
+// AcceptEx / GetAcceptExSockaddrs are Microsoft extensions fetched through
+// WSAIoctl at run time (no mswsock import library needed). Thread-local like
+// the rest of the loop state.
+static __declspec(thread) LPFN_ACCEPTEX __yo_win_acceptex = NULL;
+static __declspec(thread) LPFN_GETACCEPTEXSOCKADDRS __yo_win_getacceptexsockaddrs = NULL;
+
+static void __yo_win_load_acceptex(SOCKET s) {
+  if (__yo_win_acceptex && __yo_win_getacceptexsockaddrs) return;
+  GUID g_accept = WSAID_ACCEPTEX;
+  GUID g_addrs = WSAID_GETACCEPTEXSOCKADDRS;
+  DWORD bytes = 0;
+  if (!__yo_win_acceptex) {
+    if (WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, &g_accept, sizeof(g_accept),
+                 &__yo_win_acceptex, sizeof(__yo_win_acceptex), &bytes, NULL, NULL) != 0) {
+      __yo_win_acceptex = NULL;
+    }
+  }
+  if (!__yo_win_getacceptexsockaddrs) {
+    if (WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, &g_addrs, sizeof(g_addrs),
+                 &__yo_win_getacceptexsockaddrs, sizeof(__yo_win_getacceptexsockaddrs), &bytes, NULL, NULL) != 0) {
+      __yo_win_getacceptexsockaddrs = NULL;
+    }
+  }
+}
+
+// Turn a finished AcceptEx into the caller's accept() result: on success the
+// accepted socket inherits the listener's context (SO_UPDATE_ACCEPT_CONTEXT,
+// without which getpeername/shutdown on it fail), the peer address is copied
+// out, and the socket joins the completion port exactly like the old
+// synchronous path did; on failure the pre-created socket is closed and the
+// WSA error is the result.
+static void __yo_win_finish_accept(__yo_win_overlapped_t* ov, bool ok) {
+  if (!ok) {
+    DWORD flags = 0;
+    DWORD transferred = 0;
+    BOOL got = WSAGetOverlappedResult(ov->listen_sock, &ov->overlapped, &transferred, FALSE, &flags);
+    ov->future->result = got ? -ECONNABORTED : -(int32_t)WSAGetLastError();
+    closesocket(ov->accept_sock);
+    return;
+  }
+  setsockopt(ov->accept_sock, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
+             (const char*)&ov->listen_sock, sizeof(SOCKET));
+  if (ov->out_addr && ov->out_addrlen && __yo_win_getacceptexsockaddrs) {
+    struct sockaddr* local = NULL;
+    struct sockaddr* remote = NULL;
+    int local_len = 0;
+    int remote_len = 0;
+    __yo_win_getacceptexsockaddrs(ov->accept_buf, 0, sizeof(SOCKADDR_STORAGE) + 16, sizeof(SOCKADDR_STORAGE) + 16,
+                                  &local, &local_len, &remote, &remote_len);
+    if (remote && remote_len > 0) {
+      uint32_t copy_len = (uint32_t)remote_len;
+      if (copy_len > *ov->out_addrlen) copy_len = *ov->out_addrlen;
+      memcpy(ov->out_addr, remote, copy_len);
+      *ov->out_addrlen = (uint32_t)remote_len;
+    }
+  }
+  if (__yo_io_iocp) {
+    CreateIoCompletionPort((HANDLE)ov->accept_sock, __yo_io_iocp, 0, 0);
+    SetFileCompletionNotificationModes((HANDLE)ov->accept_sock, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
+  }
+  ov->future->result = (int32_t)(uintptr_t)ov->accept_sock;
+}
 
 // Per-thread free list for __yo_win_overlapped_t to eliminate malloc/free
 // per I/O op. The first sizeof(void*) bytes of an overlapped struct overlay
@@ -2170,6 +2243,12 @@ static inline void __yo_win_free_overlapped(__yo_win_overlapped_t* ov);
 
 static void __yo_win_process_completion(__yo_win_overlapped_t* ov, DWORD bytes) {
   if (!ov) return;
+  if (ov->is_accept) {
+    __yo_win_finish_accept(ov, ((NTSTATUS)ov->overlapped.Internal) == 0);
+    __yo_io_wake_continuation(ov->future);
+    __yo_win_free_overlapped(ov);
+    return;
+  }
 
   // The byte count is already in OVERLAPPED_ENTRY.dwNumberOfBytesTransferred
   // (passed in as the bytes argument) and the NTSTATUS is in
@@ -3187,8 +3266,65 @@ static __yo_io_future_t* __yo_async_accept_start(int32_t sockfd, void* addr, uin
   atomic_init(&future->continuation_fn, NULL);
   atomic_init(&future->continuation_sm, NULL);
 
+  SOCKET ls = (SOCKET)(uintptr_t)(uint32_t)sockfd;
+  // Overlapped accept. The previous implementation called accept() and
+  // BLOCKED THE EVENT LOOP until a peer connected — fine when the client had
+  // already connected, fatal when a spawned server task awaits accept before
+  // a client on the same loop connects (the whole loop, client included, sat
+  // in accept() forever: the D6 Windows hang,
+  // issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md).
+  __yo_win_load_acceptex(ls);
+  if (__yo_win_acceptex) {
+    // The accept socket must exist before the call, with the listener's family.
+    struct sockaddr_storage local_name;
+    int local_name_len = (int)sizeof(local_name);
+    int family = AF_INET;
+    if (getsockname(ls, (struct sockaddr*)&local_name, &local_name_len) == 0) {
+      family = local_name.ss_family;
+    }
+    SOCKET as = WSASocketW(family, SOCK_STREAM, IPPROTO_TCP, NULL, 0, WSA_FLAG_OVERLAPPED);
+    if (as == INVALID_SOCKET) {
+      future->result = -(int32_t)WSAGetLastError();
+      atomic_init(&future->state, -1);
+      return future;
+    }
+    __yo_win_associate_handle((HANDLE)ls);
+    __yo_win_overlapped_t* ov = (__yo_win_overlapped_t*)__yo_malloc(sizeof(__yo_win_overlapped_t));
+    memset(ov, 0, sizeof(__yo_win_overlapped_t));
+    ov->future = future;
+    ov->is_socket = true;
+    ov->is_accept = true;
+    ov->sock = ls;
+    ov->listen_sock = ls;
+    ov->accept_sock = as;
+    ov->out_addr = addr;
+    ov->out_addrlen = addrlen;
+    DWORD received = 0;
+    BOOL ok = __yo_win_acceptex(ls, as, ov->accept_buf, 0, sizeof(SOCKADDR_STORAGE) + 16,
+                                sizeof(SOCKADDR_STORAGE) + 16, &received, &ov->overlapped);
+    if (ok) {
+      // Synchronous completion: with FILE_SKIP_COMPLETION_PORT_ON_SUCCESS on
+      // the listener no packet is posted, so finish inline.
+      __yo_win_finish_accept(ov, true);
+      atomic_init(&future->state, -1);
+      __yo_win_free_overlapped(ov);
+      return future;
+    }
+    int err = WSAGetLastError();
+    if (err == ERROR_IO_PENDING || err == WSA_IO_PENDING) {
+      atomic_init(&future->state, 0);
+      __yo_pending_io_count++;
+      return future;
+    }
+    closesocket(as);
+    future->result = -(int32_t)err;
+    atomic_init(&future->state, -1);
+    __yo_win_free_overlapped(ov);
+    return future;
+  }
+  // Extension unavailable: the historical blocking accept.
   int len = (int)(*addrlen);
-  SOCKET result = accept((SOCKET)(uintptr_t)(uint32_t)sockfd, (struct sockaddr*)addr, &len);
+  SOCKET result = accept(ls, (struct sockaddr*)addr, &len);
   if (result == INVALID_SOCKET) {
     future->result = -(int32_t)WSAGetLastError();
   } else {

--- a/src/codegen/async/runtime_io_windows.yo
+++ b/src/codegen/async/runtime_io_windows.yo
@@ -3273,15 +3273,30 @@ static __yo_io_future_t* __yo_async_accept_start(int32_t sockfd, void* addr, uin
   // a client on the same loop connects (the whole loop, client included, sat
   // in accept() forever: the D6 Windows hang,
   // issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md).
-  __yo_win_load_acceptex(ls);
-  if (__yo_win_acceptex) {
+  //
+  // AcceptEx is an AF_INET/AF_INET6 extension. Windows' AF_UNIX implements
+  // neither AcceptEx nor GetAcceptExSockaddrs, so a Unix-domain listener must
+  // keep the blocking accept() below. The family test CANNOT be left to
+  // __yo_win_load_acceptex failing on the socket: the extension pointers are
+  // cached in THREAD-LOCAL statics with an early return, and every socket on
+  // this event loop shares that thread — so one earlier TCP accept leaves
+  // __yo_win_acceptex non-NULL, and an AF_UNIX listener would then sail past
+  // the "extension unavailable" fallback into a path its socket cannot serve.
+  // Decide by the LISTENER'S FAMILY, before the pointer is consulted.
+  // (tests/net/unix.test.yo "bind, connect, accept, echo round-trip".)
+  struct sockaddr_storage local_name;
+  int local_name_len = (int)sizeof(local_name);
+  int family = AF_INET;
+  if (getsockname(ls, (struct sockaddr*)&local_name, &local_name_len) == 0) {
+    family = local_name.ss_family;
+  }
+  bool acceptex_family = (family == AF_INET || family == AF_INET6);
+  if (acceptex_family) {
+    __yo_win_load_acceptex(ls);
+  }
+  if (acceptex_family && __yo_win_acceptex) {
     // The accept socket must exist before the call, with the listener's family.
-    struct sockaddr_storage local_name;
-    int local_name_len = (int)sizeof(local_name);
-    int family = AF_INET;
-    if (getsockname(ls, (struct sockaddr*)&local_name, &local_name_len) == 0) {
-      family = local_name.ss_family;
-    }
+    // IPPROTO_TCP is correct for exactly the two families gated above.
     SOCKET as = WSASocketW(family, SOCK_STREAM, IPPROTO_TCP, NULL, 0, WSA_FLAG_OVERLAPPED);
     if (as == INVALID_SOCKET) {
       future->result = -(int32_t)WSAGetLastError();
@@ -3322,7 +3337,7 @@ static __yo_io_future_t* __yo_async_accept_start(int32_t sockfd, void* addr, uin
     __yo_win_free_overlapped(ov);
     return future;
   }
-  // Extension unavailable: the historical blocking accept.
+  // AF_UNIX, or the extension is unavailable: the historical blocking accept.
   int len = (int)(*addrlen);
   SOCKET result = accept(ls, (struct sockaddr*)addr, &len);
   if (result == INVALID_SOCKET) {

--- a/tests/crypto/tls.test.yo
+++ b/tests/crypto/tls.test.yo
@@ -6,13 +6,6 @@
 //! all, which is how a broken backend stays green
 //! (issues/fixed/live-tls-tests-pass-vacuously-when-the-handshake-fails.md).
 //! The error-enum and availability tests are pure.
-// SKIPPED ON WINDOWS for now — deliberately, and only in this first re-land.
-// The Schannel backend below compiles and links here; whether its handshake
-// COMPLETES is unproven: the first attempt (#413) ran this suite on Windows
-// and the legs hung for the 4-hour job timeout, leaving no log
-// (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md). The
-// un-skip is a separate PR with a per-test deadline on every network test.
-pragma(Pragma.SkipWindows);
 pragma(Pragma.SkipWasm32Emscripten); // no network stack in WASM
 pragma(Pragma.SkipWasm32Wasi); // no network stack in WASM
 { assert, panic } :: import("std/assert");

--- a/tests/crypto/tls_available_sync.test.yo
+++ b/tests/crypto/tls_available_sync.test.yo
@@ -16,18 +16,10 @@ pragma(Pragma.SkipWasm32Wasi); // no network stack in WASM
 { println } :: import("std/fmt");
 
 test("tls_available links and answers in a sync-only program", {
-  avail := tls_available();
-  // unix links OpenSSL, so a `false` there is a build or wiring regression
-  // (CI — the only place this assertion is made — always has OpenSSL; the
-  // same reasoning gates the availability test in tests/crypto/tls.test.yo
-  // behind `CI`). Windows has Schannel in the OS, but its answer is REPORTED
-  // rather than asserted in this first re-land: the one #413 run that did not
-  // hang failed exactly this assertion (exit 22), and every later run hung
-  // with no log. Printing the value is the diagnostic that was never
-  // obtained; the assertion flips to `true` on Windows in the un-skip PR
-  // (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md).
-  cond(
-    (platform == Platform.Windows) => println(`  [D6] tls_available() on Windows (Schannel) = ${avail}`),
-    true => assert(avail, "unix builds carry the OpenSSL backend")
-  );
+  // Not platform-branched: unix links OpenSSL and Windows has Schannel in the
+  // OS (#442 measured `true` on both Windows runners), so a `false` on either
+  // is a build or wiring regression. CI — the only place this assertion is
+  // made — always has OpenSSL; the same reasoning gates the availability test
+  // in tests/crypto/tls.test.yo behind `CI`.
+  assert(tls_available(), "every non-wasm target must carry a working TLS backend");
 });

--- a/tests/http/http.test.yo
+++ b/tests/http/http.test.yo
@@ -1,9 +1,15 @@
 pragma(Pragma.SkipWasm32Emscripten); // https needs a network stack + TLS
 pragma(Pragma.SkipWasm32Wasi); // https needs a network stack + TLS
-// Windows used to skip this whole file because https had no backend there
-// (OpenSSL is absent on the runners). The Schannel backend closed that
-// (plans/D6_TLS_PLAN.md item 3), so every test here — the loopback client,
-// the server, chunked bodies AND the live https fetch — now runs on Windows.
+// Windows: the Schannel backend (plans/D6_TLS_PLAN.md item 3) made the LIVE
+// https fetch pass on both Windows runners, but the loopback test right after
+// it — "fetch follows redirects, resolving relative and absolute-path
+// Locations" — hangs the leg until the job deadline. Plain loopback TCP passes
+// on Windows (tests/net/tcp.test.yo), so the hang is specific to this file's
+// shape: one listener accepting several sequential connections while the
+// client reconnects after each close. tests/net/tcp.test.yo carries the
+// bisecting probes; this gate comes off once they are green on Windows
+// (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md).
+pragma(Pragma.SkipWindows);
 { assert, panic } :: import("std/assert");
 { HttpMethod, HttpRequest, HttpResponse, parse_response } :: import("std/http/http");
 { HttpHeader, http_status_text } :: import("std/http/http");

--- a/tests/http/http.test.yo
+++ b/tests/http/http.test.yo
@@ -1,12 +1,9 @@
 pragma(Pragma.SkipWasm32Emscripten); // https needs a network stack + TLS
 pragma(Pragma.SkipWasm32Wasi); // https needs a network stack + TLS
-// SKIPPED ON WINDOWS for now. Windows has a TLS backend (Schannel, plans/
-// D6_TLS_PLAN.md item 3) and this file compiles and links there — but the
-// first time it RAN on Windows (#413) the legs hung for the 4-hour job
-// timeout with no log to read
-// (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md). The
-// un-skip is a separate PR, with a per-test deadline on every network test.
-pragma(Pragma.SkipWindows);
+// Windows used to skip this whole file because https had no backend there
+// (OpenSSL is absent on the runners). The Schannel backend closed that
+// (plans/D6_TLS_PLAN.md item 3), so every test here — the loopback client,
+// the server, chunked bodies AND the live https fetch — now runs on Windows.
 { assert, panic } :: import("std/assert");
 { HttpMethod, HttpRequest, HttpResponse, parse_response } :: import("std/http/http");
 { HttpHeader, http_status_text } :: import("std/http/http");

--- a/tests/http/http.test.yo
+++ b/tests/http/http.test.yo
@@ -1,15 +1,11 @@
 pragma(Pragma.SkipWasm32Emscripten); // https needs a network stack + TLS
 pragma(Pragma.SkipWasm32Wasi); // https needs a network stack + TLS
-// Windows: the Schannel backend (plans/D6_TLS_PLAN.md item 3) made the LIVE
-// https fetch pass on both Windows runners, but the loopback test right after
-// it — "fetch follows redirects, resolving relative and absolute-path
-// Locations" — hangs the leg until the job deadline. Plain loopback TCP passes
-// on Windows (tests/net/tcp.test.yo), so the hang is specific to this file's
-// shape: one listener accepting several sequential connections while the
-// client reconnects after each close. tests/net/tcp.test.yo carries the
-// bisecting probes; this gate comes off once they are green on Windows
-// (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md).
-pragma(Pragma.SkipWindows);
+// Windows: the Schannel backend (plans/D6_TLS_PLAN.md item 3) made the live
+// https fetch pass on both Windows runners; the loopback tests here then hung
+// the legs because the runtime's `accept` was a BLOCKING call on the event
+// loop (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md —
+// root cause, fixed with an overlapped AcceptEx). Every test in this file
+// runs on Windows again.
 { assert, panic } :: import("std/assert");
 { HttpMethod, HttpRequest, HttpResponse, parse_response } :: import("std/http/http");
 { HttpHeader, http_status_text } :: import("std/http/http");

--- a/tests/net/tcp.test.yo
+++ b/tests/net/tcp.test.yo
@@ -424,13 +424,13 @@ _d6_scripted_server :: (
   io.async(e => {
     k := usize(0);
     while(runtime(k < rounds), {
-      unsafe(printf("  server: accept %zu pending\n", k));
+      eprintln(`  server: accept ${k} pending`);
       s := e.io.await(listener.accept(e.io), e);
       req := e.io.await(_d6_read_headers(s, e.io), e);
       seen.push(req);
       _w := e.io.await(s.write_str("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok", e.io), e);
       e.io.await(s.close(e.io), e);
-      unsafe(printf("  server: round %zu done\n", k));
+      eprintln(`  server: round ${k} done`);
       k = (k + usize(1));
     });
     return(());
@@ -449,10 +449,13 @@ test("accept pending in a spawned task before the client connects (D6 Windows pr
   listener := io.await(TcpListener.bind(addr, io), IoExn(io : io, exn : exn));
   seen := ArrayList(String).new();
   server := io.spawn(_d6_scripted_server(listener, usize(1), seen, io), IoExn(io : io, exn : exn));
+  eprintln(`  client: connecting while the server task's accept is pending`);
   client := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : exn));
+  eprintln(`  client: connected, writing the request`);
   _n := io.await(client.write_str("GET /one HTTP/1.1\r\nHost: x\r\n\r\n", io), IoExn(io : io, exn : exn));
+  eprintln(`  client: written, reading to EOF`);
   body := io.await(client.read_to_end(io), IoExn(io : io, exn : exn));
-  unsafe(printf("  client: got %zu bytes\n", body.len()));
+  eprintln(`  client: got ${body.len()} bytes`);
   assert(body.len() == usize(59), "the whole response, then EOF from the server's close");
   io.await(client.close(io), IoExn(io : io, exn : exn));
   server.await(io);
@@ -475,11 +478,11 @@ test("three request/response rounds against a spawned scripted server (D6 Window
   server := io.spawn(_d6_scripted_server(listener, usize(3), seen, io), IoExn(io : io, exn : exn));
   round := 0;
   while(round < 3, {
-    unsafe(printf("  client: round %d connect\n", round));
+    eprintln(`  client: round ${round} connect`);
     client := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : exn));
     _n := io.await(client.write_str("GET /hop HTTP/1.1\r\nHost: x\r\n\r\n", io), IoExn(io : io, exn : exn));
     body := io.await(client.read_to_end(io), IoExn(io : io, exn : exn));
-    unsafe(printf("  client: round %d got %zu bytes\n", round, body.len()));
+    eprintln(`  client: round ${round} got ${body.len()} bytes`);
     assert(body.len() == usize(59), "each hop's whole response");
     io.await(client.close(io), IoExn(io : io, exn : exn));
     round = (round + 1);

--- a/tests/net/tcp.test.yo
+++ b/tests/net/tcp.test.yo
@@ -316,7 +316,7 @@ test("accept reports the real peer address", {
   io.await(server_stream.close(io), IoExn(io : io, exn : exn));
   io.await(listener.close(io), IoExn(io : io, exn : exn));
 });
-test("one listener accepts three sequential connections (D6 Windows re-arm probe)", {
+test("one listener accepts three sequential connections", {
   // issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md: the
   // http redirect test hangs on Windows while single-accept TCP passes there.
   // This is the first half of that shape in isolation — accept, exchange a
@@ -350,7 +350,7 @@ test("one listener accepts three sequential connections (D6 Windows re-arm probe
   });
   io.await(listener.close(io), IoExn(io : io, exn : exn));
 });
-test("client reads to EOF after the server closes, twice on one listener (D6 Windows probe)", {
+test("client reads to EOF after the server closes, twice on one listener", {
   // Second half of the redirect shape: the SERVER writes and closes first, the
   // client reads until EOF (how an http response without keep-alive ends),
   // then the client reconnects to the same listener for the next hop.
@@ -380,12 +380,15 @@ test("client reads to EOF after the server closes, twice on one listener (D6 Win
   io.await(listener.close(io), IoExn(io : io, exn : exn));
 });
 // ---------------------------------------------------------------------------
-// D6 Windows probes, round 2 (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md).
-// The sequential accept/reconnect probes above PASS on windows-latest, so the
-// redirect test's remaining distinctive shape is reproduced here in raw TCP:
-// the server runs as a SPAWNED task whose `accept` is already pending when
-// the client connects, then reads the request up to the blank line, writes,
+// The shape that deadlocked Windows for four hours, pinned in raw TCP
+// (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md): the
+// server runs as a SPAWNED task whose `accept` is already pending when the
+// client connects, then reads the request up to the blank line, writes,
 // closes — three times — while the client reconnects after each response.
+// Windows `accept` used to be a BLOCKING accept() on the event-loop thread,
+// so the loop sat in it forever and the client — on the same loop — never got
+// to connect. Every pre-existing TCP test connected first and accepted
+// second, which is why nothing caught it until a server was spawned first.
 // ---------------------------------------------------------------------------
 _d6_ends_headers :: (fn(b : ArrayList(u8)) -> bool)({
   n := b.len();
@@ -436,7 +439,7 @@ _d6_scripted_server :: (
     return(());
   })
 );
-test("accept pending in a spawned task before the client connects (D6 Windows probe)", {
+test("accept pending in a spawned task before the client connects", {
   exn := Exception(
     throw : (
       err -> {
@@ -463,7 +466,7 @@ test("accept pending in a spawned task before the client connects (D6 Windows pr
   assert(seen(usize(0)).starts_with(`GET /one`), "the request line");
   io.await(listener.close(io), IoExn(io : io, exn : exn));
 });
-test("three request/response rounds against a spawned scripted server (D6 Windows probe — the redirect shape in raw TCP)", {
+test("three request/response rounds against a spawned scripted server", {
   exn := Exception(
     throw : (
       err -> {

--- a/tests/net/tcp.test.yo
+++ b/tests/net/tcp.test.yo
@@ -316,3 +316,66 @@ test("accept reports the real peer address", {
   io.await(server_stream.close(io), IoExn(io : io, exn : exn));
   io.await(listener.close(io), IoExn(io : io, exn : exn));
 });
+test("one listener accepts three sequential connections (D6 Windows re-arm probe)", {
+  // issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md: the
+  // http redirect test hangs on Windows while single-accept TCP passes there.
+  // This is the first half of that shape in isolation — accept, exchange a
+  // byte, close, and accept AGAIN on the same listener.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  addr := SocketAddr.loopback(u16(19911));
+  listener := io.await(TcpListener.bind(addr, io), IoExn(io : io, exn : exn));
+  round := 0;
+  while(round < 3, {
+    unsafe(printf("  round %d: connect\n", round));
+    client := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : exn));
+    unsafe(printf("  round %d: accept\n", round));
+    server_stream := io.await(listener.accept(io), IoExn(io : io, exn : exn));
+    n := io.await(client.write_str("x", io), IoExn(io : io, exn : exn));
+    assert(n == usize(1), "should send 1 byte");
+    buf := *(u8)(malloc(usize(8)).unwrap());
+    nr := io.await(server_stream.read(buf, usize(8), io), IoExn(io : io, exn : exn));
+    assert(nr == usize(1), "server should read the 1 byte");
+    free(.Some(*(void)(buf)));
+    io.await(server_stream.close(io), IoExn(io : io, exn : exn));
+    io.await(client.close(io), IoExn(io : io, exn : exn));
+    unsafe(printf("  round %d: done\n", round));
+    round = (round + 1);
+  });
+  io.await(listener.close(io), IoExn(io : io, exn : exn));
+});
+test("client reads to EOF after the server closes, twice on one listener (D6 Windows probe)", {
+  // Second half of the redirect shape: the SERVER writes and closes first, the
+  // client reads until EOF (how an http response without keep-alive ends),
+  // then the client reconnects to the same listener for the next hop.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  addr := SocketAddr.loopback(u16(19912));
+  listener := io.await(TcpListener.bind(addr, io), IoExn(io : io, exn : exn));
+  round := 0;
+  while(round < 2, {
+    client := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : exn));
+    server_stream := io.await(listener.accept(io), IoExn(io : io, exn : exn));
+    io.await(server_stream.write_str("HTTP/1.1 302 Found\r\nContent-Length: 0\r\n\r\n", io), IoExn(io : io, exn : exn));
+    io.await(server_stream.close(io), IoExn(io : io, exn : exn));
+    unsafe(printf("  round %d: server closed, client read_to_end\n", round));
+    body := io.await(client.read_to_end(io), IoExn(io : io, exn : exn));
+    unsafe(printf("  round %d: got %zu bytes\n", round, body.len()));
+    assert(body.len() == usize(41), "client must see the whole response then EOF");
+    io.await(client.close(io), IoExn(io : io, exn : exn));
+    round = (round + 1);
+  });
+  io.await(listener.close(io), IoExn(io : io, exn : exn));
+});

--- a/tests/net/tcp.test.yo
+++ b/tests/net/tcp.test.yo
@@ -379,3 +379,112 @@ test("client reads to EOF after the server closes, twice on one listener (D6 Win
   });
   io.await(listener.close(io), IoExn(io : io, exn : exn));
 });
+// ---------------------------------------------------------------------------
+// D6 Windows probes, round 2 (issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md).
+// The sequential accept/reconnect probes above PASS on windows-latest, so the
+// redirect test's remaining distinctive shape is reproduced here in raw TCP:
+// the server runs as a SPAWNED task whose `accept` is already pending when
+// the client connects, then reads the request up to the blank line, writes,
+// closes — three times — while the client reconnects after each response.
+// ---------------------------------------------------------------------------
+_d6_ends_headers :: (fn(b : ArrayList(u8)) -> bool)({
+  n := b.len();
+  cond(
+    (n < usize(4)) => false,
+    true => ((b(n - usize(4)) == u8(13)) && (b(n - usize(3)) == u8(10)) && ((b(n - usize(2)) == u8(13)) && (b(n - usize(1)) == u8(10))))
+  )
+});
+_d6_read_headers :: (fn(stream : TcpStream, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async(e => {
+    buf := *(u8)(malloc(usize(4096)).unwrap());
+    bytes := ArrayList(u8).new();
+    eof := false;
+    while(runtime(!eof && !_d6_ends_headers(bytes)), {
+      n := e.io.await(stream.read(buf, usize(4096), e.io), e);
+      cond(
+        (n == usize(0)) => {
+          eof = true;
+        },
+        true => {
+          i := usize(0);
+          while(runtime(i < n), {
+            bytes.push((buf.add(i)).*);
+            i = (i + usize(1));
+          });
+        }
+      );
+    });
+    free(.Some(*(void)(buf)));
+    String.from_bytes(bytes)
+  })
+);
+_d6_scripted_server :: (
+  fn(listener : TcpListener, rounds : usize, seen : ArrayList(String), io : Io) -> Impl(Future(unit, IoExn))
+)(
+  io.async(e => {
+    k := usize(0);
+    while(runtime(k < rounds), {
+      unsafe(printf("  server: accept %zu pending\n", k));
+      s := e.io.await(listener.accept(e.io), e);
+      req := e.io.await(_d6_read_headers(s, e.io), e);
+      seen.push(req);
+      _w := e.io.await(s.write_str("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok", e.io), e);
+      e.io.await(s.close(e.io), e);
+      unsafe(printf("  server: round %zu done\n", k));
+      k = (k + usize(1));
+    });
+    return(());
+  })
+);
+test("accept pending in a spawned task before the client connects (D6 Windows probe)", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  addr := SocketAddr.loopback(u16(19913));
+  listener := io.await(TcpListener.bind(addr, io), IoExn(io : io, exn : exn));
+  seen := ArrayList(String).new();
+  server := io.spawn(_d6_scripted_server(listener, usize(1), seen, io), IoExn(io : io, exn : exn));
+  client := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : exn));
+  _n := io.await(client.write_str("GET /one HTTP/1.1\r\nHost: x\r\n\r\n", io), IoExn(io : io, exn : exn));
+  body := io.await(client.read_to_end(io), IoExn(io : io, exn : exn));
+  unsafe(printf("  client: got %zu bytes\n", body.len()));
+  assert(body.len() == usize(59), "the whole response, then EOF from the server's close");
+  io.await(client.close(io), IoExn(io : io, exn : exn));
+  server.await(io);
+  assert(seen.len() == usize(1), "one request seen");
+  assert(seen(usize(0)).starts_with(`GET /one`), "the request line");
+  io.await(listener.close(io), IoExn(io : io, exn : exn));
+});
+test("three request/response rounds against a spawned scripted server (D6 Windows probe — the redirect shape in raw TCP)", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  addr := SocketAddr.loopback(u16(19914));
+  listener := io.await(TcpListener.bind(addr, io), IoExn(io : io, exn : exn));
+  seen := ArrayList(String).new();
+  server := io.spawn(_d6_scripted_server(listener, usize(3), seen, io), IoExn(io : io, exn : exn));
+  round := 0;
+  while(round < 3, {
+    unsafe(printf("  client: round %d connect\n", round));
+    client := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : exn));
+    _n := io.await(client.write_str("GET /hop HTTP/1.1\r\nHost: x\r\n\r\n", io), IoExn(io : io, exn : exn));
+    body := io.await(client.read_to_end(io), IoExn(io : io, exn : exn));
+    unsafe(printf("  client: round %d got %zu bytes\n", round, body.len()));
+    assert(body.len() == usize(59), "each hop's whole response");
+    io.await(client.close(io), IoExn(io : io, exn : exn));
+    round = (round + 1);
+  });
+  server.await(io);
+  assert(seen.len() == usize(3), "three requests seen");
+  io.await(listener.close(io), IoExn(io : io, exn : exn));
+});


### PR DESCRIPTION
Stacked on #442. Un-skips `tests/crypto/tls.test.yo` and `tests/http/http.test.yo` on Windows and asserts `tls_available()` there (#442 measured `true` on both runners, legs completed in 28/37 min).

**Purpose: find which test hangs.** The runner streams a `✓` per test under `--verbose`, and the Windows legs now have a 75-minute budget, so a hang ends in a *failed* job with a downloadable log — the last `✓` names the culprit. Not for merge as-is; the fix (and per-test deadlines) follow from what this run shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)