### PR TITLE
std/async: `timeout` returns Result(T, TimeoutError) (D18, first half)

### DIFF
--- a/issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md
+++ b/issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md
@@ -1,7 +1,8 @@
 # `Thread(T).spawn` cannot take a callback returning a ZST — the spawn path emits `void* tmp = <void expr>`
 
-**Status:** OPEN — the codegen bug is real and unfixed. D18 part 2 **DID land**
-by routing around it; see "The workaround that landed" below.
+**Status:** OPEN, and D18 part 2 is **BLOCKED**. The workaround recorded below
+dodges this bug and then hits a SECOND wall — see "Why the workaround does not
+land either".
 
 Found 2026-09-07 attempting **D18 part 2**
 (`plans/STD_API_STABILIZATION.md` §2: *"`Thread(T).spawn` carries its result and
@@ -123,7 +124,7 @@ buffered and a blocking `recv` would only risk hanging when the body unwound
 without sending. `unit` is both `Send` and `Acyclic` (`std/prelude.yo:817,820`),
 so `Channel(unit)` satisfies the bound.
 
-## The workaround that landed
+## The workaround (dodges this bug)
 
 Control #2 above is also the way out. Moving the call-and-send OFF the
 spawn-lowered closure body and into an ordinary top-level generic function
@@ -154,8 +155,38 @@ raw := __yo_thread_spawn((io : Io) => {
 });
 ```
 
-`Thread(unit)` and `Thread(i32)` both compile and run with that shape, so **no
-compiler change was required to land D18**. The bug below is still worth
-fixing: any future API that hands a spawn callback a non-`unit` return type
-will hit it again, and the workaround is non-obvious enough that it needs the
-comment it now carries in `std/thread.yo`.
+`Thread(unit)` and `Thread(i32)` both compile and run with that shape in
+isolation.
+
+## Why the workaround does not land either
+
+The full suite rejects it. `tests/sync/once.test.yo` fails with:
+
+```
+error: Captured variable 'cb' (type Impl : (Fn(Io) -> unit + Send)) does not
+implement Send. To move it across threads, wrap it in Arc/Iso, or capture a
+Send projection of it instead.
+```
+
+The helper makes the spawn closure **capture** `cb`, where before the change
+`cb` went straight to `__yo_thread_spawn` and was never a captured variable.
+#451's Send enforcement (`validate_capture_trait_requirements`,
+`src/evaluator/utils/closure.yo:224`) then judges it — and
+`_capture_judgement_type` resolves a captured CLOSURE to its own capture
+struct. One more level of nesting therefore puts a struct in front of the
+checker that carries no `Send` impl, even though every value inside it is
+`Send`.
+
+**Adding `Send` to the helper's parameter does NOT fix it** (tried): the
+declared type is what the message prints, but the judged type is the resolved
+capture struct.
+
+So D18 part 2 needs a compiler change either way:
+
+* fix this bug (the spawn lowering's ZST-returning captured call), which makes
+  the INLINE form work and removes the need for the helper; or
+* teach `_capture_judgement_type` that a closure whose own captures are all
+  `Send` is itself `Send`, which makes the HELPER form work.
+
+The first is the narrower change. The second touches a security-relevant
+checker and should not be rushed.

--- a/issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md
+++ b/issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md
@@ -1,0 +1,121 @@
+# `Thread(T).spawn` cannot take a callback returning a ZST — the spawn path emits `void* tmp = <void expr>`
+
+**Status:** OPEN. Found 2026-09-07 attempting **D18 part 2**
+(`plans/STD_API_STABILIZATION.md` §2: *"`Thread(T).spawn` carries its result and
+`join() -> T`"*). It is the reason that half is not landed.
+
+## What fails
+
+Making `Thread` generic over its result — the D18 design — means `spawn` takes
+`cb : Impl(Fn(io : Io) -> T, Send)` and the thread body does the send:
+
+```rust
+spawn : (fn(cb : Impl(Fn(io : Io) -> T, Send)) -> Self)({
+  chan := Channel(T).new(usize(1));
+  sink := chan;
+  raw := __yo_thread_spawn((io : Io) => {
+    sink.send(cb(io));
+    ()
+  });
+  Self(handle : raw, _joined : false, _result : chan)
+}),
+```
+
+At `T = unit` — which is what EVERY existing `Thread.spawn` call site becomes —
+the emitted C does not compile:
+
+```
+error: initializing 'void *' with an expression of incompatible type 'void'
+ 3640 |   void* _file____priv_temp_13182 = closure_yo_id_11371(&(((__yo_t34*)closure_context)->cb), io);
+
+warning: call to undeclared function 'yo_id_11019_..._ret_enum_..._value_unit_error_...'
+error: initializing '__yo_t23' with an expression of incompatible type 'int'
+ 3644 |   __yo_t23 _file____priv_temp_13268 = yo_id_11019_...(((__yo_t34*)closure_context)->sink, _file____priv_temp_13182);
+```
+
+Two symptoms: the captured callback's `unit` result is bound to a `void*` temp,
+and the `Channel(unit).send` specialisation is never emitted (implicit
+declaration).
+
+Writing `sink.send(cb(io))` without the intermediate local does NOT help — the
+temp is created either way.
+
+## What NARROWS it to the spawn path
+
+Three controls, all of which compile AND run:
+
+1. **`Channel(unit)` on its own** — `new` / `send` / `try_recv` at `T = unit`.
+2. **A generic fn calling a `Impl(Fn() -> T)` parameter at `T = unit`.**
+3. **The same closure CAPTURED into a second closure** that is handed to a
+   `Fn() -> unit` consumer, sending through a `Channel(T)` — i.e. the exact
+   shape above, minus `__yo_thread_spawn`.
+
+So it is neither `unit`-as-a-ZST in general, nor generic closure calls, nor
+nested capture. It is specific to the **thread-spawn lowering**.
+
+## Where it lives
+
+`src/codegen/exprs/parallelism.yo` gives spawn callbacks their own
+capture-struct lowering, separate from ordinary closures — its own comments say
+so:
+
+- line 156: *"selects the primitive + **(unit) return convention**"*
+- line 166: *"SPECIALIZED Thread.spawn body — the lowered capture-struct PARAM
+  (cei.ty IS the SomeT)"*
+- it imports `is_unit_type` from `../../types/guards.yo`
+
+and `_generate_spawn_wrapper` emits a wrapper that is `static void` and
+DISCARDS the callback's result:
+
+```c
+static void <wrapper>(void* closure) {
+  <closure_fn>(closure, <runtime_args>);
+}
+```
+
+That wrapper shape is correct for the D18 design (the inner closure really does
+return `unit`). The failure is one level in: the **captured** `Impl(Fn(io) -> T)`
+call inside that lowered body binds its result to a temp without asking whether
+`T` is a ZST.
+
+`src/evaluator/calls/function.yo:2285` notes the matching evaluator-side
+special case (*"specialized `Thread.spawn -> Self` would never be emitted"*), so
+a fix likely has to touch both sides.
+
+## Blast radius if fixed
+
+152 real `Thread.spawn(` call sites (all in `tests/`; `std/` and `src/` only
+mention it in comments) become `Thread(unit).spawn(`. Nothing outside tests
+calls it.
+
+## The std-side design, ready to go
+
+Recorded so it is not re-derived. `Thread` becomes:
+
+```rust
+Thread :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
+  ref(struct(handle : __yo_thread_t, _joined : bool, _result : Channel(T)))
+);
+```
+
+`join` keeps the join-once assert and the detach-on-drop `Dispose` from
+`issues/fixed/thread-join-was-re-callable-and-handles-leaked.md`, then reads the
+value:
+
+```rust
+join : (fn(self : Self) -> T)({
+  assert(!self._joined, "Thread.join: this thread was already joined");
+  self._joined = true;
+  __yo_thread_join(self.handle);
+  match(
+    self._result.try_recv(),
+    .Some(v) => v,
+    .None => __yo_panic("Thread.join: the thread body produced no value (it unwound)")
+  )
+}),
+```
+
+`try_recv` rather than `recv`: the OS join has already returned, so the value is
+buffered and a blocking `recv` would only risk hanging when the body unwound
+without sending. `unit` is both `Send` and `Acyclic` (`std/prelude.yo:817,820`),
+so `Channel(unit)` satisfies the bound.

--- a/issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md
+++ b/issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md
@@ -1,8 +1,11 @@
 # `Thread(T).spawn` cannot take a callback returning a ZST — the spawn path emits `void* tmp = <void expr>`
 
-**Status:** OPEN. Found 2026-09-07 attempting **D18 part 2**
+**Status:** OPEN — the codegen bug is real and unfixed. D18 part 2 **DID land**
+by routing around it; see "The workaround that landed" below.
+
+Found 2026-09-07 attempting **D18 part 2**
 (`plans/STD_API_STABILIZATION.md` §2: *"`Thread(T).spawn` carries its result and
-`join() -> T`"*). It is the reason that half is not landed.
+`join() -> T`"*).
 
 ## What fails
 
@@ -119,3 +122,40 @@ join : (fn(self : Self) -> T)({
 buffered and a blocking `recv` would only risk hanging when the body unwound
 without sending. `unit` is both `Send` and `Acyclic` (`std/prelude.yo:817,820`),
 so `Channel(unit)` satisfies the bound.
+
+## The workaround that landed
+
+Control #2 above is also the way out. Moving the call-and-send OFF the
+spawn-lowered closure body and into an ordinary top-level generic function
+keeps it on the normal closure path, which handles the ZST correctly:
+
+```rust
+/// Deliberately a top-level generic function rather than inline in the spawn
+/// closure — see `Thread(T).spawn`.
+_run_and_send :: (
+  fn(
+    generic(T : Type),
+    cb : Impl(Fn(io : Io) -> T),
+    sink : Channel(T),
+    io : Io,
+    where(T <: (Send, Acyclic))
+  ) -> unit
+)({
+  sink.send(cb(io));
+});
+```
+
+and the spawn closure becomes:
+
+```rust
+raw := __yo_thread_spawn((io : Io) => {
+  _run_and_send(cb, sink, io);
+  ()
+});
+```
+
+`Thread(unit)` and `Thread(i32)` both compile and run with that shape, so **no
+compiler change was required to land D18**. The bug below is still worth
+fixing: any future API that hands a spawn callback a non-`unit` return type
+will hit it again, and the workaround is non-obvious enough that it needs the
+comment it now carries in `std/thread.yo`.

--- a/std/async/index.yo
+++ b/std/async/index.yo
@@ -25,6 +25,9 @@ pragma(Pragma.AllowUnsafe);
 { ArrayList } :: import("../collections/array_list");
 { assert } :: import("../assert");
 { Duration } :: import("../time/duration");
+{ Error } :: import("../error");
+{ ToString } :: import("../fmt");
+open(import("../string"));
 IO_timer :: import("../sys/timer");
 extern(
   "Yo",
@@ -116,16 +119,46 @@ any :: (fn(generic(T : Type), handles : ArrayList(JoinHandle(T)), io : Io) -> Op
   });
   result
 });
-/// Await `handle` with a deadline: its result if it finishes within `limit`
-/// (`.None` if it was aborted), otherwise `abort()` it and return `.None`.
-/// The handle is consumed either way. Millisecond granularity (the timer
-/// contract of `std/time/sleep`).
+/// Why `timeout(...)` produced no value (D18).
+///
+/// The old `Option(T)` return collapsed these two outcomes into each other —
+/// and, when `T` was itself an `Option`, into a task that legitimately
+/// returned `.None`. A caller that wants to retry on a slow task but give up
+/// on a cancelled one could not tell them apart.
+TimeoutError :: enum(
+  /// The deadline fired first; `timeout` aborted the handle.
+  Elapsed,
+  /// The task was already aborted (or unwound) while the deadline was still
+  /// unexpired, so it never produced a value.
+  Aborted
+);
+impl(
+  TimeoutError,
+  ToString(
+    to_string : (
+      self ->
+        match(
+          self,
+          .Elapsed => `timeout: the deadline elapsed before the task finished`,
+          .Aborted => `timeout: the task was aborted before it produced a value`
+        )
+    )
+  )
+);
+impl(TimeoutError, Error());
+/// Await `handle` with a deadline: `.Ok(v)` if it finishes within `limit`,
+/// `.Err(TimeoutError.Elapsed)` if the deadline fires first (the handle is
+/// `abort()`ed), `.Err(TimeoutError.Aborted)` if the task was cancelled on
+/// its own. The handle is consumed either way. Millisecond granularity (the
+/// timer contract of `std/time/sleep`).
 ///
 /// KNOWN RESIDUAL (bounded): when the task finishes BEFORE the deadline, the
 /// deadline timer stays armed in the I/O backend until it fires, and its
 /// future struct (~tens of bytes) is never reclaimed — see
 /// `issues/timeout-deadline-timer-future-leak.md`.
-timeout :: (fn(generic(T : Type), handle : JoinHandle(T), limit : Duration, io : Io) -> Option(T))({
+timeout :: (
+  fn(generic(T : Type), handle : JoinHandle(T), limit : Duration, io : Io) -> Result(T, TimeoutError)
+)({
   // The deadline is a spawned TASK, not a bare io-timer future: a raw
   // `IoFuture` local would be auto-dropped at scope end while the backend
   // still holds the armed timer (issues/pending-io-future-local-drop-uaf.md);
@@ -137,6 +170,10 @@ timeout :: (fn(generic(T : Type), handle : JoinHandle(T), limit : Duration, io :
   });
   dh := io.spawn(deadline_fut, io);
   (waiting : bool) = true;
+  // Which arm ended the wait — the ONLY place the two failure modes are
+  // distinguishable. After the loop, `handle.await` reports `.None` for a
+  // deadline abort and a self-abort alike.
+  (elapsed : bool) = false;
   while(waiting, {
     cond(
       handle.is_finished() => {
@@ -144,6 +181,7 @@ timeout :: (fn(generic(T : Type), handle : JoinHandle(T), limit : Duration, io :
       },
       dh.is_finished() => {
         handle.abort();
+        elapsed = true;
         waiting = false;
       },
       true => __yo_async_poll_step()
@@ -155,6 +193,13 @@ timeout :: (fn(generic(T : Type), handle : JoinHandle(T), limit : Duration, io :
   // releases the state machine then.
   dh.abort();
   _deadline_r := dh.await(io);
-  handle.await(io)
+  match(
+    handle.await(io),
+    .Some(v) => .Ok(v),
+    .None => cond(
+      elapsed => .Err(TimeoutError.Elapsed),
+      true => .Err(TimeoutError.Aborted)
+    )
+  )
 });
-export(yield, join_all, race, any, timeout);
+export(yield, join_all, race, any, timeout, TimeoutError);

--- a/tests/async/combinators.test.yo
+++ b/tests/async/combinators.test.yo
@@ -3,7 +3,7 @@
 pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
 { ArrayList } :: import("std/collections/array_list");
-{ join_all, race, any, timeout } :: import("std/async");
+{ join_all, race, any, timeout, TimeoutError } :: import("std/async");
 { Duration } :: import("std/time/duration");
 { sleep } :: import("std/sys/timer");
 
@@ -100,7 +100,24 @@ test("Test any with all aborted", {
 test("Test timeout completes in time", {
   h := io.spawn(sleepy(i32(7), u64(5), io), io);
   r := timeout(h, Duration.from_millis(i64(200)), io);
-  assert(match(r, .Some(v) => (v == i32(7)), .None => false), "task inside the limit should deliver its value");
+  assert(match(r, .Ok(v) => (v == i32(7)), .Err(_) => false), "task inside the limit should deliver its value");
+});
+// ---------------------------------------------------------------------------
+// 7b. timeout — a SELF-aborted task is Aborted, not Elapsed (D18)
+// ---------------------------------------------------------------------------
+test("Test timeout distinguishes an aborted task from an elapsed deadline", {
+  fut := io.async((io : Io) => {
+    io.await(sleep(u64(200)), io);
+    return(i32(1));
+  });
+  h := io.spawn(fut, io);
+  // Cancel the task ourselves, well inside a generous deadline.
+  h.abort();
+  r := timeout(h, Duration.from_millis(i64(500)), io);
+  assert(
+    match(r, .Ok(_) => false, .Err(e) => match(e, .Aborted => true, .Elapsed => false)),
+    "a task cancelled before its deadline must report Aborted"
+  );
 });
 // ---------------------------------------------------------------------------
 // 7. timeout — deadline aborts the task
@@ -114,7 +131,10 @@ test("Test timeout aborts on deadline", {
   });
   h := io.spawn(fut, io);
   r := timeout(h, Duration.from_millis(i64(10)), io);
-  assert(match(r, .Some(_) => false, .None => true), "an over-deadline task should time out to .None");
+  assert(
+    match(r, .Ok(_) => false, .Err(e) => match(e, .Elapsed => true, .Aborted => false)),
+    "an over-deadline task should report Elapsed, not a bare .None"
+  );
   // Outlive the aborted task's timer so its completion fires the entry guard.
   io.await(sleep(u64(120)), io);
   assert(!(ran.*), "the timed-out body must not resume past its suspension point");


### PR DESCRIPTION
## What

`timeout -> Option(T)` collapsed three outcomes into `.None`:

- the deadline fired,
- the task was cancelled on its own,
- and, when `T` was itself an `Option`, the task legitimately returning `.None`.

A caller that wants to retry a slow task but give up on a cancelled one could not tell which had happened. **D18** in `plans/STD_API_STABILIZATION.md` §2.

`timeout` now returns `Result(T, TimeoutError)`:

```rust
TimeoutError :: enum(
  /// The deadline fired first; `timeout` aborted the handle.
  Elapsed,
  /// The task was already aborted (or unwound) while the deadline was still
  /// unexpired, so it never produced a value.
  Aborted
);
```

with `ToString` + `Error` impls, matching every other std error enum.

## Why two variants and not just `Elapsed`

Rust's `tokio::time::timeout` is `Result<T, Elapsed>` — but it wraps a *future*. Yo's `timeout` takes a **`JoinHandle`**, which adds cancellation as a genuinely separate failure. Collapsing it back into `Elapsed` would rebuild the ambiguity D18 exists to remove.

## Implementation note

The two failures are distinguishable **only inside the poll loop** — once it exits, `handle.await(io)` reports `.None` for a deadline abort and a self-abort alike. So the deadline arm records which arm ended the wait, and that flag picks the variant.

## Blast radius

No `std/` or `src/` caller used `timeout`, so the churn is confined to `tests/async/combinators.test.yo`.

Added **"timeout distinguishes an aborted task from an elapsed deadline"** — it cancels a task well inside a generous deadline and asserts `Aborted`. That case could not be expressed at all under the old signature.

`tests/async/combinators.test.yo`: **8/8 pass**.

## Not in this PR

D18's second half (`Thread(T).spawn` carrying its result, `join() -> T`). `Thread` is non-generic today and `Thread.spawn` is wired into the evaluator's closure-specialization and the codegen/parallelism paths, so it needs its own change rather than being bolted onto this one.

## Merge timing

Breaking, so it belongs to the **v0.2.28** window — please hold until v0.2.27 is out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)