### PR TITLE
std/fmt: Debug is split from ToString (D15)

### DIFF
--- a/std/fmt/index.yo
+++ b/std/fmt/index.yo
@@ -2,8 +2,8 @@
 pragma(Pragma.AllowUnsafe);
 { fwrite, stdout, stderr, FILE } :: import("../libc/stdio");
 { String } :: import("../string");
-{ ToString } :: import("./to_string.yo");
-export(ToString);
+{ ToString, Debug } :: import("./to_string.yo");
+export(ToString, Debug);
 { Format } :: import("./format.yo");
 export(Format);
 { FormatSpec } :: import("./spec.yo");

--- a/std/fmt/to_string.yo
+++ b/std/fmt/to_string.yo
@@ -10,6 +10,32 @@ ToString :: trait(
   to_string : (fn(inout(self) : Self) -> String)
 );
 export(ToString);
+/**
+* `Debug` — the STRUCTURAL render of a value (Rust's `std::fmt::Debug`), split
+* from `ToString` by D15.
+*
+* `derive(ToString)` used to emit the structural render, which is Rust's
+* `Debug`, not Rust's `Display`. That conflation meant no error type could
+* DERIVE its user-facing message — all ten std error enums hand-write
+* `to_string` — while also getting a structural dump for free.
+*
+* Now the two are separate channels:
+*
+* ```rust
+* MyError :: enum(NotFound(path : String));
+* derive(Debug);                    // "MyError.NotFound(/tmp/x)"  — structural
+* impl(MyError, ToString(...));     // "no such file: /tmp/x"      — user-facing
+* ```
+*
+* There is deliberately NO blanket `impl(T <: ToString) Debug for T`: it would
+* give any type with a hand-written message a `debug_string` that returns that
+* MESSAGE rather than a structural render, which is exactly the conflation
+* D15 removes.
+*/
+Debug :: trait(
+  debug_string : (fn(inout(self) : Self) -> String)
+);
+export(Debug);
 /// The one shared body behind every numeric `ToString` impl (audit fmt row:
 /// dedupe the snprintf helpers). `fmt` is a comptime `str` parameter, so it
 /// forwards into the extern call as a literal — no runtime conversion.
@@ -392,10 +418,134 @@ impl(
     )
   )
 );
