### PR TITLE
std: `iter()` yields POINTERS on ArrayList and OrderedMap (D14)

### DIFF
--- a/issues/fmt-pointer-type-paren-verdict-is-context-dependent.md
+++ b/issues/fmt-pointer-type-paren-verdict-is-context-dependent.md
@@ -36,12 +36,28 @@ it away in another. Whatever selects between them is NOT the pointer type, the
 enclosing `Iterator(...)`, the `where` clause, or where `MapEntry` comes from —
 those are the same on both sides.
 
-A reduced probe (a fresh file with the same `impl` shape and a one-line `.None`
-body) reports rc=1, i.e. it behaves like `ordered_map.yo`, NOT like
-`hash_map.yo` — so `hash_map.yo` is the outlier and something in its context is
-suppressing the rewrite. The remaining difference between the two real files is
-the shape of the `next` BODY: `hash_map.yo` opens `(` + newline + `cond(`,
-while `ordered_map.yo` opens `({`.
+Three experiments narrow it to a **file-scope** trigger, not a construct-scope
+one:
+
+1. **A reduced probe fails.** A fresh file containing the same `impl` shape
+   (same `where`, same `Iterator(...)`, `MapEntry` imported from
+   `std/collections/entry.yo`) reports rc=1 — it behaves like
+   `ordered_map.yo`, so `hash_map.yo` is the outlier.
+2. **`hash_map.yo`'s rc=0 is NOT vacuous** — fmt really does process it.
+   Damaging an unrelated line (`contains_key`'s indent, ~250 lines away)
+   makes `fmt --check` report rc=1, and `fmt` then repairs that indent — while
+   leaving `Item : *(MapEntry(K, V))` on line 690 untouched in the same run.
+   So this is not fmt bailing out on the file.
+3. **The SAME block is preserved when pasted INTO `hash_map.yo`.** Appending
+   the reduced probe's `impl` verbatim to the end of `hash_map.yo` and running
+   `fmt` leaves BOTH `Item : *(MapEntry(K, V))` lines (690 and 998) intact —
+   the identical text that gets rewritten in a standalone file.
+
+So something at FILE scope in `hash_map.yo` makes the formatter keep the
+parentheses, and it is not the pointer type, the enclosing `Iterator(...)`,
+the `where` clause, where `MapEntry` comes from, or the surrounding `impl`.
+The mechanism is NOT yet isolated — that needs reading `src/formatter.yo`,
+which is why this is filed rather than fixed.
 
 ## Why it matters
 

--- a/issues/fmt-pointer-type-paren-verdict-is-context-dependent.md
+++ b/issues/fmt-pointer-type-paren-verdict-is-context-dependent.md
@@ -1,0 +1,72 @@
+# `yo fmt` gives two different verdicts for the SAME pointer-type spelling
+
+**Status:** OPEN. Observed 2026-09-07 while integrating the D-batch PRs
+(`plans/STD_API_STABILIZATION.md`). Not a blocker — the fix is to run `yo fmt`
+and take whatever it produces — but it makes `fmt --check` unpredictable when
+writing new code, and it cost a CI-visible failure on PR #461.
+
+## The observation
+
+Two files in `std/collections/` contain the **byte-identical** text
+`Item : *(MapEntry(K, V)),` inside a structurally identical `impl` block:
+
+| file:line | text | `fmt --check` |
+| --- | --- | --- |
+| `std/collections/hash_map.yo:694` | `    Item : *(MapEntry(K, V)),` | **rc=0 (clean)** |
+| `std/collections/ordered_map.yo:280` (as written by D14, PR #461) | `    Item : *(MapEntry(K, V)),` | **rc=1**, rewritten to `*MapEntry(K, V)` |
+
+Both sit in:
+
+```rust
+impl(
+  generic(K : Type, V : Type),
+  where(K <: (Eq(K), Hash)),
+  <Iter>(K, V),
+  Iterator(
+    Item : *(MapEntry(K, V)),
+    next : (fn(inout(self) : Self) -> Option(*(MapEntry(K, V))))(...)
+  )
+);
+```
+
+and both import `MapEntry` from `./entry.yo`.
+
+So the formatter accepts the parenthesized form in one place and canonicalizes
+it away in another. Whatever selects between them is NOT the pointer type, the
+enclosing `Iterator(...)`, the `where` clause, or where `MapEntry` comes from —
+those are the same on both sides.
+
+A reduced probe (a fresh file with the same `impl` shape and a one-line `.None`
+body) reports rc=1, i.e. it behaves like `ordered_map.yo`, NOT like
+`hash_map.yo` — so `hash_map.yo` is the outlier and something in its context is
+suppressing the rewrite. The remaining difference between the two real files is
+the shape of the `next` BODY: `hash_map.yo` opens `(` + newline + `cond(`,
+while `ordered_map.yo` opens `({`.
+
+## Why it matters
+
+`fmt --check ./std ./tests ./src` is a required CI step
+(`.github/workflows/test.yml`), so writing the "wrong" one of two spellings that
+both appear in the tree fails the build. A contributor copying the shape from
+`hash_map.yo` — the natural thing to do, since it is the sibling
+implementation — produces a file CI rejects.
+
+Related, already recorded as working knowledge: `yo fmt` is non-idempotent and
+is not a syntax gate.
+
+## Reproducing
+
+No new fixture needed — both witnesses are checked in:
+
+```bash
+yo fmt --check std/collections/hash_map.yo    # rc=0
+# then write `Item : *(MapEntry(K, V))` into ordered_map.yo's OrderedMapIterPtr
+yo fmt --check std/collections/ordered_map.yo # rc=1
+```
+
+## Next step
+
+Find the branch in `src/formatter.yo` that decides whether to keep the
+parentheses around a parameterized pointee, and make it a single rule. Then
+pick ONE canonical spelling and sweep the tree, the way #459 did for the
+callee-position prefix cast `(*T)(x)`.

--- a/std/collections/array_list.yo
+++ b/std/collections/array_list.yo
@@ -748,19 +748,78 @@ impl(
     )
   )
 );
