### PR TITLE
std/collections: `sort` is STABLE, `sort_unstable` is the heapsort (D17)

### DIFF
--- a/issues/generic-fn-specialized-at-two-types-hands-the-closure-the-wrong-param-type.md
+++ b/issues/generic-fn-specialized-at-two-types-hands-the-closure-the-wrong-param-type.md
@@ -1,0 +1,65 @@
+# A generic fn instantiated at two `T` hands one closure the other's parameter type
+
+**Status: OPEN** (found 2026-09-07, while implementing D17's stable sort).
+
+**Severity: emitted C does not compile.** Not silent — clang rejects it — but
+the diagnostic names a generated symbol and a `__yo_tN` type, so the user has
+no way to see which of their calls is at fault.
+
+## Symptom
+
+The trigger is narrower than "two instantiations". Both of these compile
+fine:
+
+- a generic `Impl(Fn(a : T, b : T) -> bool)` helper called at two `T` from
+  `main`;
+- the same helper taking a `*(T)` as well, still called at two `T` from
+  `main`.
+
+What breaks is an **outer generic instantiating an inner generic at a
+DIFFERENT type, with a closure that captures the outer `T`'s data**:
+
+```rust
+_inner :: (fn(generic(T : Type), ptr : *(T), n : usize, less : Impl(Fn(a : T, b : T) -> bool)) -> bool)(...);
+
+_outer :: (fn(generic(T : Type), ptr : *(T), n : usize, less : Impl(Fn(a : T, b : T) -> bool)) -> bool)({
+  idx := ...;                      // *(usize)
+  // _inner at T = usize, from inside _outer whose T = Rec; the comparator
+  // closes over the OUTER ptr/less.
+  _inner(idx, n, (a, b) => unsafe(less((ptr.add(a)).*, (ptr.add(b)).*)))
+});
+```
+
+```
+error: passing 'size_t' (aka 'unsigned long') to parameter of incompatible
+       type '__yo_t0' (aka 'struct __yo_t0_struct')
+```
+
+The inner call's `usize` index is passed to a closure whose emitted C
+signature took the OUTER instantiation's element type.
+
+Reproducer: `issues/repros/generic-fn-at-two-types-wrong-closure-param.yo`
+(verified to fail; the two non-triggering shapes above were checked first, so
+the file pins the actual trigger rather than a superset).
+
+## Where it was hit
+
+`std/collections/array_list.yo`. D17's stable sort wanted an outer generic
+over the element type to sort an INDEX array (`usize`) by comparing elements
+— exactly the shape above. Worked around by making the index merge
+**monomorphic**, so the shipped `sort` is unaffected and the bug is untouched.
+
+## Why it matters beyond sorting
+
+"Sort/search/group indices by comparing elements" is a standard shape, and so
+is any combinator that delegates to a generic helper at a different type
+while closing over its own. The failure arrives as a C compile error naming
+internal `__yo_tN` symbols, which is the diagnostic class C69 was filed for.
+
+## Suspected area
+
+The closure's C signature is emitted per closure *id*, but the call site
+appears to pick the parameter type from the enclosing specialization rather
+than from the closure's own resolved type — the `SomeT` resolution-cell
+family (see `yo-varbound-receiver-cell-recovery`, C27). Confirming that needs
+a walk of the specialization keys for the two instantiations.

--- a/issues/repros/generic-fn-at-two-types-wrong-closure-param.yo
+++ b/issues/repros/generic-fn-at-two-types-wrong-closure-param.yo
@@ -1,0 +1,34 @@
+pragma(Pragma.AllowUnsafe);
+open(import("std/fmt"));
+open(import("std/string"));
+{ GlobalAllocator } :: import("std/allocator");
+{ malloc } :: GlobalAllocator;
+Rec :: struct(key : i32, tag : i32);
+_inner :: (
+  fn(generic(T : Type), ptr : *(T), n : usize, less : Impl(Fn(a : T, b : T) -> bool)) -> bool
+)(
+  cond(
+    (n < usize(2)) => true,
+    true => unsafe(less((ptr.add(usize(0))).*, (ptr.add(usize(1))).*))
+  )
+);
+/// The real shape: an OUTER generic over T that instantiates `_inner` at a
+/// DIFFERENT type (usize) while its own T is live, with a closure that
+/// captures the outer T's data.
+_outer :: (
+  fn(generic(T : Type), ptr : *(T), n : usize, less : Impl(Fn(a : T, b : T) -> bool)) -> bool
+)({
+  idx := (*(usize))(malloc(sizeof(usize) * usize(2)).unwrap());
+  unsafe(consume((idx.add(usize(0))).* = usize(0)));
+  unsafe(consume((idx.add(usize(1))).* = usize(1)));
+  // _inner at T = usize, from inside _outer whose T = Rec; the comparator
+  // closes over the OUTER ptr/less.
+  _inner(idx, n, (a, b) => unsafe(less((ptr.add(a)).*, (ptr.add(b)).*)))
+});
+main :: (fn() -> unit)({
+  recs := (*(Rec))(malloc(sizeof(Rec) * usize(2)).unwrap());
+  unsafe(consume((recs.add(usize(0))).* = Rec(key : i32(1), tag : i32(0))));
+  unsafe(consume((recs.add(usize(1))).* = Rec(key : i32(2), tag : i32(1))));
+  println(`outer=${_outer(recs, usize(2), (p, q) => (p.key < q.key))}`);
+});
+export(main);

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -83,7 +83,19 @@ the work in §4 does not re-open them.
   (§3) is present in both. `unit` is a true ZST as of v0.2.26, so the map's
   value slot costs nothing. Same treatment for `imm/set` over `imm/map`.
 - **D17 — `sort` is stable; `sort_unstable` is the heapsort.** Today `sort` is
-  heapsort under Rust's stable name.
+  heapsort under Rust's stable name — **LANDED**: `sort`/`sort_by` are stable,
+  `sort_unstable`/`sort_unstable_by` keep the allocation-free heapsort. The
+  stable path sorts an INDEX array with a bottom-up merge (a tie takes the
+  left run) and then permutes the elements in place through the *same* swap
+  the heapsort uses — witnessed RC-balanced with a `Dispose` counter, so no
+  RC-typed uninitialised scratch exists to get `consume(p.* = v)` wrong on.
+  Two things fell out: the heapsort's bare-deref swaps are NOT an `imm/vec`
+  style bug (measured, suspicion refuted), and reusing the generic
+  `_heapsort_by` at a second `T` tripped a specializer bug — the element
+  comparator was handed the index type and the emitted C passed a `size_t`
+  where the closure wanted the element struct
+  (`issues/generic-fn-specialized-at-two-types-hands-the-closure-the-wrong-param-type.md`);
+  the merge is monomorphic to avoid it.
 - **D18 — `timeout` returns `Result(T, Elapsed)`; `Thread(T).spawn` carries
   its result and `join() -> T`.** `timeout -> Option(T)` conflates timed-out /
   aborted / `Some(None)`; D7's blocker on the join result is fixed.

--- a/std/collections/array_list.yo
+++ b/std/collections/array_list.yo
@@ -926,16 +926,136 @@ _heapsort_by :: (
     });
   });
 });
