### PR TITLE
std/imm/vec: stop leaking a reference per element on grow, pop and reverse; initialize fresh buffers with consume (+ Deque C35 guard)

### DIFF
--- a/issues/fixed/imm-vec-leaks-on-grow-and-drops-uninitialized-memory.md
+++ b/issues/fixed/imm-vec-leaks-on-grow-and-drops-uninitialized-memory.md
@@ -1,0 +1,64 @@
+# `imm/Vec` leaks one reference per element on every grow, `pop` and `reverse`, and drops uninitialized memory in five methods
+
+**Status: FIXED 2026-09-06** (`std/imm/vec.yo`; `Deque._grow` got the same C35
+guard in the same change). Found by the std API stabilization audit
+(`plans/STD_API_STABILIZATION.md` §3 item 1).
+
+**Severity: memory safety.** Silent for every RC element type (`ImmString`, a
+nested imm `Vec`, any `Send + Acyclic` aggregate) — and invisible to the test
+suite, whose only RC-element test pushed 3 elements into a capacity-4 vector
+(no grow) and popped a SHARED vector (the copy path).
+
+## The leaks — measured with `rc()` on one shared `ImmString` witness
+
+| operation (unique owner) | want | got | why |
+| --- | --- | --- | --- |
+| `with_capacity(1).push(s).push(s)` (second push grows) | 3 | **4** | `_copy_elems` dups every element into the new buffer, then the old buffer is `free`d without dropping — +1 per element per grow (`push` :144-149) |
+| `concat` that grows | 6 | **7** | same shape (`concat` :236-247) |
+| `new().push(s).pop()` | 2 | **3** | `val := slot.*` dups; the unique path only shrinks `_len`, so the slot's own reference is now outside `Dispose`'s loop and is never released (`pop` :189-193) |
+| `new().push(s).push(t).reverse()` (in place) | 2 | **3** | the swap used `consume(...)` — *initialize without dropping* — on two LIVE slots, so each overwritten reference was lost |
+
+(The audit's grow-path attribution was right; the `reverse` leak was found by
+applying the same reasoning to the in-place swap. Counts above are with a
+develop-built compiler; the v0.2.24 seed adds a separate, already-fixed +1 per
+`own(self)` call in generic impls — #428 — which is why the first probes read
+one higher still.)
+
+## The drops of uninitialized memory
+
+`map` (:292), `filter` (:304), the copy path of `reverse` (:281), the copy path
+of `dedup` (:408) and `zip_with` (:425) wrote `(new_ptr.add(i)).* = v` into a
+fresh `malloc` buffer. A bare deref-store DROPS the destination's previous
+value; only `consume(dst.* = v)` initializes. On zeroed fresh pages the bogus
+drop is a no-op, which is why nothing crashed — under
+`MallocPreScribble=1 MallocScribble=1` (0xAA-filled allocations) the
+`initialize fresh buffers` test dies with SIGSEGV before the fix and passes
+after.
+
+## Fix
+
+- Unique-owner grow paths MOVE the elements as raw bytes (`_move_elems` →
+  `memcpy`): ownership travels with the bytes, nothing is dup'd, the old buffer
+  is just freed. `_copy_elems` (dup per element) stays for the buffer the
+  source keeps sharing (`concat`'s `other`, every `rc > 1` copy path).
+- `pop`'s unique path `unsafe.drop`s the slot it vacates.
+- The in-place `reverse` swap uses plain stores (drop the overwritten value,
+  dup the stored one — the three stores balance).
+- The five fresh-buffer stores are `consume(...)`.
+- `_raw_alloc` and `Deque._grow` gained the C35 `size_would_overflow` guard
+  (`Deque` also clamps its doubling loop, which could wrap to 0 and spin); they
+  were the two collections `issues/fixed/collection-capacity-overflow-unchecked.md`
+  left out.
+
+## Regression tests
+
+`tests/imm_vec.test.yo`: five `rc()`-witness tests, one per path, red-first on
+the unpatched std with a develop-built compiler (4/5 by count; the fifth by
+SIGSEGV under `MallocPreScribble`).
+
+## Lesson
+
+**Probe std reference counts with a compiler built from the tree, never with the
+PATH `yo` (the seed).** The seed is the PREVIOUS release: here it lacked #428,
+so every count read one higher than the std bug alone explained, and the first
+two rounds of "fixes" appeared not to work.

--- a/std/collections/deque.yo
+++ b/std/collections/deque.yo
@@ -11,7 +11,8 @@
 //! x := d.pop_front().unwrap();  // 0
 //! ```
 pragma(Pragma.AllowUnsafe);
-{ GlobalAllocator, AllocError } :: import("../allocator");
+{ GlobalAllocator, AllocError, size_would_overflow } :: import("../allocator");
+{ SIZE_MAX } :: import("../libc/stdint");
 { assert } :: import("../assert");
 { malloc, realloc, free } :: GlobalAllocator;
 /// Circular buffer supporting efficient push/pop at both front and back.
@@ -47,7 +48,19 @@ impl(
       (self._capacity == usize(0)) => usize(8),
       true => (self._capacity * usize(2))
     );
-    while(new_cap < min_cap, new_cap = (new_cap * usize(2)), ());
+    // Same wrap as ArrayList.with_capacity: `new_cap * sizeof(T)` is computed in
+    // usize, and the doubling loop itself can wrap to 0 and spin forever
+    // (issues/fixed/collection-capacity-overflow-unchecked.md — the C35 guard
+    // every other collection carries; Deque was the one left out).
+    while(new_cap < min_cap, {
+      new_cap = cond(
+        (new_cap > (SIZE_MAX / usize(2))) => min_cap,
+        true => (new_cap * usize(2))
+      );
+    });
+    if(size_would_overflow(T, new_cap), {
+      __yo_panic("Deque: capacity overflow");
+    });
     size := (new_cap * sizeof(T));
     new_buf := *(T)(malloc(size).unwrap());
     // Linearise existing elements into the new buffer

--- a/std/imm/vec.yo
+++ b/std/imm/vec.yo
@@ -25,7 +25,8 @@
 //! assert((v.len() == usize(3)), "length is 3");
 //! ```
 pragma(Pragma.AllowUnsafe);
-{ GlobalAllocator } :: import("../allocator.yo");
+{ GlobalAllocator, size_would_overflow } :: import("../allocator.yo");
+{ memcpy } :: import("../libc/string.yo");
 { ArrayList } :: import("../collections/array_list.yo");
 { assert } :: import("../assert");
 { malloc, free } :: GlobalAllocator;
@@ -76,6 +77,11 @@ impl(
       (cap > usize(0)) => cap,
       true => usize(1)
     );
+    // `sizeof(T) * cap` wraps in usize — the C35 guard every other collection
+    // carries (issues/fixed/collection-capacity-overflow-unchecked.md).
+    if(size_would_overflow(T, alloc_cap), {
+      __yo_panic("imm.Vec: capacity overflow");
+    });
     sz := (sizeof(T) * alloc_cap);
     match(
       malloc(sz),
@@ -96,6 +102,18 @@ impl(
     i := usize(0);
     while(i < count, i = (i + usize(1)), {
       consume((dst.add(dst_offset + i)).* = (src.add(src_offset + i)).*);
+    });
+  }),
+  /// MOVE `count` elements from `src` into the fresh buffer `dst` as raw bytes:
+  /// ownership of every reference transfers with the bytes, so nothing is
+  /// dup'd and nothing needs dropping — the old buffer is then just freed.
+  /// This is the unique-owner grow path; `_copy_elems` (dup per element) is
+  /// for a buffer the source keeps sharing. Copying with `_copy_elems` and then
+  /// freeing the old buffer leaked one reference per element per grow
+  /// (issues/fixed/imm-vec-leaks-on-grow-and-drops-uninitialized-memory.md).
+  _move_elems : (fn(dst : *T, src : *T, count : usize) -> unit)({
+    if(count > usize(0), {
+      _ := unsafe(memcpy((*void)(dst), (*void)(src), count * sizeof(T)));
     });
   }),
   /// Create a new empty vector.
@@ -142,9 +160,7 @@ impl(
       if(self._len >= self._cap, {
         new_cap := (self._cap * usize(2));
         new_ptr := Self._raw_alloc(new_cap);
-        if(self._len > usize(0), {
-          Self._copy_elems(new_ptr, self._ptr, usize(0), usize(0), self._len);
-        });
+        Self._move_elems(new_ptr, self._ptr, self._len);
         free(.Some(*(void)(self._ptr)));
         self._ptr = new_ptr;
         self._cap = new_cap;
@@ -189,6 +205,9 @@ impl(
     val := (self._ptr.add(self._len - usize(1))).*;
     new_len := (self._len - usize(1));
     if(rc(self) == usize(1), {
+      // `val` holds its own reference; the slot's reference must be released
+      // here — shrinking `_len` alone moves it outside `Dispose`'s loop.
+      unsafe.drop((self._ptr.add(new_len)).*);
       self._len = new_len;
       return(PopResult(T)(vec : self, value : .Some(val)));
     });
@@ -234,9 +253,7 @@ impl(
         true => (self._cap * usize(2))
       );
       new_ptr := Self._raw_alloc(new_cap);
-      if(self._len > usize(0), {
-        Self._copy_elems(new_ptr, self._ptr, usize(0), usize(0), self._len);
-      });
+      Self._move_elems(new_ptr, self._ptr, self._len);
       if(other._len > usize(0), {
         Self._copy_elems(new_ptr, other._ptr, self._len, usize(0), other._len);
       });
@@ -269,16 +286,20 @@ impl(
         left = (left + usize(1));
         right = (right - usize(1));
       }, {
+        // A swap of two LIVE slots: a plain store drops the value it overwrites
+        // and dups the one it stores, so the three stores balance. `consume`
+        // (initialize, no drop) is for FRESH memory only — used here it leaked
+        // one reference of each swapped element.
         tmp := (self._ptr.add(left)).*;
-        consume((self._ptr.add(left)).* = (self._ptr.add(right)).*);
-        consume((self._ptr.add(right)).* = tmp);
+        (self._ptr.add(left)).* = (self._ptr.add(right)).*;
+        (self._ptr.add(right)).* = tmp;
       });
       return(self);
     });
     new_ptr := Self._raw_alloc(self._len);
     i := usize(0);
     while(i < self._len, i = (i + usize(1)), {
-      (new_ptr.add(i)).* = (self._ptr.add(self._len - usize(1) - i)).*;
+      consume((new_ptr.add(i)).* = (self._ptr.add(self._len - usize(1) - i)).*);
     });
     result := Self(_ptr : new_ptr, _len : self._len, _cap : self._len);
     unsafe.drop(self);
@@ -289,7 +310,7 @@ impl(
     new_ptr := Vec(U)._raw_alloc(self._len);
     i := usize(0);
     while(i < self._len, i = (i + usize(1)), {
-      (new_ptr.add(i)).* = f((self._ptr.add(i)).*);
+      consume((new_ptr.add(i)).* = f((self._ptr.add(i)).*));
     });
     Vec(U)(_ptr : new_ptr, _len : self._len, _cap : self._len)
   }),
@@ -301,7 +322,7 @@ impl(
     while(i < self._len, i = (i + usize(1)), {
       elem := (self._ptr.add(i)).*;
       if(f(elem), {
-        (new_ptr.add(count)).* = elem;
+        consume((new_ptr.add(count)).* = elem);
         count = (count + usize(1));
       });
     });
@@ -405,7 +426,7 @@ impl(
         });
       });
       if(!found, {
-        (new_ptr.add(count)).* = elem;
+        consume((new_ptr.add(count)).* = elem);
         count = (count + usize(1));
       });
     });
