### PR TITLE
std/net: parse_v4 rejects empty/wrapping/leading-zero octets; UdpSocket.bind reads back its port and gains connect

### DIFF
--- a/issues/fixed/ipaddr-parse-v4-accepts-empty-and-wrapping-octets.md
+++ b/issues/fixed/ipaddr-parse-v4-accepts-empty-and-wrapping-octets.md
@@ -1,0 +1,33 @@
+# `IpAddr.parse_v4` accepted empty octets, wrapping octets and leading zeros — three silent wrong values
+
+**Status: FIXED 2026-09-06** (`std/net/addr.yo`). Found by the std API
+stabilization audit (`plans/STD_API_STABILIZATION.md` §3 item 6).
+
+**Severity: wrong value.** Not an error that could be caught — a *different
+address*:
+
+| input | parsed as | why |
+| --- | --- | --- |
+| `"..."` | `0.0.0.0` | three separators each hit the `.` arm with `val == 0`; nothing counted the digits in an octet |
+| `"1.2.3."` | `1.2.3.0` | same — the trailing empty octet became 0 |
+| `"4294967297.0.0.0"` | `1.0.0.0` | the accumulator `val * 10 + d` was range-checked only at the separator, after it had wrapped `u32` |
+| `"01.2.3.4"` | `1.2.3.4` | leading zeros accepted; Rust's `Ipv4Addr::from_str` rejects them (octal ambiguity) |
+
+`tests/net/addr.test.yo` covered `999.0.0.1`, `1.2.3` and `1.2.3.abc` — none of
+these shapes.
+
+## Fix
+
+Count the digits in the current octet: a separator or the end of input with
+zero digits is an error; a digit after a leading `0` is an error; the range
+check runs after every digit, so the accumulator can never wrap.
+
+## Regression tests
+
+`tests/net/addr.test.yo`: three tests (empty octets ×5 shapes, wrapping
+octets ×2, leading zeros ×2 plus `0.0.0.0` as the acceptance canary), red-first.
+
+Still open for this function (P1 in the plan): it throws through `Exception`
+with a stringly `NetError.Other` payload for a pure parse — D1 puts parsing on
+`Result(T, TypedError)`; `AddrParseError` and `parse_v6`/`SocketAddr.parse`
+are the follow-up.

--- a/issues/fixed/udpsocket-bind-echoes-its-argument-and-send-has-no-connect.md
+++ b/issues/fixed/udpsocket-bind-echoes-its-argument-and-send-has-no-connect.md
@@ -1,0 +1,36 @@
+# `UdpSocket.bind` echoed its argument (an ephemeral bind reported port 0) and `send`/`recv` required a `connect` that did not exist
+
+**Status: FIXED 2026-09-06** (`std/net/udp.yo`, `std/net/tcp.yo`). Found by the
+std API stabilization audit (`plans/STD_API_STABILIZATION.md` §3 item 7).
+
+## Two defects
+
+1. **`bind` stored the bind ARGUMENT as `_local_addr`** (`udp.yo:87`). Binding
+   port 0 — the only reason to bind port 0 — therefore reported port **0**
+   forever, and there was no other way to learn the kernel-assigned port.
+   `TcpListener.bind` was fixed for exactly this as C2 (`getsockname` readback,
+   `tcp.yo:168-181`); UDP never received it. The existing test asserted only
+   `la.ip.is_loopback()` and never looked at the port.
+2. **`send` and `recv` said "requires prior connect" and no `connect` existed**
+   anywhere in `std/net` — they were dead on arrival (`ENOTCONN`, always).
+
+## Fix
+
+- `bind` reads the bound address back with `SockInfo.getsockname`, decoding it
+  through TCP's sockaddr decoder — exported from `std/net/tcp` as
+  `sockaddr_to_socket_addr` (it was `_sockaddr_to_socket_addr`, private; one
+  decoder for the whole `net` layer, and §1 forbids underscore names in
+  `export(...)`).
+- `UdpSocket.connect(addr, io)` — `connect(2)` on the datagram socket via the
+  existing `IO_tcp.connect` future; Rust's `UdpSocket::connect`.
+
+## Regression tests
+
+`tests/net/udp.test.yo`: *bind to port 0 reports the kernel-assigned port*
+(asserts `port != 0`) and *connect makes send and recv usable* (a connected
+pair exchanging a datagram each way). Red-first: the second did not compile
+(`connect` unresolved), which masked the first until the fix.
+
+Still open (P1): `recv_from` hands back a raw `sockaddr` buffer instead of a
+`SocketAddr` — the same decoder now makes `recv_from -> (n, from)` a small
+change.

