### PR TITLE
std/encoding: hex, base64 and utf16 decoders return Result (D13, part 1)

### DIFF
--- a/std/encoding/base64.yo
+++ b/std/encoding/base64.yo
@@ -64,19 +64,19 @@ export(base64_encode, base64_encode_url);
 // ============================================================================
 // Decoding
 // ============================================================================
-_decode_char :: (fn(c : u8, alpha : str, exn : Exception) -> u8)({
+_decode_char_res :: (fn(c : u8, alpha : str) -> Result(u8, EncodingError))({
   i := usize(0);
   while(i < usize(64), i = (i + usize(1)), {
     cond(
       (alpha.bytes(i) == c) => {
-        return(u8(i));
+        return(.Ok(u8(i)));
       },
       true => ()
     );
   });
-  exn.throw(dyn(EncodingError.InvalidChar(c)))
+  .Err(EncodingError.InvalidChar(c))
 });
-_decode_with :: (fn(s : String, alpha : str, exn : Exception) -> ArrayList(u8))({
+_decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), EncodingError))({
   // Strip trailing padding
   len := s.len();
   while((len > usize(0)) && (s.byte_at(len - usize(1)) == _PAD), len = (len - usize(1)), ());
@@ -84,26 +84,50 @@ _decode_with :: (fn(s : String, alpha : str, exn : Exception) -> ArrayList(u8))(
   // error, not a zero byte (issues/fixed/base64-decode-accepted-impossible-lengths-and-trailing-bits.md).
   cond(
     ((len % usize(4)) == usize(1)) => {
-      exn.throw(dyn(EncodingError.InvalidLength));
+      return(.Err(EncodingError.InvalidLength));
     },
     true => ()
   );
   out := ArrayList(u8).with_capacity((len * usize(3)) / usize(4));
   i := usize(0);
   while(i < len, i = (i + usize(4)), {
-    c0 := _decode_char(s.byte_at(i), alpha, exn);
+    c0 := match(
+      _decode_char_res(s.byte_at(i), alpha),
+      .Ok(v) => v,
+      .Err(e) => {
+        return(.Err(e));
+      }
+    );
     c1 := cond(
-      ((i + usize(1)) < len) => _decode_char(s.byte_at(i + usize(1)), alpha, exn),
+      ((i + usize(1)) < len) => match(
+        _decode_char_res(s.byte_at(i + usize(1)), alpha),
+        .Ok(v) => v,
+        .Err(e) => {
+          return(.Err(e));
+        }
+      ),
       true => u8(0)
     );
     out.push((c0 << u8(2)) | (c1 >> u8(4)));
     cond(
       ((i + usize(2)) < len) => {
-        c2 := _decode_char(s.byte_at(i + usize(2)), alpha, exn);
+        c2 := match(
+          _decode_char_res(s.byte_at(i + usize(2)), alpha),
+          .Ok(v) => v,
+          .Err(e) => {
+            return(.Err(e));
+          }
+        );
         out.push(((c1 & u8(15)) << u8(4)) | (c2 >> u8(2)));
         cond(
           ((i + usize(3)) < len) => {
-            c3 := _decode_char(s.byte_at(i + usize(3)), alpha, exn);
+            c3 := match(
+              _decode_char_res(s.byte_at(i + usize(3)), alpha),
+              .Ok(v) => v,
+              .Err(e) => {
+                return(.Err(e));
+              }
+            );
             out.push(((c2 & u8(3)) << u8(6)) | c3);
           },
           true => {
@@ -112,7 +136,7 @@ _decode_with :: (fn(s : String, alpha : str, exn : Exception) -> ArrayList(u8))(
             // encoding (Rust rejects it as InvalidLastSymbol).
             cond(
               ((c2 & u8(3)) != u8(0)) => {
-                exn.throw(dyn(EncodingError.InvalidLastSymbol(s.byte_at(i + usize(2)))));
+                return(.Err(EncodingError.InvalidLastSymbol(s.byte_at(i + usize(2)))));
               },
               true => ()
             );
@@ -124,24 +148,34 @@ _decode_with :: (fn(s : String, alpha : str, exn : Exception) -> ArrayList(u8))(
         // second must be zero.
         cond(
           ((c1 & u8(15)) != u8(0)) => {
-            exn.throw(dyn(EncodingError.InvalidLastSymbol(s.byte_at(i + usize(1)))));
+            return(.Err(EncodingError.InvalidLastSymbol(s.byte_at(i + usize(1)))));
           },
           true => ()
         );
       }
     );
   });
-  out
+  .Ok(out)
 });
-/// Decode a standard base64 string to bytes. Throws via `Exception` on invalid
-/// input: a symbol outside the alphabet (`InvalidChar`), a length of 1 mod 4
-/// (`InvalidLength`), or a final symbol with non-zero unused bits
-/// (`InvalidLastSymbol`). Padding is optional and, when present, trailing.
-base64_decode :: (fn(s : String, exn : Exception) -> ArrayList(u8))(
-  _decode_with(s, _STD_ALPHA, exn)
+/// Decode a standard base64 string to bytes (D13 — a pure transform returns a
+/// `Result`). `.Err` on a symbol outside the alphabet (`InvalidChar`), a
+/// length of 1 mod 4 (`InvalidLength`), or a final symbol with non-zero
+/// unused bits (`InvalidLastSymbol`). Padding is optional and, when present,
+/// trailing.
+base64_decode :: (fn(s : String) -> Result(ArrayList(u8), EncodingError))(
+  _decode_with_res(s, _STD_ALPHA)
 );
-/// Decode a URL-safe base64 string to bytes. Throws via `Exception` on invalid input.
-base64_decode_url :: (fn(s : String, exn : Exception) -> ArrayList(u8))(
-  _decode_with(s, _URL_ALPHA, exn)
+/// Decode a URL-safe base64 string to bytes.
+base64_decode_url :: (fn(s : String) -> Result(ArrayList(u8), EncodingError))(
+  _decode_with_res(s, _URL_ALPHA)
 );
-export(base64_decode, base64_decode_url);
+/// `base64_decode` as an effect: throws the `EncodingError` through `exn`
+/// instead of returning it. Kept for callers already inside an effect scope.
+base64_decode_exn :: (fn(s : String, exn : Exception) -> ArrayList(u8))(
+  match(base64_decode(s), .Ok(v) => v, .Err(e) => exn.throw(dyn(e)))
+);
+/// `base64_decode_url` as an effect.
+base64_decode_url_exn :: (fn(s : String, exn : Exception) -> ArrayList(u8))(
+  match(base64_decode_url(s), .Ok(v) => v, .Err(e) => exn.throw(dyn(e)))
+);
+export(base64_decode, base64_decode_url, base64_decode_exn, base64_decode_url_exn);

--- a/std/encoding/hex.yo
+++ b/std/encoding/hex.yo
@@ -8,7 +8,7 @@
 //! { hex_encode, hex_decode } :: import "std/encoding/hex";
 //!
 //! s := hex_encode(data);         // "deadbeef"
-//! b := hex_decode("deadbeef");
+//! b := hex_decode(`deadbeef`).unwrap();
 //! ```
 open(import("../string"));
 { ArrayList } :: import("../collections/array_list");
@@ -39,32 +39,51 @@ export(hex_encode);
 // ============================================================================
 // Decoding
 // ============================================================================
-_hex_nibble :: (fn(c : u8, exn : Exception) -> u8)(
+/// Nibble value of one hex digit, or which character was wrong (D13).
+_hex_nibble_res :: (fn(c : u8) -> Result(u8, EncodingError))(
   cond(
-    ((c >= u8(48)) && (c <= u8(57))) => (c - u8(48)),
+    ((c >= u8(48)) && (c <= u8(57))) => .Ok(c - u8(48)),
     // '0'-'9'
-    ((c >= u8(97)) && (c <= u8(102))) => ((c - u8(97)) + u8(10)),
+    ((c >= u8(97)) && (c <= u8(102))) => .Ok((c - u8(97)) + u8(10)),
     // 'a'-'f'
-    ((c >= u8(65)) && (c <= u8(70))) => ((c - u8(65)) + u8(10)),
+    ((c >= u8(65)) && (c <= u8(70))) => .Ok((c - u8(65)) + u8(10)),
     // 'A'-'F'
-    true => exn.throw(dyn(EncodingError.InvalidChar(c)))
+    true => .Err(EncodingError.InvalidChar(c))
   )
 );
-/// Decode a hexadecimal string to bytes. Throws via `Exception` on invalid input.
-hex_decode :: (fn(s : String, exn : Exception) -> ArrayList(u8))({
+/// Decode a hexadecimal string to bytes (D13 — a pure transform returns a
+/// `Result`; `hex_decode_exn` is the effect-carrying wrapper).
+hex_decode :: (fn(s : String) -> Result(ArrayList(u8), EncodingError))({
   cond(
     ((s.len() % usize(2)) != usize(0)) => {
-      exn.throw(dyn(EncodingError.OddLength));
+      return(.Err(EncodingError.OddLength));
     },
     true => ()
   );
   out := ArrayList(u8).with_capacity(s.len() / usize(2));
   i := usize(0);
   while(i < s.len(), i = (i + usize(2)), {
-    hi := _hex_nibble(s.byte_at(i), exn);
-    lo := _hex_nibble(s.byte_at(i + usize(1)), exn);
+    hi := match(
+      _hex_nibble_res(s.byte_at(i)),
+      .Ok(v) => v,
+      .Err(e) => {
+        return(.Err(e));
+      }
+    );
+    lo := match(
+      _hex_nibble_res(s.byte_at(i + usize(1))),
+      .Ok(v) => v,
+      .Err(e) => {
+        return(.Err(e));
+      }
+    );
     out.push((hi << u8(4)) | lo);
   });
-  out
+  .Ok(out)
 });
-export(hex_decode);
+/// `hex_decode` as an effect: throws the `EncodingError` through `exn`
+/// instead of returning it. Kept for callers already inside an effect scope.
+hex_decode_exn :: (fn(s : String, exn : Exception) -> ArrayList(u8))(
+  match(hex_decode(s), .Ok(v) => v, .Err(e) => exn.throw(dyn(e)))
+);
+export(hex_decode, hex_decode_exn);

--- a/std/encoding/utf16.yo
+++ b/std/encoding/utf16.yo
@@ -49,11 +49,12 @@ export(utf8_to_utf16);
 // ============================================================================
 // UTF-16 → UTF-8
 // ============================================================================
-/// Convert UTF-16 code units to a UTF-8 `String`.
+/// Convert UTF-16 code units to a UTF-8 `String` (D13 — a pure transform
+/// returns a `Result`; `utf16_to_utf8_exn` is the effect-carrying wrapper).
 ///
 /// Decodes surrogate pairs back into supplementary code points.
-/// Throws via `Exception` on unpaired surrogates.
-utf16_to_utf8 :: (fn(data : ArrayList(u16), exn : Exception) -> String)({
+/// `.Err(EncodingError.InvalidChar)` on an unpaired surrogate.
+utf16_to_utf8 :: (fn(data : ArrayList(u16)) -> Result(String, EncodingError))({
   out := ArrayList(u8).new();
   i := usize(0);
   while(i < data.len(), {
@@ -63,14 +64,14 @@ utf16_to_utf8 :: (fn(data : ArrayList(u16), exn : Exception) -> String)({
       ((w >= u32(0xD800)) && (w <= u32(0xDBFF))) => {
         cond(
           ((i + usize(1)) >= data.len()) => {
-            exn.throw(dyn(EncodingError.InvalidChar(u8(0))));
+            return(.Err(EncodingError.InvalidChar(u8(0))));
           },
           true => ()
         );
         w2 := u32(data(i + usize(1)));
         cond(
           ((w2 < u32(0xDC00)) || (w2 > u32(0xDFFF))) => {
-            exn.throw(dyn(EncodingError.InvalidChar(u8(0))));
+            return(.Err(EncodingError.InvalidChar(u8(0))));
           },
           true => ()
         );
@@ -81,9 +82,9 @@ utf16_to_utf8 :: (fn(data : ArrayList(u16), exn : Exception) -> String)({
       // A LOW surrogate that was not consumed by the branch above is
       // unpaired. The old code let it fall through and wrote it out as a
       // 3-byte CESU-8 sequence — invalid UTF-8 — despite this function's
-      // documented "throws on unpaired surrogates" contract.
+      // documented "rejects unpaired surrogates" contract.
       ((w >= u32(0xDC00)) && (w <= u32(0xDFFF))) => {
-        exn.throw(dyn(EncodingError.InvalidChar(u8(0))));
+        return(.Err(EncodingError.InvalidChar(u8(0))));
       },
       true => {
         // A BMP scalar: nothing is ever substituted here.
@@ -92,6 +93,11 @@ utf16_to_utf8 :: (fn(data : ArrayList(u16), exn : Exception) -> String)({
       }
     );
   });
-  String.from_bytes(out)
+  .Ok(String.from_bytes(out))
 });
-export(utf16_to_utf8);
+/// `utf16_to_utf8` as an effect: throws the `EncodingError` through `exn`
+/// instead of returning it. Kept for callers already inside an effect scope.
+utf16_to_utf8_exn :: (fn(data : ArrayList(u16), exn : Exception) -> String)(
+  match(utf16_to_utf8(data), .Ok(v) => v, .Err(e) => exn.throw(dyn(e)))
+);
+export(utf16_to_utf8, utf16_to_utf8_exn);

--- a/tests/encoding/base64.test.yo
+++ b/tests/encoding/base64.test.yo
@@ -59,27 +59,11 @@ test("base64_encode_url no padding", {
 });
 // ===== Decoding Tests =====
 test("base64_decode empty string", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
-  bytes := base64_decode(String.from(""), exn);
+  bytes := base64_decode(String.from("")).unwrap();
   assert(bytes.len() == usize(0), "empty string should decode to 0 bytes");
 });
 test("base64_decode Hello", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
-  bytes := base64_decode(String.from("SGVsbG8="), exn);
+  bytes := base64_decode(String.from("SGVsbG8=")).unwrap();
   assert(bytes.len() == usize(5), "SGVsbG8= should decode to 5 bytes");
   assert(bytes(usize(0)) == u8(72), "byte 0 = H");
   assert(bytes(usize(1)) == u8(101), "byte 1 = e");
@@ -88,15 +72,7 @@ test("base64_decode Hello", {
   assert(bytes(usize(4)) == u8(111), "byte 4 = o");
 });
 test("base64_decode no padding", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
-  bytes := base64_decode(String.from("TWFu"), exn);
+  bytes := base64_decode(String.from("TWFu")).unwrap();
   assert(bytes.len() == usize(3), "TWFu should decode to 3 bytes");
   assert(bytes(usize(0)) == u8(77), "byte 0 = M");
   assert(bytes(usize(1)) == u8(97), "byte 1 = a");
@@ -110,19 +86,11 @@ test("base64_decode invalid character error", {
       }
     )
   );
-  base64_decode(String.from("!!!!"), exn);
+  base64_decode_exn(String.from("!!!!"), exn);
   assert(false, "invalid chars should have thrown");
 });
 // ===== Roundtrip Tests =====
 test("base64 roundtrip", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   data := ArrayList(u8).new();
   i := u8(0);
   while(i < u8(255), i = (i + u8(1)), {
@@ -130,7 +98,7 @@ test("base64 roundtrip", {
   });
   data.push(u8(255));
   encoded := base64_encode(data);
-  decoded := base64_decode(encoded, exn);
+  decoded := base64_decode(encoded).unwrap();
   assert(decoded.len() == usize(256), "roundtrip should preserve length");
   j := usize(0);
   while(j < usize(256), j = (j + usize(1)), {
@@ -138,20 +106,12 @@ test("base64 roundtrip", {
   });
 });
 test("base64 url roundtrip", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   data := ArrayList(u8).new();
   data.push(u8(0xFB));
   data.push(u8(0xFF));
   data.push(u8(0xFE));
   encoded := base64_encode_url(data);
-  decoded := base64_decode_url(encoded, exn);
+  decoded := base64_decode_url(encoded).unwrap();
   assert(decoded.len() == usize(3), "url roundtrip should preserve length");
   assert(decoded(usize(0)) == u8(0xFB), "url roundtrip byte 0");
   assert(decoded(usize(1)) == u8(0xFF), "url roundtrip byte 1");
@@ -171,37 +131,42 @@ test("encode a String's bytes", {
   assert(base64_encode(String.from("Hello, World!").as_bytes()) == "SGVsbG8sIFdvcmxkIQ==", "Hello, World!");
 });
 test("decode to a String through from_utf8", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected decode error");
-        unwind(());
-      }
-    )
-  );
-  s := String.from_utf8(base64_decode(String.from("SGVsbG8sIFdvcmxkIQ=="), exn));
+  s := String.from_utf8(base64_decode(String.from("SGVsbG8sIFdvcmxkIQ==")).unwrap());
   assert(match(s, .Ok(v) => (v == "Hello, World!"), .Err(_) => false), "Hello, World!");
   // "w6k=" is 0xC3 0xA9 — U+00E9, valid UTF-8.
-  m := String.from_utf8(base64_decode(String.from("w6k="), exn));
+  m := String.from_utf8(base64_decode(String.from("w6k=")).unwrap());
   assert(match(m, .Ok(v) => ((v.chars().count() == usize(1)) && (v.len() == usize(2))), .Err(_) => false), "one rune, two bytes");
   // "/w==" is the single byte 0xFF, never valid UTF-8: the byte decode is fine,
   // the String conversion is the honest error.
-  bad := String.from_utf8(base64_decode(String.from("/w=="), exn));
+  bad := String.from_utf8(base64_decode(String.from("/w==")).unwrap());
   assert(match(bad, .Ok(_) => false, .Err(_) => true), "a non-UTF-8 payload is a StringError, not a broken String");
 });
 test("whitespace inside base64 text is rejected, like any other non-alphabet byte", {
-  (threw : bool) = false;
-  r := ArrayList(u8).new();
-  exn := Exception(
-    throw : (
-      err -> {
-        unwind(());
-      }
-    )
+  // Under D13 this is a direct assertion on the error, not the old proxy of
+  // "the returned list came back empty, so it must have unwound" — and the
+  // direct assertion immediately showed that the two inputs below fail for
+  // DIFFERENT reasons, which the old test could not see.
+  //
+  // "Zm9v YmFy" is 9 symbols, so the 1-mod-4 LENGTH check fires before the
+  // scan ever reaches the space.
+  assert(
+    match(
+      base64_decode(String.from("Zm9v YmFy")),
+      .Ok(_) => false,
+      .Err(e) => match(e, .InvalidLength => true, _ => false)
+    ),
+    "a 9-symbol input is InvalidLength, whatever else is wrong with it"
   );
-  r = base64_decode(String.from("Zm9v YmFy"), exn);
-  threw = (r.len() == usize(0));
-  assert(threw, "the decode must have unwound before returning bytes");
+  // "Zm9v YmFyIQ==" strips to 11 symbols (3 mod 4), so the scan runs and the
+  // space itself is reported.
+  assert(
+    match(
+      base64_decode(String.from("Zm9v YmFyIQ==")),
+      .Ok(_) => false,
+      .Err(e) => match(e, .InvalidChar(c) => (c == u8(32)), _ => false)
+    ),
+    "the space is reported as InvalidChar(0x20)"
+  );
 });
 // ===== Canonical-form rejection =====
 // issues/fixed/base64-decode-accepted-impossible-lengths-and-trailing-bits.md
@@ -213,7 +178,7 @@ test("base64_decode rejects a length of 1 mod 4", {
       }
     )
   );
-  base64_decode(String.from("QUJDR"), exn);
+  base64_decode_exn(String.from("QUJDR"), exn);
   assert(false, "a lone trailing sextet encodes nothing and must throw InvalidLength");
 });
 test("base64_decode rejects non-zero trailing bits in a two-symbol group", {
@@ -226,7 +191,7 @@ test("base64_decode rejects non-zero trailing bits in a two-symbol group", {
   );
   // "QR": Q=16, R=17 → the second symbol's low four bits are 0001, which no
   // byte can occupy. The canonical encoding of 0x41 is "QQ==".
-  base64_decode(String.from("QR=="), exn);
+  base64_decode_exn(String.from("QR=="), exn);
   assert(false, "must throw InvalidLastSymbol");
 });
 test("base64_decode rejects non-zero trailing bits in a three-symbol group", {
@@ -238,24 +203,16 @@ test("base64_decode rejects non-zero trailing bits in a three-symbol group", {
     )
   );
   // "QUJ": J=9 → low two bits 01. "AB" encodes canonically as "QUI=".
-  base64_decode(String.from("QUJ="), exn);
+  base64_decode_exn(String.from("QUJ="), exn);
   assert(false, "must throw InvalidLastSymbol");
 });
 test("base64_decode still accepts the canonical short groups, padded or not", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
-  a := base64_decode(String.from("QQ=="), exn);
+  a := base64_decode(String.from("QQ==")).unwrap();
   assert((a.len() == usize(1)) && (a(usize(0)) == u8(65)), "QQ== is A");
-  b := base64_decode(String.from("QQ"), exn);
+  b := base64_decode(String.from("QQ")).unwrap();
   assert((b.len() == usize(1)) && (b(usize(0)) == u8(65)), "QQ is A without padding");
-  c := base64_decode(String.from("QUI="), exn);
+  c := base64_decode(String.from("QUI=")).unwrap();
   assert((c.len() == usize(2)) && ((c(usize(0)) == u8(65)) && (c(usize(1)) == u8(66))), "QUI= is AB");
-  d := base64_decode(String.from("QUI"), exn);
+  d := base64_decode(String.from("QUI")).unwrap();
   assert(d.len() == usize(2), "QUI is AB without padding");
 });

--- a/tests/encoding/hex.test.yo
+++ b/tests/encoding/hex.test.yo
@@ -1,6 +1,6 @@
 { assert } :: import("std/assert");
 open(import("std/string"));
-{ hex_encode, hex_decode } :: import("std/encoding/hex");
+{ hex_encode, hex_decode, hex_decode_exn } :: import("std/encoding/hex");
 { EncodingError } :: import("std/encoding/error");
 { ArrayList } :: import("std/collections/array_list");
 { Error, AnyError, Exception } :: import("std/error");
@@ -46,49 +46,39 @@ test("hex_encode sequential bytes", {
   assert(result == "0123456789abcdef", "should encode all hex digits");
 });
 // ===== Decoding Tests =====
-test("hex_decode empty string", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
-  bytes := hex_decode(String.from(""), exn);
-  assert(bytes.len() == usize(0), "empty string should decode to 0 bytes");
+test("hex_decode returns bytes on valid input", {
+  assert(hex_decode(``).unwrap().len() == usize(0), "empty string decodes to 0 bytes");
+  lower := hex_decode(`deadbeef`).unwrap();
+  assert(lower.len() == usize(4), "deadbeef decodes to 4 bytes");
+  assert(lower(usize(0)) == u8(0xDE), "first byte");
+  assert(lower(usize(1)) == u8(0xAD), "second byte");
+  assert(lower(usize(2)) == u8(0xBE), "third byte");
+  assert(lower(usize(3)) == u8(0xEF), "fourth byte");
+  upper := hex_decode(`DEADBEEF`).unwrap();
+  assert(upper.len() == usize(4), "uppercase decodes too");
+  assert(upper(usize(0)) == u8(0xDE), "first byte");
+  assert(upper(usize(3)) == u8(0xEF), "fourth byte");
 });
-test("hex_decode valid lowercase", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
+test("hex_decode reports WHICH error (D13)", {
+  // The exn form could only say "it threw"; the Result form names the reason.
+  assert(
+    match(
+      hex_decode(`abc`),
+      .Ok(_) => false,
+      .Err(e) => match(e, .OddLength => true, _ => false)
+    ),
+    "odd length is OddLength"
   );
-  bytes := hex_decode(String.from("deadbeef"), exn);
-  assert(bytes.len() == usize(4), "deadbeef should decode to 4 bytes");
-  assert(bytes(usize(0)) == u8(0xDE), "first byte should be 0xDE");
-  assert(bytes(usize(1)) == u8(0xAD), "second byte should be 0xAD");
-  assert(bytes(usize(2)) == u8(0xBE), "third byte should be 0xBE");
-  assert(bytes(usize(3)) == u8(0xEF), "fourth byte should be 0xEF");
+  assert(
+    match(
+      hex_decode(`xxyz`),
+      .Ok(_) => false,
+      .Err(e) => match(e, .InvalidChar(c) => (c == u8(120)), _ => false)
+    ),
+    "a bad digit is InvalidChar carrying the offending byte 'x'"
+  );
 });
-test("hex_decode valid uppercase", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
-  bytes := hex_decode(String.from("DEADBEEF"), exn);
-  assert(bytes.len() == usize(4), "DEADBEEF should decode to 4 bytes");
-  assert(bytes(usize(0)) == u8(0xDE), "first byte should be 0xDE");
-  assert(bytes(usize(3)) == u8(0xEF), "fourth byte should be 0xEF");
-});
-test("hex_decode odd length error", {
+test("hex_decode_exn still throws for callers inside an effect scope", {
   exn := Exception(
     throw : (
       err -> {
@@ -96,30 +86,11 @@ test("hex_decode odd length error", {
       }
     )
   );
-  hex_decode(String.from("abc"), exn);
+  hex_decode_exn(String.from("abc"), exn);
   assert(false, "odd length should have thrown");
-});
-test("hex_decode invalid character error", {
-  exn := Exception(
-    throw : (
-      err -> {
-        unwind(());
-      }
-    )
-  );
-  hex_decode(String.from("xxyz"), exn);
-  assert(false, "invalid chars should have thrown");
 });
 // ===== Roundtrip Tests =====
 test("hex roundtrip", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   data := ArrayList(u8).new();
   data.push(u8(0x48));
   data.push(u8(0x65));
@@ -127,7 +98,7 @@ test("hex roundtrip", {
   data.push(u8(0x6C));
   data.push(u8(0x6F));
   encoded := hex_encode(data);
-  decoded := hex_decode(encoded, exn);
+  decoded := hex_decode(encoded).unwrap();
   assert(decoded.len() == usize(5), "roundtrip should preserve length");
   assert(decoded(usize(0)) == u8(0x48), "roundtrip byte 0");
   assert(decoded(usize(1)) == u8(0x65), "roundtrip byte 1");

--- a/tests/encoding/utf16.test.yo
+++ b/tests/encoding/utf16.test.yo
@@ -1,6 +1,6 @@
 { assert } :: import("std/assert");
 open(import("std/string"));
-{ utf8_to_utf16, utf16_to_utf8 } :: import("std/encoding/utf16");
+{ utf8_to_utf16, utf16_to_utf8, utf16_to_utf8_exn } :: import("std/encoding/utf16");
 { ArrayList } :: import("std/collections/array_list");
 { Error, AnyError, Exception } :: import("std/error");
 // Helper: build a str from raw bytes via ArrayList(u8) -> String -> as_str()
@@ -27,26 +27,16 @@ _make_str_4 :: (fn(b0 : u8, b1 : u8, b2 : u8, b3 : u8) -> String)({
   arr.push(b3);
   String.from_bytes(arr)
 });
-/// Run `utf16_to_utf8` over "A" + an unpaired LOW surrogate and report whether
-/// it threw. The handler `unwind`s out of this function, so the trailing
-/// `false` is only reached when nothing was thrown.
+/// Decode "A" + an unpaired LOW surrogate and report whether it was rejected.
 ///
 /// The old decoder let a lone low surrogate fall through and wrote it out as a
-/// 3-byte CESU-8 sequence — invalid UTF-8 — despite the documented "throws on
+/// 3-byte CESU-8 sequence — invalid UTF-8 — despite the documented "rejects
 /// unpaired surrogates" contract.
-_lone_low_surrogate_throws :: (fn() -> bool)({
-  exn := Exception(
-    throw : (
-      err -> {
-        unwind(true);
-      }
-    )
-  );
+_lone_low_surrogate_rejected :: (fn() -> bool)({
   data := ArrayList(u16).new();
   data.push(u16(0x0041));
   data.push(u16(0xDC00));
-  utf16_to_utf8(data, exn);
-  false
+  match(utf16_to_utf8(data), .Ok(_) => false, .Err(_) => true)
 });
 // ===== UTF-8 to UTF-16 =====
 test("utf8_to_utf16 empty string", {
@@ -86,49 +76,25 @@ test("utf8_to_utf16 four-byte UTF-8 surrogate pair", {
 });
 // ===== UTF-16 to UTF-8 =====
 test("utf16_to_utf8 empty", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   data := ArrayList(u16).new();
-  result := utf16_to_utf8(data, exn);
+  result := utf16_to_utf8(data).unwrap();
   assert(result == "", "should be empty string");
 });
 test("utf16_to_utf8 ASCII", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   data := ArrayList(u16).new();
   data.push(u16(72));
   data.push(u16(101));
   data.push(u16(108));
   data.push(u16(108));
   data.push(u16(111));
-  result := utf16_to_utf8(data, exn);
+  result := utf16_to_utf8(data).unwrap();
   assert(result == "Hello", "should be Hello");
 });
 test("utf16_to_utf8 BMP character", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   // U+20AC = € (euro sign)
   data := ArrayList(u16).new();
   data.push(u16(0x20AC));
-  s := utf16_to_utf8(data, exn);
+  s := utf16_to_utf8(data).unwrap();
   bytes := s.as_bytes();
   assert(bytes.len() == usize(3), "euro sign should be 3 UTF-8 bytes");
   assert(bytes(usize(0)) == u8(0xE2), "byte 0");
@@ -136,19 +102,11 @@ test("utf16_to_utf8 BMP character", {
   assert(bytes(usize(2)) == u8(0xAC), "byte 2");
 });
 test("utf16_to_utf8 surrogate pair", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   // U+1F600 as surrogate pair: D83D DE00
   data := ArrayList(u16).new();
   data.push(u16(0xD83D));
   data.push(u16(0xDE00));
-  s := utf16_to_utf8(data, exn);
+  s := utf16_to_utf8(data).unwrap();
   bytes := s.as_bytes();
   assert(bytes.len() == usize(4), "U+1F600 should be 4 UTF-8 bytes");
   assert(bytes(usize(0)) == u8(0xF0), "byte 0");
@@ -158,47 +116,23 @@ test("utf16_to_utf8 surrogate pair", {
 });
 // ===== Roundtrip =====
 test("utf16 roundtrip ASCII", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   input := String.from("Hello, World!");
   utf16 := utf8_to_utf16(input);
-  result := utf16_to_utf8(utf16, exn);
+  result := utf16_to_utf8(utf16).unwrap();
   assert(result == input, "ASCII roundtrip should preserve string");
 });
 test("utf16 roundtrip two-byte", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   // é = U+00E9 as UTF-8 bytes
   input := _make_str_2(u8(0xC3), u8(0xA9));
   utf16 := utf8_to_utf16(input);
-  result := utf16_to_utf8(utf16, exn);
+  result := utf16_to_utf8(utf16).unwrap();
   assert(result == input, "two-byte roundtrip should preserve string");
 });
 test("utf16 roundtrip surrogate pair", {
-  exn := Exception(
-    throw : (
-      err -> {
-        assert(false, "unexpected exception");
-        unwind(());
-      }
-    )
-  );
   // U+1F600 as UTF-8 bytes
   input := _make_str_4(u8(0xF0), u8(0x9F), u8(0x98), u8(0x80));
   utf16 := utf8_to_utf16(input);
-  result := utf16_to_utf8(utf16, exn);
+  result := utf16_to_utf8(utf16).unwrap();
   bytes := result.as_bytes();
   assert(bytes.len() == usize(4), "roundtrip should preserve length");
   assert(bytes(usize(0)) == u8(0xF0), "roundtrip byte 0");
@@ -206,6 +140,20 @@ test("utf16 roundtrip surrogate pair", {
   assert(bytes(usize(2)) == u8(0x98), "roundtrip byte 2");
   assert(bytes(usize(3)) == u8(0x80), "roundtrip byte 3");
 });
+test("utf16_to_utf8_exn still throws for callers inside an effect scope", {
+  exn := Exception(
+    throw : (
+      err -> {
+        unwind(());
+      }
+    )
+  );
+  data := ArrayList(u16).new();
+  data.push(u16(0x0041));
+  data.push(u16(0xDC00));
+  utf16_to_utf8_exn(data, exn);
+  assert(false, "an unpaired low surrogate should have thrown");
+});
 test("utf16_to_utf8 rejects an unpaired low surrogate", {
-  assert(_lone_low_surrogate_throws(), "an unpaired low surrogate should throw");
+  assert(_lone_low_surrogate_rejected(), "an unpaired low surrogate should throw");
 });


### PR DESCRIPTION
## What

`hex_decode`, `base64_decode`, `base64_decode_url` and `utf16_to_utf8` are **pure transforms** — bytes in, bytes out — that reported failure by throwing through `Exception`. **D13** in `plans/STD_API_STABILIZATION.md` §2.

That costs twice over: every caller must be inside an effect scope for what is just a parse, and the *reason* for the failure becomes nearly unreachable, because a handler only sees a `dyn` error. The tests show the consequence — they were reduced to asserting proxies:

```rust
r = base64_decode(String.from("Zm9v YmFy"), exn);
threw = (r.len() == usize(0));
assert(threw, "the decode must have unwound before returning bytes");
```

## The new shape

```rust
hex_decode(s)                            -> Result(ArrayList(u8), EncodingError)
base64_decode(s) / base64_decode_url(s)  -> Result(ArrayList(u8), EncodingError)
utf16_to_utf8(data)                      -> Result(String, EncodingError)
```

with `hex_decode_exn`, `base64_decode_exn`, `base64_decode_url_exn` and `utf16_to_utf8_exn` kept for callers already inside an effect scope — each still covered by a test.

**No `std/` or `src/` code called any of them**, so all call-site churn is in tests.

## Asserting on the error found a test passing for the wrong reason

Converting that whitespace test from the proxy to a direct assertion immediately failed — and it was the *test* that was wrong, not the decoder:

`"Zm9v YmFy"` is **9 symbols**, so the `1 mod 4` **length** check fires before the scan ever reaches the space. The old test could not tell, because "it unwound" is all it ever checked. It now asserts `InvalidLength` for that input **and** `InvalidChar(0x20)` for `"Zm9v YmFyIQ=="` (11 symbols, so the scan does run), documenting the precedence between the two checks.

## Verification

- `tests/encoding/hex.test.yo` **9/9**
- `tests/encoding/base64.test.yo` **20/20**
- `tests/encoding/utf16.test.yo` **14/14**
- `yo check ./std` **173/173**

Orphaned `exn` locals left behind by the conversion are removed (18 of them); pre-existing unused imports are left alone.

## Not in this PR — D13 part 2

- **`Url.parse`** is a long function with `exn.throw` threaded through its whole body; converting it means restructuring the parser, not wrapping it.
- **`json.yo` ships two complete parsers** — `json_parse`/`json_parse_bytes`/`json_parse_string` (exn) and `json_parse_result` (Result) — and D13 wants them unified. That is ~94 call sites and the duplication removal is the real work.

Both are worth their own PR rather than being bolted onto this one.

## Merge timing

Breaking, so it belongs to the **v0.2.28** window — please hold until v0.2.27 is out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)