+/// STABLE sort over raw storage (D17): equal elements keep their input
+/// order, which is what `sort` means in Rust, Python, Java and Go.
+///
+/// The elements are not what gets sorted — an INDEX array is, by a bottom-up
+/// merge sort (naturally stable: a tie takes the left run). The elements then
+/// move exactly once each, through the same three-line swap `_heapsort_by`
+/// uses, which is witnessed RC-balanced (nothing is disposed during a sort;
+/// every element is released exactly once at scope end).
+///
+/// Sorting indices rather than elements buys two things: the scratch is
+/// plain `usize`, so there is no RC-typed uninitialised buffer to get the
+/// `consume(p.* = v)` discipline wrong on (the trap that bit `imm/vec`), and
+/// the merge is monomorphic — instantiating the generic `_heapsort_by` at a
+/// second `T` made the specializer hand the element comparator the index
+/// type, emitting C that passes a `size_t` where the closure wants the
+/// element struct.
+_merge_sort_indices :: (
+  fn(
+    generic(T : Type),
+    order : ArrayList(usize),
+    scratch : ArrayList(usize),
+    ptr : *(T),
+    n : usize,
+    less : Impl(Fn(a : T, b : T) -> bool)
+  ) -> unit
+)({
+  (width : usize) = usize(1);
+  while(width < n, {
+    (lo : usize) = usize(0);
+    while(lo < n, {
+      mid := cond(((lo + width) < n) => (lo + width), true => n);
+      hi := cond(((mid + width) < n) => (mid + width), true => n);
+      (a : usize) = lo;
+      (b : usize) = mid;
+      (w : usize) = lo;
+      while(w < hi, {
+        take_left := cond(
+          (a >= mid) => false,
+          (b >= hi) => true,
+          // `!less(right, left)` — on a tie the LEFT run wins, which is
+          // exactly what makes the merge stable.
+          true => !unsafe(less((ptr.add(order(b))).*, (ptr.add(order(a))).*))
+        );
+        cond(
+          take_left => {
+            scratch(w) = order(a);
+            a = (a + usize(1));
+          },
+          true => {
+            scratch(w) = order(b);
+            b = (b + usize(1));
+          }
+        );
+        w = (w + usize(1));
+      });
+      lo = (lo + (width * usize(2)));
+    });
+    (c : usize) = usize(0);
+    while(c < n, {
+      order(c) = scratch(c);
+      c = (c + usize(1));
+    });
+    width = (width * usize(2));
+  });
+});
+_stable_sort_by :: (
+  fn(generic(T : Type), ptr : *(T), n : usize, less : Impl(Fn(a : T, b : T) -> bool)) -> unit
+)({
+  order := ArrayList(usize).new();
+  scratch := ArrayList(usize).new();
+  (k : usize) = usize(0);
+  while(k < n, {
+    order.push(k);
+    scratch.push(k);
+    k = (k + usize(1));
+  });
+  _merge_sort_indices(order, scratch, ptr, n, less);
+  // `order(i)` is the SOURCE index of the element that belongs at `i`. The
+  // cycle-following swap below consumes DESTINATION indices ("the element
+  // at i moves to dest(i)"), so invert first — applying the cycle walk to
+  // source indices sorts the wrong way round (`[A,B,C]` with `order=[2,0,1]`
+  // yields `[B,C,A]`, not `[C,A,B]`). `scratch` is free now, so the inverse
+  // costs no extra allocation.
+  (m : usize) = usize(0);
+  while(m < n, {
+    scratch(order(m)) = m;
+    m = (m + usize(1));
+  });
+  // Apply the permutation in place by following cycles: O(n) swaps, and the
+  // only element movement in the whole routine.
+  (i : usize) = usize(0);
+  while(i < n, {
+    while(scratch(i) != i, {
+      j := scratch(i);
+      tmp := unsafe((ptr.add(i)).*);
+      unsafe((ptr.add(i)).* = (ptr.add(j)).*);
+      unsafe((ptr.add(j)).* = tmp);
+      scratch(i) = scratch(j);
+      scratch(j) = j;
+    });
+    i = (i + usize(1));
+  });
+});
 impl(
   generic(T : Type),
   where(T <: Ord(T)),
   ArrayList(T),
   /**
-  * Sort elements in ascending order (heapsort — see _heapsort_by).
+  * Sort elements in ascending order. STABLE: equal elements keep their
+  * input order, as `sort` does in Rust, Python, Java and Go. Use
+  * `sort_unstable` for the allocation-free heapsort when order among
+  * equals does not matter.
   */
   sort : (fn(self : Self) -> unit)({
-    // Heapsort (was O(n²) insertion sort — plans/STD_API_AUDIT.md §7
-    // collections row): O(n log n) worst case, in place, not stable.
+    cond(
+      (self._length <= usize(1)) => (),
+      true =>
+        match(
+          self._ptr,
+          .Some(_ptr) => _stable_sort_by(_ptr, self._length, (a, b) => (a < b)),
+          .None => ()
+        )
+    );
+  }),
+  /**
+  * Sort elements in ascending order WITHOUT preserving the order of equal
+  * elements (heapsort — see `_heapsort_by`). O(n log n) worst case, in
+  * place, no allocation. Rust's `sort_unstable`.
+  */
+  sort_unstable : (fn(self : Self) -> unit)({
     cond(
       (self._length <= usize(1)) => (),
       true =>
@@ -1132,7 +1252,22 @@ impl(
   /// Sort ascending by a strict "less" closure — `less(a, b)` true when `a`
   /// must come before `b`. Heapsort: O(n log n) worst case, in place, not
   /// stable.
+  /// Sort by a caller-supplied strict "less". STABLE — equal elements keep
+  /// their input order, matching Rust's `sort_by`. Use `sort_unstable_by`
+  /// for the allocation-free heapsort.
   sort_by : (fn(self : Self, less : Impl(Fn(a : T, b : T) -> bool)) -> unit)({
+    cond(
+      (self._length <= usize(1)) => (),
+      true => match(
+        self._ptr,
+        .Some(_ptr) => _stable_sort_by(_ptr, self._length, less),
+        .None => ()
+      )
+    );
+  }),
+  /// Sort by a caller-supplied strict "less" WITHOUT preserving the order of
+  /// equal elements (heapsort). Rust's `sort_unstable_by`.
+  sort_unstable_by : (fn(self : Self, less : Impl(Fn(a : T, b : T) -> bool)) -> unit)({
     cond(
       (self._length <= usize(1)) => (),
       true => match(

--- a/tests/collections/array_list_convenience.test.yo
+++ b/tests/collections/array_list_convenience.test.yo
@@ -256,3 +256,100 @@ test("retain over twenty thousand elements is one pass and leaves refcounts bala
   assert(list.len() == usize(0), "reject everything");
   assert(rc(shared) == base, "all references released, none double-released");
 });
+// ===== D17: sort is STABLE; sort_unstable is the heapsort =====
+// plans/STD_API_STABILIZATION.md D17. `sort` was heapsort under Rust's name,
+// so equal elements reordered: the witness below returned
+// `0:6 0:2 0:0 0:4 1:5 1:7 1:3 1:1` before this change.
+_SortRec :: struct(key : i32, tag : i32);
+test("sort_by is stable: equal keys keep their input order", {
+  xs := ArrayList(_SortRec).new();
+  i := i32(0);
+  while(runtime(i < i32(8)), {
+    xs.push(_SortRec(key : (i % i32(2)), tag : i));
+    i = (i + i32(1));
+  });
+  xs.sort_by((a, b) => (a.key < b.key));
+  // Keys ascending, and within each key the tags stay in insertion order.
+  expect_tags := ArrayList(i32).new();
+  expect_tags.push(i32(0));
+  expect_tags.push(i32(2));
+  expect_tags.push(i32(4));
+  expect_tags.push(i32(6));
+  expect_tags.push(i32(1));
+  expect_tags.push(i32(3));
+  expect_tags.push(i32(5));
+  expect_tags.push(i32(7));
+  j := usize(0);
+  while(runtime(j < xs.len()), {
+    assert(xs(j).tag == expect_tags(j), `stable order at ${j}: got tag ${xs(j).tag}, want ${expect_tags(j)}`);
+    j = (j + usize(1));
+  });
+});
+test("sort orders correctly with duplicates", {
+  ns := ArrayList(i32).new();
+  ns.push(i32(5));
+  ns.push(i32(1));
+  ns.push(i32(4));
+  ns.push(i32(1));
+  ns.push(i32(3));
+  ns.sort();
+  assert(ns(usize(0)) == i32(1), "0");
+  assert(ns(usize(1)) == i32(1), "1");
+  assert(ns(usize(2)) == i32(3), "2");
+  assert(ns(usize(3)) == i32(4), "3");
+  assert(ns(usize(4)) == i32(5), "4");
+});
+test("sort_unstable still sorts (heapsort path retained)", {
+  us := ArrayList(i32).new();
+  us.push(i32(9));
+  us.push(i32(2));
+  us.push(i32(7));
+  us.push(i32(2));
+  us.sort_unstable();
+  assert(us(usize(0)) == i32(2), "a");
+  assert(us(usize(1)) == i32(2), "b");
+  assert(us(usize(2)) == i32(7), "c");
+  assert(us(usize(3)) == i32(9), "d");
+});
+test("sort_unstable_by sorts by a supplied comparator", {
+  us := ArrayList(i32).new();
+  us.push(i32(1));
+  us.push(i32(9));
+  us.push(i32(5));
+  us.sort_unstable_by((a, b) => (b < a));
+  assert(us(usize(0)) == i32(9), "descending head");
+  assert(us(usize(2)) == i32(1), "descending tail");
+});
+test("sort of an empty or single-element list is a no-op", {
+  e := ArrayList(i32).new();
+  e.sort();
+  assert(e.len() == usize(0), "empty stays empty");
+  s := ArrayList(i32).new();
+  s.push(i32(42));
+  s.sort();
+  assert((s.len() == usize(1)) && (s(usize(0)) == i32(42)), "single element preserved");
+});
+test("sort is stable across a larger run with many ties", {
+  xs := ArrayList(_SortRec).new();
+  i := i32(0);
+  while(runtime(i < i32(64)), {
+    xs.push(_SortRec(key : (i % i32(4)), tag : i));
+    i = (i + i32(1));
+  });
+  xs.sort_by((a, b) => (a.key < b.key));
+  ok := true;
+  j := usize(1);
+  while(runtime(j < xs.len()), {
+    prev := xs(j - usize(1));
+    cur := xs(j);
+    // ascending by key, and ties strictly increasing by original tag
+    if(cur.key < prev.key, {
+      ok = false;
+    });
+    if((cur.key == prev.key) && (cur.tag < prev.tag), {
+      ok = false;
+    });
+    j = (j + usize(1));
+  });
+  assert(ok, "64 elements with 4 distinct keys stay stable");
+});


### PR DESCRIPTION
## What

`ArrayList.sort` was a **heapsort under Rust's stable name**. Rust guarantees `sort` is stable and offers `sort_unstable` for the faster non-stable one; Yo had the fast one wearing the stable name, so any code sorting by a secondary key silently lost the primary order. **D17** in `plans/STD_API_STABILIZATION.md` §2.

- `sort` / `sort_by` → a new stable bottom-up merge sort
- `sort_unstable` / `sort_unstable_by` → the existing heapsort, now correctly named

## Implementation

`_merge_sort_indices` sorts an index permutation (bottom-up, ties take the **left** run — that is what makes it stable), then the elements are permuted in place by cycle-following.

Two things worth flagging for review:

**1. The permutation had to be inverted.** The merge sort yields `order(i)` = the *source* index for destination `i`, but the cycle-following swap consumes *destination* indices. Using them directly produced `3 5 1 1 4` from a 5-element list. Verified on paper (`[A,B,C]` with `order=[2,0,1]` → `[B,C,A]`, not `[C,A,B]`) before fixing, and the inversion into `scratch` is commented in place.

**2. `_merge_sort_indices` is deliberately monomorphic** (`usize` indices), not a reuse of the generic `_heapsort_by`. Reusing the generic at `T=usize` emitted C that passed a `size_t` to a closure expecting the element struct — a **compiler specializer bug**, filed with a reduced reproducer in the second commit (`issues/generic-fn-specialized-at-two-types-hands-the-closure-the-wrong-param-type.md` + `issues/repros/`). The monomorphic version sidesteps it; the bug itself is independent of this PR and still open.

The trigger took three attempts to reduce — the first two reproducers compiled cleanly. It needs an **outer** generic instantiating an **inner** generic at a *different* type, with a closure capturing the outer `T`'s data.

## Verification

6 new tests in `tests/collections/array_list_convenience.test.yo` using a `struct(key, tag)` record so stability is observable (equal keys must keep their original `tag` order). **30/30 pass.**

I also suspected the heapsort swaps were leaking RC handles and checked with a `Dispose`-counter witness — they are not. Recording that so it is not re-investigated.

## Merge timing

Breaking (`sort`'s complexity/ordering guarantees change), so it belongs to the **v0.2.28** window — please hold until v0.2.27 is out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)