### PR TITLE
evaluator: enforce Send at spawn boundaries (P0 item 2) — faithful port of validateCaptureTraitRequirements

### DIFF
--- a/issues/fixed/send-was-not-enforced-at-spawn-boundaries.md
+++ b/issues/fixed/send-was-not-enforced-at-spawn-boundaries.md
@@ -1,0 +1,85 @@
+# `Send` was not enforced at any spawn boundary — `validate_capture_trait_requirements` was a no-op stub
+
+**Status: FIXED** (2026-09-06, `src/evaluator/utils/closure.yo`,
+`src/evaluator/calls/closure_type.yo`, `src/evaluator/values/anonymous_function.yo`).
+Found by the std API audit — `plans/STD_API_STABILIZATION.md` §3 item 2.
+
+## Symptom
+
+`Thread.spawn` and `spawn(pool, …)` take `Impl(Fn(io : Io) -> unit, Send)`.
+The `Send` was decorative: the evaluator function that checks a closure's
+captures against the wrapper's non-Fn traits was ported as
+
+```rust
+validate_capture_trait_requirements :: (fn(_wrapper_type, _capture_type, _env, _error_token) -> unit)(());
+```
+
+and — worse — nothing called even that. A closure capturing a non-atomic
+`ref` struct (an `ArrayList`, a `String`, any `ref(struct)`), an `Io` or a
+`JoinHandle` crossed an OS thread without a diagnostic; the `Type.impls(…,
+Send) == false` assertions in `tests/thread_safety.test.yo` proved the trait
+answers were right and nothing consumed them.
+
+## Fix — the faithful port
+
+`validate_capture_trait_requirements` now mirrors the TS
+(`src/evaluator/utils/closure.ts:105-175`): for every non-Fn trait in the
+wrapper `SomeT`'s `required_trait_types`,
+
+1. each captured variable is checked first (`type_implements_trait_bool`), so
+   the error lands on the CAPTURE site —
+   `Captured variable 'items' (type ArrayList(i32)) does not implement Send. To
+   move it across threads, wrap it in Arc/Iso, or capture a Send projection of
+   it instead.`;
+2. then the capture struct as a whole, listing the offending fields at the
+   closure site.
+
+It is called from both places the TS called it: the `Impl(Fn)`-wrapper route
+(`closure_type.yo`, TS `closure-type.ts:269`) and the anonymous-function route
+(`anonymous_function.yo`, TS `anonymous-function.ts:1184`), each right after
+the capture struct is created.
+
+## A captured closure is judged by ITS captures
+
+The first full-suite run under the check produced exactly one failure:
+`tests/sync/once.test.yo` binds `(racer : Impl(Fn() -> unit)) = (() => …)` over
+an `OnceCell` and two `AtomicI32`s and spawns `io => racer()` four times. The
+captured variable's type is the `Impl(Fn)` wrapper SomeT, which carries no
+`Send` in its required traits, so a naive check rejected it. In Rust a closure
+is `Send` iff its captures are (an auto trait), and here that is exactly what
+the closure's capture struct encodes — `auto_derive_traits_for_struct_type`
+gives it `Send` when every field is. `_capture_judgement_type` therefore
+resolves a SomeT capture to its concrete type — the SomeT's own resolved cell,
+then the global registry, then the captured VALUE's registered capture struct —
+and judges that; a closure with no capture struct captures nothing and is
+trivially `Send`. With capture info present, the per-variable pass is
+authoritative and the aggregate struct check is skipped (the struct's fields
+ARE those variables, and re-judging a wrapper SomeT field without its value
+would undo the resolution). `once.test.yo` is unchanged and passes;
+`thread_safety.test.yo` pins both directions (a closure over an `ArrayList` is
+rejected, one over an `AtomicI32` is accepted).
+
+## Known remaining gaps
+
+**Only CAPTURES are checked.** A module-level binding referenced from a spawned
+closure is a global, not a capture, so a `ref(struct)` global reached from a
+thread is not rejected (the TS check had the same scope). Whether globals may
+be touched from spawned closures at all is a separate design question for the
+thread-safety model; the regression tests therefore make the offending value
+a FUNCTION LOCAL (a `comptime_expect_error` block that defines and calls a fn).
+
+
+`issues/type-impls-reports-true-for-a-blanket-impl-whose-where-clause-fails.md`:
+`Type.impls(*(NonSend), Send)` answers `true` because the prelude's
+where-bounded blanket impls are matched without discharging their `where`
+clause. Until that is fixed the enforcement UNDER-rejects raw pointers,
+`Array(NonSend, N)` and `?(*NonSend)` captures; direct `ref` struct, `Io` and
+`JoinHandle` captures are rejected correctly.
+
+## Regression tests
+
+`tests/thread_safety.test.yo`, "Phase L: Send is ENFORCED": two
+`comptime_expect_error` blocks (a `ref(struct)` capture and an `ArrayList`
+capture in `Thread.spawn`) — both were "Expected compile error, but the
+expression was evaluated successfully" on the pre-fix compiler — plus an
+over-rejection canary spawning with a scalar and an `Arc` capture.

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -97,7 +97,7 @@ reference-counted — Rust's `Rc`) keeps its name (§5).
 
 Memory safety / UB / deadlock:
 