--- a/std/net/addr.yo
+++ b/std/net/addr.yo
@@ -33,12 +33,18 @@ IpAddr :: enum(
 impl(
   IpAddr,
   /// Parse an IPv4 address from a dotted-decimal `String` (e.g. "127.0.0.1").
-  /// Throws on invalid input.
+  /// Throws on invalid input. Exactly four octets of 1–3 decimal digits, each
+  /// 0–255, no leading zeros (`01.2.3.4` is rejected, as Rust's
+  /// `Ipv4Addr::from_str` does — octal ambiguity), no empty octet (`1..2.3`,
+  /// `1.2.3.`, `...` used to parse as 0-filled addresses).
   parse_v4 : (fn(s : String, exn : Exception) -> IpAddr)({
     bytes := s.as_bytes();
     parts := Array(u8, usize(4)).fill(u8(0));
     part_idx := usize(0);
     val := u32(0);
+    // Digits seen in the CURRENT octet — an octet with none is a wrong value,
+    // not a zero (issues/fixed/ipaddr-parse-v4-accepts-empty-and-wrapping-octets.md).
+    digits := usize(0);
     i := usize(0);
     while(runtime(i < bytes.len()), {
       ch := bytes(i);
@@ -49,21 +55,33 @@ impl(
             (part_idx >= usize(3)) => {
               exn.throw(dyn(NetError.Other(String.from("invalid IPv4 address"))));
             },
-            true => ()
-          );
-          cond(
-            (val > u32(255)) => {
-              exn.throw(dyn(NetError.Other(String.from("IPv4 octet out of range"))));
+            (digits == usize(0)) => {
+              exn.throw(dyn(NetError.Other(String.from("empty IPv4 octet"))));
             },
             true => ()
           );
           parts(part_idx) = u8(val);
           part_idx = (part_idx + usize(1));
           val = u32(0);
+          digits = usize(0);
         },
         ((ch >= _ASCII_ZERO) && (ch <= _ASCII_NINE)) => {
-          // digit
+          // digit. Range-check as we go: the accumulator used to be checked
+          // only at the separator, so `4294967297.0.0.0` wrapped to 1.0.0.0.
+          cond(
+            ((digits > usize(0)) && (val == u32(0))) => {
+              exn.throw(dyn(NetError.Other(String.from("leading zero in IPv4 octet"))));
+            },
+            true => ()
+          );
           val = ((val * u32(10)) + u32(ch - _ASCII_ZERO));
+          digits = (digits + usize(1));
+          cond(
+            (val > u32(255)) => {
+              exn.throw(dyn(NetError.Other(String.from("IPv4 octet out of range"))));
+            },
+            true => ()
+          );
         },
         true => {
           exn.throw(dyn(NetError.Other(String.from("invalid character in IPv4 address"))));
@@ -75,11 +93,8 @@ impl(
       (part_idx != usize(3)) => {
         exn.throw(dyn(NetError.Other(String.from("invalid IPv4 address"))));
       },
-      true => ()
-    );
-    cond(
-      (val > u32(255)) => {
-        exn.throw(dyn(NetError.Other(String.from("IPv4 octet out of range"))));
+      (digits == usize(0)) => {
+        exn.throw(dyn(NetError.Other(String.from("empty IPv4 octet"))));
       },
       true => ()
     );

--- a/std/net/tcp.yo
+++ b/std/net/tcp.yo
@@ -53,9 +53,11 @@ _make_sockaddr :: (fn(addr : SocketAddr) -> IO_tcp.SockAddr)(
     }
   )
 );
-// Parse a low-level sockaddr buffer (as filled in by accept/getsockname)
-// back into a SocketAddr. Unknown families fall back to 0.0.0.0:0.
-_sockaddr_to_socket_addr :: (fn(buf : *u8) -> SocketAddr)({
+/// Parse a low-level sockaddr buffer (as filled in by accept/getsockname/
+/// recvfrom) back into a `SocketAddr`. Unknown families fall back to 0.0.0.0:0.
+/// Shared with `std/net/udp` (its `bind` readback) — one decoder for the whole
+/// `net` layer.
+sockaddr_to_socket_addr :: (fn(buf : *u8) -> SocketAddr)({
   fam := IO_tcp.get_family(buf);
   cond(
     (fam == u16(AF_INET)) => {
@@ -120,7 +122,7 @@ _shutdown_to_how :: (fn(how : Shutdown) -> i32)(
     .Both => SHUT_RDWR
   )
 );
-export(Shutdown);
+export(Shutdown, sockaddr_to_socket_addr);
 /// A TCP socket that listens for incoming connections.
 TcpListener :: ref(
   struct(
@@ -173,7 +175,7 @@ impl(
       la_len.* = u32(128);
       gsn := SockInfo.getsockname(fd, la_buf, la_len);
       local := cond(
-        (gsn == i32(0)) => _sockaddr_to_socket_addr(la_buf),
+        (gsn == i32(0)) => sockaddr_to_socket_addr(la_buf),
         true => addr
       );
       free(.Some(*(void)(la_buf)));
@@ -200,7 +202,7 @@ impl(
       );
       // Parse the peer address the kernel filled in. This used to read only
       // the port and fabricate 0.0.0.0 as the IP (plans/STD_API_AUDIT.md C2).
-      peer_addr := _sockaddr_to_socket_addr(addr_buf);
+      peer_addr := sockaddr_to_socket_addr(addr_buf);
       free(.Some(*(void)(addr_buf)));
       free(.Some(*(void)(addr_len)));
       return(

--- a/std/net/udp.yo
+++ b/std/net/udp.yo
@@ -26,6 +26,8 @@ open(import("../fmt"));
 { Error, AnyError, Exception, IoExn } :: import("../error");
 IO_udp :: import("../sys/udp");
 IO_tcp :: import("../sys/tcp");
+SockInfo :: import("../sys/sockinfo");
+{ sockaddr_to_socket_addr } :: import("./tcp");
 { AF_INET, AF_INET6, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST } :: import("../sys/socket");
 { snprintf } :: import("../libc/stdio");
 // ============================================================================
@@ -84,9 +86,42 @@ impl(
         },
         true => ()
       );
-      return(UdpSocket(_fd : fd, _local_addr : addr, _is_closed : false));
+      // Read back the ACTUAL bound address — a port-0 bind gets its port from
+      // the kernel; echoing the bind argument reported port 0 forever. Same
+      // fix as TcpListener.bind (C2), which UDP never received
+      // (issues/fixed/udpsocket-bind-echoes-its-argument-and-send-has-no-connect.md).
+      la_buf := *(u8)(malloc(usize(128)).unwrap());
+      la_len := *(u32)(malloc(usize(4)).unwrap());
+      la_len.* = u32(128);
+      gsn := SockInfo.getsockname(fd, la_buf, la_len);
+      local := cond(
+        (gsn == i32(0)) => sockaddr_to_socket_addr(la_buf),
+        true => addr
+      );
+      free(.Some(*(void)(la_buf)));
+      free(.Some(*(void)(la_len)));
+      return(UdpSocket(_fd : fd, _local_addr : local, _is_closed : false));
     })
   ),
+  /// Set the default destination for `send` and filter `recv` to datagrams
+  /// from `addr` — `connect(2)` on a UDP socket. Rust: `UdpSocket::connect`.
+  /// `send`/`recv` documented "requires prior connect" for as long as they
+  /// existed while no `connect` did, so they could only fail with ENOTCONN.
+  connect : (fn(self : Self, addr : SocketAddr, io : Io) -> Impl(Future(unit, IoExn)))({
+    fd := self._fd;
+    io.async(e => {
+      saddr := _make_sockaddr(addr);
+      r := e.io.await(IO_tcp.connect(fd, saddr.buf, saddr.len), e.io);
+      IO_tcp.free_sockaddr(saddr);
+      cond(
+        (r < i32(0)) => {
+          _throw_net_io(i32(0) - r, e.exn);
+        },
+        true => ()
+      );
+      return(());
+    })
+  }),
   /// Send a datagram to a specific address.
   /// Returns the number of bytes sent.
   send_to : (fn(self : Self, data : ArrayList(u8), addr : SocketAddr, io : Io) -> Impl(Future(usize, IoExn)))({
@@ -116,7 +151,7 @@ impl(
       usize(NetError.check(r, e.exn))
     })
   }),
-  /// Send data on a connected socket (requires prior connect).
+  /// Send data to the peer set by `connect`. Returns the number of bytes sent.
   send : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(usize, IoExn)))({
     fd := self._fd;
     io.async(e => {

--- a/tests/net/addr.test.yo
+++ b/tests/net/addr.test.yo
@@ -147,3 +147,46 @@ test("SocketAddr with parsed IP", {
   unsafe(printf("  addr = %s\n", s.to_cstr().ptr().unwrap()));
   assert(s == `10.20.30.40:443`, "should be 10.20.30.40:443");
 });
+// `parse_v4` accepted two shapes it must reject — both are silent WRONG VALUES,
+// not errors: an empty octet (`"..."` parsed as 0.0.0.0, `"1.2.3."` as 1.2.3.0)
+// because nothing counted the digits in an octet, and an octet that wraps u32
+// (`"4294967297.0.0.0"` parsed as 1.0.0.0) because the accumulator was only
+// range-checked at the separator. Rust's Ipv4Addr::from_str rejects both, and
+// leading zeros (`"01.2.3.4"`, octal ambiguity) — so do we now.
+// issues/fixed/ipaddr-parse-v4-accepts-empty-and-wrapping-octets.md
+_must_reject_v4 :: (fn(s : String) -> unit)({
+  exn := Exception(
+    throw : (
+      err -> {
+        unwind(());
+      }
+    )
+  );
+  IpAddr.parse_v4(s, exn);
+  assert(false, `parse_v4 accepted ${s}`);
+});
+test("IpAddr.parse_v4 rejects empty octets", {
+  _must_reject_v4(`...`);
+  _must_reject_v4(`1.2.3.`);
+  _must_reject_v4(`.1.2.3`);
+  _must_reject_v4(`1..2.3`);
+  _must_reject_v4(``);
+});
+test("IpAddr.parse_v4 rejects an octet that wraps the accumulator", {
+  _must_reject_v4(`4294967297.0.0.0`);
+  _must_reject_v4(`99999999999.0.0.0`);
+});
+test("IpAddr.parse_v4 rejects leading zeros like Rust", {
+  _must_reject_v4(`01.2.3.4`);
+  _must_reject_v4(`1.2.3.007`);
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "0.0.0.0 is valid");
+        unwind(());
+      }
+    )
+  );
+  z := IpAddr.parse_v4(`0.0.0.0`, exn);
+  assert(z.to_string() == "0.0.0.0", "a lone 0 octet is not a leading zero");
+});

--- a/tests/net/udp.test.yo
+++ b/tests/net/udp.test.yo
@@ -161,3 +161,55 @@ test("UDP bind to a non-local IPv6 address must fail (was: sockaddr hardcoded ::
   io.await(sock.close(io), IoExn(io : io, exn : exn));
   assert(false, "UDP bind to non-local 2001:db8::1 must fail — the sockaddr was hardcoded to ::1");
 });
+// `bind` used to ECHO its argument as `_local_addr`, so a port-0 (ephemeral)
+// bind — the only reason to bind port 0 — reported port 0 forever. TCP got this
+// fix as C2 (getsockname readback); UDP was left out.
+// issues/fixed/udpsocket-bind-echoes-its-argument-and-send-has-no-connect.md
+test("UdpSocket.bind to port 0 reports the kernel-assigned port", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  sock := io.await(UdpSocket.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+  la := sock.local_addr();
+  assert(la.port != u16(0), "an ephemeral bind must report the real port");
+  assert(la.ip.is_loopback(), "and the real address");
+  io.await(sock.close(io), IoExn(io : io, exn : exn));
+});
+// `send`/`recv` documented "requires prior connect" — and no `connect` existed,
+// so they could only ever fail with ENOTCONN.
+test("UdpSocket.connect makes send and recv usable", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  server := io.await(UdpSocket.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+  client := io.await(UdpSocket.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+  io.await(client.connect(server.local_addr(), io), IoExn(io : io, exn : exn));
+  io.await(server.connect(client.local_addr(), io), IoExn(io : io, exn : exn));
+  msg := ArrayList(u8).new();
+  msg.push(u8(104));
+  msg.push(u8(105));
+  sent := io.await(client.send(msg, io), IoExn(io : io, exn : exn));
+  assert(sent == usize(2), "send on a connected socket sends the datagram");
+  buf := *(u8)(malloc(usize(16)).unwrap());
+  got := io.await(server.recv(buf, usize(16), io), IoExn(io : io, exn : exn));
+  assert(got == usize(2), "recv on the connected peer gets it");
+  assert(((buf.add(usize(0))).* == u8(104)) && ((buf.add(usize(1))).* == u8(105)), "payload intact");
+  reply := ArrayList(u8).new();
+  reply.push(u8(33));
+  _r := io.await(server.send(reply, io), IoExn(io : io, exn : exn));
+  got2 := io.await(client.recv(buf, usize(16), io), IoExn(io : io, exn : exn));
+  assert((got2 == usize(1)) && ((buf.add(usize(0))).* == u8(33)), "the reply comes back over the connected pair");
+  free(.Some(*(void)(buf)));
+  io.await(client.close(io), IoExn(io : io, exn : exn));
+  io.await(server.close(io), IoExn(io : io, exn : exn));
+});


### PR DESCRIPTION
`plans/STD_API_STABILIZATION.md` (#444) §3 items 6–7 — two silent **wrong values**, not errors:

| bug | before | after |
|---|---|---|
| `IpAddr.parse_v4("...")` | `0.0.0.0` | rejected (empty octet) |
| `IpAddr.parse_v4("1.2.3.")` | `1.2.3.0` | rejected |
| `IpAddr.parse_v4("4294967297.0.0.0")` | `1.0.0.0` (u32 wrap) | rejected (range-checked per digit) |
| `IpAddr.parse_v4("01.2.3.4")` | `1.2.3.4` | rejected, as Rust's `Ipv4Addr::from_str` does |
| `UdpSocket.bind(loopback(0)).local_addr().port` | **0** — the bind argument echoed back | the kernel-assigned port (`getsockname`, the C2 fix TCP got and UDP never did) |
| `UdpSocket.send`/`recv` | "requires prior connect" — no `connect` existed | `UdpSocket.connect(addr, io)` |

TCP's sockaddr decoder is exported as `sockaddr_to_socket_addr` (was the private `_sockaddr_to_socket_addr`) so `net` has one decoder; §1 forbids `_` names in `export(...)`.

Tests red-first (the `connect` test failed to *compile* before, which is its red). `tests/net` 54/54, `tests/http` 41/41 with a develop-built compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)