### PR TITLE
std: FromStr + `s.parse(T)` with real parse errors (D12)

### DIFF
--- a/std/error.yo
+++ b/std/error.yo
@@ -3,7 +3,7 @@
 // re-exported ALL of string/fmt through std/error — every error-module
 // importer gained println, String, Format, ... — for the two names actually
 // used here).
-{ String } :: import("./string");
+{ String, ParseIntError, ParseFloatError, ParseBoolError } :: import("./string");
 { ToString } :: import("./fmt/to_string.yo");
 /// Standard error trait for typed error propagation.
 /// All error types should implement this trait along with `ToString`.
@@ -17,6 +17,11 @@ AnyError :: Dyn(Error);
 export(AnyError);
 /// Allows using `String` directly as an error type.
 impl(String, Error());
+/// The D12 parse errors: defined in `std/string`, rendered in `std/fmt`, and
+/// made propagable here — each at the lowest layer that can name what it needs.
+impl(ParseIntError, Error());
+impl(ParseFloatError, Error());
+impl(ParseBoolError, Error());
 /// Non-resumable exception handling effect record.
 /// Use `throw` to raise an `AnyError` and abort the current computation.
 /// `throw` is `ctl(...)` — handler body may contain `unwind`, and the

--- a/std/fmt/to_string.yo
+++ b/std/fmt/to_string.yo
@@ -1,6 +1,6 @@
 //! ToString trait and implementations for all primitive types.
 pragma(Pragma.AllowUnsafe);
-{ String, rune } :: import("../string");
+{ String, rune, ParseIntError, ParseFloatError, ParseBoolError } :: import("../string");
 { snprintf } :: import("../libc/stdio");
 { ArrayList } :: import("../collections/array_list");
 utf8 :: import("../encoding/utf8");
@@ -358,6 +358,44 @@ impl(
       });
       `${out}]`
     })
+  )
+);
+/// The D12 parse errors live in `std/string` (below this module, so they
+/// cannot name `ToString` themselves); their renderings live here, the same
+/// split `impl(String, Error())` uses one layer up.
+impl(
+  ParseIntError,
+  ToString(
+    to_string : (
+      self ->
+        match(
+          self,
+          .Empty => `cannot parse integer from empty string`,
+          .InvalidDigit => `invalid digit found in string`,
+          .PosOverflow => `number too large to fit in target type`,
+          .NegOverflow => `number too small to fit in target type`,
+          .InvalidRadix => `radix must be between 2 and 36`
+        )
+    )
+  )
+);
+impl(
+  ParseFloatError,
+  ToString(
+    to_string : (
+      self ->
+        match(
+          self,
+          .Empty => `cannot parse float from empty string`,
+          .Invalid => `invalid float literal`
+        )
+    )
+  )
+);
+impl(
+  ParseBoolError,
+  ToString(
+    to_string : (self -> `provided string was not \`true\` or \`false\``)
   )
 );
 // --- derive_rule for ToString ---

