### PR TITLE
plans: std audit handover (2026-09-06 17:30), v0.2.26 release-notes draft, yield-order CI observation

### DIFF
--- a/issues/yield-resumption-order-differs-on-macos-latest-ci.md
+++ b/issues/yield-resumption-order-differs-on-macos-latest-ci.md
@@ -1,0 +1,41 @@
+# `yield` resumption order differed on a `macos-latest` CI leg — "Test basic spawn of two futures" failed once
+
+**Status: OPEN — observed once on CI, not reproduced locally.** 2026-09-06.
+
+## Evidence
+
+PR #449's first `test.yml` run (run `34014524807`, job `test (macos-latest)`
+id `101441185697`, head `48ebed985`) failed exactly one test:
+
+```
+✗ Test basic spawn of two futures
+  Test failed with exit code 6
+  counter should be 12 after yield in task2 (at std/assert.yo:25:17)
+```
+
+`tests/async_await.test.yo`'s test spawns two cold tasks that each bump a
+shared counter, `yield`, and assert the OTHER task ran in between:
+task1 0→1, yield; task2 1→11, yield; task1 resumes expecting 11 → 12;
+task2 resumes expecting 12. The failure says task2 resumed while the counter
+was still 11 — i.e. **task2's yield completed before task1's**, the reverse
+of submission order.
+
+#449 touches `std/path`, `std/glob`, `std/encoding/base64`, `std/time`,
+`std/libc/time` — nothing in the async runtime or `std/async`. The same head
+passed `test (macos-26-intel)` and the Linux legs. Locally
+(`aarch64-apple-darwin`, `/tmp/yo-send3`) the test passed 3/3 consecutive
+runs.
+
+## What to establish
+
+1. Does #449's rerun (after `1281bd788` / `c8de17627`) pass `macos-latest`?
+   If yes, this is a scheduler-order flake and the runtime's `yield` on macOS
+   (kqueue-based, `src/codegen/async/runtime_io_macos.yo`) does not guarantee
+   FIFO resumption — either make it FIFO (a ready-queue, not a kevent
+   completion) or rewrite the test not to assume interleaving order.
+2. If the rerun fails the same test, bisect against develop at `c733b1a92`
+   (which has #447/#448 but not #449): a std change that alters allocation
+   patterns could be exposing a use-after-free in the async runtime instead.
+
+Do not delete or weaken the assertion to get green: the test encodes the
+documented cooperative-scheduling contract (`docs/en-US/ASYNC_AWAIT.md`).

--- a/plans/HANDOVER_STD_AUDIT_2026-09-06.md
+++ b/plans/HANDOVER_STD_AUDIT_2026-09-06.md
@@ -1,0 +1,299 @@
+# Handover — std API stabilization, P0 sweep nearly complete (2026-09-06, 17:30 CST)
+
+**For the agent taking over the std campaign.** Written for the 17:30 CST
+handover on 2026-09-06; the state below was last refreshed at the time given
+in §8. Everything was verified against `origin/develop` at `c733b1a92` (the
+merge of #448) unless marked otherwise. This supersedes
+`HANDOVER_STD_AUDIT_NEXT.md` for the std campaign; that file's §0 (the
+standing goal, the pre-authorizations) still applies verbatim.
+
+---
+
+## 0. The standing goal and the maintainer's standing constraints
+
+> "Finish @plans/HANDOVER_STD_AUDIT_NEXT.md. Document and fix any surfaced bug
+> and issue along the way. No workaround is allowed. Feel free to open PRs or
+> stacked PRs, and admin merge when needed to save CI cycles."
+
+And, from this session:
+
+> "lets do a thorough audit on our ./std api design and update related docs.
+> The goal is to stabilize std apis and make yo battery included. I also would
+> like to follow rusts patterns when we can"
+
+Constraints the maintainer stated in this session — follow them exactly:
+
+- **At most 5 concurrent agents** ("eating my usage"). **Do NOT use the
+  `Workflow` tool** ("No dont use dynamic workflows for this"). Read and
+  implement directly; plain `Agent` fan-out ≤ 5 if you must.
+- **Admin merges are pre-authorized** when CI is green
+  (`gh pr merge N --squash --admin --delete-branch`). Required checks take
+  ~55 min; the wasm and macos-26-intel legs are the slow ones.
+- **API-shape decisions are delegated** ("feel free to prioritize tasks and
+  adjust the std APIs"); prefer Rust's shape when one exists.
+- **Patch releases are pre-authorized**; every breaking std change must be
+  called out in the release notes. v0.2.26 is the next one (§6).
+- The `gh` token lacks the `workflow` scope, so PRs touching
+  `.github/workflows/*` cannot be merged by an agent (#442 is blocked on this).
+  The maintainer must run, in their terminal: `! gh auth refresh -h github.com -s workflow`.
+
+The authoritative plan is **`plans/STD_API_STABILIZATION.md`** (merged as
+#444). §3 is the P0 list (18 items, each with `file:line`); every fixed item is
+marked **FIXED yyyy-mm-dd** in place with its issue record (the marks for items
+still in open PRs live on those PR branches and land with them). §2 holds the
+decisions D9–D18 (made), §4 the P1 batteries, §5 the maintainer decisions
+still needed, §6 the phasing. Raw per-group findings:
+`plans/STD_API_STABILIZATION_FINDINGS.md`.
+
+---
+
+## 1. The PR stack — what is open, in which order, and how to land it
+
+Two stacks plus independents. **Before merging a PR whose branch is another
+PR's base, retarget the dependent PR to `develop` first** (`gh pr edit N
+--base develop`) — GitHub CLOSES a stacked PR when its base branch is deleted
+(memory `retarget-stacked-prs-before-base-merge`). Squash-merging a base and
+then the dependent is safe: the dependent's net diff is only its own commits.
+
+Stack A (thread/Send), all carry the wasm TZ-gate cherry-pick:
+
+| PR | branch | base | content |
+| --- | --- | --- | --- |
+| **#449** | `fix/std-p0-path-glob-base64-datetime` | develop | §3 items 8–10: `Path.strip_prefix -> Option` (+ `relative_to` = old node behaviour; compiler callers moved); polynomial glob with `[a-z]`; base64 `InvalidLength`/`InvalidLastSymbol`; `DateTime.now` real zone offset (`localtime_r` / `_localtime64_s`); cheatsheet + skills goldens. Its first run was red on the wasm legs (my `TZ=Asia/Tokyo` test — no zone db on wasm; gated by `0ed3cf707`) and on **`test (macos-latest)`: "Test basic spawn of two futures … counter should be 12 after yield in task2"** — an async test #449 does not touch. Treat as a flake ONLY if the rerun passes it; otherwise it is a real, pre-existing scheduling-order bug to file. |
+| **#450** | `fix/std-p0-thread-log-html` | #449 | §3 items 3–5: `Thread` is a `ref` struct with join-once + `Dispose` detaches via NEW runtime fn `__yo_thread_detach`; re-entrant pool submission lock (`__yo_thread_self`); log globals under the mutex; eager html tables; cli-case `thread-join-twice-panics`; cheatsheet + goldens. First run red on the wasm legs for the same TZ test — the gate was cherry-picked (`da32fb57d`). |
+| **#451** | `fix/std-p0-send-enforcement` | #450 | §3 item 2: **`Send` enforced at spawn boundaries** — `validate_capture_trait_requirements` is the faithful TS port, called from both closure routes; rejection routed through `flag_flow_violation` (def-eval swallow); a captured CLOSURE is judged by ITS captures (`_capture_judgement_type` resolves the `Impl(Fn)` wrapper to the concrete capture struct). Full fast suite: 3561 passed / 0 failed under a stage-1 with it. Gate cherry-picked (`7af469648`). |
+
+Stack B (independent of A, based on develop):
+
+| PR | branch | base | content |
+| --- | --- | --- | --- |
+| **#452** | `fix/std-p0-btree-insert-child-kill` | develop | §3 items 16–17: `BTreeMap.insert -> Option(V)` (replaced value), push `Result`s guarded in `BTreeMap`/`PriorityQueue`; `Child.kill(signum, exn)` throws `IoError` via `IoError.check`. Its first run failed BOTH Windows legs on my new ESRCH test (spawns `/bin/sleep`, no Windows guard) — guarded in `bdbb4d794`, cherry-picked into #453 (`3a9ee6008`) and #454 (`9209ed6dc`) so the stack never reverts it. |
+| **#453** | `fix/std-p0-http-server-resilience` | #452 | §3 item 18: `read_http_message` returns `Result(String, HttpError)` (D13); `serve_once` answers 413/400 and keeps serving; `## Stability: unstable` on `http/server`; two codegen shapes recorded (below). |
+| **#454** | `fix/std-p0-http-parse-error` | #453 | §3 item 15, HTTP half: `parse_request`/`parse_response` return `Result(_, HttpParseError)` (variants carry the offending text; `to_string` keeps today's messages). Also carries the SIGSEGV addendum + reproducer for the `unwind`-inside-`io.async` issue. |
+
+Other open PRs:
+
+| PR | what | blocker / next |
+| --- | --- | --- |
+| **#442** | D6 step 1: Schannel TLS backend compiles+links on Windows (suites still skipped). 32/32 green. | `workflow` scope — maintainer refreshes the token, then `gh pr merge 442 --squash --admin` |
+| **#443** | D6 step 2 (diagnostic), base = #442's branch: `tls.test.yo` un-gated, `http.test.yo` re-gated, FOUR bisecting probes in `tests/net/tcp.test.yo`. See §5. | read its Windows legs' verdict |
+| **#441** | issue doc: `json_parse` accepts trailing content. Green. | merge or fold into a fix |
+
+Merged this session (all in develop): #437 (unit is a true ZST — **breaking**:
+`sizeof(unit)` 0 again), #444 (plan), #445 (imm/vec), #446 (net), #447
+(Writer/Rng/derive pins), #448 (hash tombstones / retain / html_decode);
+earlier #440, #434, #436, #438.
+
+---
+
+## 2. Work in progress — none uncommitted
+
+Every change made this session is committed and pushed on one of the branches
+above. The working tree on `fix/std-p0-http-server-resilience` holds only
+two untracked docs, this file and `plans/RELEASE_NOTES_v0.2.26_DRAFT.md` —
+commit them to develop (a docs-only PR is fine to admin-merge).
+
+Nine worktrees under `/private/tmp/yo-*` were used for the stacked branches
+and D6; `git worktree list` shows them. They are disposable
+(`git worktree remove <path>`).
+
+---
+
+## 3. Binaries, commands, and the rules that bit this session
+
+**Binaries** (all in `/tmp`, all built from this tree; they vanish on reboot —
+rebuild with `yo build --std-path ./std`, ~10 min, output
+`yo-out/aarch64-apple-darwin/bin/yo`):
+
+| path | contents | use for |
+| --- | --- | --- |
+| PATH `yo` | v0.2.25 seed | `yo build` ONLY. Never for std tests: its bundled std and evaluator lag the tree |
+| `/tmp/yo-zst5` | develop stage-1 before the thread changes | anything not touching threads |
+| `/tmp/yo-thr` | + `__yo_thread_detach` (#450) | thread tests |
+| `/tmp/yo-send3` | + Send enforcement with re-raise + closure resolver (#451) — **the current head** | everything |
+| `/tmp/yo-d6bin` | develop + the D6 `AcceptEx` runtime (built from `/private/tmp/yo-d6`) | Windows cross-emits of the D6 fix |
+| `/tmp/yo-send`, `/tmp/yo-send2` | intermediate Send builds | do not use |
+
+**Commands:**
+
+```bash
+/tmp/yo-send3 check ./std --std-path ./std        # evaluator-only; async-codegen rules are NOT checked here
+/tmp/yo-send3 check ./src --std-path ./std
+/tmp/yo-send3 test ./tests/X.test.yo --std-path ./std --parallel 1 -v &> out.txt
+/tmp/yo-send3 test ./tests --exclude tests/internal --exclude tests/cli-cases --std-path ./std   # ~35 min, 3561 tests
+find tests -name '.yo_selftest_batch_*' -delete   # stray batch files after a killed run
+# cli-case goldens — YO_SKILLS is MANDATORY for a binary outside the checkout
+YO_SKILLS=$PWD/.github/skills YO_SELF_BIN=/tmp/yo-send3 bash scripts/cli-diff-test.sh --record <case>
+# Windows gate for emitted C (~1 min instead of a 50-min leg)
+/tmp/yo-send3 compile tmp/fixme.yo --std-path ./std --target x86_64-pc-windows-msvc --emit-c --skip-c-compiler --optimize 2 -o /tmp/x
+zig cc -target x86_64-windows-gnu -c /tmp/x.c -o /tmp/x.o -Wno-everything -Wincompatible-pointer-types -Wint-conversion -Wimplicit-function-declaration -Werror=return-type
+# find the error a def-eval trial swallowed
+YO_DEBUG_SWALLOW=1 /tmp/yo-send3 check <file> --std-path ./std 2>&1 | grep -a "\[swallow\]"
+```
+
+**Rules learned the hard way this session** (all in
+`.github/skills/yo-syntax/syntax-cheatsheet.md` or memory; the cheatsheet
+edits live on the branches that made them):
+
+- `__yo_panic` takes the ENCLOSING FUNCTION's return type: make it the
+  `cond`'s VALUE with the real body in the `true =>` arm (std/rand.yo).
+- A `c_include` opaque struct type (`tm : Type`) is emitted as bare `tm` in C;
+  type such pointers as `*(void)`. MSVC's `localtime_s` has REVERSED
+  arguments vs C11 Annex K — never call the Annex-K binding on Windows.
+- `extern("Yo", …)` runtime symbols come from DIFFERENT preambles:
+  `__yo_get_thread_id` is async-core-only (absent without `io`);
+  `__yo_thread_self()` is always present. Probe new std→runtime dependencies
+  with a `main` that has NO `io`.
+- **No mid-loop `return(...)` inside an `io.async` body** — `check` is clean,
+  codegen dies with "this io.async closure's body was never fully evaluated".
+  Record the outcome in a local, end the loop, produce the value in the tail.
+- **No `io.await` inside a `match` scrutinee in an async body** — the value
+  comes back empty. Hoist it into a binding first.
+- **`unwind` from an `Exception` handler installed INSIDE an `io.async` body
+  is memory-unsafe**: one frame shape exits 0 in silence, another SIGSEGVs
+  (`issues/unwind-from-a-handler-installed-inside-io-async-exits-main-with-rc-0.md`,
+  reproducer `issues/repros/unwind-inside-io-async-helper-sigsegv.yo`). The
+  runtime's "main future Aborted → panic" path is NOT what fires; the emitted
+  C unwinds to the wrong frame. Recommended: make the evaluator REJECT an
+  unwinding `ctl` bound inside an `io.async` body first, then design the
+  semantics. Until then there is no way to catch an error inside an async
+  body — use D13's shape (a `Result`-returning core).
+- A local `(fn(...) -> T)(body)` literal cannot capture enclosing locals.
+- Backtick literals cannot be nested inside `${…}` — hoist to a local.
+- `{ expr }` without a semicolon is a struct literal (E0007): `io => ()`, not
+  `io => { () }`.
+- A def-eval rejection you add to the evaluator must go through
+  `flag_flow_violation` before the throw or the trial wall swallows it.
+- The Send check is over CAPTURES: a module-level binding is a global, not a
+  capture — regression tests must make the offending value a function local.
+- Editing ANYTHING under `.github/skills/` reds the tier-1 CLI gate until
+  `skills-install` / `skills-install-zh` are re-recorded WITH `YO_SKILLS` set
+  (without it the record "succeeds" and writes goldens of the failure).
+- Don't edit `src/`/`std/` while a build or a test run is in flight; two
+  `yo test` runs over `tests/` collide on `.yo_selftest_batch_*` files.
+- A test that spawns `/bin/sleep` or any POSIX binary needs the file's
+  Windows guard (`if(platform == Platform.Windows, { return(()); });`) — the
+  Windows legs run `tests/process` too.
+- A PR whose branch still carries commits that were squash-merged elsewhere
+  turns `mergeable=CONFLICTING` and GitHub then runs NO Actions for any push to
+  it (no run, no check-suite, an empty-commit push changes nothing). Rebase the
+  branch onto develop (git drops the upstream patches), force-push with
+  `--force-with-lease`, then re-stack the dependents on the new base.
+- `sed -n "…" $f` with an EMPTY `$f` reads stdin and hangs a script forever.
+
+---
+
+## 4. §3 P0 scoreboard (plans/STD_API_STABILIZATION.md)
+
+| item | subject | status |
+| --- | --- | --- |
+| 1 | `imm/vec` leaks / drop-of-uninit; `Deque`/`vec` C35 guards | MERGED #445 |
+| 2 | `Send` not enforced at spawn | PR #451 |
+| 3 | pool `spawn` self-deadlock in inline fallback | PR #450 |
+| 4 | `Thread.join` re-callable, no Dispose | PR #450 (new runtime fn `__yo_thread_detach`) |
+| 5 | html lazy-init race; log globals raced | PR #450 |
+| 6 | `IpAddr.parse_v4` octets | MERGED #446 |
+| 7 | `UdpSocket.bind` echoes arg; no `connect` | MERGED #446 |
+| 8 | `Path.strip_prefix` was node's relative | PR #449 |
+| 9 | `DateTime.now` returned UTC | PR #449 |
+| 10 | base64 tails; glob ranges + exponential `*` | PR #449 |
+| 11 | derive fallbacks (WITHDRAWN — builtin guard already rejects); `Rng.range(x,x)` SIGFPE | MERGED #447 |
+| 12 | `Writer.to_string` aliases buffer | MERGED #447 |
+| 13 | hash tombstones never reclaimed | MERGED #448 |
+| 14 | `html_decode` O(n²); `retain` O(n²) | MERGED #448 |
+| 15 | `Result(_, String)` in `env.cwd/current_exe/chdir` and `http.parse_request/parse_response` | http half: PR #454. **env half TODO** — the only P0 work left: 48 compiler call sites match on `env`'s `Result(_, String)` (`grep -rn "cwd()\|current_exe()\|chdir(" src/`); do it in the v0.2.27 breaking window per §6 |
+| 16 | `BTreeMap.insert -> unit`; push `Result`s discarded | PR #452 |
+| 17 | `Child.kill -> i32` errno | PR #452 |
+| 18 | one malformed request kills `HttpServer.serve`; no `## Stability` | PR #453 (peer-reset I/O errors still propagate — needs the catch primitive) |
+
+After 15: §2's D9–D18 decisions that change signatures (infallible `push` +
+`try_push`, `replace` = all, max-heap `PriorityQueue`, `FromStr -> Result`,
+`Debug` split from `ToString`, `HashSet := HashMap(T, unit)`, stable `sort`,
+`timeout -> Result`) — one release window (v0.2.27 per §6). Then §4 P1
+batteries module by module (`## Stability` marker on every module). §5 lists
+the maintainer decisions still pending (Box name, `imm/Vec` structure,
+`MemoryOrder.Consume`, HashMap random keys) — ask, don't guess.
+
+Also filed today: `issues/yield-resumption-order-differs-on-macos-latest-ci.md`
+(the "Test basic spawn of two futures" failure on #449's first run — CI-only so
+far, 3/3 green locally; correlate with #449's rerun).
+
+Held for later (not P0): #433 (dyn trait check), #420 (`comptime_assert` in fn
+bodies — 1559 dormant assertions), #441 (json trailing junk),
+`issues/type-impls-reports-true-for-a-blanket-impl-whose-where-clause-fails.md`
+(soundness; gates full `Send` enforcement for pointers/arrays),
+`issues/unwind-from-a-handler-installed-inside-io-async-exits-main-with-rc-0.md`
+(runtime: rc 0 on an aborted main future; language: no catch inside async),
+`issues/unit-zst-residual-gaps.md`,
+`issues/equality-operator-without-an-eq-impl-evaluates-to-unit.md`.
+
+---
+
+## 5. D6 — Windows TLS (Schannel) re-land — ROOT CAUSE FOUND, FIX PUSHED
+
+Record: `issues/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md`
+(read its "Root cause" section). Plan: `plans/D6_TLS_PLAN.md`. Worktree
+`/private/tmp/yo-d6`, branch `d6/step2-unskip` (PR #443, base = #442's branch).
+
+**Root cause.** `__yo_async_accept_start` in
+`src/codegen/async/runtime_io_windows.yo` was a plain BLOCKING `accept()` on
+the event-loop thread (and `connect_start` a blocking `connect()`). A server
+task that awaits `accept` before the client on the same loop has connected
+blocks the whole loop forever. Every pre-existing TCP test connects first, so
+nothing noticed; the redirect test and the round-2 probe spawn the server
+first. Both Windows legs hung identically. The Schannel code was never at
+fault.
+
+**Fix (on `d6/step2-unskip`, last commits of this session):** an overlapped
+`AcceptEx` path — extension pointers via `WSAIoctl(SIO_GET_EXTENSION_FUNCTION_POINTER)`
+(`<mswsock.h>` typedefs only, NO new import library, so the four Windows
+link-flag sites are untouched), an `is_accept` overlapped record, completion
+does `SO_UPDATE_ACCEPT_CONTEXT` + `GetAcceptExSockaddrs` + IOCP association;
+blocking `accept()` kept only as the no-extension fallback. `check ./src`
+clean; the emitted C was gated with `zig cc -target x86_64-windows-gnu` and
+`aarch64-windows-gnu` (see §8 for whether that finished). `http.test.yo` is
+un-gated again in the same push so the Windows legs test the real redirect
+test; `server.test.yo` is still `SkipWindows` — un-gate it next.
+
+**What to read next:** #443's Windows legs on the new head. A pass (~30 min
+legs) means D6 is done: un-gate `server.test.yo`, merge #442 (needs the token
+scope) then #443 (retarget to develop first), ship in v0.2.26. A failure now
+shows as a test failure with the probes' stderr progress lines, not a hang.
+Follow-up in the same class: `__yo_async_connect_start` is still a blocking
+`connect()` (harmless on loopback) — `ConnectEx` is the proper form.
+
+---
+
+## 6. v0.2.26 release
+
+Draft notes: **`plans/RELEASE_NOTES_v0.2.26_DRAFT.md`** (update it). Breaking
+entries to call out: `sizeof(unit)` is 0 again (was 1 in v0.2.25; all-unit
+aggregates are 1 byte, MSVC gives empty aggregates 4); `Path.strip_prefix ->
+Option` (old behaviour is `relative_to`); `Thread` is a ref type with join-once
++ detach-on-drop; `base64_decode` rejects non-canonical input (`EncodingError`
+gained `InvalidLength`/`InvalidLastSymbol`); `Rng.range` panics on empty
+ranges; `Writer.to_string` resets the writer; `DateTime.now` is really local;
+`BTreeMap.insert` returns `Option(V)`; `Child.kill` takes `exn` and throws;
+`read_http_message` returns `Result`; `Send` is enforced at spawn boundaries
+(a spawn closure capturing an `ArrayList`/`String`/`ref(struct)` is now a
+compile error — wrap in `Arc`/`Iso`).
+
+Mechanics (memory `draft-release-patch-resets-tag-name`): the release workflow
+creates a DRAFT, `publish-release` flips it public; a body-only PATCH on a
+draft resets `tag_name` to `untagged-…` — always send `tag_name` too and
+re-read before publishing. The release gate must see ≥3 real `test (…)` legs.
+SEED_VERSION bumps on develop after the release.
+
+---
+
+## 7. Background monitors / tasks at handover
+
+All monitors and background jobs of this session are stopped at 17:30. Nothing
+depends on them; the states above were read from GitHub directly. Re-arm what
+you need with `gh pr checks N --json name,bucket`.
+
+---
+
+## 8. Live state at 17:30
+
+_(filled in at handover time — see the bottom of this file)_

--- a/plans/HANDOVER_STD_AUDIT_2026-09-06.md
+++ b/plans/HANDOVER_STD_AUDIT_2026-09-06.md
@@ -294,6 +294,33 @@ you need with `gh pr checks N --json name,bucket`.
 
 ---
 
-## 8. Live state at 17:30
+## 8. Live state at 17:30 CST, 2026-09-06
 
-_(filled in at handover time — see the bottom of this file)_
+`origin/develop` = `c733b1a92` (merge of #448). Nothing uncommitted; the docs
+(this file, the release draft, the yield-order issue) are PR **#455**
+(`docs/std-audit-handover-2026-09-06`, docs-only — admin-merge it).
+
+| PR | head | checks (pass / pending / fail) | note |
+| --- | --- | --- | --- |
+| #443 (D6 fix) | `88e88f595` | 7 / 11 / 0 | Windows legs had not started yet; a pass takes ~30 min once they do. `server.test.yo` still `SkipWindows`. |
+| #449 | `c8de17627` | 24 / 2 / 0 | rebased onto develop; **merge when green** (retarget #450 to develop FIRST) |
+| #450 | `1661ef9e1` | 20 / 1 / **1** | `test (ubuntu-24.04-arm)` failed — log fetch returned 2 lines at 17:30 (not yet available); read it: `gh run list --branch fix/std-p0-thread-log-html`. Could be the log/thread canary tests under arm timing — do not assume flake. |
+| #451 | `3fd7994f0` | 18 / 4 / 0 | |
+| #452 | `bdbb4d794` | 7 / 13 / **1** | `Full-corpus hollow sweep` reports `tests/http/http_limits.test.yo RED` — a NEW regression under the self-hosted compiler built from THIS branch (which touches btree_map, priority_queue, process/command and the command test only). Reproduce: build a stage-1 from the branch and run `BIN=<stage1> OUT=/tmp/hs bash scripts/bootstrap/hollow_sweep69.sh`, or just that file with the stage-1. |
+| #453 | `3a9ee6008` | 11 / 9 / **1** | `Bootstrap fixpoint (yo-self self-compile)` failed — the fetched log showed only emitted-C dumps; read the job's tail for STAGE2/STAGE3/FIXPOINT lines. This PR changes std/http only, so a fixpoint break is suspicious: check whether the wire.yo restructure changed emitted C for the compiler's own http use (`src/version_cache.yo` uses `std/http`). |
+| #454 | `9209ed6dc` | 11 / 10 / 0 | |
+| #442 | `0a92f03a8` | 32 / 0 / 0 | blocked on the `workflow` token scope |
+| #441 | `1f61bcb70` | 3 / 0 / 0 | docs-only issue PR |
+
+Monitors and background jobs of this session were stopped at 17:30. Local
+binaries listed in §3 exist until reboot. Worktrees: `/private/tmp/yo-449`,
+`/private/tmp/yo-452`, `/private/tmp/yo-453`,
+`/private/tmp/yo-fix-std-p0-thread-log-html`,
+`/private/tmp/yo-fix-std-p0-send-enforcement`, `/private/tmp/yo-d6` (+ older
+ones) — `git worktree list`; all disposable.
+
+**First three things to do:** (1) read the three red legs above and decide
+flake vs regression for each — #452's `http_limits RED` and #453's fixpoint
+break are the ones that could be real; (2) merge #449 → retarget/merge #450,
+#451 as they go green; #452 → #453 → #454 likewise; (3) read #443's Windows
+verdict and finish D6 (§5).

--- a/plans/RELEASE_NOTES_v0.2.26_DRAFT.md
+++ b/plans/RELEASE_NOTES_v0.2.26_DRAFT.md
@@ -1,0 +1,102 @@
+# v0.2.26
+
+A small, deliberate release: **`unit` is now a true zero-sized type**, the
+lazy-binding campaign closes with forward references allowed in `std/` and
+`src/` themselves, and Windows regains a TLS backend (Schannel) — compiled and
+linked on the Windows runners, with its live suites still gated off there until
+the handshake is proven.
+
+## ⚠️ Breaking changes (patch-release policy)
+
+- **`sizeof(unit)` is 0, and a `unit` field costs nothing** (#437). A `unit`
+  struct/tuple field emits no C member, an enum variant field is erased,
+  `Array(unit, N)` has no data. `struct(a : i32, b : unit)` is **4** bytes
+  (was 8), `Tuple(i32, unit)` is **4**. An aggregate whose EVERY field is
+  `unit` is **1 byte** (one `_zst_dummy` member) — not 0: an empty C struct is
+  4 bytes on the MSVC ABI and 0 on GNU, so it is not a portable representation
+  (measured; the first cut crashed both Windows CI legs). This is
+  Rust's model (`size_of::<()>() == 0`). **`sizeof(unit)` has now moved
+  0 → 1 → 0 across v0.2.24 → v0.2.25 → v0.2.26**: the 1 in v0.2.25 was the safe
+  stopgap for a live heap overflow and could not wait; this release is the
+  erasure that makes 0 right. The one place a `unit` still occupies a byte is a
+  by-value *parameter* (C cannot declare a `void` parameter) — calling
+  convention, not layout; `sizeof` never observes it.
+- **`ArrayList` of a zero-sized element type allocates one anchor byte per
+  list and reports `SIZE_MAX` capacity** (#437). It never resizes. Rust's
+  `Vec<()>` never allocates at all; Yo cannot form a non-null dangling
+  pointer, and routing a zero-byte request through the allocator is
+  `malloc(0)` then `realloc(p, 0)` — which frees `p` and returns NULL on glibc
+  and the Windows CRT.
+
+- **std API stabilization, P0 sweep** (`plans/STD_API_STABILIZATION.md`,
+  #444–#454). These follow Rust's shapes and change signatures:
+  - `Path.strip_prefix(base)` is now Rust's: `Option(Path)` — the remainder when
+    `base` is a segment-wise prefix, `.None` otherwise. The old behaviour
+    (node's `path.relative`, with `..` segments) is `Path.relative_to(base)`.
+  - `Thread` is a reference type with `JoinHandle` semantics: `join` twice
+    panics; dropping an un-joined handle DETACHES the thread. `Thread.is_joined()` added.
+  - `BTreeMap.insert` returns `Option(V)` (the replaced value) instead of `unit`.
+  - `Child.kill(signum, exn)` throws the errno as an `IoError` instead of
+    returning a raw `-errno` `i32`.
+  - `http.parse_request` / `parse_response` return `Result(_, HttpParseError)`
+    instead of `Result(_, String)`; `read_http_message` returns
+    `Result(String, HttpError)` and the server answers 413/400 instead of dying.
+  - `base64_decode` rejects a length of 1 mod 4 and non-canonical trailing bits
+    (`EncodingError.InvalidLength` / `InvalidLastSymbol`).
+  - `Rng.range(x, x)` and `Rng.next_below(0)` panic (they divided by zero).
+  - `fmt.Writer.to_string` hands over the buffer and leaves the writer empty.
+  - `DateTime.now()` is really local (zone offset from the C library).
+  - **`Send` is enforced at spawn boundaries**: a `Thread.spawn` / `spawn(pool, …)`
+    closure that captures a non-`Send` value (an `ArrayList`, a `String`, any
+    plain `ref(struct)`, an `Io`, a `JoinHandle`) is now a compile error —
+    wrap it in `Arc`/`Iso` or capture a `Send` projection. A captured closure
+    is judged by its own captures.
+
+## Language
+
+- **Forward references are now allowed in `std/` and `src/` themselves** (#438,
+  P5 — the last phase of `plans/reference/LAZY_TOPLEVEL_BINDINGS.md`). The
+  "seed gate" that kept the standard library and the compiler on
+  definition-before-use is lifted now that the seed (v0.2.25) carries P1–P3;
+  the first forward references land in `module_manager.yo` and the type
+  synthesizer, replacing two IIFE-wired function-pointer slots that only
+  existed to express mutual recursion. `yo explain E0401` / `E0906` texts that
+  still described the old rule are rewritten with examples that still fail.
+- **`unit` implements `Eq`, `Ord`, `Hash` and `Clone`** (#437), as Rust's `()`
+  does. Note: infix `==` on two `unit` operands does not yet dispatch to that
+  impl (a pre-existing gap in the operator fall-through, tracked in
+  `issues/equality-operator-without-an-eq-impl-evaluates-to-unit.md`), so
+  `derive(Eq)` over a struct with a `unit` field still does not work.
+
+## Platforms
+
+- **Windows: the Schannel TLS backend is back** (#442, re-landing #413). It
+  compiles and links on both Windows runners and `tls_available()` is observable
+  there. **The TLS and HTTP test suites remain skipped on Windows in this
+  release**: the first attempt ran them against the brand-new backend and the
+  Windows legs hung for the 4-hour job timeout with no log to read. They are
+  un-skipped in a follow-up with a per-test deadline on every network test.
+  Windows `test` legs now carry a 75-minute budget so a hang produces a failed
+  job with a downloadable log.
+
+## Correctness
+
+- **An enum with no non-unit variant field was 8 bytes on Windows against a
+  layout model of 4** (#437, pre-existing). Its data union was empty, and an
+  empty union is 4 bytes on the MSVC ABI (0 on GNU), so every container of an
+  `Option(unit)`-shaped enum was under-allocated on Windows. Such an enum now
+  emits no data union at all: it is its tag, 4 bytes on every target.
+- **`cond` with a comptime-true condition in a non-first arm emitted a dangling
+  `else`** (#437). The arm was written as a bare `else { … }` but the chain kept
+  going and wrote the next arm as a second `else` — invalid C. Any `cond`
+  mixing a runtime guard with a type-level fact (`sizeof(T) == usize(0)` in a
+  generic body) hit it. The chain now stops after a comptime-true arm.
+
+## Testing
+
+- `tests/unit_as_value_type.test.yo` pins every unit-bearing shape's size
+  against the *emitted* layout with a differential round trip, plus
+  `ArrayList(unit)` to 1000 elements, an all-unit struct to 300, a `ref` struct
+  with a unit field between an `i32` and a `String`, `HashMap(String, unit)`,
+  a generic struct at `T = unit`, `Array(unit, 3)`, and a *counted*
+  side-effecting unit constructor argument (#437).


### PR DESCRIPTION
Docs only.

- `plans/HANDOVER_STD_AUDIT_2026-09-06.md` — the handover for the agent taking over the std campaign: the PR stack and its landing order, every rule that bit this session, the P0 scoreboard, the D6 root cause + fix, the v0.2.26 checklist, and a live-state section written at 17:30 CST.
- `plans/RELEASE_NOTES_v0.2.26_DRAFT.md` — draft notes with every breaking std entry of the P0 sweep called out.
- `issues/yield-resumption-order-differs-on-macos-latest-ci.md` — the one-off `macos-latest` failure of "Test basic spawn of two futures" on #449's first run (CI-only so far; 3/3 green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)