@@ -422,7 +443,7 @@ impl(
     new_ptr := Vec(V)._raw_alloc(min_len);
     i := usize(0);
     while(i < min_len, i = (i + usize(1)), {
-      (new_ptr.add(i)).* = f((self._ptr.add(i)).*, other(i));
+      consume((new_ptr.add(i)).* = f((self._ptr.add(i)).*, other(i)));
     });
     Vec(V)(_ptr : new_ptr, _len : min_len, _cap : min_len)
   }),

--- a/tests/imm_vec.test.yo
+++ b/tests/imm_vec.test.yo
@@ -377,3 +377,59 @@ test("O7: a cyclic element type is rejected — atomic RC cannot collect cycles"
   comptime_expect_error(Vec(CyclicNode));
   assert(true, "rejected at comptime");
 });
+// REFERENCE-COUNT WITNESS: `rc(s)` on one shared ImmString counts exactly how
+// many slots (plus the local) hold it, so every path below is a precise leak
+// gate — a dup without a matching drop shows as a count one too high, and a
+// dropped-garbage store shows as a crash or a count one too low.
+// issues/fixed/imm-vec-leaks-on-grow-and-drops-uninitialized-memory.md
+test("Vec: a unique push that GROWS the buffer does not leak the moved elements", {
+  s := ImmString.from("w");
+  v := Vec(ImmString).with_capacity(usize(1)).push(s).push(s);
+  assert(v.len() == usize(2), "two slots");
+  assert(rc(s) == usize(3), `one local + two slots, got ${rc(s)}`);
+});
+test("Vec: a unique concat that GROWS the buffer does not leak the moved elements", {
+  s := ImmString.from("w");
+  a := Vec(ImmString).with_capacity(usize(1)).push(s);
+  b := Vec(ImmString).new().push(s).push(s);
+  c := a.concat(b);
+  assert(c.len() == usize(3), "three slots in c");
+  assert(rc(s) == usize(6), `one local + c's three + b's two, got ${rc(s)}`);
+});
+test("Vec: a unique pop releases the popped slot exactly once", {
+  s := ImmString.from("w");
+  v := Vec(ImmString).new().push(s);
+  r := v.pop();
+  assert(r.value.is_some(), "popped a value");
+  assert(r.vec.len() == usize(0), "vector is empty");
+  assert(rc(s) == usize(2), `one local + the popped value, got ${rc(s)}`);
+});
+test("Vec: an in-place reverse swaps without leaking", {
+  s := ImmString.from("w");
+  t := ImmString.from("z");
+  v := Vec(ImmString).new().push(s).push(t).reverse();
+  assert(v(usize(0)).eq_str("z"), "reversed");
+  assert(rc(s) == usize(2), `s: one local + one slot, got ${rc(s)}`);
+  assert(rc(t) == usize(2), `t: one local + one slot, got ${rc(t)}`);
+});
+// A bare `p.* = v` into fresh malloc memory DROPS the garbage destination; this
+// test is red only when that garbage is a live-looking pointer — run it under
+// `MallocPreScribble=1 MallocScribble=1` (macOS; SIGSEGV before the fix) or
+// Linux ASan. Without scribbling, fresh pages are usually zero and the bogus
+// drop is a no-op, so the count below alone is not the gate.
+test("Vec: map, filter, a shared reverse, a shared dedup and zip_with initialize fresh buffers", {
+  s := ImmString.from("w");
+  v := Vec(ImmString).new().push(s).push(s).push(s);
+  shared_r := v;
+  shared_d := v;
+  m := v.map(x -> x);
+  f := v.filter(x -> true);
+  r := shared_r.reverse();
+  d := shared_d.dedup();
+  z := v.zip_with(v, (a, b) -> a);
+  assert((m.len() == usize(3)) && (f.len() == usize(3)), "map/filter keep three");
+  assert((r.len() == usize(3)) && (d.len() == usize(1)), "reverse keeps three, dedup keeps one");
+  assert(z.len() == usize(3), "zip_with keeps three");
+  // local + v(3) + m(3) + f(3) + r(3) + d(1) + z(3)
+  assert(rc(s) == usize(17), `every fresh buffer holds exactly one ref per slot, got ${rc(s)}`);
+});