--- a/std/string/string.yo
+++ b/std/string/string.yo
@@ -2222,6 +2222,9 @@ impl(
   /**
   * Parse the string as a boolean.
   * Returns .Some(true) for "true", .Some(false) for "false", .None for anything else.
+  *
+  * DEPRECATED (D12), kept for one release: use `s.parse(bool)`, which reports
+  * WHY the parse failed instead of collapsing every reason into `.None`.
   */
   parse_bool : (fn(self : Self) -> Option(bool))(
     match(
@@ -2402,11 +2405,71 @@ _radix_digit :: (fn(b : u8, radix : u32) -> Option(u64))({
 });
 /// Magnitude of the digit run starting at `start` (sign already consumed),
 /// with overflow checks. The whole remainder must be digits.
-_radix_magnitude :: (fn(s : String, radix : u32, start : usize) -> Option(u64))({
+/**
+* Why a string could not be parsed as an integer — Rust's `ParseIntError`
+* (D12). The older `parse_*() -> Option(T)` methods collapsed all of these
+* into `.None`, so a caller could not tell a missing field from a malformed
+* one from one that simply did not fit.
+*/
+ParseIntError :: enum(
+  /// The string was empty, or held only a sign.
+  Empty,
+  /// A byte was not a digit in the requested radix.
+  InvalidDigit,
+  /// The value is larger than the type's maximum.
+  PosOverflow,
+  /// The value is smaller than the type's minimum.
+  NegOverflow,
+  /// The radix passed to a `*_radix` parser was outside 2..=36. Rust panics
+  /// here; Yo reports it, because the radix is often user input too.
+  InvalidRadix
+);
+/// Why a string could not be parsed as a float — Rust's `ParseFloatError`.
+ParseFloatError :: enum(
+  /// The string was empty.
+  Empty,
+  /// The string did not match the float grammar.
+  Invalid
+);
+/// Why a string could not be parsed as a bool — Rust's `ParseBoolError`.
+/// Only `"true"` and `"false"` are accepted.
+ParseBoolError :: enum(
+  Invalid
+);
+/**
+* `FromStr` — parse a value of this type out of a `String` (Rust's
+* `core::str::FromStr`).
+*
+* Call it as `s.parse(T)`, which forwards to `T.from_str(s)`:
+*
+* ```rust
+* match(`42`.parse(i32), .Ok(v) => v, .Err(e) => i32(0));
+* ```
+*
+* `Err` is the type's own error, so a caller can tell an EMPTY string from
+* garbage from an out-of-range value — the distinction the older
+* `parse_*() -> Option(T)` methods threw away (D12).
+*/
+FromStr :: trait(
+  /// What this type reports when the string is not a valid value.
+  Err : Type,
+  from_str : (fn(s : String) -> Result(Self, Self.Err))
+);
+/// Magnitude scanner shared by every integer parser. Distinguishes an empty
+/// digit run, a non-digit and an overflow — the whole point of D12.
+_radix_magnitude_res :: (
+  fn(s : String, radix : u32, start : usize) -> Result(u64, ParseIntError)
+)({
+  cond(
+    ((radix < u32(2)) || (radix > u32(36))) => {
+      return(.Err(ParseIntError.InvalidRadix));
+    },
+    true => ()
+  );
   bytes := s.as_bytes();
   (n : usize) = bytes.len();
   if(start >= n, {
-    return(.None);
+    return(.Err(ParseIntError.Empty));
   });
   (mag : u64) = u64(0);
   i := start;
@@ -2415,17 +2478,88 @@ _radix_magnitude :: (fn(s : String, radix : u32, start : usize) -> Option(u64))(
       _radix_digit(bytes(i), radix),
       .Some(v) => v,
       .None => {
-        return(.None);
+        return(.Err(ParseIntError.InvalidDigit));
       }
     );
     // mag * radix + d > u64.MAX  ⇔  mag > (u64.MAX - d) / radix
     if(mag > ((u64.MAX - d) / u64(radix)), {
-      return(.None);
+      return(.Err(ParseIntError.PosOverflow));
     });
     mag = ((mag * u64(radix)) + d);
     i = (i + usize(1));
   });
-  .Some(mag)
+  .Ok(mag)
+});
+/// Signed core: sign, then magnitude, then the i64 range check. The sign is
+/// what turns a magnitude overflow into Pos- or NegOverflow.
+_parse_i64_radix_res :: (
+  fn(s : String, radix : u32) -> Result(i64, ParseIntError)
+)({
+  cond(
+    ((radix < u32(2)) || (radix > u32(36))) => {
+      return(.Err(ParseIntError.InvalidRadix));
+    },
+    true => ()
+  );
+  bytes := s.as_bytes();
+  (n : usize) = bytes.len();
+  if(n == usize(0), {
+    return(.Err(ParseIntError.Empty));
+  });
+  (neg : bool) = false;
+  (start : usize) = usize(0);
+  (b0 : u8) = bytes(usize(0));
+  if((b0 == u8(0x2B)) || (b0 == u8(0x2D)), {
+    neg = (b0 == u8(0x2D));
+    start = usize(1);
+  });
+  match(
+    _radix_magnitude_res(s, radix, start),
+    .Ok(mag) => cond(
+      neg => cond(
+        // -2^63 is representable; anything past it is not
+        (mag == u64(0x8000000000000000)) => .Ok(i64.MIN),
+        (mag <= u64(9223372036854775807)) => .Ok(i64(0) - i64(mag)),
+        true => .Err(ParseIntError.NegOverflow)
+      ),
+      true => cond(
+        (mag <= u64(9223372036854775807)) => .Ok(i64(mag)),
+        true => .Err(ParseIntError.PosOverflow)
+      )
+    ),
+    // A magnitude that overflowed u64 is a NEGATIVE overflow when signed.
+    .Err(e) => match(
+      e,
+      .PosOverflow => cond(
+        neg => .Err(ParseIntError.NegOverflow),
+        true => .Err(ParseIntError.PosOverflow)
+      ),
+      _ => .Err(e)
+    )
+  )
+});
+/// Unsigned core: an optional `+`, then the magnitude. A leading `-` is a
+/// digit error, not a negative number — same as Rust.
+_parse_u64_radix_res :: (
+  fn(s : String, radix : u32) -> Result(u64, ParseIntError)
+)({
+  cond(
+    ((radix < u32(2)) || (radix > u32(36))) => {
+      return(.Err(ParseIntError.InvalidRadix));
+    },
+    true => ()
+  );
+  bytes := s.as_bytes();
+  (n : usize) = bytes.len();
+  if(n == usize(0), {
+    return(.Err(ParseIntError.Empty));
+  });
+  (start : usize) = usize(0);
+  (b0 : u8) = bytes(usize(0));
+  if(b0 == u8(0x2B), {
+    start = usize(1);
+  });
+  _radix_magnitude_res(s, radix, start)
 });
 impl(
   String,
@@ -2434,6 +2568,9 @@ impl(
   * with optional fraction and exponent, or `inf`/`infinity`/`nan`
   * (case-insensitive). Leading/trailing whitespace and hex floats are NOT
   * accepted. `.None` when the string is not a valid number.
+  *
+  * DEPRECATED (D12), kept for one release: use `s.parse(f64)`, which reports
+  * WHY the parse failed instead of collapsing every reason into `.None`.
   */
   parse_f64 : (fn(self : Self) -> Option(f64))({
     (ok : bool) = _f64_grammar_ok(self.as_bytes());
@@ -2452,71 +2589,31 @@ impl(
   * Rust's `i64::from_str_radix`. An optional leading `+`/`-` is allowed;
   * `_` is not. `.None` on an empty digit run, any non-digit, a bad radix,
   * or overflow.
+  *
+  * DEPRECATED (D12), kept for one release: use `s.parse(i64)`, which reports
+  * WHY the parse failed instead of collapsing every reason into `.None`.
   */
-  parse_i64_radix : (fn(self : Self, radix : u32) -> Option(i64))({
-    (bad : bool) = ((radix < u32(2)) || (radix > u32(36)));
-    cond(
-      bad => .None,
-      true => {
-        bytes := self.as_bytes();
-        (n : usize) = bytes.len();
-        if(n == usize(0), {
-          return(.None);
-        });
-        (neg : bool) = false;
-        (start : usize) = usize(0);
-        (b0 : u8) = bytes(usize(0));
-        if((b0 == u8(0x2B)) || (b0 == u8(0x2D)), {
-          neg = (b0 == u8(0x2D));
-          start = usize(1);
-        });
-        match(
-          _radix_magnitude(self, radix, start),
-          .Some(mag) => cond(
-            neg => cond(
-              // -2^63 is representable; anything past it is not
-              (mag == u64(0x8000000000000000)) => .Some(i64.MIN),
-              (mag <= u64(9223372036854775807)) => .Some(i64(0) - i64(mag)),
-              true => .None
-            ),
-            true => cond(
-              (mag <= u64(9223372036854775807)) => .Some(i64(mag)),
-              true => .None
-            )
-          ),
-          .None => .None
-        )
-      }
-    )
-  }),
+  parse_i64_radix : (fn(self : Self, radix : u32) -> Option(i64))(
+    match(_parse_i64_radix_res(self, radix), .Ok(v) => .Some(v), .Err(_) => .None)
+  ),
   /**
   * Parse a `u64` in the given `radix` (2..=36) — Rust's
   * `u64::from_str_radix`. An optional leading `+` is allowed; `-` is not.
   * `.None` on any non-digit, a bad radix, or overflow.
+  *
+  * DEPRECATED (D12), kept for one release: use `s.parse(u64)`, which reports
+  * WHY the parse failed instead of collapsing every reason into `.None`.
   */
-  parse_u64_radix : (fn(self : Self, radix : u32) -> Option(u64))({
-    (bad : bool) = ((radix < u32(2)) || (radix > u32(36)));
-    cond(
-      bad => .None,
-      true => {
-        bytes := self.as_bytes();
-        (n : usize) = bytes.len();
-        if(n == usize(0), {
-          return(.None);
-        });
-        (start : usize) = usize(0);
-        (b0 : u8) = bytes(usize(0));
-        if(b0 == u8(0x2B), {
-          start = usize(1);
-        });
-        _radix_magnitude(self, radix, start)
-      }
-    )
-  }),
+  parse_u64_radix : (fn(self : Self, radix : u32) -> Option(u64))(
+    match(_parse_u64_radix_res(self, radix), .Ok(v) => .Some(v), .Err(_) => .None)
+  ),
   /**
   * Parse the string as a signed 32-bit integer — Rust's `i32::from_str`.
   * An optional leading `+`/`-` is allowed. `.None` on an empty digit run,
   * any non-digit, or a value outside `i32`.
+  *
+  * DEPRECATED (D12), kept for one release: use `s.parse(i32)`, which reports
+  * WHY the parse failed instead of collapsing every reason into `.None`.
   */
   parse_i32 : (fn(self : Self) -> Option(i32))(
     match(
@@ -2532,12 +2629,18 @@ impl(
   * Parse the string as a signed 64-bit integer — Rust's `i64::from_str`.
   * An optional leading `+`/`-` is allowed. `.None` on an empty digit run,
   * any non-digit, or overflow (`i64.MIN` itself is accepted).
+  *
+  * DEPRECATED (D12), kept for one release: use `s.parse(i64)`, which reports
+  * WHY the parse failed instead of collapsing every reason into `.None`.
   */
   parse_i64 : (fn(self : Self) -> Option(i64))(self.parse_i64_radix(u32(10))),
   /**
   * Parse the string as an unsigned 32-bit integer — Rust's `u32::from_str`.
   * An optional leading `+` is allowed, `-` is not. `.None` on an empty digit
   * run, any non-digit, or a value outside `u32`.
+  *
+  * DEPRECATED (D12), kept for one release: use `s.parse(u32)`, which reports
+  * WHY the parse failed instead of collapsing every reason into `.None`.
   */
   parse_u32 : (fn(self : Self) -> Option(u32))(
     match(
@@ -2553,8 +2656,117 @@ impl(
   * Parse the string as an unsigned 64-bit integer — Rust's `u64::from_str`.
   * An optional leading `+` is allowed, `-` is not. `.None` on an empty digit
   * run, any non-digit, or overflow.
+  *
+  * DEPRECATED (D12), kept for one release: use `s.parse(u64)`, which reports
+  * WHY the parse failed instead of collapsing every reason into `.None`.
   */
   parse_u64 : (fn(self : Self) -> Option(u64))(self.parse_u64_radix(u32(10)))
+);
+// ============================================================================
+// FromStr impls + `s.parse(T)` (D12)
+// ============================================================================
+impl(
+  i64,
+  FromStr(
+    Err : ParseIntError,
+    from_str : (fn(s : String) -> Result(i64, ParseIntError))(
+      _parse_i64_radix_res(s, u32(10))
+    )
+  )
+);
+impl(
+  u64,
+  FromStr(
+    Err : ParseIntError,
+    from_str : (fn(s : String) -> Result(u64, ParseIntError))(
+      _parse_u64_radix_res(s, u32(10))
+    )
+  )
+);
+impl(
+  i32,
+  FromStr(
+    Err : ParseIntError,
+    from_str : (fn(s : String) -> Result(i32, ParseIntError))(
+      match(
+        _parse_i64_radix_res(s, u32(10)),
+        .Ok(v) => cond(
+          (v > i64(2147483647)) => .Err(ParseIntError.PosOverflow),
+          (v < i64(-2147483648)) => .Err(ParseIntError.NegOverflow),
+          true => .Ok(i32(v))
+        ),
+        .Err(e) => .Err(e)
+      )
+    )
+  )
+);
+impl(
+  u32,
+  FromStr(
+    Err : ParseIntError,
+    from_str : (fn(s : String) -> Result(u32, ParseIntError))(
+      match(
+        _parse_u64_radix_res(s, u32(10)),
+        .Ok(v) => cond(
+          (v > u64(4294967295)) => .Err(ParseIntError.PosOverflow),
+          true => .Ok(u32(v))
+        ),
+        .Err(e) => .Err(e)
+      )
+    )
+  )
+);
+impl(
+  f64,
+  FromStr(
+    Err : ParseFloatError,
+    from_str : (fn(s : String) -> Result(f64, ParseFloatError))(
+      cond(
+        (s.len() == usize(0)) => .Err(ParseFloatError.Empty),
+        true => match(s.parse_f64(), .Some(v) => .Ok(v), .None => .Err(ParseFloatError.Invalid))
+      )
+    )
+  )
+);
+impl(
+  bool,
+  FromStr(
+    Err : ParseBoolError,
+    from_str : (fn(s : String) -> Result(bool, ParseBoolError))(
+      match(s.parse_bool(), .Some(v) => .Ok(v), .None => .Err(ParseBoolError.Invalid))
+    )
+  )
+);
+impl(
+  String,
+  /**
+  * Parse this string as a `T` — Rust's `str::parse::<T>()` (D12).
+  *
+  * ```rust
+  * match(`42`.parse(i32), .Ok(v) => v, .Err(_) => i32(0));
+  * ```
+  *
+  * The error is `T`'s own, so a caller can tell an empty string from garbage
+  * from an out-of-range value. `T` is written out because it cannot be
+  * inferred from the arguments — only from the result, which Yo does not do.
+  */
+  parse : (fn(self : Self, comptime(T) : Type, where(T <: FromStr)) -> Result(T, T.Err))(
+    T.from_str(self)
+  ),
+  /**
+  * Parse a signed integer in `radix` (2..=36) — Rust's `i64::from_str_radix`,
+  * reporting WHY it failed.
+  */
+  parse_i64_radix_res : (fn(self : Self, radix : u32) -> Result(i64, ParseIntError))(
+    _parse_i64_radix_res(self, radix)
+  ),
+  /**
+  * Parse an unsigned integer in `radix` (2..=36) — Rust's
+  * `u64::from_str_radix`, reporting WHY it failed.
+  */
+  parse_u64_radix_res : (fn(self : Self, radix : u32) -> Result(u64, ParseIntError))(
+    _parse_u64_radix_res(self, radix)
+  )
 );
 /// Index trait implementation — access a single byte by index.
 /// Panics if the string is empty.
@@ -2627,5 +2839,9 @@ export(
   StringCharIndices,
   StringBytes,
   StringLines,
-  Pattern
+  Pattern,
+  FromStr,
+  ParseIntError,
+  ParseFloatError,
+  ParseBoolError
 );

--- a/tests/string/string.test.yo
+++ b/tests/string/string.test.yo
@@ -2137,6 +2137,107 @@ test("String replace_all with empty search inserts everywhere", {
   assert(s.replace_all(String.from(""), String.from("-")) == String.from("-a-b-c-"), "Rust: \"abc\".replace_all(\"\", \"-\") == \"-a-b-c-\"");
   assert(String.from("").replace_all(String.from(""), String.from("-")) == String.from("-"), "the empty string still has one boundary");
 });
+// ===== FromStr / s.parse(T) (D12) =====
+test("parse(i32) distinguishes empty, garbage and overflow", {
+  // The whole point of D12: parse_i32 collapsed all three into .None.
+  assert(match(`42`.parse(i32), .Ok(v) => (v == i32(42)), .Err(_) => false), "42 parses");
+  assert(
+    match(``.parse(i32), .Ok(_) => false, .Err(e) => match(e, .Empty => true, _ => false)),
+    "empty string is Empty, not InvalidDigit"
+  );
+  assert(
+    match(`12x`.parse(i32), .Ok(_) => false, .Err(e) => match(e, .InvalidDigit => true, _ => false)),
+    "trailing garbage is InvalidDigit"
+  );
+  assert(
+    match(`2147483648`.parse(i32), .Ok(_) => false, .Err(e) => match(e, .PosOverflow => true, _ => false)),
+    "i32.MAX + 1 is PosOverflow, NOT InvalidDigit"
+  );
+  assert(
+    match(`-2147483649`.parse(i32), .Ok(_) => false, .Err(e) => match(e, .NegOverflow => true, _ => false)),
+    "i32.MIN - 1 is NegOverflow"
+  );
+  assert(
+    match(`-`.parse(i32), .Ok(_) => false, .Err(e) => match(e, .Empty => true, _ => false)),
+    "a lone sign has an empty digit run"
+  );
+});
+test("parse(i32) keeps the boundary values", {
+  assert(match(`2147483647`.parse(i32), .Ok(v) => (v == i32(2147483647)), .Err(_) => false), "i32.MAX");
+  assert(match(`-2147483648`.parse(i32), .Ok(v) => (v == i32(-2147483648)), .Err(_) => false), "i32.MIN");
+});
+test("parse(i64) keeps i64.MIN and rejects one past it", {
+  assert(
+    match(`-9223372036854775808`.parse(i64), .Ok(v) => (v == i64.MIN), .Err(_) => false),
+    "i64.MIN is representable"
+  );
+  assert(
+    match(`-9223372036854775809`.parse(i64), .Ok(_) => false, .Err(e) => match(e, .NegOverflow => true, _ => false)),
+    "one past i64.MIN is NegOverflow"
+  );
+  assert(
+    match(`9223372036854775808`.parse(i64), .Ok(_) => false, .Err(e) => match(e, .PosOverflow => true, _ => false)),
+    "one past i64.MAX is PosOverflow"
+  );
+});
+test("a u64-magnitude overflow on a NEGATIVE number reports NegOverflow", {
+  // The magnitude scanner overflows u64 and can only say PosOverflow; the
+  // signed core has to re-sign it. Regression guard for exactly that.
+  assert(
+    match(
+      `-99999999999999999999999`.parse(i64),
+      .Ok(_) => false,
+      .Err(e) => match(e, .NegOverflow => true, _ => false)
+    ),
+    "a huge negative is NegOverflow, not PosOverflow"
+  );
+});
+test("parse(u32)/parse(u64) reject a leading minus as a digit error", {
+  assert(match(`7`.parse(u32), .Ok(v) => (v == u32(7)), .Err(_) => false), "7 parses");
+  assert(
+    match(`-1`.parse(u32), .Ok(_) => false, .Err(e) => match(e, .InvalidDigit => true, _ => false)),
+    "unsigned rejects a sign as InvalidDigit, like Rust"
+  );
+  assert(
+    match(`4294967296`.parse(u32), .Ok(_) => false, .Err(e) => match(e, .PosOverflow => true, _ => false)),
+    "u32.MAX + 1 is PosOverflow"
+  );
+  assert(match(`+9`.parse(u64), .Ok(v) => (v == u64(9)), .Err(_) => false), "a leading + is allowed");
+});
+test("parse(f64) and parse(bool) carry their own error types", {
+  assert(match(`1.5`.parse(f64), .Ok(v) => (v == 1.5), .Err(_) => false), "1.5 parses");
+  assert(
+    match(``.parse(f64), .Ok(_) => false, .Err(e) => match(e, .Empty => true, .Invalid => false)),
+    "empty is ParseFloatError.Empty"
+  );
+  assert(
+    match(`nope`.parse(f64), .Ok(_) => false, .Err(e) => match(e, .Invalid => true, .Empty => false)),
+    "garbage is ParseFloatError.Invalid"
+  );
+  assert(match(`true`.parse(bool), .Ok(v) => v, .Err(_) => false), "true parses");
+  assert(match(`false`.parse(bool), .Ok(v) => !v, .Err(_) => false), "false parses");
+  assert(match(`True`.parse(bool), .Ok(_) => false, .Err(_) => true), "only lowercase, like Rust");
+});
+test("the radix parsers report a bad radix instead of silently failing", {
+  assert(
+    match(`ff`.parse_u64_radix_res(u32(16)), .Ok(v) => (v == u64(255)), .Err(_) => false),
+    "hex ff is 255"
+  );
+  assert(
+    match(`ff`.parse_u64_radix_res(u32(99)), .Ok(_) => false, .Err(e) => match(e, .InvalidRadix => true, _ => false)),
+    "radix 99 is InvalidRadix, not InvalidDigit"
+  );
+  assert(
+    match(`-80`.parse_i64_radix_res(u32(16)), .Ok(v) => (v == i64(-128)), .Err(_) => false),
+    "signed hex with a sign"
+  );
+});
+test("the deprecated parse_* Option methods still agree with parse(T)", {
+  assert(`42`.parse_i32().unwrap() == i32(42), "parse_i32 still works");
+  assert(`12x`.parse_i32().is_none(), "and still collapses garbage to .None");
+  assert(`2147483648`.parse_i32().is_none(), "and overflow to .None");
+  assert(`ff`.parse_u64_radix(u32(16)).unwrap() == u64(255), "radix form still works");
+});
 // ===== parse_f64 =====
 test("String parse_f64 accepts the Rust f64::from_str grammar", {
   assert_approx(String.from("3.25").parse_f64().unwrap_or(f64(0)), f64(3.25), f64(0.000000000001), "plain decimal");


### PR DESCRIPTION
## What

Eight `parse_*` methods returned `Option`, collapsing **"empty string"**, **"contains garbage"** and **"does not fit the type"** into a single `.None`. A caller that wants to tell a missing config field from a malformed one from an out-of-range one had nothing to branch on. **D12** in `plans/STD_API_STABILIZATION.md` §2.

```rust
`2147483648`.parse_i32()  // .None — overflow? garbage? no way to know
`2147483648`.parse(i32)   // .Err(ParseIntError.PosOverflow)
```

## The new API

- **`FromStr`** trait (Rust's `core::str::FromStr`) with an associated `Err`, so each type reports its own error type.
- **`s.parse(T)`** forwards to `T.from_str(s)`. `T` is written out because it can only be inferred from the *result*, which Yo does not do — so `s.parse(i32)`, not a turbofish.
- **`ParseIntError`** (`Empty`, `InvalidDigit`, `PosOverflow`, `NegOverflow`, `InvalidRadix`), **`ParseFloatError`** (`Empty`, `Invalid`), **`ParseBoolError`**.
- Impls for `i32`, `i64`, `u32`, `u64`, `f64`, `bool` — the six types that had a `parse_*`. The remaining widths are a follow-up, called out rather than silently omitted.
- **`parse_i64_radix_res` / `parse_u64_radix_res`** are the `Result`-returning radix parsers. Rust *panics* on a radix outside 2..=36; Yo reports `InvalidRadix`, because in practice the radix is often user input too.

## Nothing breaks

The eight `Option` methods stay for one release as **deprecated wrappers over the same cores**, so no call site changes and there is exactly one parsing implementation rather than two that can drift. `_radix_magnitude` lost its last caller and is deleted.

## Layering

`string` < `fmt` < `error`, and the pieces had to land at the lowest layer that can name what they need:

| piece | module | why |
|---|---|---|
| enums + `FromStr` + `parse` | `std/string` | `std/error` imports `./string`, so string cannot import back |
| `ToString` impls | `std/fmt/to_string.yo` | first layer that can name `ToString` |
| `Error()` impls | `std/error.yo` | same split `impl(String, Error())` already uses |

## One subtlety, with a regression test

The magnitude scanner overflows `u64` and can only report `PosOverflow`, so the **signed core re-signs it** — otherwise `-99999999999999999999999` would come back as `PosOverflow`. There is a test named for exactly that.

## Verification

- `tests/string/string.test.yo` **275/275** (8 new tests)
- `yo check ./std` **173/173**, `yo check ./src` **266/266**, full `yo build` green — this touches `std/error.yo` and `std/fmt`, which the compiler itself uses

New tests cover empty vs garbage vs positive vs negative overflow, the `i32`/`i64` boundary values (including `i64.MIN`, which *is* representable), unsigned rejecting a leading `-` as `InvalidDigit` (Rust's behaviour), the bad radix, and the deprecated methods still agreeing.

## Merge timing

Additive — nothing breaks — but it belongs with the rest of the D-batch in the **v0.2.28** window unless you would rather take it into v0.2.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)