### PR TITLE
std: PriorityQueue is a MAX-heap; add Reverse(T) (D11)

### DIFF
--- a/std/collections/priority_queue.yo
+++ b/std/collections/priority_queue.yo
@@ -1,4 +1,4 @@
-//! Binary min-heap priority queue.
+//! Binary MAX-heap priority queue — Rust's `BinaryHeap` (D11).
 //!
 //! ## Example
 //!
@@ -9,12 +9,24 @@
 //! pq.push(5);
 //! pq.push(1);
 //! pq.push(3);
-//! x := pq.pop().unwrap();  // 1
+//! x := pq.pop().unwrap();  // 5 — the LARGEST
+//! ```
+//!
+//! For a min-heap, wrap the elements in the prelude's `Reverse(T)`, whose
+//! `Ord` is the inverted one:
+//!
+//! ```rust
+//! pq := PriorityQueue(Reverse(i32)).new();
+//! pq.push(Reverse(i32)(5));
+//! pq.push(Reverse(i32)(1));
+//! x := pq.pop().unwrap().value;  // 1 — the SMALLEST
 //! ```
 pragma(Pragma.AllowUnsafe);
 { ArrayList } :: import("./array_list");
-/// Min-heap backed by an ArrayList.
-/// Elements are ordered ascending (smallest first). Negate keys for max-heap behavior.
+/// MAX-heap backed by an ArrayList (D11 — Rust's `BinaryHeap`).
+/// `peek`/`pop` yield the LARGEST element. For a min-heap, use
+/// `PriorityQueue(Reverse(T))` rather than negating keys — negation is wrong
+/// for unsigned types and for the minimum of a signed type.
 PriorityQueue :: (fn(comptime(T) : Type) -> comptime(Type))(
   ref(
     struct(
@@ -37,7 +49,7 @@ impl(
   is_empty : (fn(self : Self) -> bool)(
     self._data.len() == usize(0)
   ),
-  // Inspect the smallest element without removing it.
+  // Inspect the largest element without removing it.
   peek : (fn(self : Self) -> Option(T))(
     cond(
       (self._data.len() == usize(0)) => .None,
@@ -59,7 +71,7 @@ impl(
       child_val := self._data(i);
       parent_val := self._data(parent);
       cond(
-        (child_val < parent_val) => {
+        (child_val > parent_val) => {
           &(self._data(i)).* = parent_val;
           &(self._data(parent)).* = child_val;
           i = parent;
@@ -70,7 +82,7 @@ impl(
       );
     });
   }),
-  // Remove and return the smallest element.
+  // Remove and return the largest element.
   pop : (fn(self : Self, where(T <: Ord(T))) -> Option(T))({
     n := self._data.len();
     cond(
@@ -85,30 +97,30 @@ impl(
         while(runtime(true), {
           left := ((i * usize(2)) + usize(1));
           right := ((i * usize(2)) + usize(2));
-          smallest := i;
+          largest := i;
           new_n := self._data.len();
           cond(
-            ((left < new_n) && (self._data(left) < self._data(smallest))) => {
-              smallest = left;
+            ((left < new_n) && (self._data(left) > self._data(largest))) => {
+              largest = left;
             },
             true => ()
           );
           cond(
-            ((right < new_n) && (self._data(right) < self._data(smallest))) => {
-              smallest = right;
+            ((right < new_n) && (self._data(right) > self._data(largest))) => {
+              largest = right;
             },
             true => ()
           );
           cond(
-            (smallest == i) => {
+            (largest == i) => {
               break;
             },
             true => {
               a := self._data(i);
-              b := self._data(smallest);
+              b := self._data(largest);
               &(self._data(i)).* = b;
-              &(self._data(smallest)).* = a;
-              i = smallest;
+              &(self._data(largest)).* = a;
+              i = largest;
             }
           );
         });

--- a/std/prelude.yo
+++ b/std/prelude.yo
@@ -667,6 +667,49 @@ Ord :: (
   )
 );
 export(Ord);
+/**
+* `Reverse(T)` — a wrapper whose `Ord` is `T`'s, inverted (Rust's
+* `core::cmp::Reverse`).
+*
+* It turns any max-ordered structure into a min-ordered one without a second
+* implementation. `PriorityQueue` is a MAX-heap (D11), so a min-heap is:
+*
+* ```rust
+* pq := PriorityQueue(Reverse(i32)).new();
+* pq.push(Reverse(i32)(i32(5)));
+* pq.push(Reverse(i32)(i32(1)));
+* pq.pop().unwrap().value;  // 1 — the SMALLEST
+* ```
+*
+* It is equally the way to sort descending: `list.sort_by((a, b) ->
+* (Reverse(i32)(a) < Reverse(i32)(b)))`.
+*/
+Reverse :: (fn(comptime(T) : Type) -> comptime(Type))(
+  struct(
+    value : T
+  )
+);
+impl(
+  generic(T : Type),
+  where(T <: Eq(T)),
+  Reverse(T),
+  Eq(Reverse(T))(
+    (==) : (fn(lhs : Self, rhs : Self) -> bool)(lhs.value == rhs.value)
+  )
+);
+impl(
+  generic(T : Type),
+  where(T <: Ord(T)),
+  Reverse(T),
+  Ord(Reverse(T))(
+    // Every operator swaps its operands — that IS the inversion.
+    (<) : (fn(lhs : Self, rhs : Self) -> bool)(rhs.value < lhs.value),
+    (<=) : (fn(lhs : Self, rhs : Self) -> bool)(rhs.value <= lhs.value),
+    (>) : (fn(lhs : Self, rhs : Self) -> bool)(rhs.value > lhs.value),
+    (>=) : (fn(lhs : Self, rhs : Self) -> bool)(rhs.value >= lhs.value)
+  )
+);
+export(Reverse);
 ComptimeOrd :: (
   fn(
     comptime(Rhs) : Type,

--- a/tests/collections/priority_queue.test.yo
+++ b/tests/collections/priority_queue.test.yo
@@ -22,14 +22,14 @@ test("PriorityQueue.push adds multiple elements", {
   assert(pq.len() == usize(3), "len should be 3");
 });
 // ===== Peek Tests =====
-test("PriorityQueue.peek returns smallest element", {
+test("PriorityQueue.peek returns largest element", {
   pq := PriorityQueue(i32).new();
   pq.push(i32(30));
   pq.push(i32(10));
   pq.push(i32(20));
   v := pq.peek();
   assert(v.is_some(), "peek should return Some");
-  assert(v.unwrap() == i32(10), "smallest should be 10");
+  assert(v.unwrap() == i32(30), "largest should be 30");
   assert(pq.len() == usize(3), "len should still be 3 after peek");
 });
 test("PriorityQueue.peek returns None for empty queue", {
@@ -44,32 +44,32 @@ test("PriorityQueue.peek does not remove element", {
   assert(pq.len() == usize(1), "peek should not change len");
 });
 // ===== Pop Tests =====
-test("PriorityQueue.pop returns smallest element", {
+test("PriorityQueue.pop returns largest element", {
   pq := PriorityQueue(i32).new();
   pq.push(i32(5));
   pq.push(i32(1));
   pq.push(i32(3));
   v := pq.pop();
   assert(v.is_some(), "pop should return Some");
-  assert(v.unwrap() == i32(1), "smallest should be 1");
+  assert(v.unwrap() == i32(5), "largest should be 5");
   assert(pq.len() == usize(2), "len should be 2 after pop");
 });
 test("PriorityQueue.pop returns None for empty queue", {
   pq := PriorityQueue(i32).new();
   assert(pq.pop().is_none(), "pop on empty should be None");
 });
-test("PriorityQueue.pop returns elements in ascending order", {
+test("PriorityQueue.pop returns elements in DESCENDING order", {
   pq := PriorityQueue(i32).new();
   pq.push(i32(50));
   pq.push(i32(10));
   pq.push(i32(40));
   pq.push(i32(20));
   pq.push(i32(30));
-  assert(pq.pop().unwrap() == i32(10), "1st pop should be 10");
-  assert(pq.pop().unwrap() == i32(20), "2nd pop should be 20");
+  assert(pq.pop().unwrap() == i32(50), "1st pop should be 50");
+  assert(pq.pop().unwrap() == i32(40), "2nd pop should be 40");
   assert(pq.pop().unwrap() == i32(30), "3rd pop should be 30");
-  assert(pq.pop().unwrap() == i32(40), "4th pop should be 40");
-  assert(pq.pop().unwrap() == i32(50), "5th pop should be 50");
+  assert(pq.pop().unwrap() == i32(20), "4th pop should be 20");
+  assert(pq.pop().unwrap() == i32(10), "5th pop should be 10");
   assert(pq.pop().is_none(), "6th pop should be None");
 });
 test("PriorityQueue.pop single element", {
@@ -83,8 +83,8 @@ test("PriorityQueue.pop two elements", {
   pq := PriorityQueue(i32).new();
   pq.push(i32(20));
   pq.push(i32(10));
-  assert(pq.pop().unwrap() == i32(10), "first pop should be 10");
-  assert(pq.pop().unwrap() == i32(20), "second pop should be 20");
+  assert(pq.pop().unwrap() == i32(20), "first pop should be 20");
+  assert(pq.pop().unwrap() == i32(10), "second pop should be 10");
   assert(pq.is_empty(), "should be empty");
 });
 // ===== Duplicate elements =====
@@ -94,10 +94,10 @@ test("PriorityQueue handles duplicate elements", {
   pq.push(i32(5));
   pq.push(i32(3));
   pq.push(i32(3));
-  assert(pq.pop().unwrap() == i32(3), "1st pop should be 3");
-  assert(pq.pop().unwrap() == i32(3), "2nd pop should be 3");
-  assert(pq.pop().unwrap() == i32(5), "3rd pop should be 5");
-  assert(pq.pop().unwrap() == i32(5), "4th pop should be 5");
+  assert(pq.pop().unwrap() == i32(5), "1st pop should be 5");
+  assert(pq.pop().unwrap() == i32(5), "2nd pop should be 5");
+  assert(pq.pop().unwrap() == i32(3), "3rd pop should be 3");
+  assert(pq.pop().unwrap() == i32(3), "4th pop should be 3");
 });
 // ===== Sorted input =====
 test("PriorityQueue with already sorted input", {
@@ -107,11 +107,11 @@ test("PriorityQueue with already sorted input", {
   pq.push(i32(3));
   pq.push(i32(4));
   pq.push(i32(5));
-  assert(pq.pop().unwrap() == i32(1), "1st should be 1");
-  assert(pq.pop().unwrap() == i32(2), "2nd should be 2");
+  assert(pq.pop().unwrap() == i32(5), "1st should be 5");
+  assert(pq.pop().unwrap() == i32(4), "2nd should be 4");
   assert(pq.pop().unwrap() == i32(3), "3rd should be 3");
-  assert(pq.pop().unwrap() == i32(4), "4th should be 4");
-  assert(pq.pop().unwrap() == i32(5), "5th should be 5");
+  assert(pq.pop().unwrap() == i32(2), "4th should be 2");
+  assert(pq.pop().unwrap() == i32(1), "5th should be 1");
 });
 test("PriorityQueue with reverse sorted input", {
   pq := PriorityQueue(i32).new();
@@ -120,25 +120,25 @@ test("PriorityQueue with reverse sorted input", {
   pq.push(i32(3));
   pq.push(i32(2));
   pq.push(i32(1));
-  assert(pq.pop().unwrap() == i32(1), "1st should be 1");
-  assert(pq.pop().unwrap() == i32(2), "2nd should be 2");
+  assert(pq.pop().unwrap() == i32(5), "1st should be 5");
+  assert(pq.pop().unwrap() == i32(4), "2nd should be 4");
   assert(pq.pop().unwrap() == i32(3), "3rd should be 3");
-  assert(pq.pop().unwrap() == i32(4), "4th should be 4");
-  assert(pq.pop().unwrap() == i32(5), "5th should be 5");
+  assert(pq.pop().unwrap() == i32(2), "4th should be 2");
+  assert(pq.pop().unwrap() == i32(1), "5th should be 1");
 });
 // ===== Interleaved push and pop =====
 test("PriorityQueue interleaved push and pop", {
   pq := PriorityQueue(i32).new();
   pq.push(i32(10));
   pq.push(i32(5));
-  assert(pq.pop().unwrap() == i32(5), "should get 5");
+  assert(pq.pop().unwrap() == i32(10), "should get 10");
   pq.push(i32(3));
   pq.push(i32(8));
-  assert(pq.pop().unwrap() == i32(3), "should get 3");
-  pq.push(i32(1));
-  assert(pq.pop().unwrap() == i32(1), "should get 1");
   assert(pq.pop().unwrap() == i32(8), "should get 8");
-  assert(pq.pop().unwrap() == i32(10), "should get 10");
+  pq.push(i32(1));
+  assert(pq.pop().unwrap() == i32(5), "should get 5");
+  assert(pq.pop().unwrap() == i32(3), "should get 3");
+  assert(pq.pop().unwrap() == i32(1), "should get 1");
   assert(pq.is_empty(), "should be empty");
 });
 // ===== Many elements =====
@@ -166,27 +166,62 @@ test("PriorityQueue with many elements", {
   pq.push(i32(6));
   pq.push(i32(10));
   assert(pq.len() == usize(20), "len should be 20");
-  // Pop all and verify ascending order
-  prev := i32(-1);
+  // Pop all and verify DESCENDING order
+  prev := i32(100);
   remaining := usize(20);
   while(remaining > usize(0), remaining = (remaining - usize(1)), {
     v := pq.pop().unwrap();
-    assert(v > prev, "elements should come out in ascending order");
+    assert(v < prev, "elements should come out in descending order");
     prev = v;
   });
   assert(pq.is_empty(), "should be empty after popping all");
 });
 // ===== Peek after pop =====
-test("PriorityQueue.peek reflects new minimum after pop", {
+test("PriorityQueue.peek reflects new maximum after pop", {
   pq := PriorityQueue(i32).new();
   pq.push(i32(10));
   pq.push(i32(5));
   pq.push(i32(15));
-  assert(pq.peek().unwrap() == i32(5), "min should be 5");
+  assert(pq.peek().unwrap() == i32(15), "max should be 15");
   pq.pop();
-  assert(pq.peek().unwrap() == i32(10), "min should be 10 after removing 5");
+  assert(pq.peek().unwrap() == i32(10), "max should be 10 after removing 15");
   pq.pop();
-  assert(pq.peek().unwrap() == i32(15), "min should be 15 after removing 10");
+  assert(pq.peek().unwrap() == i32(5), "max should be 5 after removing 10");
+});
+// ===== Reverse(T) gives a min-heap (D11) =====
+test("PriorityQueue(Reverse(T)) is a min-heap", {
+  pq := PriorityQueue(Reverse(i32)).new();
+  pq.push(Reverse(i32)(i32(50)));
+  pq.push(Reverse(i32)(i32(10)));
+  pq.push(Reverse(i32)(i32(40)));
+  pq.push(Reverse(i32)(i32(20)));
+  pq.push(Reverse(i32)(i32(30)));
+  assert(pq.peek().unwrap().value == i32(10), "peek is the SMALLEST under Reverse");
+  assert(pq.pop().unwrap().value == i32(10), "1st pop should be 10");
+  assert(pq.pop().unwrap().value == i32(20), "2nd pop should be 20");
+  assert(pq.pop().unwrap().value == i32(30), "3rd pop should be 30");
+  assert(pq.pop().unwrap().value == i32(40), "4th pop should be 40");
+  assert(pq.pop().unwrap().value == i32(50), "5th pop should be 50");
+  assert(pq.pop().is_none(), "6th pop should be None");
+});
+test("Reverse inverts every Ord operator and keeps Eq", {
+  a := Reverse(i32)(i32(1));
+  b := Reverse(i32)(i32(2));
+  assert(b < a, "2 wrapped is LESS than 1 wrapped");
+  assert(b <= a, "<= inverted");
+  assert(a > b, "> inverted");
+  assert(a >= b, ">= inverted");
+  assert(a == Reverse(i32)(i32(1)), "Eq is NOT inverted");
+  assert(!(a == b), "distinct values are not equal");
+});
+test("Reverse works on unsigned types, where negating keys cannot", {
+  pq := PriorityQueue(Reverse(usize)).new();
+  pq.push(Reverse(usize)(usize(3)));
+  pq.push(Reverse(usize)(usize(0)));
+  pq.push(Reverse(usize)(usize(7)));
+  assert(pq.pop().unwrap().value == usize(0), "0 is the minimum");
+  assert(pq.pop().unwrap().value == usize(3), "then 3");
+  assert(pq.pop().unwrap().value == usize(7), "then 7");
 });
 // ---- Iterator Tests ----
 test("PriorityQueue into_iter - empty queue", {


### PR DESCRIPTION
## What

`PriorityQueue` was a **min-heap**. Rust's `BinaryHeap` — the type it corresponds to — is a **max-heap**. **D11** in `plans/STD_API_STABILIZATION.md` §2.

Its own doc comment gave the workaround, and the workaround was wrong:

```rust
/// Elements are ordered ascending (smallest first). Negate keys for max-heap behavior.
```

Negating keys does not work for **unsigned** types at all, and for signed types `-i32.MIN` overflows. That is why `Reverse(T)` comes with this change rather than after it.

## Changes

- `peek`/`pop` yield the **largest** element — the sift-up and sift-down comparisons flip, and `smallest` becomes `largest`.
- New prelude **`Reverse(T)`** (Rust's `core::cmp::Reverse`): wraps a value and inverts its `Ord` by swapping the operands of every operator, leaving `Eq` alone. `PriorityQueue(Reverse(T))` is the min-heap.

```rust
pq := PriorityQueue(Reverse(i32)).new();
pq.push(Reverse(i32)(i32(5)));
pq.push(Reverse(i32)(i32(1)));
pq.pop().unwrap().value;  // 1 — the smallest
```

`Reverse` lives in the prelude next to `Ord`/`Ordering` because it is a general comparison utility (it is equally the way to sort descending), not a heap-specific one — same placement Rust gives it in `core::cmp`.

## One thing I want you to weigh

**This flip is more contestable than D10's**, and I would rather say so than have it look settled:

| language | `PriorityQueue`-ish type | order |
|---|---|---|
| Rust | `BinaryHeap` | **max** |
| C++ | `std::priority_queue` | **max** |
| **Java** | **`PriorityQueue`** | **min** |
| Python | `heapq` | min |

The name `PriorityQueue` is *literally* Java's, and Java's is a min-heap — so unlike `replace` (where every major language agreed and Yo was the outlier), the name alone does not settle this one. I implemented it as decided, on the campaign's stated rule of preferring Rust's shape. If you would rather keep the min-heap and rename the type to `BinaryHeap` instead, that is a coherent alternative and this PR is easy to invert — say the word.

## Blast radius

**Nothing in `std/` or `src/` uses `PriorityQueue`**, so all 42 call sites are in its own test file. Nothing silently changes behaviour outside the tests.

## Verification

- `tests/collections/priority_queue.test.yo` **24/24**, including three new tests: the `Reverse` min-heap, `Reverse` inverting each of `<`, `<=`, `>`, `>=` while leaving `==` alone, and a `Reverse(usize)` heap (the case negation cannot express).
- `yo check ./std` **173/173**, `yo check ./src` and a full `yo build` run because this touches `prelude.yo`.

## Merge timing

Breaking, so it belongs to the **v0.2.28** window — please hold until v0.2.27 is out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)