### PR TITLE
std: BTreeMap.insert returns the replaced value; push Results guarded; Child.kill throws IoError (P0 items 16–17)

### DIFF
--- a/issues/fixed/btree-map-insert-dropped-the-old-value-and-push-results-were-ignored.md
+++ b/issues/fixed/btree-map-insert-dropped-the-old-value-and-push-results-were-ignored.md
@@ -1,0 +1,33 @@
+# `BTreeMap.insert` dropped the old value and, with `PriorityQueue.push`, discarded `push`'s `Result` before `len() - 1`
+
+**Status: FIXED** (2026-09-06, `std/collections/btree_map.yo`,
+`std/collections/priority_queue.yo`). Found by the std API audit —
+`plans/STD_API_STABILIZATION.md` §3 item 16.
+
+## Symptoms
+
+1. `BTreeMap.insert(k, v) -> unit`. Rust's `BTreeMap::insert` returns
+   `Option<V>` — the value that was replaced — and callers rely on it
+   ("was this key new?", "give me back what I overwrote"). Yo's threw the old
+   value away with no way to observe it short of a `get` beforehand.
+2. Both `BTreeMap.insert` (new-key path) and `PriorityQueue.push` called
+   `self._entries.push(...)` / `self._data.push(val)` and ignored the returned
+   `Result`, then computed `len() - 1`. On an allocation failure nothing was
+   stored, `len()` was unchanged, and for an empty container `len() - 1`
+   underflowed to `usize::MAX` — the sift/shift loop then indexed off the end.
+
+## Fix
+
+- `insert -> Option(V)`: `.Some(old)` when the key existed, `.None` when it
+  was new. The one caller pattern that changes is `m.insert(k, v);` as a
+  statement, which still compiles (the value is simply unused).
+- Both `push` results are checked; failure is the same panic
+  `ArrayList.with_capacity` raises (`… : allocation failed`), so the container
+  is never left half-updated. (D9 — infallible `push` + `try_push` — will make
+  the guard the default shape; until then it is explicit here.)
+
+## Regression test
+
+`tests/collections/btree_map.test.yo` — "insert returns None for a new key and
+Some(old) when it replaces" (and the new value is what `get` sees, and the map
+does not grow).

--- a/issues/fixed/child-kill-returned-a-raw-errno.md
+++ b/issues/fixed/child-kill-returned-a-raw-errno.md
@@ -1,0 +1,27 @@
+# `Child.kill -> i32` handed back a raw `-errno`
+
+**Status: FIXED** (2026-09-06, `std/process/command.yo`). Found by the std
+API audit — `plans/STD_API_STABILIZATION.md` §3 item 17.
+
+## Symptom
+
+```rust
+k := child.kill(i32(9));   // 0, or -ESRCH / -EPERM … as a bare i32
+```
+
+Every other io-path function in `std/process` and `std/fs` reports failure as
+an `IoError` through the caller's `Exception` (or as `IoExn` when async).
+`kill` alone leaked the C convention — a negative errno the caller had to
+recognize and decode by hand, and that most callers ignored.
+
+## Fix
+
+`kill : (fn(self : Self, signum : i32, exn : Exception) -> unit)` — the
+result goes through `IoError.check`, so `ESRCH` (the child was already
+reaped) or `EPERM` is thrown as an `IoError`, Rust's
+`Child::kill -> io::Result<()>`.
+
+## Regression tests
+
+`tests/process/command.test.yo` — the existing SIGKILL test now passes `exn`;
+a new test reaps a child with `wait` and then `kill`s it, which must throw.

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -180,8 +180,12 @@ window as D9–D18):
     `http.parse_request/parse_response` (`http.yo:231,313` → `HttpParseError`).
 16. **`BTreeMap.insert -> unit`** drops the old value (`btree_map.yo:77-82`) and
     discards `push`'s `Result` then underflows `len() - 1` (:86-87); same
-    discard in `priority_queue.yo:49`.
-17. **`Child.kill -> i32` errno** (`process/command.yo:635`) → throws `IoExn`.
+    discard in `priority_queue.yo:49` — **FIXED 2026-09-06**: `insert ->
+    Option(V)` (the replaced value), both push results guarded
+    (`issues/fixed/btree-map-insert-dropped-the-old-value-and-push-results-were-ignored.md`).
+17. **`Child.kill -> i32` errno** (`process/command.yo:635`) → throws `IoExn` —
+    **FIXED 2026-09-06**: `kill(signum, exn)` throws the errno as an `IoError`
+    through `IoError.check` (`issues/fixed/child-kill-returned-a-raw-errno.md`).
 18. **One malformed request kills `HttpServer.serve`** — framing throws
     propagate out of the loop (`http/server.yo:86-113`); and `http/server` has
     no `## Stability` marker, so this shape is already frozen.