+/**
+* Pointer iterator for ArrayList — yields `*(T)` INTO the list's own buffer
+* (D14). This is what `iter()` returns; `into_iter()` keeps yielding values.
+*
+* The elements are borrowed, not dup'd, so iterating a list of RC values costs
+* no refcount traffic and writing through the pointer mutates the list in
+* place. HashMapIterPtr established the shape.
+*
+* The pointers alias the buffer, so any operation that REALLOCATES it (`push`
+* past capacity, `reserve`, `shrink_to_fit`) invalidates every pointer already
+* yielded. Live-length semantics are otherwise the same as ArrayListIter's:
+* `_length` is re-read on each `next`.
+*/
+ArrayListIterPtr :: (fn(comptime(T) : Type) -> comptime(Type))(
+  struct(
+    _list : ArrayList(T),
+    _index : usize,
+    /// See ArrayListIter._back_taken — a COUNTER, so the forward guard keeps
+    /// reading `_list._length` live.
+    _back_taken : usize
+  )
+);
+impl(
+  generic(T : Type),
+  ArrayListIterPtr(T),
+  Iterator(
+    Item : *(T),
+    next : (fn(inout(self) : Self) -> Option(*(T)))(
+      cond(
+        ((self._index + self._back_taken) >= self._list._length) => .None,
+        true => {
+          // The guard above proves `_length > _index >= 0`, so the buffer is
+          // allocated and `_ptr` is `.Some`.
+          base := self._list._ptr.unwrap();
+          p := base.add(self._index);
+          self._index = (self._index + usize(1));
+          .Some(p)
+        }
+      )
+    )
+  )
+);
+impl(
+  generic(T : Type),
+  ArrayListIterPtr(T),
+  DoubleEndedIterator(
+    Item : *(T),
+    next_back : (fn(inout(self) : Self) -> Option(*(T)))(
+      cond(
+        ((self._index + self._back_taken) >= self._list._length) => .None,
+        true => {
+          base := self._list._ptr.unwrap();
+          self._back_taken = (self._back_taken + usize(1));
+          .Some(base.add(self._list._length - self._back_taken))
+        }
+      )
+    )
+  )
+);
 impl(
   generic(T : Type),
   ArrayList(T),
   /**
-  * Non-consuming iteration over a shared handle: yields each element by
-  * value (each dup'd), leaving the list intact — for(list.iter(), ...)
-  * where into_iter would move the list. HashMap.keys/values established
-  * the shape: the receiver arrives RC-dup'd at the method boundary, so
-  * moving it into the iterator is balanced. Live-length semantics are the
-  * iterator's own (see ArrayListIter).
+  * Non-consuming iteration over a shared handle: yields a `*(T)` into the
+  * list's buffer, leaving the list intact — `for(list.iter(), ptr => ...)`
+  * where `into_iter` would move the list and yield values (D14; this is the
+  * `iter` / `into_iter` split every other std collection already had).
+  * The receiver arrives RC-dup'd at the method boundary, so moving it into
+  * the iterator is balanced and the buffer outlives the walk.
   */
-  iter : (fn(self : Self) -> ArrayListIter(T))(
-    ArrayListIter(T)(_list : self, _index : usize(0), _back_taken : usize(0))
+  iter : (fn(self : Self) -> ArrayListIterPtr(T))(
+    ArrayListIterPtr(T)(_list : self, _index : usize(0), _back_taken : usize(0))
   )
 );
 impl(
@@ -1023,7 +1082,8 @@ impl(
 export(
   ArrayList,
   ArrayListError,
-  ArrayListIter
+  ArrayListIter,
+  ArrayListIterPtr
 );
 // =============================================================================
 // array_list! literal macro

--- a/std/collections/hash_map.yo
+++ b/std/collections/hash_map.yo
@@ -417,6 +417,26 @@ impl(
     )
   }),
   /**
+  * Pointer to the LIVE entry for `key`, or `.None` when the key is absent.
+  *
+  * The pointer aliases the map's own bucket array — the same storage
+  * `iter()` hands out (D14) — so writing `p.*.value` updates the map in
+  * place, and any operation that REHASHES the table (an `insert` that grows
+  * it, `remove`, `clear`) invalidates it.
+  */
+  get_entry_ptr : (fn(self : Self, key : K) -> Option(*(MapEntry(K, V))))({
+    cond(
+      (self.capacity == usize(0)) => return(.None),
+      true => ()
+    );
+    hash := self._hash(key);
+    match(
+      Self._find_bucket(self, key, hash),
+      .Some(index) => .Some(Self._data_ptr(self).add(index)),
+      .None => .None
+    )
+  }),
+  /**
   * Check if a key exists in the map
   */
   contains_key : (fn(self : Self, key : K) -> bool)({

--- a/std/collections/ordered_map.yo
+++ b/std/collections/ordered_map.yo
@@ -32,6 +32,10 @@
 //!   );
 //! };
 //! ```
+// `iter()` yields `*(MapEntry(K, V))` into the backing HashMap's buckets (D14),
+// so this module names a raw pointer type. The pointers are produced by
+// `HashMap.get_entry_ptr` and never dereferenced here.
+pragma(Pragma.AllowUnsafe);
 { MapEntry } :: import("./entry.yo");
 open(import("./array_list"));
 open(import("./hash_map"));
@@ -216,32 +220,97 @@ impl(
   generic(K : Type, V : Type),
   where(K <: (Eq(K), Hash)),
   OrderedMapIter(K, V),
-  next : (fn(inout(self) : Self) -> Option(MapEntry(K, V)))({
-    cond(
-      (self._index >= self._map._order.len()) => {
-        return(.None);
-      },
-      true => ()
-    );
-    match(
-      self._map._order.get(self._index),
-      .Some(k) => {
-        self._index = (self._index + usize(1));
-        match(
-          self._map._map.get(k),
-          .Some(v) => {
-            return(.Some(MapEntry(K, V)(key : k, value : v)));
-          },
-          .None => {
-            return(.None);
-          }
-        );
-      },
-      .None => {
-        return(.None);
-      }
-    );
-  })
+  Iterator(
+    Item : MapEntry(K, V),
+    next : (fn(inout(self) : Self) -> Option(MapEntry(K, V)))({
+      cond(
+        (self._index >= self._map._order.len()) => {
+          return(.None);
+        },
+        true => ()
+      );
+      match(
+        self._map._order.get(self._index),
+        .Some(k) => {
+          self._index = (self._index + usize(1));
+          match(
+            self._map._map.get(k),
+            .Some(v) => {
+              return(.Some(MapEntry(K, V)(key : k, value : v)));
+            },
+            .None => {
+              return(.None);
+            }
+          );
+        },
+        .None => {
+          return(.None);
+        }
+      );
+    })
+  )
+);
+/// Pointer iterator over an `OrderedMap`'s `(key, value)` pairs, in insertion
+/// order — what `iter()` returns (D14).
+///
+/// Each `next` yields a `*(MapEntry(K, V))` INTO the backing `HashMap`'s
+/// bucket array (the same storage `HashMap.iter()` hands out), so entries are
+/// borrowed rather than rebuilt by value, and writing `p.*.value` updates the
+/// map in place. Any mutation that rehashes the map (`insert` that grows it,
+/// `remove`, `clear`) invalidates pointers already yielded.
+OrderedMapIterPtr :: (
+  fn(
+    comptime(K) : Type,
+    comptime(V) : Type,
+    where(K <: (Eq(K), Hash))
+  ) -> comptime(Type)
+)(
+  ref(
+    struct(
+      _map : OrderedMap(K, V),
+      _index : usize
+    )
+  )
+);
+impl(
+  generic(K : Type, V : Type),
+  where(K <: (Eq(K), Hash)),
+  OrderedMapIterPtr(K, V),
+  Iterator(
+    Item : *MapEntry(K, V),
+    next : (fn(inout(self) : Self) -> Option(*MapEntry(K, V)))({
+      cond(
+        (self._index >= self._map._order.len()) => {
+          return(.None);
+        },
+        true => ()
+      );
+      match(
+        self._map._order.get(self._index),
+        .Some(k) => {
+          self._index = (self._index + usize(1));
+          return(self._map._map.get_entry_ptr(k));
+        },
+        .None => {
+          return(.None);
+        }
+      );
+    })
+  )
+);
+impl(
+  generic(K : Type, V : Type),
+  where(K <: (Eq(K), Hash)),
+  OrderedMap(K, V),
+  IntoIterator(
+    Item : MapEntry(K, V),
+    IntoIter : OrderedMapIter(K, V),
+    /// Iterate `(key, value)` pairs BY VALUE in insertion order — the shape
+    /// `iter()` had before D14, and what `for(map, ...)` expands to.
+    into_iter : (fn(self : Self) -> OrderedMapIter(K, V))(
+      OrderedMapIter(K, V)(_map : self, _index : usize(0))
+    )
+  )
 );
 impl(
   generic(K : Type, V : Type),
@@ -255,9 +324,11 @@ impl(
   values : (fn(self : Self) -> OrderedMapValues(K, V))(
     OrderedMapValues(K, V)(_map : self, _index : usize(0))
   ),
-  /// Iterator over `(key, value)` pairs in insertion order.
-  iter : (fn(self : Self) -> OrderedMapIter(K, V))(
-    OrderedMapIter(K, V)(_map : self, _index : usize(0))
+  /// Iterator over `(key, value)` pairs in insertion order, yielding a
+  /// `*(MapEntry(K, V))` into the map's own storage (D14). Use `into_iter()`
+  /// for the by-value form.
+  iter : (fn(self : Self) -> OrderedMapIterPtr(K, V))(
+    OrderedMapIterPtr(K, V)(_map : self, _index : usize(0))
   )
 );
 export(
@@ -265,5 +336,6 @@ export(
   MapEntry,
   OrderedMapKeys,
   OrderedMapValues,
-  OrderedMapIter
+  OrderedMapIter,
+  OrderedMapIterPtr
 );

--- a/tests/collections/array_list.test.yo
+++ b/tests/collections/array_list.test.yo
@@ -286,14 +286,14 @@ test("ArrayList.drain end == length is allowed", {
   assert(drained(usize(0)) == i32(2));
   assert(list.len() == usize(1));
 });
-test("ArrayList.iter yields every element and does not consume the list", {
+test("ArrayList.iter yields POINTERS and does not consume the list", {
   list := ArrayList(i32).new();
   list.push(i32(1));
   list.push(i32(2));
   list.push(i32(3));
   sum := i32(0);
-  for(list.iter(), x => {
-    sum = (sum + x);
+  for(list.iter(), ptr => {
+    sum = (sum + ptr.*);
   });
   assert(sum == i32(6));
   // The list is intact after iter(): into_iter() would have moved it.
@@ -301,17 +301,55 @@ test("ArrayList.iter yields every element and does not consume the list", {
   assert(list(usize(0)) == i32(1));
   assert(list(usize(2)) == i32(3));
 });
+test("ArrayList.iter pointers alias the buffer — writing through one mutates the list", {
+  list := ArrayList(i32).new();
+  list.push(i32(1));
+  list.push(i32(2));
+  list.push(i32(3));
+  for(list.iter(), ptr => {
+    ptr.* = (ptr.* * i32(10));
+  });
+  assert(list(usize(0)) == i32(10), "first doubled in place");
+  assert(list(usize(1)) == i32(20), "second doubled in place");
+  assert(list(usize(2)) == i32(30), "third doubled in place");
+  assert(list.len() == usize(3));
+});
+test("ArrayList.into_iter still yields VALUES", {
+  list := ArrayList(i32).new();
+  list.push(i32(4));
+  list.push(i32(5));
+  sum := i32(0);
+  for(list.into_iter(), x => {
+    sum = (sum + x);
+  });
+  assert(sum == i32(9));
+});
 test("ArrayList.iter works on a list of RC strings", {
   list := ArrayList(String).new();
   list.push(String.from("a"));
   list.push(String.from("b"));
   count := usize(0);
-  for(list.iter(), s => {
-    assert(s.len() == usize(1));
+  for(list.iter(), ptr => {
+    assert(ptr.*.len() == usize(1));
     count = (count + usize(1));
   });
   assert(count == usize(2));
   assert(list.len() == usize(2));
+  // The strings are BORROWED through the pointers, never dup'd, so the list
+  // still owns them and reading them again is safe.
+  assert(list(usize(0)) == String.from("a"));
+  assert(list(usize(1)) == String.from("b"));
+});
+test("ArrayList.iter walks backwards through next_back", {
+  list := ArrayList(i32).new();
+  list.push(i32(1));
+  list.push(i32(2));
+  list.push(i32(3));
+  it := list.iter();
+  assert(it.next_back().unwrap().* == i32(3), "last first");
+  assert(it.next().unwrap().* == i32(1), "then the front");
+  assert(it.next_back().unwrap().* == i32(2), "then the middle");
+  assert(it.next().is_none(), "exhausted from both ends");
 });
 // ===== Slice Tests =====
 test("ArrayList.slice creates new list with subset of elements", {
@@ -795,7 +833,7 @@ test("ArrayList into_iter - multiple elements in order", {
   assert(count == usize(3), "should yield all elements");
   assert(sum == i32(60), "sum should be correct");
 });
-test("ArrayList iter - empty list", {
+test("ArrayList for(list) - empty list", {
   list := ArrayList(i32).new();
   count := usize(0);
   for(list, x => {
@@ -804,7 +842,7 @@ test("ArrayList iter - empty list", {
   });
   assert(count == usize(0), "empty list should yield no elements");
 });
-test("ArrayList iter - reads elements by value", {
+test("ArrayList for(list) - reads elements by value (into_iter)", {
   list := ArrayList(i32).new();
   list.push(i32(100));
   list.push(i32(200));

--- a/tests/collections/ordered_map.test.yo
+++ b/tests/collections/ordered_map.test.yo
@@ -1,3 +1,4 @@
+pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
 { OrderedMap, MapEntry } :: import("std/collections/ordered_map");
 open(import("std/collections/array_list"));
@@ -86,7 +87,7 @@ test("OrderedMap iteration in insertion order", {
   assert(vs(usize(1)) == i32(1), "1 second");
   assert(vs(usize(2)) == i32(13), "13 third");
 });
-test("OrderedMap iter pairs", {
+test("OrderedMap iter yields entry POINTERS in insertion order", {
   m := OrderedMap(String, i32).new();
   m.insert(`one`, i32(1));
   m.insert(`two`, i32(2));
@@ -94,10 +95,35 @@ test("OrderedMap iter pairs", {
   e1 := it.next().unwrap();
   e2 := it.next().unwrap();
   assert(it.next().is_none(), "two entries");
-  assert(e1.key == `one`, "first key");
-  assert(e1.value == i32(1), "first value");
-  assert(e2.key == `two`, "second key");
-  assert(e2.value == i32(2), "second value");
+  assert(e1.*.key == `one`, "first key");
+  assert(e1.*.value == i32(1), "first value");
+  assert(e2.*.key == `two`, "second key");
+  assert(e2.*.value == i32(2), "second value");
+});
+test("OrderedMap iter pointers alias the map — writing through one updates it", {
+  m := OrderedMap(String, i32).new();
+  m.insert(`a`, i32(1));
+  m.insert(`b`, i32(2));
+  for(m.iter(), ptr => {
+    ptr.*.value = (ptr.*.value + i32(100));
+  });
+  assert(m.get(`a`).unwrap() == i32(101), "a updated in place");
+  assert(m.get(`b`).unwrap() == i32(102), "b updated in place");
+});
+test("OrderedMap into_iter yields entries BY VALUE in insertion order", {
+  m := OrderedMap(String, i32).new();
+  m.insert(`one`, i32(1));
+  m.insert(`two`, i32(2));
+  keys := ArrayList(String).new();
+  total := i32(0);
+  for(m.into_iter(), e => {
+    keys.push(e.key);
+    total = (total + e.value);
+  });
+  assert(keys.len() == usize(2), "two entries");
+  assert(keys(usize(0)) == `one`, "insertion order preserved");
+  assert(keys(usize(1)) == `two`, "insertion order preserved");
+  assert(total == i32(3), "values summed");
 });
 test("OrderedMap remove", {
   m := OrderedMap(String, i32).new();


### PR DESCRIPTION
## What

Every other std collection — `HashMap`, `HashSet`, `Deque`, `PriorityQueue`, `BTreeMap`, `LinkedList` — already hands `iter()` a `*(T)` into its own storage, and both cheatsheets document `.iter()` that way:

> `| .iter() | *(T) | Borrow via pointer; yields pointers |`

`ArrayList` and `OrderedMap` were the two holdouts, yielding **values**, so `iter()` meant two different things depending on the receiver. **D14** in `plans/STD_API_STABILIZATION.md` §2.

## Changes

- **`ArrayList.iter -> ArrayListIterPtr(T)`**, yielding `*(T)` into the buffer (`Iterator` + `DoubleEndedIterator`, mirroring `ArrayListIter`). `into_iter` already existed with the by-value shape and is unchanged — the old `iter` body was a **byte-identical copy of `into_iter`'s**, so nothing is lost.
- **`OrderedMap.iter -> OrderedMapIterPtr(K, V)`**, yielding `*(MapEntry(K, V))` into the backing `HashMap`'s bucket array. The by-value iterator becomes `into_iter` via a new `IntoIterator` impl — so **`for(map, ...)` works on an `OrderedMap` for the first time** — and `OrderedMapIter`'s bare `next` becomes a real `Iterator` impl.
- **New `HashMap.get_entry_ptr(key) -> Option(*(MapEntry(K, V)))`**, which is what lets `OrderedMap` point *into* the map rather than rebuild entries by value.

## Why it matters beyond consistency

Elements are now **borrowed rather than dup'd**, so iterating a list of RC values costs no refcount traffic, and writing through the pointer mutates in place. Both are covered by new tests:

```rust
for(list.iter(), ptr => { ptr.* = (ptr.* * i32(10)); });
assert(list(usize(0)) == i32(10));   // the list itself changed
```

The pointers alias the storage, so a reallocating mutation mid-walk invalidates them — documented on each iterator type.

## Blast radius

**No `std/`, `src/` or `vendor/` caller used either method** — every `.iter()` in those trees is on a `HashMap`, which is unchanged. So the only call-site churn is in tests.

Two pre-existing tests named `"ArrayList iter - …"` actually exercised `for(list, ...)` (i.e. `into_iter`); renamed to say so, since D14 makes the old names misleading.

`ordered_map.yo` gains `pragma(Pragma.AllowUnsafe)` because it now names a raw pointer type; the pointers come from `HashMap.get_entry_ptr` and are never dereferenced in that module.

## Verification

- `tests/collections` suite: **416/416**
- `yo check ./src`: **266/266**

## Merge timing

Breaking, so it belongs to the **v0.2.28** window — please hold until v0.2.27 is out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)