+impl(ParseBoolError, ToString(to_string : (self -> `provided string was not \`true\` or \`false\``)));
+// ============================================================================
+// Debug for the primitives (D15) — structural and display coincide here.
+// ============================================================================
+/// `Debug` for `i8` — a primitive renders the same either way.
 impl(
-  ParseBoolError,
-  ToString(
-    to_string : (self -> `provided string was not \`true\` or \`false\``)
+  i8,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `i16` — a primitive renders the same either way.
+impl(
+  i16,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `i32` — a primitive renders the same either way.
+impl(
+  i32,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `i64` — a primitive renders the same either way.
+impl(
+  i64,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `u8` — a primitive renders the same either way.
+impl(
+  u8,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `u16` — a primitive renders the same either way.
+impl(
+  u16,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `u32` — a primitive renders the same either way.
+impl(
+  u32,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `u64` — a primitive renders the same either way.
+impl(
+  u64,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `usize` — a primitive renders the same either way.
+impl(
+  usize,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `isize` — a primitive renders the same either way.
+impl(
+  isize,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `f32` — a primitive renders the same either way.
+impl(
+  f32,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `f64` — a primitive renders the same either way.
+impl(
+  f64,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `bool` — a primitive renders the same either way.
+impl(
+  bool,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `char` — a primitive renders the same either way.
+impl(
+  char,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `rune` — a primitive renders the same either way.
+impl(
+  rune,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `str` — a primitive renders the same either way.
+impl(
+  str,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `String` — a primitive renders the same either way.
+impl(
+  String,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
+  )
+);
+/// `Debug` for `unit` — a primitive renders the same either way.
+impl(
+  unit,
+  Debug(
+    debug_string : (fn(inout(self) : Self) -> String)(self.to_string())
   )
 );
 // --- derive_rule for ToString ---
@@ -430,7 +580,12 @@ __derive_join_plus :: (fn(comptime(parts) : comptime_str, comptime(new_part) : c
     true => __ts_s5("(", parts, " + ", new_part, ")")
   )
 );
-__derive_tostring :: (fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comptime(trait_params) : ComptimeList(Expr)) -> comptime(Expr))({
+/// The structural render shared by `derive(Debug)` and the deprecated
+/// `derive(ToString)` (D15). Returns the BODY EXPRESSION as comptime source;
+/// the caller wraps it in whichever trait impl it wants. `m` is the method
+/// invoked on each field — `".debug_string()"` for Debug, `".to_string()"`
+/// for the legacy ToString rule.
+__derive_structural_body :: (fn(comptime(T) : Type, comptime(m) : comptime_str) -> comptime(comptime_str))({
   type_name :: Type.to_comptime_string(T);
   info :: Type.get_info(T);
   cond(
@@ -440,13 +595,7 @@ __derive_tostring :: (fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comp
       cond(
         (fc == 0) => {
           label :: __ts_s3("String.from(\"", type_name, "()\")");
-          ctx.make_impl(
-            quote(
-              ToString(
-                to_string : ((self) -> #(label.to_expr()))
-              )
-            )
-          )
+          label
         },
         true => {
           body :: __ts_fold_range(
@@ -458,17 +607,11 @@ __derive_tostring :: (fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comp
                 (fi == 0) => a,
                 true => __derive_join_plus(a, "String.from(\", \")")
               );
-              __derive_join_plus(with_sep, __ts_s3("self.", fname, ".to_string()"))
+              __derive_join_plus(with_sep, __ts_s4("self.", fname, m, ""))
             })
           );
           full_body :: __derive_join_plus(body, "String.from(\")\")");
-          ctx.make_impl(
-            quote(
-              ToString(
-                to_string : ((self) -> #(full_body.to_expr()))
-              )
-            )
-          )
+          full_body
         }
       )
     },
@@ -504,7 +647,7 @@ __derive_tostring :: (fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comp
                     (fi == 0) => a,
                     true => __derive_join_plus(a, "String.from(\", \")")
                   );
-                  __derive_join_plus(with_sep, __ts_s3("__v_", fname, ".to_string()"))
+                  __derive_join_plus(with_sep, __ts_s4("__v_", fname, m, ""))
                 })
               );
               full_body :: __derive_join_plus(body, "String.from(\")\")");
@@ -518,24 +661,39 @@ __derive_tostring :: (fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comp
         })
       );
       match_body :: __ts_s3("match(self,\n    ", ts_branches, "\n  )");
-      ctx.make_impl(
-        quote(
-          ToString(
-            to_string : ((self) -> #(match_body.to_expr()))
-          )
-        )
-      )
+      match_body
     },
     true => {
       label :: __ts_s3("String.from(\"", type_name, "\")");
-      ctx.make_impl(
-        quote(
-          ToString(
-            to_string : ((self) -> #(label.to_expr()))
-          )
-        )
-      )
+      label
     }
+  )
+});
+/// `derive(Debug)` — Rust's structural render, now its OWN trait (D15).
+__derive_debug :: (fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comptime(trait_params) : ComptimeList(Expr)) -> comptime(Expr))({
+  body :: __derive_structural_body(T, ".debug_string()");
+  ctx.make_impl(
+    quote(
+      Debug(
+        debug_string : ((self) -> #(body.to_expr()))
+      )
+    )
+  )
+});
+derive_rule(Debug, __derive_debug);
+/// `derive(ToString)` — DEPRECATED (D15), kept for one release. It emits the
+/// same STRUCTURAL render, which is Rust's `Debug`, not Rust's `Display`: that
+/// conflation is why no error enum could derive its user-facing message and
+/// all ten std error enums hand-write `to_string`. Use `derive(Debug)` for the
+/// structural form and hand-write `ToString` for the message.
+__derive_tostring :: (fn(comptime(T) : Type, comptime(ctx) : DeriveContext, comptime(trait_params) : ComptimeList(Expr)) -> comptime(Expr))({
+  body :: __derive_structural_body(T, ".to_string()");
+  ctx.make_impl(
+    quote(
+      ToString(
+        to_string : ((self) -> #(body.to_expr()))
+      )
+    )
   )
 });
 derive_rule(ToString, __derive_tostring);

--- a/tests/derive.test.yo
+++ b/tests/derive.test.yo
@@ -718,3 +718,41 @@ test("derive on a tuple, union or array is a comptime error; the smallest aggreg
   assert(hash_one(DeriveUnitE.A) != hash_one(DeriveUnitE.B), "unit enum Hash separates variants");
   assert(DeriveUnitE.B.to_string() == `DeriveUnitE.B`, "unit enum ToString");
 });
+// ===== D15: Debug is split from ToString =====
+_D15Err :: enum(NotFound(path : String), Denied);
+derive(_D15Err, Debug);
+impl(
+  _D15Err,
+  ToString(
+    to_string : (
+      self ->
+        match(
+          self,
+          .NotFound(path) => `no such file: ${path}`,
+          .Denied => `permission denied`
+        )
+    )
+  )
+);
+_D15Point :: struct(x : i32, y : i32);
+derive(_D15Point, Debug);
+test("derive(Debug) and a hand-written ToString coexist (D15)", {
+  // The whole point of D15: before it, `derive(ToString)` emitted the
+  // STRUCTURAL render, so an error type could not derive a structural dump
+  // AND carry a user-facing message. Now they are separate channels.
+  e := _D15Err.NotFound(path : `/tmp/x`);
+  assert(e.to_string() == `no such file: /tmp/x`, "user-facing message");
+  assert(e.debug_string() == `_D15Err.NotFound(/tmp/x)`, "structural render");
+  d := _D15Err.Denied;
+  assert(d.to_string() == `permission denied`, "unit variant message");
+  assert(d.debug_string() == `_D15Err.Denied`, "unit variant structural");
+});
+test("derive(Debug) on a struct renders structurally (D15)", {
+  p := _D15Point(x : i32(1), y : i32(2));
+  assert(p.debug_string() == `_D15Point(1, 2)`, "struct structural render");
+});
+test("Debug on the primitives matches their display form (D15)", {
+  assert(i32(42).debug_string() == `42`, "i32");
+  assert(true.debug_string() == `true`, "bool");
+  assert(String.from("hi").debug_string() == `hi`, "String");
+});


### PR DESCRIPTION
## What

`derive(ToString)` emitted a **structural** render — which is Rust's `Debug`, not Rust's `Display`. That conflation meant no error type could *derive* a structural dump while also carrying a user-facing message, which is why all ten std error enums hand-write `to_string`. **D15** in `plans/STD_API_STABILIZATION.md` §2.

Now they are separate channels:

```rust
e.to_string()      // "no such file: /tmp/x"       — hand-written message
e.debug_string()   // "MyError.NotFound(/tmp/x)"   — derived structural
```

- **`Debug`** trait (`debug_string`), exported from `std/fmt`
- **`derive(Debug)`** emits the structural render; `derive(ToString)` stays one release, deprecated, emitting the same thing so nothing breaks
- Explicit `Debug` impls for the 18 primitives, where structural and display genuinely coincide

## It is a factoring, not a duplication

`__derive_structural_body(T, method)` produces the render once and each rule wraps it in its own trait. The legacy path is behaviourally untouched — existing `tests/derive.test.yo` 50/50 and `bootstrap_verification` 12/12 pass unchanged.

## A blanket impl was tried and rejected

`impl(generic(T), where(T <: ToString), T, Debug(...))` **compiles**, and an explicit impl **silently shadows** it (I probed both). I rejected it anyway: it would give any type with a hand-written message a `debug_string` returning that *message* rather than a structural render — exactly the conflation D15 exists to remove. Hence explicit primitive impls, matching Rust, which has no blanket `Debug` over `Display`.

## Not in this PR

`derive(Error)` with per-variant format strings (thiserror's `#[error("…")]`). `derive_rule` does receive `trait_params`, so it looks expressible — but it is its own change.

## Verification

- `tests/derive.test.yo` **53/53** (3 new: an error enum carrying both channels, a struct's structural render, `Debug` on primitives)
- `yo check ./std` 173/173, `./src` 266/266, `fmt --check` clean, compiler self-build green
- full suite **3595 passed**

## Merge timing

Additive, but sequenced with the rest of the D-batch for the **v0.2.28** window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)