### PR TITLE
std/json: a JSON text is ONE value — reject trailing content (closes #441)

### DIFF
--- a/issues/fixed/json-parse-accepts-trailing-content-after-the-value.md
+++ b/issues/fixed/json-parse-accepts-trailing-content-after-the-value.md
@@ -1,0 +1,108 @@
+# `json_parse` accepts trailing content after the value — `[1,2][3,4]` parses as `[1,2]`
+
+**Status: FIXED** (2026-09-06, `std/encoding/json.yo`).
+
+**Severity: strictness gap, C34 family.** RFC 8259 §2: *"A JSON text is a
+serialized value."* One value — anything after it is a parse error. `json_parse`
+parses the first value, stops, and never checks that the cursor reached the end
+of the input, so it returns `.Ok` for input that is not JSON.
+
+**Found** 2026-09-06, while auditing `std/` for the read-overshoot class fixed in
+`issues/http-body-is-not-truncated-to-content-length.md`. It is the same
+*shape* — a buffer that may hold more than one message, consumed as if it held
+one — but not the same bug: no bytes are misattributed, they are simply ignored.
+
+## Reproducer
+
+```rust
+open(import("std/string"));
+{ json_parse, json_stringify } :: import("std/encoding/json");
+{ Exception } :: import("std/error");
+{ println } :: import("std/fmt");
+main :: (fn() -> unit)({
+  exn := Exception(throw : (err -> { println(`   Err -> ${err.to_string()}`); unwind(()); }));
+  println(`${json_stringify(json_parse("[1,2][3,4]", exn))}`);
+  println(`${json_stringify(json_parse("1 garbage", exn))}`);
+  println(`${json_stringify(json_parse("[1,2]]]]", exn))}`);
+  println(`${json_stringify(json_parse("null null", exn))}`);
+});
+export(main);
+```
+
+```
+input: [1,2][3,4]   ->  [1,2]     want an error
+input: 1 garbage    ->  1         want an error
+input: [1,2]]]]     ->  [1,2]     want an error
+input: null null    ->  null      want an error
+input: [1,2]        ->  [1,2]     OK
+```
+
+Rust's `serde_json::from_str` rejects all four with `trailing characters`.
+
+## Why it matters
+
+This is the same failure mode C34 was filed for — *"an HTML error page where JSON
+was expected"*. C34 fixed the number grammar so `"<html>"` no longer parses as
+the number `0`, but a response whose first bytes happen to be a valid JSON value
+followed by anything at all still parses cleanly. A truncated-then-retried
+response, two concatenated frames, or a JSON body with an HTML error appended all
+read as success.
+
+## Where to look
+
+`std/encoding/json.yo:782`, `json_parse_bytes`: it returns `.Ok(v)` straight out
+of `_parse_value(p)` with no end-of-input check. `json_parse` (`:791`) routes
+through it.
+
+## Fix shape, and the thing to check FIRST
+
+After `_parse_value`, skip whitespace and require the cursor to be at the end of
+input; otherwise `JsonError` naming the offset.
+
+**Check `src/lsp/server.yo` before tightening anything.** The LSP parses every
+JSON-RPC frame through `json_parse`, and if it hands over a read buffer that can
+contain the *next* frame's bytes, this tightening would break the language
+server outright. That is the over-acceptance canary for this change, and it must
+be verified before the fix, not after.
+
+The other canary is cheap and must keep passing: leading and trailing
+**whitespace** around a value is legal JSON text (`"  [1,2]  "`), so the
+end-of-input check skips whitespace rather than demanding exact length.
+
+## Regression tests
+
+`tests/encoding/json.test.yo`. Four rejections (the reproducer's cases, so the
+concatenated-value, junk-suffix, unbalanced-bracket and repeated-literal shapes
+are each pinned separately) plus two acceptances — `"  [1,2]  "` and a value with
+a trailing newline — so a fix that over-rejects is caught.
+
+## Fix
+
+`_expect_eof(p)` — skip whitespace, then require the cursor to be at end of
+input — runs after `_parse_value` in **both** public entry points:
+`json_parse_bytes` (so `json_parse` / `json_parse_string` throw) and
+`json_parse_result` (so it returns `.Err`). The error is
+`JsonError.UnexpectedChar(ch, pos)`, which names the offending byte and its
+position, the way `serde_json` reports `trailing characters`.
+
+Whitespace around a lone value is still accepted (`  [1,2]  `), so the check
+does not over-reject — pinned by its own test.
+
+## Regression tests
+
+`tests/encoding/json.test.yo`, verified RED before the fix (2 failed / 57
+passed) and green after (59 passed):
+
+- `json_parse_result rejects content after the top-level value` — all five
+  shapes from the reproducer above.
+- `json_parse_result still accepts a lone value with surrounding whitespace` —
+  the over-rejection canary.
+- `json_parse throws on content after the value, and names the position` —
+  asserts the message carries `position 5` for `[1,2][3,4]`.
+
+## Note for the caller in `src/`
+
+`src/lsp/server.yo` parses a Content-Length-framed body with
+`json_parse_string`. Stricter parsing is correct there — the body should be
+exactly the message — and a trailing `\r\n` is still tolerated because
+`_expect_eof` skips whitespace first.

--- a/std/encoding/json.yo
+++ b/std/encoding/json.yo
@@ -778,12 +778,32 @@ _parse_value :: (fn(p : _Parser) -> Result(JsonValue, JsonError))({
 // ============================================================================
 // Public API
 // ============================================================================
-/// Parse JSON bytes into a `JsonValue` tree. Throws via `Exception` on invalid input.
+/// RFC 8259 §2: "A JSON text is a serialized value." Exactly one — so after
+/// the value is parsed the cursor must be at end of input, whitespace aside.
+/// Without this `[1,2][3,4]` parsed as `[1,2]` and `1 garbage` as `1`: the
+/// trailing bytes were silently dropped and the caller was handed `.Ok` for
+/// input that is not JSON
+/// (`issues/fixed/json-parse-accepts-trailing-content-after-the-value.md`).
+_expect_eof :: (fn(p : _Parser) -> Result(unit, JsonError))({
+  p.skip_ws();
+  match(
+    p.peek(),
+    .None => .Ok(()),
+    .Some(c) => .Err(JsonError.UnexpectedChar(c, p.pos))
+  )
+});
+/// Parse JSON bytes into a `JsonValue` tree. Throws via `Exception` on invalid
+/// input, INCLUDING any content after the single top-level value.
 json_parse_bytes :: (fn(bytes : ArrayList(u8), exn : Exception) -> JsonValue)({
   p := _Parser.new(bytes);
   match(
     _parse_value(p),
-    .Ok(v) => v,
+    .Ok(v) =>
+      match(
+        _expect_eof(p),
+        .Ok(_) => v,
+        .Err(e) => exn.throw(dyn(e))
+      ),
     .Err(e) => exn.throw(dyn(e))
   )
 });
@@ -1336,7 +1356,11 @@ impl(
 /// plumbing — the decode-side counterpart of `json_stringify`).
 json_parse_result :: (fn(s : String) -> Result(JsonValue, JsonError))({
   p := _Parser.new(s.as_bytes());
-  _parse_value(p)
+  match(
+    _parse_value(p),
+    .Ok(v) => match(_expect_eof(p), .Ok(_) => .Ok(v), .Err(e) => .Err(e)),
+    .Err(e) => .Err(e)
+  )
 });
 /// Serialise any `ToJson` value to JSON text.
 json_encode :: (fn(generic(T : Type), v : T, where(T <: ToJson)) -> String)(

--- a/tests/encoding/json.test.yo
+++ b/tests/encoding/json.test.yo
@@ -763,3 +763,44 @@ test("derived roundtrip with a None Option field", {
     .Err(_) => assert(false, "decode should succeed for a None field")
   );
 });
+// ===== RFC 8259 §2: a JSON text is ONE serialized value =====
+// issues/fixed/json-parse-accepts-trailing-content-after-the-value.md — the
+// parser stopped at the end of the first value and never checked it had
+// consumed the input, so `[1,2][3,4]` came back `.Ok([1,2])`.
+test("json_parse_result rejects content after the top-level value", {
+  cases := ArrayList(String).new();
+  cases.push(`[1,2][3,4]`.to_string());
+  cases.push(`1 garbage`.to_string());
+  cases.push(`[1,2]]]]`.to_string());
+  cases.push(`null null`.to_string());
+  cases.push(`{"a":1} {"b":2}`.to_string());
+  i := usize(0);
+  while(runtime(i < cases.len()), {
+    src := cases(i);
+    assert(
+      match(json_parse_result(src.clone()), .Ok(_) => false, .Err(_) => true),
+      `expected trailing content to be rejected: ${src}`
+    );
+    i = (i + usize(1));
+  });
+});
+test("json_parse_result still accepts a lone value with surrounding whitespace", {
+  assert(match(json_parse_result(`  [1,2]  `.to_string()), .Ok(_) => true, .Err(_) => false), "whitespace around one value is fine");
+  assert(match(json_parse_result(`null`.to_string()), .Ok(_) => true, .Err(_) => false), "a bare null is one value");
+  assert(match(json_parse_result(`{"a":1}`.to_string()), .Ok(_) => true, .Err(_) => false), "a lone object is one value");
+});
+test("json_parse throws on content after the value, and names the position", {
+  // The handler unwinds, so the assert below is reached only if NO throw
+  // happened. A ctl handler cannot capture an enclosing runtime local, which
+  // is why the outcome is encoded in reachability rather than a flag.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(err.to_string().contains(`unexpected character at position 5`), `want the offending position, got ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  json_parse("[1,2][3,4]", exn);
+  assert(false, "json_parse must throw on trailing content");
+});


### PR DESCRIPTION
**Supersedes #441**, which filed this as an issue record. Rather than merge the doc alone, this fixes the bug and moves the record to `issues/fixed/`.

## The bug

RFC 8259 §2: *"A JSON text is a serialized value."* The parser stopped at the end of the first value and never checked it had consumed the input, so it returned `.Ok` for input that is not JSON:

```
[1,2][3,4]   ->  [1,2]      want an error
1 garbage    ->  1          want an error
[1,2]]]]     ->  [1,2]      want an error
null null    ->  null       want an error
```

No bytes are misattributed — they are silently ignored — which is the same shape as the C34 read-overshoot family: a buffer that may hold more than one message, consumed as if it held one. `serde_json::from_str` rejects all four with `trailing characters`.

## The fix

`_expect_eof(p)` skips whitespace and requires end of input, and runs after `_parse_value` in **both** public entry points — `json_parse_bytes` (so `json_parse` / `json_parse_string` throw) and `json_parse_result` (so it returns `.Err`). The error is `JsonError.UnexpectedChar(ch, pos)`, naming the offending byte and its position.

## Not over-rejecting

Whitespace around a lone value is still accepted, pinned by its own canary test — a strictness fix that also rejected `  [1,2]  ` would be a worse bug than the one it closes.

## Verification

- Tests verified **RED first** (2 failed / 57 passed), green after (**59 passed**).
- `check ./std` 173/173, `check ./src` 266/266.
- The one `src/` caller is `src/lsp/server.yo`, which parses a Content-Length-framed body — stricter parsing is correct there, and a trailing CRLF is still tolerated since `_expect_eof` skips whitespace first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)