--- a/std/collections/btree_map.yo
+++ b/std/collections/btree_map.yo
@@ -72,18 +72,24 @@ impl(
       true => .None
     )
   }),
-  // Insert or update the value for key `k`.
-  // For new keys: append at end then shift-left to correct sorted position.
-  insert : (fn(self : Self, k : K, v : V, where(K <: Ord(K))) -> unit)({
+  /// Insert or update the value for key `k`, returning the value it REPLACED
+  /// (`.None` for a new key) — Rust's `BTreeMap::insert`. Until 2026-09-06
+  /// this returned `unit`, dropping the old value silently, and discarded
+  /// `push`'s `Result` before computing `len() - 1`
+  /// (issues/fixed/btree-map-insert-dropped-the-old-value-and-push-results-were-ignored.md).
+  /// For new keys: append at end then shift-left to the sorted position.
+  insert : (fn(self : Self, k : K, v : V, where(K <: Ord(K))) -> Option(V))({
     r := self._find(k);
     cond(
       r.found => {
         entry := self._entries(r.idx);
         &(self._entries(r.idx)).* = MapEntry(K, V)(key : entry.key, value : v);
+        .Some(entry.value)
       },
+      // An allocation failure must not leave the map half-updated and then
+      // underflow `len() - 1`; it is the same panic ArrayList.with_capacity raises.
+      self._entries.push(MapEntry(K, V)(key : k, value : v)).is_err() => __yo_panic("BTreeMap.insert: allocation failed"),
       true => {
-        // Append new entry then bubble left to sorted position
-        self._entries.push(MapEntry(K, V)(key : k, value : v));
         pos := (self._entries.len() - usize(1));
         while(pos > r.idx, pos = (pos - usize(1)), {
           curr := self._entries(pos);
@@ -91,8 +97,9 @@ impl(
           &(self._entries(pos)).* = prev;
           &(self._entries(pos - usize(1))).* = curr;
         });
+        .None
       }
-    );
+    )
   }),
   // Remove the entry with key `k`. Returns the old value, or .None.
   remove : (fn(self : Self, k : K, where(K <: Ord(K))) -> Option(V))({

--- a/std/collections/priority_queue.yo
+++ b/std/collections/priority_queue.yo
@@ -46,7 +46,12 @@ impl(
   ),
   // Insert a new element.
   push : (fn(self : Self, val : T, where(T <: Ord(T))) -> unit)({
-    self._data.push(val);
+    // `push`'s Result used to be discarded, so an allocation failure went on
+    // to sift an element that was never stored and underflowed `len() - 1`.
+    cond(
+      self._data.push(val).is_err() => __yo_panic("PriorityQueue.push: allocation failed"),
+      true => ()
+    );
     // Sift up
     i := (self._data.len() - usize(1));
     while(i > usize(0), {

--- a/std/process/command.yo
+++ b/std/process/command.yo
@@ -631,10 +631,14 @@ impl(
       out
     })
   }),
-  /// Send a signal to the child (e.g. 15 = SIGTERM, 9 = SIGKILL).
-  kill : (fn(self : Self, signum : i32) -> i32)(
-    IO_process.kill(self._pid, signum)
-  ),
+  /// Send a signal to the child (e.g. 15 = SIGTERM, 9 = SIGKILL). A failure —
+  /// `ESRCH` once the child has been reaped, `EPERM` — is thrown as an
+  /// `IoError` through `exn`, Rust's `Child::kill -> io::Result<()>`. Until
+  /// 2026-09-06 this handed back the raw `-errno` as an `i32`
+  /// (issues/fixed/child-kill-returned-a-raw-errno.md).
+  kill : (fn(self : Self, signum : i32, exn : Exception) -> unit)({
+    _rc := IoError.check(IO_process.kill(self._pid, signum), exn);
+  }),
   /// Wait for the child to exit and return its status. Closes any pipe fds
   /// still open on this handle.
   wait : (fn(self : Self, io : Io) -> Impl(Future(ExitStatus, IoExn)))(

--- a/tests/collections/btree_map.test.yo
+++ b/tests/collections/btree_map.test.yo
@@ -233,3 +233,14 @@ test("BTreeMap values - yields values in sorted key order", {
   });
   assert(val_sum == i32(60));
 });
+// ===== insert returns the replaced value =====
+// issues/fixed/btree-map-insert-dropped-the-old-value-and-push-results-were-ignored.md
+test("BTreeMap.insert returns None for a new key and Some(old) when it replaces", {
+  m := BTreeMap(i32, i32).new();
+  assert(m.insert(i32(5), i32(50)).is_none(), "new key");
+  assert(m.insert(i32(7), i32(70)).is_none(), "another new key");
+  old := m.insert(i32(5), i32(55));
+  assert(old.is_some() && (old.unwrap() == i32(50)), "the replaced value comes back");
+  assert(m.get(i32(5)).unwrap() == i32(55), "and the new value is stored");
+  assert(m.len() == usize(2), "replacing does not grow the map");
+});

--- a/tests/process/command.test.yo
+++ b/tests/process/command.test.yo
@@ -221,6 +221,10 @@ test("a signal death is code None, not exit 0", {
 test("Child.kill after the child was reaped throws ESRCH as an IoError", {
   // issues/fixed/child-kill-returned-a-raw-errno.md — `kill` handed back the
   // raw -errno; now the failure is thrown through the caller's Exception.
+  // POSIX-only like the other spawn tests here (/bin/sleep; posix_spawn plumbing).
+  if(platform == Platform.Windows, {
+    return(());
+  });
   exn := Exception(
     throw : (
       err -> {

--- a/tests/process/command.test.yo
+++ b/tests/process/command.test.yo
@@ -212,12 +212,38 @@ test("a signal death is code None, not exit 0", {
   cmd := Command.new(`/bin/sleep`.to_string());
   cmd.arg(`5`.to_string());
   child := io.await(cmd.spawn(io), e);
-  k := child.kill(i32(9));
-  assert(k == i32(0), "kill delivered");
+  child.kill(i32(9), exn);
   st := io.await(child.wait(io), e);
   assert(st.code().is_none(), "signal death has NO exit code");
   assert(st.signal() == i32(9), "SIGKILL recorded");
   assert(st.success() == false, "not a success");
+});
+test("Child.kill after the child was reaped throws ESRCH as an IoError", {
+  // issues/fixed/child-kill-returned-a-raw-errno.md — `kill` handed back the
+  // raw -errno; now the failure is thrown through the caller's Exception.
+  exn := Exception(
+    throw : (
+      err -> {
+        unwind(());
+      }
+    )
+  );
+  ok_exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : ok_exn);
+  cmd := Command.new(`/bin/sleep`.to_string());
+  cmd.arg(`0`.to_string());
+  child := io.await(cmd.spawn(io), e);
+  _st := io.await(child.wait(io), e);
+  // The pid is reaped: a signal to it has nobody to reach.
+  child.kill(i32(15), exn);
+  assert(false, "kill on a reaped child must throw");
 });
 test("Stdio.Null discards child stdout", {
   // POSIX-only (the Child/spawn plumbing is posix_spawn + pipes + fcntl;


### PR DESCRIPTION
Independent of the stacked P0 PRs (based on `develop`). `plans/STD_API_STABILIZATION.md` §3 items 16–17.

## `BTreeMap.insert -> Option(V)` (item 16)
Rust's `BTreeMap::insert` returns the value it replaced; Yo's returned `unit` and dropped it. Now `.Some(old)` / `.None`. `m.insert(k, v);` as a statement still compiles. Both `BTreeMap.insert` (new-key path) and `PriorityQueue.push` discarded `ArrayList.push`'s `Result` and then computed `len() - 1` — on an allocation failure nothing was stored and the index underflowed to `usize::MAX`. The result is now checked and fails with the same panic `ArrayList.with_capacity` raises (D9's infallible `push` + `try_push` will make this the default shape). `issues/fixed/btree-map-insert-dropped-the-old-value-and-push-results-were-ignored.md`.

## `Child.kill(signum, exn)` (item 17)
Was `-> i32` handing back a raw `-errno`, unlike every other io-path function in `std/process` / `std/fs`. Now the errno (`ESRCH` once the child is reaped, `EPERM`) is thrown as an `IoError` through `IoError.check` — Rust's `Child::kill -> io::Result<()>`. `issues/fixed/child-kill-returned-a-raw-errno.md`.

## Tests
- `tests/collections/btree_map.test.yo`: insert returns `None` for a new key, `Some(old)` on replace; the new value is stored; the map does not grow.
- `tests/process/command.test.yo`: the SIGKILL test passes `exn`; a new test reaps a child with `wait` and then `kill`s it, which must throw.

`check ./std` clean; btree_map 26 / priority_queue 21 / command 12 passed (develop stage-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)