-1. **`std/imm/vec.yo` leaks and drops uninitialized memory.** _(fix in PR #445)_ `push` grow
+1. **`std/imm/vec.yo` leaks and drops uninitialized memory.** — **FIXED 2026-09-06 (#445, `8d5523d84`)** `push` grow
    (144-149) and `concat` grow (236-247) `free` the old buffer without dropping
    the elements `_copy_elems` (87-100) dup'd; `pop`'s unique path (189-193)
    leaves the popped slot outside the `Dispose` loop. `map` (292), `filter`
@@ -111,7 +111,11 @@ Memory safety / UB / deadlock:
    (`src/evaluator/utils/closure.yo:125-132`); the `Send` on
    `Thread.spawn`/`spawn(pool)` (`thread.yo:40,45,57,211`) is decorative. A
    closure capturing a non-atomic `ref` struct, an `Io` or a `JoinHandle`
-   crosses an OS thread. Compiler fix + `comptime_expect_error` negatives.
+   crosses an OS thread. Compiler fix + `comptime_expect_error` negatives —
+   **FIXED 2026-09-06**: the stub is the faithful TS port, called from both
+   closure-creation routes; raw-pointer captures still slip through until
+   `issues/type-impls-reports-true-for-a-blanket-impl-whose-where-clause-fails.md`
+   is fixed (`issues/fixed/send-was-not-enforced-at-spawn-boundaries.md`).
 3. **`spawn(pool, …)` self-deadlocks on nested spawn** whenever the runtime
    takes its inline fallback: the pool mutex is held across
    `__yo_worker_spawn` (`thread.yo:218-221`) and the fallback runs the task on
@@ -132,9 +136,9 @@ Memory safety / UB / deadlock:
 
 Wrong values:
 
-6. _(fix in PR #446)_ **`IpAddr.parse_v4`** accepts `"..."` as `0.0.0.0` and wraps octets past
+6. **FIXED 2026-09-06 (#446, `b8e5cfb76`)** — **`IpAddr.parse_v4`** accepts `"..."` as `0.0.0.0` and wraps octets past
    `u32` (`net/addr.yo:37-88`).
-7. _(fix in PR #446)_ **`UdpSocket.bind` echoes the bind argument** so an ephemeral-port bind
+7. **FIXED 2026-09-06 (#446)** — **`UdpSocket.bind` echoes the bind argument** so an ephemeral-port bind
    reports port 0 (`net/udp.yo:87`; TCP got this fix as C2, `tcp.yo:168-181`);
    **`UdpSocket.send` requires a `connect` that does not exist** (`udp.yo:119`).
 8. **`Path.strip_prefix` is node's `relative` under Rust's name** — emits `..`
@@ -182,7 +186,7 @@ Performance cliffs that are correctness in practice:
     remove goes straight back to `EMPTY`
     (`issues/fixed/hash-tombstones-are-never-reclaimed.md`). **`Deque._grow`
     has no C35 overflow guard** (`deque.yo:50-52`), nor does
-    `imm/vec._raw_alloc` (`vec.yo:79`) — _(both guarded in PR #445)_.
+    `imm/vec._raw_alloc` (`vec.yo:79`) — **both guarded, FIXED in #445**.
 14. **`html_decode` is O(n²)** — rebuilds the result via a template string per
     character (`html.yo:162` + 12 sites) — **FIXED 2026-09-06**: appends in
     place into a pre-sized `String`. **`ArrayList.retain` is O(n²)** with an

--- a/src/evaluator/calls/closure_type.yo
+++ b/src/evaluator/calls/closure_type.yo
@@ -69,6 +69,7 @@ _(env : cap_dbg_env_closure_call) :: import("std/env");
 {
   enrich_captured_variables,
   create_capture_type_and_value,
+  validate_capture_trait_requirements,
   FuncCapturedVarInfo
 } :: import("../utils/closure.yo");
 /// Convert a closure body expression into a typed closure value against
@@ -312,6 +313,13 @@ try_to_implement_closure_by_fn_module_type :: (
     tok
   );
   capture_ty := cap_result.capture_type;
+  // Validate that the capture struct implements every required non-Fn trait
+  // of the wrapper (e.g. `Send` on a spawn closure) — TS closure-type.ts:269.
+  match(
+    capture_ty.clone(),
+    .Some(vct) => validate_capture_trait_requirements(wrapper_type.clone(), vct, captured_vars_with_values_opt, caller_env, ctx, tok, exn),
+    .None => ()
+  );
   // Record the capture struct type + defining frame level by func_id so codegen's
   // generate_function can set the closure-capture context (rewriting captured vars
   // like `k` to `((<cap>*)closure_context)->k`). Mirrors anonymous_function.yo:1068.

--- a/src/evaluator/utils/closure.yo
+++ b/src/evaluator/utils/closure.yo
@@ -27,6 +27,12 @@ _(env : clo_dbg_env) :: import("std/env");
 { TypeValue } :: import("../../types/definitions.yo");
 { t_unit } :: import("../../types/creators.yo");
 { type_to_string } :: import("../../types/string.yo");
+{ is_fn_trait_type } :: import("../../types/guards.yo");
+{ format_error_message } :: import("../../error.yo");
+{ type_implements_trait_bool } :: import("../trait_checking.yo");
+{ flag_flow_violation, flow_violation_pending, propagate_def_time_errors } :: import("../../types/flowability.yo");
+{ lookup_some_resolved_concrete } :: import("../../expr_info.yo");
+{ get_closure_capture_info } :: import("../../function_value.yo");
 // Deterministic capture-struct ids: keyed by the closure's source position +
 // capture field signature, so the SAME closure (re-evaluated across the eval and
 // codegen passes) gets the SAME capture-struct id. A fresh `random_id` per call
@@ -115,21 +121,151 @@ build_path_collection_from_captured_variables :: (
 // ---------------------------------------------------------------------------
 // validate_capture_trait_requirements
 // ---------------------------------------------------------------------------
-/// Validate that the closure's capture struct implements all required
-/// non-Fn traits from the wrapper type.
-///
-/// Phase 3 stub: no-op.
+/// Raise a capture-trait violation so it SURVIVES the def-time trial wall. A
+/// closure body is usually created inside a def-time TRIAL evaluation, which
+/// swallows thrown errors (anonymous_function.yo's def-eval wall); a `Send`
+/// violation is a deliberate rejection, so it takes the wall's re-raise
+/// channel — flag a flow violation first, then throw — the same shape as the
+/// callable-argument and C19 checks in calls/helper.yo.
+_raise_capture_trait_violation :: (
+  fn(ctx : EvalContext, exn : Exception, tok : Token, msg : String) -> unit
+)({
+  if(!ctx.is_in_function_call_checking_phase && !propagate_def_time_errors() && !flow_violation_pending(), {
+    flag_flow_violation(msg.clone());
+  });
+  exn.throw(dyn(format_error_message(tok, msg)));
+});
+/// The type a captured variable is JUDGED by for a marker trait such as
+/// `Send`. A captured CLOSURE arrives as its `Impl(Fn(...))` wrapper SomeT,
+/// which carries no `Send` in its required traits — yet a closure is `Send`
+/// iff its captures are (Rust's auto trait), and its captures live in its
+/// capture struct, which auto-derives `Send` when every field is
+/// (`auto_derive_traits_for_struct_type` above). Resolve the wrapper: the
+/// SomeT's own resolved cell, then the global registry, then the VALUE's
+/// registered capture struct. `.None` means "nothing to judge": a closure
+/// with no capture struct captures nothing and is trivially `Send`.
+/// (tests/sync/once.test.yo's `racer` — a closure over atomics, spawned
+/// four times — was the one false rejection in the whole suite.)
+_capture_judgement_type :: (fn(ty : TypeValue, value : Option(EvalValue)) -> Option(TypeValue))(
+  match(
+    ty,
+    .SomeT({ id : sid, resolved_concrete : rc }) => match(
+      rc.get(usize(0)),
+      .Some(c) => Option(TypeValue).Some(c),
+      .None => match(
+        lookup_some_resolved_concrete(sid),
+        .Some(c2) => Option(TypeValue).Some(c2),
+        .None => match(
+          value,
+          .Some(v) => match(
+            v,
+            .FuncVal(fvd, _) => match(
+              get_closure_capture_info(fvd.*.func_id.clone()),
+              .Some(cci) => Option(TypeValue).Some(cci.capture_type),
+              .None => Option(TypeValue).None
+            ),
+            _ => Option(TypeValue).Some(ty)
+          ),
+          .None => Option(TypeValue).Some(ty)
+        )
+      )
+    ),
+    _ => Option(TypeValue).Some(ty)
+  )
+);
+/// Validate that a closure created for an `Impl(Fn(...), Send, …)` wrapper
+/// satisfies every NON-Fn trait the wrapper requires — the check that makes
+/// the `Send` on `Thread.spawn` / `spawn(pool, …)` mean something. Each
+/// captured variable is checked first, so the error lands on the capture
+/// site; then the capture struct as a whole. A no-op stub until 2026-09-06
+/// (issues/fixed/send-was-not-enforced-at-spawn-boundaries.md).
 ///
 /// Mirrors `validateCaptureTraitRequirements` from
 /// `src/evaluator/utils/closure.ts`.
 validate_capture_trait_requirements :: (
   fn(
-    _wrapper_type : TypeValue,
-    _capture_type : TypeValue,
-    _env : Environment,
-    _error_token : Token
+    wrapper_type : TypeValue,
+    capture_type : TypeValue,
+    captured_variables_with_values : Option(HashMap(String, FuncCapturedVarInfo)),
+    env : Environment,
+    ctx : EvalContext,
+    error_token : Token,
+    exn : Exception
   ) -> unit
-)(());
+)({
+  match(
+    wrapper_type,
+    .SomeT({ required_trait_types : rtts }) => {
+      (ti : usize) = usize(0);
+      while(ti < rtts.len(), ti = (ti + usize(1)), {
+        trait_type := rtts(ti);
+        if(!is_fn_trait_type(trait_type), {
+          trait_name := type_to_string(trait_type);
+          // Per-variable first: each offending capture gets its own error at
+          // the capture site, not the closure site.
+          match(
+            captured_variables_with_values,
+            .Some(cvwv) => {
+              key_iter := cvwv.keys();
+              (more : bool) = true;
+              while(more, {
+                match(
+                  key_iter.next(),
+                  .None => {
+                    more = false;
+                  },
+                  .Some(var_name) => match(
+                    cvwv.get(var_name.clone()),
+                    .None => (),
+                    .Some(info) => match(
+                      _capture_judgement_type(info.ty, info.value),
+                      .None => (),
+                      .Some(judged) => if(!type_implements_trait_bool(judged, trait_type, env), {
+                        var_msg := `Captured variable '${var_name}' (type ${type_to_string(info.ty)}) does not implement ${trait_name}. To move it across threads, wrap it in Arc/Iso, or capture a ${trait_name} projection of it instead.`;
+                        _raise_capture_trait_violation(ctx, exn, info.token, var_msg);
+                      })
+                    )
+                  )
+                );
+              });
+            },
+            .None => ()
+          );
+          // Then the capture struct as a whole — only when no per-variable
+          // information exists: the struct's fields ARE the captured
+          // variables, and re-judging a captured closure's wrapper SomeT
+          // field without its value would undo the resolution above.
+          if(captured_variables_with_values.is_none() && !type_implements_trait_bool(capture_type, trait_type, env), {
+            details := String.new();
+            match(
+              capture_type,
+              .Struct({ field_labels : fls, field_types : fts }) => {
+                (fi : usize) = usize(0);
+                while(fi < fls.len(), fi = (fi + usize(1)), {
+                  match(
+                    fts.get(fi),
+                    .Some(fty) => if(!type_implements_trait_bool(fty, trait_type, env), {
+                      if(details.len() > usize(0), {
+                        details.push_str("\n  ");
+                      });
+                      fl := match(fls.get(fi), .Some(l) => l, .None => String.from(""));
+                      details.push_string(`'${fl}' has type ${type_to_string(fty)} which does not implement ${trait_name}`);
+                    }),
+                    .None => ()
+                  );
+                });
+              },
+              _ => ()
+            );
+            agg_msg := `Closure does not implement ${trait_name} because captured variable ${details}`;
+            _raise_capture_trait_violation(ctx, exn, error_token, agg_msg);
+          });
+        });
+      });
+    },
+    _ => ()
+  );
+});
 // ---------------------------------------------------------------------------
 // enrich_captured_variables
 // ---------------------------------------------------------------------------

--- a/src/evaluator/values/anonymous_function.yo
+++ b/src/evaluator/values/anonymous_function.yo
@@ -103,6 +103,7 @@ _(env : anonfn_dbg_env) :: import("std/env");
   enrich_captured_variables,
   generate_captured_variable_dup_expressions,
   create_capture_type_and_value,
+  validate_capture_trait_requirements,
   FuncCapturedVarInfo
 } :: import("../utils/closure.yo");
 { extract_fn_trait_from_type } :: import("../trait_checking.yo");
@@ -1943,6 +1944,13 @@ Result type: ${type_to_string(decl_result_ty)}`
     closure_capture_dups = dup_res.dup_exprs;
     cap_res := create_capture_type_and_value(Option(TypeValue).None, cvwv, env, tok);
     closure_capture_type = cap_res.capture_type;
+    // The wrapper's non-Fn trait requirements (`Send`) hold for each capture
+    // and for the capture struct — TS anonymous-function.ts:1184.
+    match(
+      closure_capture_type,
+      .Some(vct) => validate_capture_trait_requirements(expected_ty, vct, cvwv, env, ctx, tok, exn),
+      .None => ()
+    );
     // Prefer an already-REGISTERED (larger) capture struct for this fid — see
     // register_closure_capture_info's keep-larger note: a re-eval that tracked
     // fewer captures must not shrink the struct the emitted body was (or will

--- a/tests/thread_safety.test.yo
+++ b/tests/thread_safety.test.yo
@@ -55,6 +55,75 @@ comptime_expect_error({
 });
 
 // ============================================================================
+// Phase L (THREAD_SAFETY): Send is ENFORCED at the spawn boundary
+// ============================================================================
+// issues/fixed/send-was-not-enforced-at-spawn-boundaries.md — the closure
+// created for `Impl(Fn(io : Io) -> unit, Send)` is checked against `Send`
+// capture by capture: a non-atomic `ref` struct (an ArrayList, a String, any
+// plain ref(struct)) may not cross an OS thread.
+{ Thread } :: import("std/thread");
+{ ArrayList } :: import("std/collections/array_list");
+// The offending value must be a FUNCTION LOCAL: the check runs over a
+// closure's captures, and a module-level binding is a global, not a capture
+// (globals reached from a spawned closure are a separate, open question).
+NotSendCell :: ref(struct(v : i32));
+comptime_expect_error({
+  _spawn_with_ref_struct :: (fn() -> unit)({
+    cell := NotSendCell(v : i32(1));
+    t := Thread.spawn(io => {
+      _v := cell.v;
+      ()
+    });
+    t.join();
+  });
+  _spawn_with_ref_struct();
+});
+comptime_expect_error({
+  _spawn_with_array_list :: (fn() -> unit)({
+    items := ArrayList(i32).new();
+    t := Thread.spawn(io => {
+      items.push(i32(1));
+      ()
+    });
+    t.join();
+  });
+  _spawn_with_array_list();
+});
+// A captured CLOSURE is judged by ITS captures (Rust's auto trait): one over
+// atomics is Send, one over an ArrayList is not.
+comptime_expect_error({
+  _spawn_with_closure_over_ref :: (fn() -> unit)({
+    items := ArrayList(i32).new();
+    (worker : Impl(Fn() -> unit)) = (
+      () => {
+        items.push(i32(1));
+      }
+    );
+    t := Thread.spawn(io => worker());
+    t.join();
+  });
+  _spawn_with_closure_over_ref();
+});
+// Over-rejection canaries: Send captures (a scalar, an Arc, a closure over an
+// atomic) still spawn. Defined, not run — the check happens when the closure
+// is created.
+_send_captures_still_spawn :: (fn() -> unit)({
+  n := i32(3);
+  a := arc(i32(4));
+  hits := AtomicI32(i32(0));
+  (bump : Impl(Fn() -> unit)) = (
+    () => {
+      hits.fetch_add(i32(1), MemoryOrder.AcqRel);
+    }
+  );
+  t := Thread.spawn(io => {
+    _s := (n + a.*);
+    bump();
+    ()
+  });
+  t.join();
+});
+// ============================================================================
 // Phase P (THREAD_SAFETY): Field visibility — same-file access works
 // ============================================================================
 test("private _-field accessible in same file", {


### PR DESCRIPTION
Stacked on #450 (base = `fix/std-p0-thread-log-html`; retarget as the stack merges). `plans/STD_API_STABILIZATION.md` §3 (P0) item 2. Compiler change — verified with a freshly built stage-1, not the seed.

## What was wrong
`validate_capture_trait_requirements` (`src/evaluator/utils/closure.yo`) was a no-op stub — and nothing even called it. The `Send` in `Impl(Fn(io : Io) -> unit, Send)` on `Thread.spawn` / `spawn(pool, …)` was decorative: a closure capturing a non-atomic `ref` struct, an `Io` or a `JoinHandle` crossed an OS thread with no diagnostic.

## The fix — faithful TS port, plus two things the port needed
For every non-Fn trait in the wrapper `SomeT`'s `required_trait_types`: each captured variable is checked first (`Captured variable 'items' (type ArrayList(i32)) does not implement Send. To move it across threads, wrap it in Arc/Iso, or capture a Send projection of it instead.`), then the capture struct as a whole. Called from both closure-creation routes (`closure_type.yo` ← TS `closure-type.ts:269`; `anonymous_function.yo` ← TS `anonymous-function.ts:1184`).

1. **Def-eval swallow.** A closure body is created inside the def-time trial wall, which swallows thrown errors (`[swallow] error: Captured variable 'cell' …` under `YO_DEBUG_SWALLOW=1`). The rejection now goes through `_raise_capture_trait_violation`: `flag_flow_violation` first (unless in the call-checking phase / under `propagate_def_time_errors` / already pending), then throw — the same shape as the C19 checks in `calls/helper.yo`.
2. **A captured closure is judged by ITS captures** (Rust's auto trait). The first full-suite run had exactly one failure: `tests/sync/once.test.yo` binds `(racer : Impl(Fn() -> unit)) = (() => …)` over an `OnceCell` and two `AtomicI32`s and spawns `io => racer()`. The captured variable's type is the `Impl(Fn)` wrapper SomeT, which carries no `Send`. `_capture_judgement_type` resolves it — the SomeT's own resolved cell, then the global registry, then the captured VALUE's registered capture struct (which `auto_derive_traits_for_struct_type` marks `Send` when every field is); a closure with no capture struct captures nothing and is trivially `Send`. With capture info present the per-variable pass is authoritative and the aggregate struct check is skipped (its fields ARE those variables).

## Verification
- Red-first: the new `comptime_expect_error` negatives fail on the pre-fix compiler with "Expected compile error, but the expression was evaluated successfully".
- `check ./src` clean; **full fast suite under the new stage-1: 3561 passed, 0 failed** (`once.test.yo` unchanged and green).
- `tests/thread_safety.test.yo` "Phase L": three rejections (a `ref(struct)` capture, an `ArrayList` capture, a captured closure over an `ArrayList`) and an over-rejection canary (scalar, `Arc`, closure over an `AtomicI32`). The offending value must be a FUNCTION LOCAL — a module-level binding is a global, not a capture (recorded as a scope note in the issue).

## Known remaining gap
`issues/type-impls-reports-true-for-a-blanket-impl-whose-where-clause-fails.md`: `Type.impls(*(NonSend), Send)` answers `true`, so raw-pointer / `Array(NonSend, N)` / `?*NonSend` captures still slip through until that is fixed. `issues/fixed/send-was-not-enforced-at-spawn-boundaries.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)