### PR DESCRIPTION
First P0 of `plans/STD_API_STABILIZATION.md` (#444) §3 item 1.

Measured with `rc()` on one shared `ImmString` witness, develop-built compiler, unique-owner paths:

| op | want | got | cause |
|---|---|---|---|
| `push` that grows | 3 | **4** | `_copy_elems` dup'd every element, old buffer `free`d without dropping |
| `concat` that grows | 6 | **7** | same |
| `pop` | 2 | **3** | slot shrunk out of `Dispose`'s loop, never released |
| `reverse` in place | 2 | **3** | `consume(...)` on two *live* slots never drops what it overwrites |

Plus five bare `p.* = v` stores into fresh `malloc` memory (`map`, `filter`, copy paths of `reverse`/`dedup`, `zip_with`) — a bare deref-store drops the garbage destination. Silent on zeroed pages; **SIGSEGV under `MallocPreScribble=1`** before the fix, clean after.

Fix: unique-owner grows *move* elements as raw bytes (`_move_elems` → `memcpy`, no dup/drop churn; `_copy_elems` stays for shared sources); `pop` drops the vacated slot; the in-place swap uses plain stores; the five fresh-buffer stores are `consume(...)`. `_raw_alloc` and `Deque._grow` gain the C35 `size_would_overflow` guard (Deque also clamps its doubling loop) — the two collections the C35 fix left out.

Tests: five `rc()`-witness tests, red-first on the unpatched std (4/5 by count; the fifth by SIGSEGV under scribble). `tests/imm_vec.test.yo` 53/53, `tests/collections/deque.test.yo` 38/38 with the develop-built compiler.

Note for anyone reproducing: the PATH `yo` is the v0.2.24 seed and lacks #428, so its counts read one higher than the std bug alone explains — use a tree-built stage-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)