### PR TITLE
verifier: Z3 solver harness + yo verify subcommand (V2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -332,6 +332,79 @@ jobs:
           path: yo-out/site
           retention-days: 7
 
+  # Formal verification (V2 of plans/backlog/FORMAL_VERIFICATION.md): the
+  # verifier harness against the REAL pinned Z3 — the hermetic layers of
+  # tests/internal/verifier.test.yo run in the ordinary `test` job; this job
+  # flips YO_TEST_Z3=1 so the real-solver obligations execute, and produces
+  # the `yo verify` JSON report as an artifact for inspection. NOT a
+  # required check until V3 lands (the plan's CI section); a red job here
+  # is a solver-harness regression, not a language regression.
+  verify:
+    name: Formal verification (pinned Z3)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      Z3_VERSION: "4.13.3"
+      YO_TEST_Z3: "1"
+      YO_STD: ${{ github.workspace }}/std
+      YO_SKILLS: ${{ github.workspace }}/.github/skills
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Z3 pin consistency guard
+        run: |
+          set -euo pipefail
+          pin_src=$(grep -E '^Z3_VERSION :: "' src/verifier/z3.yo | sed -E 's/^Z3_VERSION :: "([^"]+)".*/\1/')
+          pin_wf="${Z3_VERSION}"
+          if [ -z "$pin_src" ] || [ "$pin_src" != "$pin_wf" ]; then
+            echo "::error::Z3 pin diverges: src/verifier/z3.yo has '$pin_src', test.yml has '$pin_wf' — a bump must change BOTH (plans/backlog/FORMAL_VERIFICATION.md §Solver harness)."
+            exit 1
+          fi
+          echo "Z3 pin consistent: $pin_src"
+
+      - name: Install the pinned Z3
+        run: |
+          set -euo pipefail
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y unzip
+          curl -fsSL -o /tmp/z3.zip \
+            "https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/z3-${Z3_VERSION}-x64-glibc-2.35.zip"
+          unzip -o /tmp/z3.zip -d /tmp/z3-install
+          sudo cp "/tmp/z3-install/z3-${Z3_VERSION}-x64-glibc-2.35/bin/z3" /usr/local/bin/z3
+          z3 --version
+
+      # The seed links liburing dynamically and cannot start without it.
+      - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
+        run: |
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
+
+      - name: Install the seed compiler
+        uses: ./.github/actions/install-seed
+        with:
+          version: ${{ env.SEED_VERSION }}
+
+      - name: Verifier unit tests (real solver)
+        run: yo test ./tests/internal/verifier.test.yo --bail -v
+
+      - name: yo verify harness report (JSON)
+        run: |
+          yo verify ./std/spec --format json | tee verify-report.json
+
+      - name: Upload the verify report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-report
+          path: verify-report.json
+          retention-days: 7
+
   test:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/issues/async-closure-value-struct-param-emits-invalid-c-cast.md
+++ b/issues/async-closure-value-struct-param-emits-invalid-c-cast.md
@@ -1,0 +1,107 @@
+# An async closure capturing a by-value struct parameter emits an invalid C cast
+
+**Status: OPEN** (surfaced 2026-09-07 by Phase V2 of
+`plans/backlog/FORMAL_VERIFICATION.md` — `src/verifier/driver.yo`'s async
+functions took a `VerifyRunConfig` value-struct parameter).
+
+## Error
+
+`yo check` passes (the def-time trial swallows it — the ICE guard for
+"never fully evaluated" does not fire because the closure body itself is
+fine; only the CAPTURE is malformed). The failure surfaces at the C
+compile step of `yo build`:
+
+```
+yo.c:2555870:160: error: used type '__yo_t50' (aka 'struct __yo_t50_struct')
+      where arithmetic or pointer type is required
+```
+
+The generated resume body reads the captured parameter as
+
+```c
+(_state_t*)yo_id_21303((__yo_t36*)(...), (__yo_t50)(sm->__yo_param_0), ...);
+```
+
+— a cast to the struct's own C type, which is not a legal scalar/pointer
+cast. The `sm->__yo_param_<i>` field is ALREADY declared with the
+parameter's C type (`ClosureParamSlot`/`SyncParamSlot` carry `c_type`), so
+the cast is redundant for every type and invalid for by-value structs.
+
+## Reproducer
+
+```rust
+open(import("std/string"));
+{ assert } :: import("std/assert");
+C :: struct(a : bool);
+probe :: (
+  fn(c : C, io : Io) -> Impl(Future(unit, IoExn))
+)(
+  io.async((e : IoExn) => {
+    if(c.a, {
+      eprintln(String.from("a"));
+    });
+    ()
+  })
+);
+export(probe);
+```
+
+`yo check` accepts it; `yo compile` dies in the C compile (or emits the
+invalid cast into `--emit-c` output). Making `C` a `ref(struct(...))`
+compiles fine — the cast is harmless for pointer types.
+
+## Root cause analysis
+
+The state-machine emitter renders a captured closure parameter's reads as
+`(T)(sm->__yo_param_<i>)`. For reference/pointer types this is a no-op
+cast; for by-value struct types C rejects it outright. The parameter slot
+fields are typed (`__yo_t50 __yo_param_0;`), so the read should be a bare
+`sm->__yo_param_<i>` — or, where a `void*` slot is genuinely used, an
+explicit dereference/memcpy rather than a cast.
+
+## Fix direction
+
+Find the variable-read remapping that wraps `__yo_param_<i>` slot reads in
+a cast (`src/codegen/exprs/async.yo` builds the slots;
+`src/codegen/async/state_machine.yo`'s variable context installs the
+remapping) and emit the bare field access — the field already carries the
+right type.
+
+## Follow-up findings (2026-09-07, deeper bisecting)
+
+The invalid cast is one face of a broader **capture-mode state-machine
+argument-rendering** defect cluster:
+
+1. **Missing-name soft-fallbacks cascade.** An `io.async` closure whose
+   body references a name not in scope (e.g. `IoExn` without
+   `import("std/error")`) silently degrades the await call's recorded arg
+   info; the result is either the "closure body never fully evaluated"
+   ICE at codegen or the invalid `(T)(slot)` cast above. The def-time
+   trial swallows the not-found error (repro: any tmp file with
+   `io.async((e : IoExn) => e.io.await(write_string(p, s, e.io), e))` and
+   no std/error import).
+2. **`.io`/`.exn` member projection is position-dependent.** In plain
+   segments, `e.io` args render `slot.io` (healthy sites across src/);
+   in cond-branch arms and in capture-mode SMs (a closure holding a
+   ref-typed local like `q : VcQuery` across a suspension) the member
+   access is dropped and the whole bundle slot is cast to the param type.
+   A bundle-typed parameter (`bundle : IoExn`, invoked as
+   `bundle.io.async(...)`) renders as a same-type slot passthrough and is
+   the only arm-safe shape found.
+3. **ASan: heap-use-after-free on resume.** A capture-mode SM with a
+   ref-struct capture (the pre-sync V2 driver) hits a UAF in
+   `__yo_incr_rc` inside the generated `<sm>_resume` — the capture is
+   dropped at suspension and re-incremented on resume
+   (`issues/async-closure-value-struct-param-emits-invalid-c-cast.md`,
+   ASan backtrace captured).
+
+The V2 verifier sidestepped the whole cluster by going synchronous (the
+`module_manager.yo` comptime-file-IO idiom: libc open/read/fopen +
+`system(3)` for the solver spawn); its only async function is the one-time
+Z3 download install, kept in `version_cache.yo`'s proven shape. The
+underlying async-backend bugs remain OPEN.
+
+## Notes
+
+- Worked around in V2 by the sync harness (see above); `VerifyRunConfig`
+  stayed a value struct after all.

--- a/issues/plain-recursive-enum-segfaults-the-evaluator.md
+++ b/issues/plain-recursive-enum-segfaults-the-evaluator.md
@@ -1,0 +1,77 @@
+# A plain (non-`ref`) enum whose variant fields recurse into itself SEGFAULTS the evaluator instead of erroring
+
+**Status: OPEN** (surfaced 2026-09-07 by Phase V2 of
+`plans/backlog/FORMAL_VERIFICATION.md` — the `src/verifier/terms.yo` VC term
+IR was originally written as a plain `enum` and crashed the compiler).
+
+## Error
+
+```
+$ yo check src/verifier/terms.yo
+Segmentation fault (core dumped)          # rc=139 — no diagnostic at all
+```
+
+Reproduces with the seed release v0.2.27 AND with a current-develop
+self-built binary. `YO_MAIN_STACK_MB=4096` does NOT help — the recursion is
+infinite, not merely deep.
+
+## Reproducer
+
+Any module that (a) defines a plain `enum` whose recursion reaches itself
+(`App(op, args : ArrayList(Self))` and/or `Quant(..., body : Self)`), (b)
+puts that enum in a `ref(struct(...))` field together with
+`ArrayList(<struct-holding-the-enum>)` fields, and (c) defines a function
+CONSTRUCTING the struct (forcing size/type walks) — the exact shape is the
+pre-`ref` `src/verifier/terms.yo` (see "Root cause" for the minimal
+reduction attempts). The crash needs the construction/machinery that forces
+a size computation of the cyclic value type; type definitions alone pass.
+
+## Root cause analysis
+
+The crash is an infinite mutual recursion in the TYPE SIZE machinery of
+`src/types/utils.yo`:
+
+- `get_size_of_type`'s `.EnumT` branch (utils.yo:1697) computes a value
+  enum's size by walking every variant's field types
+  (`_variant_storage_field_types` → `_aggregate_size` → per-field
+  `get_size_of_type`).
+- For a plain enum `E` with `App(args : ArrayList(E))`, the walk descends
+  `E → ArrayList(E) → E → …` — but `ArrayList` IS reference semantics, so
+  that particular cycle terminates (pointer size). The crash needs the
+  cycle to be re-entered through the *enclosing struct* machinery
+  (`VcQuery` field walks via compat/constructor paths), where the
+  ref-indirection bookkeeping does not cut the loop.
+- `get_size_of_type`'s only cycle guard is the `e_ref` short-circuit for
+  `ref(enum(…))` ("without it the variant-field walk recurses forever on a
+  recursive ref-enum", utils.yo:1691-1696) — there is NO guard for plain
+  enums reached through struct fields, and no `visited` set anywhere in the
+  size/alignment family (`get_alignment_of_type`, `_aggregate_size`,
+  `_max_field_alignment`).
+
+Under gdb the stack is thousands of frames of
+`get_size_of_type ↔ _aggregate_size` until the crash lands in mimalloc.
+
+The DEEPER issue: a plain value enum that recursively contains itself
+WITHOUT a reference indirection on every cycle is not layoutable in C at
+all (infinite size) — `AstExpr` is `ref(enum(…))` for exactly this reason
+(`src/expr.yo:281`). The compiler should REJECT such a definition with a
+clean diagnostic ("recursive value enum must be `ref(enum(…))` — a value
+enum cannot contain itself by value"), not segfault at the next size query.
+
+## Fix direction
+
+1. At enum-type evaluation (definition time), run a structural cycle check
+   over the variant field types: any path from the enum back to itself that
+   does not pass through reference-semantics indirection (`ref(struct)`,
+   `ref(enum)`, `ArrayList`, `Box`, …) is a hard error with the hint above.
+2. Belt-and-braces: thread a `visited` set through the size/alignment
+   walkers in `src/types/utils.yo` so a missed cycle yields `.None`
+   (unknown size) instead of a stack overflow.
+
+## Notes
+
+- `JsonValue` (`std/encoding/json.yo`) is the surviving precedent of a
+  plain enum recursive only via `ArrayList(Self)` — legal and unchanged.
+- The V2 verifier IR uses `ref(enum(…))` for `VcTerm`/`Z3Sexpr` (the
+  `AstExpr` shape), which is the correct design for an interned tree IR
+  regardless of this bug.

--- a/plans/backlog/FORMAL_VERIFICATION.md
+++ b/plans/backlog/FORMAL_VERIFICATION.md
@@ -897,6 +897,37 @@ all `tests/spec/` green; cheatsheet updated.
 
 ### Phase V2 — Solver harness & verifier skeleton
 
+> **Status: LANDED 2026-09-07.** `src/verifier/{terms,encode,z3,driver}.yo`
+> + the `yo verify` subcommand + `tests/internal/verifier.test.yo`
+> (17 tests: encode goldens, mangling, sexpr scanning, verdict mapping,
+> cache-key stability, and two YO_TEST_Z3=1-gated real-solver tests) + the
+> `verify` CI job in test.yml (installs the pinned Z3, Z3-pin consistency
+> guard, JSON report artifact; NOT a required check until V3).
+> Validated end-to-end locally: `yo verify` proves `1+1==2`, refutes
+> `1+1==3` with counter-example `x = #x00000002`, harness OK; cache
+> roundtrip verified.
+>
+> **Deviations from the plan (recorded):**
+> 1. The harness is **synchronous** (the `module_manager.yo`
+>    comptime-file-IO idiom: libc open/read/fopen + `system(3)` for the
+>    solver spawn; script and redirected output travel as FILE paths).
+>    The async route hit a cluster of pre-existing capture-mode
+>    state-machine bugs — invalid C struct casts, `.io` member-projection
+>    loss in cond-branch arms, an ASan-confirmed use-after-free on resume
+>    — filed as
+>    `issues/async-closure-value-struct-param-emits-invalid-c-cast.md`.
+>    The ONE async path left is the one-time download install
+>    (`_install_z3`), in `version_cache.yo`'s proven shape.
+> 2. **One z3 process per query** (stronger isolation than push/pop per
+>    function) — spawn cost is ms-scale.
+> 3. z3's nonzero exit on unavailable post-check-sat evidence
+>    (get-value on unsat / get-unsat-core on sat) is tolerated when a
+>    verdict was parsed; `system(3)`'s wait status is decoded.
+> 4. Surfaced and filed on the way:
+>    `issues/plain-recursive-enum-segfaults-the-evaluator.md` (a plain
+>    `enum` recursing into itself SIGSEGVs the size walk instead of
+>    erroring — the V2 IR uses `ref(enum)` per the `AstExpr` precedent).
+
 **Scope:** everything needed to talk to Z3, before any real VC.
 
 Tasks:

--- a/src/main.yo
+++ b/src/main.yo
@@ -54,6 +54,16 @@ _(env : proc_env) :: import("std/env");
 { generate_public_safe_report, format_public_safe_report, public_safe_report_to_json } :: import("./public_safe_report.yo");
 { HashMap } :: import("std/collections/hash_map");
 { remove_dir_all } :: import("./fetch.yo");
+{
+  verify_mode_of_string,
+  default_verify_run_config,
+  resolve_solver_sync,
+  SolverResolution,
+  verifier_harness_self_test
+} :: import("./verifier/driver.yo");
+{ ensure_z3 } :: import("./verifier/z3.yo");
+{ Z3_VERSION } :: import("./verifier/z3.yo");
+{ json_stringify, JsonValue } :: import("std/encoding/json");
 { Environment } :: import("./env.yo");
 // The demand-driven module loader, the cached prelude env, the shared codegen
 // ExprInfoTable and std-path resolution all live in `module_manager.yo` — the
@@ -776,6 +786,301 @@ run_check :: (
   if(failed > usize(0), {
     exn.throw(dyn(`check: ${failed.to_string()} file(s) failed evaluator coverage`));
   });
+});
+/// Run the `verify` subcommand — the compile-time verifier driver (V2 of
+/// plans/backlog/FORMAL_VERIFICATION.md).
+///
+/// V2 scope: resolve the pinned Z3 (YO_Z3_PATH → `~/.cache/yo/solvers/…`,
+/// auto-install on miss), run the harness SELF-TEST obligations through
+/// the full encode → spawn → parse → cache pipeline, and report harness
+/// health. The path argument is accepted and scanned (so bad paths fail
+/// fast); real per-function verification obligations land in V3.
+run_verify_cmd :: (
+  fn(
+    argv : ArrayList(String),
+    io : Io,
+    exn : Exception
+  ) -> unit
+)({
+  (target_path : String) = String.new();
+  (solver_path : Option(String)) = Option(String).None;
+  (mode_str : String) = String.new();
+  (rlimit_opt : Option(usize)) = Option(usize).None;
+  (format_json : bool) = false;
+  (no_cache : bool) = false;
+  (explain_fn : Option(String)) = Option(String).None;
+  (ai : usize) = usize(2);
+  while(ai < argv.len(), {
+    a := argv(ai);
+    (a_name : String) = a.clone();
+    (a_val : Option(String)) = Option(String).None;
+    if(a.starts_with("--"), {
+      (eq_at : isize) = (isize(0) - isize(1));
+      (sc_i : usize) = usize(0);
+      while((sc_i < a.len()) && (eq_at < isize(0)), {
+        if(a.byte_at(sc_i) == u8(61), {
+          eq_at = isize(sc_i);
+        });
+        sc_i = (sc_i + usize(1));
+      });
+      if(eq_at > isize(0), {
+        a_name = a.substring(usize(0), usize(eq_at));
+        a_val = Option(String).Some(a.substring(usize(eq_at) + usize(1), a.len()));
+      });
+    });
+    cond(
+      ((a_name == "--verify-mode") || (a_name == "--solver-path")) => {
+        v := _opt_value(argv, ai, a_name.clone(), a_val.clone(), exn);
+        if(a_name == "--verify-mode", {
+          mode_str = v;
+        }, {
+          solver_path = Option(String).Some(v);
+        });
+        ai = (ai + _opt_step(a_val));
+      },
+      (a_name == "--rlimit") => {
+        v2 := _opt_value(argv, ai, a_name.clone(), a_val.clone(), exn);
+        match(
+          v2.parse_u64(),
+          .Some(n) => {
+            rlimit_opt = Option(usize).Some(usize(n));
+          },
+          .None => {
+            exn.throw(dyn(`verify: --rlimit expects a non-negative integer, got '${v2}'`));
+          }
+        );
+        ai = (ai + _opt_step(a_val));
+      },
+      (a_name == "--format") => {
+        v3 := _opt_value(argv, ai, a_name.clone(), a_val.clone(), exn);
+        if(v3 == "json", {
+          format_json = true;
+        }, {
+          if(v3 == "text", {
+            format_json = false;
+          }, {
+            exn.throw(dyn(`verify: --format expects 'text' or 'json', got '${v3}'`));
+          });
+        });
+        ai = (ai + _opt_step(a_val));
+      },
+      (a_name == "--no-cache") => {
+        no_cache = true;
+        ai = (ai + usize(1));
+      },
+      (a_name == "--explain") => {
+        explain_fn = Option(String).Some(_opt_value(argv, ai, a_name.clone(), a_val.clone(), exn));
+        ai = (ai + _opt_step(a_val));
+      },
+      a.starts_with(String.from("-")) => {
+        exn.throw(
+          dyn(
+            `verify: unknown option '${a}'. Usage: yo verify [path] [--verify-mode runtime|verify|verify+] [--solver-path PATH] [--rlimit N] [--format text|json] [--explain FN] [--no-cache]`
+          )
+        );
+      },
+      true => {
+        if(target_path.len() > usize(0), {
+          exn.throw(dyn(`verify: multiple paths given ('${target_path}' and '${a}') — verify one path per invocation`));
+        });
+        target_path = a.clone();
+        ai = (ai + usize(1));
+      }
+    );
+  });
+  if(mode_str.len() > usize(0), {
+    match(
+      verify_mode_of_string(mode_str.clone()),
+      .Some(_) => (),
+      .None => {
+        exn.throw(
+          dyn(`verify: --verify-mode expects 'runtime', 'verify', or 'verify+', got '${mode_str}'`)
+        );
+      }
+    );
+  });
+  if(explain_fn.is_some(), {
+    exn.throw(dyn(`verify: --explain arrives with the per-function verification pass (Phase V3)`));
+  });
+  // Validate the target path up front (fail fast on a typo) and report the
+  // file count; the verification pass itself is V3.
+  (file_count : usize) = usize(0);
+  if(target_path.len() > usize(0), {
+    files := collect_check_files(target_path.clone(), ArrayList(String).new(), io, exn);
+    file_count = files.len();
+    if(file_count == usize(0), {
+      exn.throw(dyn(`verify: no .yo files found at ${target_path}`));
+    });
+  });
+  cfg := default_verify_run_config();
+  cfg.solver_path = solver_path;
+  cfg.no_cache = no_cache;
+  match(
+    rlimit_opt,
+    .Some(n) => {
+      cfg.encode_opts.rlimit = n;
+    },
+    .None => ()
+  );
+  // Sync resolution first (discovery / explicit path); only a discovery MISS
+  // runs the async one-time download install — the rest of the harness is
+  // synchronous by design (see src/verifier/z3.yo's header note).
+  binary := match(
+    resolve_solver_sync(cfg),
+    .Resolved(path) => path,
+    .InvalidPath(path) => {
+      exn.throw(dyn(`verify: solver path '${path}' does not exist`));
+      String.new()
+    },
+    .Installable => io.await(ensure_z3(io, exn), IoExn(io : io, exn : exn))
+  );
+  results := verifier_harness_self_test(cfg, binary.clone());
+  // Harness health: obligation 1 must PROVE, obligation 2 must REFUTE with
+  // a concrete counter-example (guards against a solver that answers
+  // garbage, or an encoding that proves by being wrong).
+  (harness_ok : bool) = true;
+  match(
+    results.get(usize(0)),
+    .Some(r1) => {
+      match(
+        r1.verdict,
+        .Proved(_) => (),
+        _ => {
+          harness_ok = false;
+        }
+      );
+    },
+    .None => {
+      harness_ok = false;
+    }
+  );
+  match(
+    results.get(usize(1)),
+    .Some(r2) => {
+      match(
+        r2.verdict,
+        .Refuted(ce) => {
+          if(ce.len() == usize(0), {
+            harness_ok = false;
+          });
+        },
+        _ => {
+          harness_ok = false;
+        }
+      );
+    },
+    .None => {
+      harness_ok = false;
+    }
+  );
+  if(format_json, {
+    entries := ArrayList(JsonValue).new();
+    (ri : usize) = usize(0);
+    while(ri < results.len(), {
+      match(
+        results.get(ri),
+        .Some(r) => {
+          verdict_json := match(
+            r.verdict,
+            .Proved(_) => JsonValue.Str(String.from("proved")),
+            .Refuted(ce) => _verify_json_strs(ce),
+            .Unproven(reason) => JsonValue.Str(`unproven: ${reason}`),
+            .SolverError(msg) => JsonValue.Str(`solver-error: ${msg}`)
+          );
+          ks := ArrayList(String).new();
+          ks.push(String.from("query"));
+          ks.push(String.from("verdict"));
+          ks.push(String.from("cached"));
+          vs := ArrayList(JsonValue).new();
+          vs.push(JsonValue.Str(r.query_name.clone()));
+          vs.push(verdict_json);
+          vs.push(JsonValue.Bool(r.cached));
+          entries.push(JsonValue.Object(keys : ks, values : vs));
+        },
+        .None => ()
+      );
+      ri = (ri + usize(1));
+    });
+    ks2 := ArrayList(String).new();
+    ks2.push(String.from("solver"));
+    ks2.push(String.from("z3_pin"));
+    ks2.push(String.from("harness_ok"));
+    ks2.push(String.from("self_test"));
+    vs2 := ArrayList(JsonValue).new();
+    vs2.push(JsonValue.Str(binary.clone()));
+    vs2.push(JsonValue.Str(String.from(Z3_VERSION)));
+    vs2.push(JsonValue.Bool(harness_ok));
+    vs2.push(JsonValue.Array(entries));
+    println(json_stringify(JsonValue.Object(keys : ks2, values : vs2)));
+  }, {
+    println(`verify: solver: ${binary} (z3 ${Z3_VERSION})`);
+    if(target_path.len() > usize(0), {
+      println(`verify: target: ${target_path} (${file_count.to_string()} .yo file(s)) — per-function verification arrives in V3`);
+    });
+    (ri2 : usize) = usize(0);
+    while(ri2 < results.len(), {
+      match(
+        results.get(ri2),
+        .Some(r) => {
+          cached_mark := if(r.cached, String.from(" (cached)"), String.from(""));
+          detail := match(
+            r.verdict,
+            .Proved(_) => String.from("PROVED"),
+            .Refuted(ce) => `REFUTED  counter-example: ${_verify_join_strs(ce, String.from(", "))}`,
+            .Unproven(reason) => `UNPROVEN  ${reason}`,
+            .SolverError(msg) => `SOLVER-ERROR  ${msg}`
+          );
+          println(`verify: ${r.query_name}: ${detail}${cached_mark}`);
+        },
+        .None => ()
+      );
+      ri2 = (ri2 + usize(1));
+    });
+    println(
+      cond(
+        harness_ok => tr(String.from("verify: harness OK"), String.from("verify：自检通过")),
+        true => tr(String.from("verify: harness FAILED"), String.from("verify：自检失败"))
+      )
+    );
+  });
+  if(!(harness_ok), {
+    exn.throw(dyn(String.from("verify: solver harness self-test failed")));
+  });
+});
+/// JSON array of strings (the verify subcommand's counter-example shape).
+_verify_json_strs :: (fn(ss : ArrayList(String)) -> JsonValue)({
+  items := ArrayList(JsonValue).new();
+  (i : usize) = usize(0);
+  while(i < ss.len(), {
+    match(
+      ss.get(i),
+      .Some(s) => {
+        items.push(JsonValue.Str(s.clone()));
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  JsonValue.Array(items)
+});
+/// Comma-join (the verify subcommand's text rendering).
+_verify_join_strs :: (fn(ss : ArrayList(String), sep : String) -> String)({
+  sb := StringBuilder.new();
+  (i : usize) = usize(0);
+  while(i < ss.len(), {
+    match(
+      ss.get(i),
+      .Some(s) => {
+        if(i > usize(0), {
+          sb.write_string(sep);
+        });
+        sb.write_string(s);
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  sb.to_string()
 });
 /// How far the arg cursor advances for a value option: 1 when the value was
 /// attached (`--flag=value`), 2 for the space form.
@@ -3900,6 +4205,11 @@ Examples:
   $ yo fmt src tests             Format .yo files under src and tests
   $ yo fmt --check               Check formatting without writing files
 
+yo verify [path] [options]       Compile-time verification (Z3)
+Examples:
+  $ yo verify ./src              Verify a file/directory
+  $ yo verify --format json      Machine-readable verdicts
+
 yo doc [path] [options]          Generate API documentation
 Examples:
   $ yo doc                       Document all .yo files in current directory
@@ -3980,6 +4290,11 @@ yo fmt [paths...] [options]      格式化 Yo 源文件
   $ yo fmt                       格式化当前目录下所有 .yo 文件
   $ yo fmt src tests             格式化 src 和 tests 下的 .yo 文件
   $ yo fmt --check               只检查格式，不写入文件
+
+yo verify [path] [options]       编译期验证（Z3）
+示例：
+  $ yo verify ./src              验证文件/目录
+  $ yo verify --format json      输出机器可读的判定结果
 
 yo doc [path] [options]          生成 API 文档
 示例：
@@ -4363,6 +4678,51 @@ Examples:
 示例：
   $ yo check ./src
   $ yo check ./std --exclude std/libc`
+      )
+    ),
+    (subcmd == "verify") => Option(String).Some(
+      tr(
+        `Usage: yo verify [path] [options]
+
+Compile-time verification with the pinned Z3 solver (Dafny/SPARK model;
+Phase V2 of plans/backlog/FORMAL_VERIFICATION.md — currently the solver
+harness self-test; per-function proof obligations arrive in V3).
+
+The solver is resolved from YO_Z3_PATH, then the pinned install in
+~/.cache/yo/solvers/, and is auto-downloaded from GitHub Releases when
+neither exists.
+
+Options:
+  --verify-mode <mode>      runtime | verify | verify+ (default runtime)
+  --solver-path <path>      Use this z3 binary (overrides discovery)
+  --rlimit <n>              Solver resource budget (default 5000000)
+  --format <text|json>      Output format (default text)
+  --explain <fn>            Show the VC set for one function (V3)
+  --no-cache                Skip the verification cache
+
+Examples:
+  $ yo verify ./src
+  $ yo verify --solver-path /usr/bin/z3 --format json`,
+        `用法：yo verify [路径] [选项]
+
+使用固定版本的 Z3 求解器做编译期验证（Dafny/SPARK 模型；
+plans/backlog/FORMAL_VERIFICATION.md 的 V2 阶段——目前为求解器管线
+自检；逐函数证明义务在 V3 落地）。
+
+求解器依次从 YO_Z3_PATH、~/.cache/yo/solvers/ 中的固定安装解析，
+都不存在时自动从 GitHub Releases 下载。
+
+选项：
+  --verify-mode <模式>     runtime | verify | verify+（默认 runtime）
+  --solver-path <路径>     使用指定的 z3 二进制（覆盖自动发现）
+  --rlimit <n>             求解器资源预算（默认 5000000）
+  --format <text|json>     输出格式（默认 text）
+  --explain <函数名>       展示单个函数的验证条件集（V3）
+  --no-cache               跳过验证缓存
+
+示例：
+  $ yo verify ./src
+  $ yo verify --solver-path /usr/bin/z3 --format json`
       )
     ),
     (subcmd == "fmt") => Option(String).Some(
@@ -4919,6 +5279,8 @@ main :: (fn(io : Io) -> unit)({
     run_fmt(argv, io, exn);
   }, if(subcmd == "check", {
     run_check(argv, io, exn);
+  }, if(subcmd == "verify", {
+    run_verify_cmd(argv, io, exn);
   }, if(subcmd == "init", {
     run_init(argv, io, exn);
   }, if(subcmd == "build", {
@@ -4940,7 +5302,7 @@ main :: (fn(io : Io) -> unit)({
   }, if(subcmd == "version", {
     run_version_cmd(argv, io, exn);
   }, {
-    exn.throw(dyn(tr(`unknown subcommand '${subcmd}'. Usage: yo <compile|test|fmt|check|init|build|fetch|install|cache|doc|version|lsp|unsafe-report|public-safe-report|skills> ...`, `未知子命令 '${subcmd}'。用法：yo <compile|test|fmt|check|init|build|fetch|install|cache|doc|version|lsp|unsafe-report|public-safe-report|skills> ...`)));
+    exn.throw(dyn(tr(`unknown subcommand '${subcmd}'. Usage: yo <compile|test|fmt|check|verify|init|build|fetch|install|cache|doc|version|lsp|unsafe-report|public-safe-report|skills> ...`, `未知子命令 '${subcmd}'。用法：yo <compile|test|fmt|check|verify|init|build|fetch|install|cache|doc|version|lsp|unsafe-report|public-safe-report|skills> ...`)));
   })))))))))))))));
 });
 export(main);

--- a/src/verifier/driver.yo
+++ b/src/verifier/driver.yo
@@ -1,0 +1,428 @@
+//! verifier/driver — scheduling, budgets, verdicts, caching (V2).
+//!
+//! The driver owns the per-obligation lifecycle: build the cache key
+//! (sha256 of the query's SMT content + the pin + the run options), look
+//! the verdict up in `~/.cache/yo/verify-cache/<key>.json`, and only on a
+//! miss spawn the solver. Cache hits are reported (`cached: proved`) so CI
+//! logs stay honest. Any input change — predicate text, callee contract
+//! set, solver pin, mode, options — invalidates the key.
+open(import("std/string"));
+open(import("std/fmt"));
+{ ArrayList } :: import("std/collections/array_list");
+{ env, home_dir } :: import("std/env");
+{ Exception, IoExn } :: import("std/error");
+{ json_parse_string, json_stringify, JsonValue } :: import("std/encoding/json");
+{ sha256_hex } :: import("std/crypto/sha256");
+{ VcQuery, VcSort, VcTerm, VcOp, new_vc_query, vc_eq } :: import("./terms.yo");
+{ encode_content, encode_script, EncodeOptions, default_encode_options } :: import("./encode.yo");
+{
+  Z3_VERSION,
+  ensure_z3,
+  discover_z3,
+  run_z3_script,
+  parse_z3_sexprs,
+  z3_check_sat_of,
+  z3_unsat_core_of,
+  z3_value_pairs_of,
+  _z3_exists_sync,
+  _z3_read_file_sync,
+  _z3_write_file_sync,
+  _z3_mkdir_p_sync
+} :: import("./z3.yo");
+// ============================================================================
+// Options & verdicts
+// ============================================================================
+/// Verification mode per the plan's pragma table (`runtime` default).
+VerifyMode :: enum(
+  /// Contracts lower to runtime asserts — today's behavior, no solver.
+  Runtime,
+  /// Proof obligations; refuted or unprovable ⇒ compile error.
+  Verify,
+  /// Flagship: prove when possible, fall back to runtime asserts.
+  VerifyOrAssert
+);
+/// Parse a `--verify-mode` spelling (`runtime` / `verify` / `verify+`).
+verify_mode_of_string :: (fn(s : String) -> Option(VerifyMode))(
+  cond(
+    (s == "runtime") => Option(VerifyMode).Some(VerifyMode.Runtime),
+    (s == "verify") => Option(VerifyMode).Some(VerifyMode.Verify),
+    (s == "verify+") => Option(VerifyMode).Some(VerifyMode.VerifyOrAssert),
+    true => Option(VerifyMode).None
+  )
+);
+/// Run configuration: budgets and overrides. Part of the cache key.
+VerifyRunConfig :: struct(
+  /// Solver binary override (`--solver-path`); `.None` = discover/install.
+  solver_path : Option(String),
+  /// Encode/run options (rlimit budget, seed, backstop, evidence).
+  encode_opts : EncodeOptions,
+  /// Skip the verification cache for this run (`--no-cache`).
+  no_cache : bool
+);
+/// Default run config: default encode options, no override, cache on.
+default_verify_run_config :: (fn() -> VerifyRunConfig)(
+  VerifyRunConfig(
+    solver_path : Option(String).None,
+    encode_opts : default_encode_options(),
+    no_cache : false
+  )
+);
+/// The verdict of one obligation.
+VerifyVerdict :: enum(
+  /// unsat — the goal holds under the assumptions. Carries the unsat
+  /// core's clause names when available.
+  Proved(core : ArrayList(String)),
+  /// sat — the goal FAILS; the counter-example names the inputs.
+  Refuted(counterexample : ArrayList(String)),
+  /// unknown / budget exhausted — nothing concluded.
+  Unproven(reason : String),
+  /// The solver could not be run at all (missing, crashed).
+  SolverError(message : String)
+);
+/// One obligation result: what was asked and what came back.
+VerifyResult :: ref(
+  struct(
+    query_name : String,
+    verdict : VerifyVerdict,
+    /// `true` when the verdict came from the cache, not the solver.
+    cached : bool
+  )
+);
+// ============================================================================
+// JSON helpers
+// ============================================================================
+/// A two-key JSON object.
+_json_obj2 :: (fn(k1 : String, v1 : JsonValue, k2 : String, v2 : JsonValue) -> JsonValue)({
+  ks := ArrayList(String).new();
+  ks.push(k1);
+  ks.push(k2);
+  vs := ArrayList(JsonValue).new();
+  vs.push(v1);
+  vs.push(v2);
+  JsonValue.Object(keys : ks, values : vs)
+});
+/// A JSON array of strings.
+_strs_to_json :: (fn(ss : ArrayList(String)) -> JsonValue)({
+  items := ArrayList(JsonValue).new();
+  (i : usize) = usize(0);
+  while(i < ss.len(), {
+    match(
+      ss.get(i),
+      .Some(s) => {
+        items.push(JsonValue.Str(s.clone()));
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  JsonValue.Array(items)
+});
+/// A `ArrayList(String)` out of a JSON array of strings (mismatched items
+/// are skipped).
+_strs_of_json :: (fn(j : JsonValue) -> ArrayList(String))({
+  out := ArrayList(String).new();
+  match(
+    j.as_array(),
+    .Some(items) => {
+      (i : usize) = usize(0);
+      while(i < items.len(), {
+        match(
+          items.get(i),
+          .Some(item) => {
+            // Nested patterns do not parse — match twice.
+            match(
+              item,
+              .Str(s) => {
+                out.push(s.clone());
+              },
+              _ => ()
+            );
+          },
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+    },
+    .None => ()
+  );
+  out
+});
+/// Serialize a verdict to the cache-file JSON shape.
+_verdict_to_json :: (fn(v : VerifyVerdict) -> JsonValue)(
+  match(
+    v,
+    .Proved(core) => _json_obj2(
+      String.from("verdict"),
+      JsonValue.Str(String.from("proved")),
+      String.from("core"),
+      _strs_to_json(core)
+    ),
+    .Refuted(ce) => _json_obj2(
+      String.from("verdict"),
+      JsonValue.Str(String.from("refuted")),
+      String.from("counterexample"),
+      _strs_to_json(ce)
+    ),
+    .Unproven(reason) => _json_obj2(
+      String.from("verdict"),
+      JsonValue.Str(String.from("unproven")),
+      String.from("reason"),
+      JsonValue.Str(reason.clone())
+    ),
+    .SolverError(msg) => _json_obj2(
+      String.from("verdict"),
+      JsonValue.Str(String.from("solver-error")),
+      String.from("message"),
+      JsonValue.Str(msg.clone())
+    )
+  )
+);
+/// Parse a cached verdict back. Returns `.None` on any shape mismatch —
+/// a corrupt cache entry is a miss, not an error.
+_verdict_of_json :: (fn(v : JsonValue) -> Option(VerifyVerdict))({
+  // Nested patterns (`.Some(.Str(s))`) do not parse — match twice, and arm
+  // bodies nest their match DIRECTLY (a `{ match(...); }` block would make
+  // the arm's value unit).
+  kind := match(
+    v.get(String.from("verdict")),
+    .Some(kind_val) => match(
+      kind_val,
+      .Str(s) => s.clone(),
+      _ => String.new()
+    ),
+    .None => String.new()
+  );
+  if(kind.len() == usize(0), {
+    return(Option(VerifyVerdict).None);
+  });
+  cond(
+    (kind == "proved") => match(
+      v.get(String.from("core")),
+      .Some(core_json) => Option(VerifyVerdict).Some(VerifyVerdict.Proved(_strs_of_json(core_json))),
+      .None => Option(VerifyVerdict).Some(VerifyVerdict.Proved(ArrayList(String).new()))
+    ),
+    (kind == "refuted") => match(
+      v.get(String.from("counterexample")),
+      .Some(ce_json) => Option(VerifyVerdict).Some(VerifyVerdict.Refuted(_strs_of_json(ce_json))),
+      .None => Option(VerifyVerdict).None
+    ),
+    (kind == "unproven") => match(
+      v.get(String.from("reason")),
+      .Some(reason_val) => match(
+        reason_val,
+        .Str(r) => Option(VerifyVerdict).Some(VerifyVerdict.Unproven(r.clone())),
+        _ => Option(VerifyVerdict).None
+      ),
+      .None => Option(VerifyVerdict).None
+    ),
+    (kind == "solver-error") => match(
+      v.get(String.from("message")),
+      .Some(msg_val) => match(
+        msg_val,
+        .Str(m) => Option(VerifyVerdict).Some(VerifyVerdict.SolverError(m.clone())),
+        _ => Option(VerifyVerdict).None
+      ),
+      .None => Option(VerifyVerdict).None
+    ),
+    true => Option(VerifyVerdict).None
+  )
+});
+// ============================================================================
+// Cache
+// ============================================================================
+/// The verification cache directory.
+verify_cache_dir :: (fn() -> String)({
+  root := match(
+    env.get(String.from("YO_CACHE_DIR")),
+    .Some(d) => d,
+    .None => match(
+      env.get(String.from("XDG_CACHE_HOME")),
+      .Some(d) => d.concat(String.from("/yo")),
+      .None => match(
+        home_dir(),
+        .Some(h) => h.concat(String.from("/.cache/yo")),
+        .None => String.from(".yo-cache")
+      )
+    )
+  );
+  `${root}/verify-cache`
+});
+/// The cache key: sha256 of (solver pin, run options, query content). All
+/// inputs are text; each part is newline-terminated so the concatenation
+/// is unambiguous.
+verify_cache_key :: (fn(q : VcQuery, cfg : VerifyRunConfig) -> String)({
+  material := StringBuilder.new();
+  material.write_string(`z3=${Z3_VERSION}\n`);
+  material.write_string(`rlimit=${cfg.encode_opts.rlimit.to_string()}\n`);
+  material.write_string(`seed=${cfg.encode_opts.random_seed.to_string()}\n`);
+  material.write_string(`timeout=${cfg.encode_opts.timeout_ms.to_string()}\n`);
+  material.write_string(encode_content(q));
+  sha256_hex(material.to_string().as_bytes())
+});
+// ============================================================================
+// Running one obligation
+// ============================================================================
+/// Interpret a raw solver response stream into a verdict (pure — the
+/// unit-testable seam between the harness and the protocol).
+verdict_of_response :: (fn(response : String) -> VerifyVerdict)({
+  forms := parse_z3_sexprs(response);
+  match(
+    z3_check_sat_of(forms),
+    .Some(v) => cond(
+      (v == "unsat") => VerifyVerdict.Proved(z3_unsat_core_of(forms)),
+      (v == "sat") => VerifyVerdict.Refuted(z3_value_pairs_of(forms)),
+      true => VerifyVerdict.Unproven(response.trim())
+    ),
+    .None => VerifyVerdict.SolverError(response.trim())
+  )
+});
+/// Cache lookup for one obligation: `.Some(result)` on a hit, `.None` on
+/// miss/no-cache/corrupt entry. Synchronous (see the z3.yo header note).
+_cache_lookup :: (fn(q : VcQuery, cfg : VerifyRunConfig) -> Option(VerifyResult))({
+  if(cfg.no_cache, {
+    return(Option(VerifyResult).None);
+  });
+  key := verify_cache_key(q, cfg);
+  cache_path := `${verify_cache_dir()}/${key}.json`;
+  match(
+    _z3_read_file_sync(cache_path.clone()),
+    .None => Option(VerifyResult).None,
+    .Some(content) => match(
+      json_parse_string(content),
+      // The store's shape is {query, verdict: {...}} — unwrap the verdict
+      // member before parsing it. A corrupt cache entry is a MISS, not an
+      // error — the store overwrites.
+      .Ok(j) => match(
+        j.get(String.from("verdict")),
+        .Some(vj) => match(
+          _verdict_of_json(vj),
+          .Some(v) => Option(VerifyResult).Some(VerifyResult(query_name : q.name.clone(), verdict : v, cached : true)),
+          .None => Option(VerifyResult).None
+        ),
+        .None => Option(VerifyResult).None
+      ),
+      .Err(_) => Option(VerifyResult).None
+    )
+  )
+});
+/// Cache store for one obligation. Terminal verdicts only — a SolverError
+/// (missing/crashed solver) must retry on the next run.
+_cache_store :: (fn(q : VcQuery, verdict : VerifyVerdict) -> unit)({
+  _z3_mkdir_p_sync(verify_cache_dir());
+  key := verify_cache_key(q, default_verify_run_config());
+  cache_path := `${verify_cache_dir()}/${key}.json`;
+  payload := _json_obj2(
+    String.from("query"),
+    JsonValue.Str(q.name.clone()),
+    String.from("verdict"),
+    _verdict_to_json(verdict)
+  );
+  _ := _z3_write_file_sync(cache_path.clone(), json_stringify(payload));
+  ()
+});
+/// Run one obligation end-to-end: cache lookup → solver → parse → cache
+/// store. Synchronous — the solver spawn itself is libc `system(3)`
+/// (z3.yo), so there is no event-loop interaction anywhere in the hot path.
+run_vc_query :: (fn(q : VcQuery, cfg : VerifyRunConfig, binary : String) -> VerifyResult)({
+  cached_opt := _cache_lookup(q, cfg);
+  match(
+    cached_opt,
+    .Some(cached) => {
+      return(cached);
+    },
+    .None => ()
+  );
+  script := encode_script(q, cfg.encode_opts);
+  verdict := match(
+    run_z3_script(binary.clone(), script),
+    .Ok(response) => verdict_of_response(response),
+    .Err(msg) => VerifyVerdict.SolverError(msg)
+  );
+  is_terminal := match(
+    verdict,
+    .SolverError(_) => false,
+    _ => true
+  );
+  if(is_terminal, {
+    _cache_store(q, verdict);
+  });
+  VerifyResult(query_name : q.name.clone(), verdict : verdict, cached : false)
+});
+/// Outcome of the synchronous solver resolution.
+SolverResolution :: enum(
+  /// A usable binary path.
+  Resolved(path : String),
+  /// Nothing found — the caller may run the async one-time install
+  /// (`ensure_z3`).
+  Installable,
+  /// An explicit `--solver-path` that does not exist (a hard error).
+  InvalidPath(path : String)
+);
+/// Sync solver resolution: an explicit `--solver-path` is validated;
+/// otherwise discovery. No event-loop interaction.
+resolve_solver_sync :: (fn(cfg : VerifyRunConfig) -> SolverResolution)(
+  match(
+    cfg.solver_path,
+    .Some(p) => if(
+      _z3_exists_sync(p.clone()),
+      SolverResolution.Resolved(path : p),
+      SolverResolution.InvalidPath(path : p)
+    ),
+    .None => match(
+      discover_z3(),
+      .Some(p) => SolverResolution.Resolved(path : p),
+      .None => SolverResolution.Installable
+    )
+  )
+);
+// ============================================================================
+// Harness self-test (V2): the two canonical obligations
+// ============================================================================
+/// The self-test assumption `x == (bvadd 1 1)` over a fresh 32-bit x.
+_self_test_sum_assumption :: (fn() -> VcTerm)({
+  eq_args := ArrayList(VcTerm).new();
+  eq_args.push(VcTerm.Var(name : String.from("x"), sort : VcSort.BvS(width : usize(32))));
+  add_args := ArrayList(VcTerm).new();
+  add_args.push(VcTerm.BvLit(value : u64(1), width : usize(32)));
+  add_args.push(VcTerm.BvLit(value : u64(1), width : usize(32)));
+  eq_args.push(VcTerm.App(VcOp.BvAdd, add_args));
+  VcTerm.App(VcOp.EqOp, eq_args)
+});
+/// Build one self-test obligation: `x := 1+1 ⊢ x == goal_val`.
+_self_test_query :: (fn(name : String, goal_val : u64) -> VcQuery)({
+  q := new_vc_query(name);
+  q.declare(String.from("x"), VcSort.BvS(width : usize(32)));
+  q.assume(_self_test_sum_assumption());
+  q.goal = vc_eq(
+    VcTerm.Var(name : String.from("x"), sort : VcSort.BvS(width : usize(32))),
+    VcTerm.BvLit(value : goal_val, width : usize(32))
+  );
+  q
+});
+/// The harness self-test obligations (plan V2 task 6): `1+1==2` must prove
+/// (unsat) and `1+1==3` must refute with a concrete counter-example (sat +
+/// model). They exercise the full encode → spawn → parse → cache pipeline
+/// with zero language surface.
+verifier_harness_self_test :: (fn(cfg : VerifyRunConfig, binary : String) -> ArrayList(VerifyResult))({
+  results := ArrayList(VerifyResult).new();
+  q1 := _self_test_query(String.from("self-test: one_plus_one_eq_2"), u64(2));
+  results.push(run_vc_query(q1, cfg, binary.clone()));
+  q2 := _self_test_query(String.from("self-test: one_plus_one_eq_3"), u64(3));
+  results.push(run_vc_query(q2, cfg, binary.clone()));
+  results
+});
+export(
+  VerifyMode,
+  verify_mode_of_string,
+  VerifyRunConfig,
+  default_verify_run_config,
+  VerifyVerdict,
+  VerifyResult,
+  verify_cache_dir,
+  verify_cache_key,
+  verdict_of_response,
+  run_vc_query,
+  resolve_solver_sync,
+  SolverResolution,
+  verifier_harness_self_test
+);

--- a/src/verifier/encode.yo
+++ b/src/verifier/encode.yo
@@ -1,0 +1,289 @@
+//! verifier/encode — VC terms → SMT-LIB 2 text (V2).
+//!
+//! The emitter is deterministic by construction (fixed walk order, no
+//! timestamps, no hashing-visible state), so golden-string unit tests can
+//! exact-match the output — the plan's requirement for readable goldens of
+//! emitted SMT-LIB.
+//!
+//! The output splits in two:
+//!   - `encode_content` — declarations + assumptions + negated goal +
+//!     check-sat: the LOGIC of the obligation. This text feeds the cache
+//!     key together with the run options.
+//!   - `encode_script` — the full script: determinism options, then the
+//!     content, then the post-check-sat evidence directives
+//!     (get-unsat-core / get-value for the counter-example).
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ VcSort, VcOp, VcTerm, VcQuantKind, VcQuery } :: import("./terms.yo");
+// ============================================================================
+// Name mangling
+// ============================================================================
+/// Sanitize a source identifier for SMT-LIB: keep [A-Za-z0-9_], replace
+/// every other byte with `_`. Mangled names are stable across runs because
+/// the walk order that produces them is stable.
+_sanitize_smt_name :: (fn(name : String) -> String)({
+  sb := StringBuilder.new();
+  {
+    it := name.chars();
+    while(true, {
+      r := match(it.next(), .Some(x) => x, .None => break);
+      c := r.char;
+      if(((c >= u32(0x41)) && (c <= u32(0x5A))) ||
+        ((c >= u32(0x61)) && (c <= u32(0x7A))) ||
+          ((c >= u32(0x30)) && (c <= u32(0x39))) || (c == u32(0x5F)), {
+        sb.write_rune(r);
+      }, {
+        sb.write_byte(u8(0x5F));
+      });
+    });
+  };
+  sb.to_string()
+});
+/// Mangle a source variable for function `fn_prefix` into the stable
+/// `__yo_v<fn>_<name>` form (the plan's name-mangling contract), so
+/// counter-examples render as the user's own names.
+mangle_vc_name :: (fn(fn_prefix : String, name : String) -> String)(
+  `__yo_v${_sanitize_smt_name(fn_prefix)}_${_sanitize_smt_name(name)}`
+);
+// ============================================================================
+// Sorts
+// ============================================================================
+/// The SMT-LIB spelling of a sort.
+encode_sort :: (fn(s : VcSort) -> String)(
+  match(
+    s,
+    .BoolS => String.from("Bool"),
+    .BvS(w) => `(_ BitVec ${w.to_string()})`
+  )
+);
+// ============================================================================
+// Operators
+// ============================================================================
+/// The SMT-LIB head for a plain (non-indexed) operator.
+_op_name :: (fn(op : VcOp) -> String)(
+  match(
+    op,
+    .BvAdd => String.from("bvadd"),
+    .BvSub => String.from("bvsub"),
+    .BvMul => String.from("bvmul"),
+    .BvSdiv => String.from("bvsdiv"),
+    .BvUdiv => String.from("bvudiv"),
+    .BvSrem => String.from("bvsrem"),
+    .BvUrem => String.from("bvurem"),
+    .BvNeg => String.from("bvneg"),
+    .BvShl => String.from("bvshl"),
+    .BvLshr => String.from("bvlshr"),
+    .BvAshr => String.from("bvashr"),
+    .BvNotOp => String.from("bvnot"),
+    .BvAndOp => String.from("bvand"),
+    .BvOrOp => String.from("bvor"),
+    .BvXorOp => String.from("bvxor"),
+    .BvUlt => String.from("bvult"),
+    .BvUle => String.from("bvule"),
+    .BvUgt => String.from("bvugt"),
+    .BvUge => String.from("bvuge"),
+    .BvSlt => String.from("bvslt"),
+    .BvSle => String.from("bvsle"),
+    .BvSgt => String.from("bvsgt"),
+    .BvSge => String.from("bvsge"),
+    .EqOp => String.from("="),
+    .DistinctOp => String.from("distinct"),
+    .NotOp => String.from("not"),
+    .AndOp => String.from("and"),
+    .OrOp => String.from("or"),
+    .ImpOp => String.from("=>"),
+    .IteOp => String.from("ite"),
+    // Indexed operators are handled structurally in encode_term.
+    .SignExtendOp(_) => String.from("sign_extend"),
+    .ZeroExtendOp(_) => String.from("zero_extend"),
+    .ExtractOp(_, _) => String.from("extract")
+  )
+);
+// ============================================================================
+// Terms
+// ============================================================================
+/// The SMT-LIB spelling of a term (deterministic walk).
+encode_term :: (fn(t : VcTerm) -> String)(
+  match(
+    t,
+    .Var(name, _) => name.clone(),
+    .BvLit(value, width) => `(_ bv${value.to_string()} ${width.to_string()})`,
+    .BoolLit(value) => cond(value => String.from("true"), true => String.from("false")),
+    .App(op, args) => {
+      head := match(
+        op,
+        .SignExtendOp(k) => `(_ sign_extend ${k.to_string()})`,
+        .ZeroExtendOp(k) => `(_ zero_extend ${k.to_string()})`,
+        .ExtractOp(hi, lo) => `(_ extract ${hi.to_string()} ${lo.to_string()})`,
+        _ => _op_name(op)
+      );
+      sb := StringBuilder.new();
+      sb.write_byte(u8(0x28));
+      sb.write_string(head);
+      (i : usize) = usize(0);
+      while(i < args.len(), {
+        match(
+          args.get(i),
+          .Some(a) => {
+            sb.write_byte(u8(0x20));
+            sb.write_string(encode_term(a));
+          },
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+      sb.write_byte(u8(0x29));
+      sb.to_string()
+    },
+    .Quant(kind, names, sorts, body) => {
+      kw := match(
+        kind,
+        .Forall => String.from("forall"),
+        .Exists => String.from("exists")
+      );
+      sb := StringBuilder.new();
+      sb.write_byte(u8(0x28));
+      sb.write_string(kw);
+      sb.write_str(" (");
+      (i : usize) = usize(0);
+      while(i < names.len(), {
+        n := match(names.get(i), .Some(x) => x, .None => String.from("_"));
+        s := match(
+          sorts.get(i),
+          .Some(x) => encode_sort(x),
+          .None => String.from("Bool")
+        );
+        if(i > usize(0), {
+          sb.write_byte(u8(0x20));
+        });
+        sb.write_byte(u8(0x28));
+        sb.write_string(n);
+        sb.write_byte(u8(0x20));
+        sb.write_string(s);
+        sb.write_byte(u8(0x29));
+        i = (i + usize(1));
+      });
+      sb.write_byte(u8(0x29));
+      sb.write_byte(u8(0x20));
+      sb.write_string(encode_term(body));
+      sb.write_byte(u8(0x29));
+      sb.to_string()
+    }
+  )
+);
+// ============================================================================
+// Queries
+// ============================================================================
+/// The logic content of one obligation: declarations, named assumptions,
+/// the negated goal, and check-sat. No options, no evidence directives —
+/// this text (plus run options) is the cache key input.
+encode_content :: (fn(q : VcQuery) -> String)({
+  sb := StringBuilder.new();
+  (di : usize) = usize(0);
+  while(di < q.declarations.len(), {
+    match(
+      q.declarations.get(di),
+      .Some(d) => {
+        sb.write_string(`(declare-fun ${d.name} () ${encode_sort(d.sort)})\n`);
+      },
+      .None => ()
+    );
+    di = (di + usize(1));
+  });
+  (ai : usize) = usize(0);
+  while(ai < q.assumptions.len(), {
+    match(
+      q.assumptions.get(ai),
+      .Some(a) => {
+        match(
+          a.name,
+          .Some(n) => {
+            sb.write_string(`(assert (! ${encode_term(a.term)} :named ${n}))\n`);
+          },
+          .None => {
+            sb.write_string(`(assert ${encode_term(a.term)})\n`);
+          }
+        );
+      },
+      .None => ()
+    );
+    ai = (ai + usize(1));
+  });
+  sb.write_string(`(assert (not ${encode_term(q.goal)}))\n`);
+  sb.write_str("(check-sat)\n");
+  sb.to_string()
+});
+/// Determinism/evidence options for one solver run. Part of the cache key
+/// (a budget bump is an honestly different query).
+EncodeOptions :: struct(
+  /// Z3's deterministic resource budget (`:rlimit`).
+  rlimit : usize,
+  /// Fixed seed (`:random-seed 0` — never time-derived).
+  random_seed : usize,
+  /// Wall-clock crash guard backstop (`:timeout`, ms). If it fires before
+  /// the rlimit the verdict is Unproven, never a different logical outcome.
+  timeout_ms : u64,
+  /// Emit `(get-unsat-core)` after check-sat (Proved clause attribution).
+  want_unsat_core : bool,
+  /// Emit `(get-value ...)` over the query's declarations after check-sat
+  /// (counter-example extraction on Refuted).
+  want_counterexample : bool
+);
+/// Default options: rlimit 5,000,000 (a few seconds of BV work), fixed
+/// seed, 30 s backstop, all evidence on.
+default_encode_options :: (fn() -> EncodeOptions)(
+  EncodeOptions(
+    rlimit : usize(5000000),
+    random_seed : usize(0),
+    timeout_ms : u64(30000),
+    want_unsat_core : true,
+    want_counterexample : true
+  )
+);
+/// The full SMT-LIB script for one obligation. Layout is fixed:
+/// set-logic, options (deterministic order), content, evidence directives.
+encode_script :: (fn(q : VcQuery, opts : EncodeOptions) -> String)({
+  sb := StringBuilder.new();
+  sb.write_str("(set-logic ALL)\n");
+  sb.write_string(`(set-option :rlimit ${opts.rlimit.to_string()})\n`);
+  sb.write_string(`(set-option :random-seed ${opts.random_seed.to_string()})\n`);
+  sb.write_string(`(set-option :timeout ${opts.timeout_ms.to_string()})\n`);
+  if(opts.want_unsat_core, {
+    sb.write_str("(set-option :produce-unsat-cores true)\n");
+  });
+  if(opts.want_counterexample, {
+    sb.write_str("(set-option :produce-models true)\n");
+  });
+  sb.write_string(encode_content(q));
+  if(opts.want_unsat_core, {
+    sb.write_str("(get-unsat-core)\n");
+  });
+  if(opts.want_counterexample && (q.declarations.len() > usize(0)), {
+    sb.write_str("(get-value (");
+    (i : usize) = usize(0);
+    while(i < q.declarations.len(), {
+      match(
+        q.declarations.get(i),
+        .Some(d) => {
+          if(i > usize(0), {
+            sb.write_byte(u8(0x20));
+          });
+          sb.write_string(d.name);
+        },
+        .None => ()
+      );
+      i = (i + usize(1));
+    });
+    sb.write_str("))\n");
+  });
+  sb.to_string()
+});
+export(
+  mangle_vc_name,
+  encode_sort,
+  encode_term,
+  encode_content,
+  encode_script,
+  EncodeOptions,
+  default_encode_options
+);

--- a/src/verifier/terms.yo
+++ b/src/verifier/terms.yo
@@ -1,0 +1,229 @@
+//! verifier/terms — the in-memory VC term representation (V2).
+//!
+//! Pure data, no I/O: sorts, terms, quantifiers, and the per-obligation
+//! query shape the encoder turns into SMT-LIB 2 and the solver harness
+//! discharges. The term vocabulary follows the SMT encoding reference in
+//! plans/backlog/FORMAL_VERIFICATION.md (bitvectors first — Yo's integers
+//! are the exact-width two's-complement values the C backend emits).
+//!
+//! Query shape: one obligation is a list of ASSUMED terms plus one GOAL.
+//! The runner asserts the assumptions, asserts the negation of the goal,
+//! and asks check-sat:
+//!   unsat    ⇒ the goal is PROVED under the assumptions
+//!   sat      ⇒ REFUTED — the model is the counter-example
+//!   unknown  ⇒ Unproven (budget)
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ ToString } :: import("std/fmt/to_string");
+// ============================================================================
+// Sorts
+// ============================================================================
+/// A VC sort. The verifiable subset starts at `bool` and exact-width
+/// bitvectors (the plan's sorts table); datatypes/arrays/Seq join in V3–V5.
+VcSort :: enum(
+  /// SMT `Bool`.
+  BoolS,
+  /// SMT `(_ BitVec <width>)` — widths 8/16/32/64 (and the target's usize).
+  BvS(width : usize)
+);
+derive(VcSort, Eq(VcSort));
+impl(
+  VcSort,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)(
+      match(
+        self,
+        .BoolS => String.from("bool"),
+        .BvS(w) => `bv${w.to_string()}`
+      )
+    )
+  )
+);
+// ============================================================================
+// Operators
+// ============================================================================
+/// A VC operator. Variant names follow SMT-LIB where there is one; the
+/// encoder maps each to its exact SMT-LIB spelling.
+VcOp :: enum(
+  // Bitvector arithmetic (exact-width, two's complement — matches the
+  // emitted C under -fwrapv).
+  BvAdd,
+  BvSub,
+  BvMul,
+  BvSdiv,
+  BvUdiv,
+  BvSrem,
+  BvUrem,
+  BvNeg,
+  // Bitvector shifts and bitwise.
+  BvShl,
+  BvLshr,
+  BvAshr,
+  BvNotOp,
+  BvAndOp,
+  BvOrOp,
+  BvXorOp,
+  // Bitvector comparisons (signedness is per the plan's operator table).
+  BvUlt,
+  BvUle,
+  BvUgt,
+  BvUge,
+  BvSlt,
+  BvSle,
+  BvSgt,
+  BvSge,
+  // Equality over any one sort.
+  EqOp,
+  DistinctOp,
+  // Boolean connectives.
+  NotOp,
+  AndOp,
+  OrOp,
+  ImpOp,
+  /// `ite` — if-then-else (3 args: cond, then, else).
+  IteOp,
+  // Width-changing casts (payload = bits added / hi..lo extracted).
+  /// `(_ sign_extend k)` — k = extra bits.
+  SignExtendOp(extra : usize),
+  /// `(_ zero_extend k)` — k = extra bits.
+  ZeroExtendOp(extra : usize),
+  /// `(_ extract hi lo)` — hi..lo inclusive, hi >= lo.
+  ExtractOp(hi : usize, lo : usize)
+);
+// ============================================================================
+// Terms
+// ============================================================================
+/// Quantifier kind (V5 surface; the term IR carries them from V2 so the
+/// encoder and goldens are stable across phases).
+VcQuantKind :: enum(Forall, Exists);
+/// A VC term. Variables reference DECLARED constants (SSA-style: every
+/// Yo binding/renaming introduces a fresh declared name — no let binders).
+VcTerm :: ref(
+  enum(
+    /// Reference to a declared constant.
+    Var(name : String, sort : VcSort),
+    /// Bitvector literal as its unsigned two's-complement bit pattern
+    /// (covers every value of widths <= 64).
+    BvLit(value : u64, width : usize),
+    /// Boolean literal.
+    BoolLit(value : bool),
+    /// Operator application. Arity/widths are the BUILDER's responsibility
+    /// (checked at VC-construction time in V3, not re-checked here).
+    App(op : VcOp, args : ArrayList(Self)),
+    /// Quantifier with explicitly-typed bound variables.
+    Quant(kind : VcQuantKind, names : ArrayList(String), sorts : ArrayList(VcSort), body : Self)
+  )
+);
+/// One declared constant of a query.
+VcDecl :: struct(name : String, sort : VcSort);
+/// One assumed term of a query. The optional name participates in unsat
+/// cores (`(! term :named <name>)`) so a proof failure can name the
+/// smallest violated clause.
+VcAssumption :: struct(name : Option(String), term : VcTerm);
+/// One verification obligation: assumptions Φ and a goal P. Discharging
+/// means proving Φ ⇒ P (the runner checks Φ ∧ ¬P for unsat).
+VcQuery :: ref(
+  struct(
+    /// Obligation group name (function name + site) for diagnostics.
+    name : String,
+    /// Declared constants (variables of Φ and P).
+    declarations : ArrayList(VcDecl),
+    /// Assumed terms, conjoined.
+    assumptions : ArrayList(VcAssumption),
+    /// The obligation proper.
+    goal : VcTerm
+  )
+);
+impl(
+  VcQuery,
+  /// Builder: push a declaration.
+  declare : (fn(self : Self, name : String, sort : VcSort) -> Self)({
+    self.declarations.push(VcDecl(name : name.clone(), sort : sort));
+    self
+  }),
+  /// Builder: push an unnamed assumption.
+  assume : (fn(self : Self, term : VcTerm) -> Self)({
+    self.assumptions.push(VcAssumption(name : Option(String).None, term : term));
+    self
+  }),
+  /// Builder: push a named assumption (unsat-core attribution).
+  assume_named : (fn(self : Self, name : String, term : VcTerm) -> Self)({
+    self.assumptions.push(VcAssumption(name : Option(String).Some(name.clone()), term : term));
+    self
+  })
+);
+/// Construct an empty query with a diagnostic name.
+new_vc_query :: (fn(name : String) -> VcQuery)(
+  VcQuery(
+    name : name,
+    declarations : ArrayList(VcDecl).new(),
+    assumptions : ArrayList(VcAssumption).new(),
+    goal : VcTerm.BoolLit(true)
+  )
+);
+// ============================================================================
+// Convenience constructors (keep VC construction sites terse and uniform)
+// ============================================================================
+/// Boolean negation.
+vc_not :: (fn(t : VcTerm) -> VcTerm)({
+  args := ArrayList(VcTerm).new();
+  args.push(t);
+  VcTerm.App(VcOp.NotOp, args)
+});
+/// N-ary conjunction.
+vc_and :: (fn(ts : ArrayList(VcTerm)) -> VcTerm)({
+  if(ts.len() == usize(0), {
+    return(VcTerm.BoolLit(true));
+  });
+  if(ts.len() == usize(1), {
+    return(match(ts.get(usize(0)), .Some(t) => t, .None => VcTerm.BoolLit(true)));
+  });
+  VcTerm.App(VcOp.AndOp, ts)
+});
+/// N-ary disjunction.
+vc_or :: (fn(ts : ArrayList(VcTerm)) -> VcTerm)({
+  if(ts.len() == usize(0), {
+    return(VcTerm.BoolLit(false));
+  });
+  if(ts.len() == usize(1), {
+    return(match(ts.get(usize(0)), .Some(t) => t, .None => VcTerm.BoolLit(false)));
+  });
+  VcTerm.App(VcOp.OrOp, ts)
+});
+/// Implication `a => b` (right-associative chain when built pairwise).
+vc_imp :: (fn(a : VcTerm, b : VcTerm) -> VcTerm)({
+  args := ArrayList(VcTerm).new();
+  args.push(a);
+  args.push(b);
+  VcTerm.App(VcOp.ImpOp, args)
+});
+/// Equality `a = b`.
+vc_eq :: (fn(a : VcTerm, b : VcTerm) -> VcTerm)({
+  args := ArrayList(VcTerm).new();
+  args.push(a);
+  args.push(b);
+  VcTerm.App(VcOp.EqOp, args)
+});
+/// Distinctness `a != b`.
+vc_distinct :: (fn(a : VcTerm, b : VcTerm) -> VcTerm)({
+  args := ArrayList(VcTerm).new();
+  args.push(a);
+  args.push(b);
+  VcTerm.App(VcOp.DistinctOp, args)
+});
+export(
+  VcSort,
+  VcOp,
+  VcTerm,
+  VcQuantKind,
+  VcDecl,
+  VcAssumption,
+  VcQuery,
+  new_vc_query,
+  vc_not,
+  vc_and,
+  vc_or,
+  vc_imp,
+  vc_eq,
+  vc_distinct
+);

--- a/src/verifier/z3.yo
+++ b/src/verifier/z3.yo
@@ -1,0 +1,670 @@
+//! verifier/z3 — the Z3 solver harness (V2): pin, discovery, acquisition,
+//! and the request/response protocol.
+//!
+//! One solver, pinned and versioned (decision D2). Same source + same
+//! compiler + same pin ⇒ byte-identical verdicts:
+//!   - `:rlimit` budgets (deterministic resource accounting), never
+//!     wall-clock semantics; the `:timeout` is a crash-guard backstop only.
+//!   - fixed `:random-seed 0`.
+//!   - one fresh Z3 process per query — stronger isolation than the plan's
+//!     original "one process per function with push/pop" (no solver state
+//!     bleeds between obligations at all) at a few ms of spawn cost.
+//!
+//! SYNCHRONOUS ON PURPOSE (the `module_manager.yo` comptime-file-IO
+//! idiom): the verifier runs inside compile-time evaluation and inside
+//! async CLI tasks, where async `std/fs` compiles to a blocking poll loop
+//! that drives the event loop from inside a task (C37/C42 — the runtime
+//! guard aborts under YO_ASYNC_STRICT=1). Script I/O and the solver spawn
+//! use libc directly (`system(3)` + open/read/fopen); the ONLY async path
+//! is the one-time download install (`_install_z3` — std/http has no sync
+//! form), which mirrors `src/version_cache.yo`'s release-fetch shape.
+//!
+//! The query protocol (plan §"The query protocol"): each obligation runs as
+//! a complete SMT-LIB script passed as a FILE argument (`z3 -smt2 <file>`)
+//! with stdout/stderr redirected to a second file — no pipes, no
+//! truncation, no interactive state. The script asserts the assumptions,
+//! the NEGATED goal, and asks check-sat, then requests evidence:
+//!   unsat    ⇒ Proved (get-unsat-core names the participating clauses)
+//!   sat      ⇒ Refuted (get-value over the declarations = counter-example)
+//!   unknown  ⇒ Unproven (budget)
+pragma(Pragma.AllowUnsafe);
+open(import("std/string"));
+{ ArrayList } :: import("std/collections/array_list");
+{ env, temp_dir, home_dir } :: import("std/env");
+{ Exception, IoExn } :: import("std/error");
+{ FetchOptions, fetch_with } :: import("std/http/client");
+{ Command } :: import("std/process/command");
+{ host_target, is_target_windows, is_target_linux, is_target_macos, arch_triple_str } :: import("../target.yo");
+stat :: import("std/libc/sys/stat");
+fcntl :: import("std/libc/fcntl");
+unistd :: import("std/libc/unistd");
+stdio :: import("std/libc/stdio");
+stdlib :: import("std/libc/stdlib");
+{ GlobalAllocator } :: import("std/allocator");
+{ malloc, free } :: GlobalAllocator;
+extern(
+  "Yo",
+  __yo_errno : (fn() -> i32)
+);
+// ============================================================================
+// Pin manifest
+// ============================================================================
+/// The one pinned Z3 version (plan: start 4.13.3). Bumps are deliberate
+/// release-note events, never a side effect; the verification cache keys on
+/// this string so a bump invalidates honestly.
+Z3_VERSION :: "4.13.3";
+/// The host's Z3 release-asset stem (e.g. `x64-glibc-2.35`), derived from
+/// the canonical triple vocabulary of `src/target.yo`.
+z3_host_asset_stem :: (fn() -> String)({
+  t := host_target();
+  arch := String.from(arch_triple_str(t.arch));
+  cond(
+    (is_target_linux(t) && (arch == "x86_64")) => String.from("x64-glibc-2.35"),
+    (is_target_linux(t) && (arch == "aarch64")) => String.from("arm64-glibc-2.34"),
+    (is_target_macos(t) && (arch == "x86_64")) => String.from("x64-osx-13.7"),
+    (is_target_macos(t) && (arch == "aarch64")) => String.from("arm64-osx-13.7"),
+    (is_target_windows(t) && (arch == "x86_64")) => String.from("x64-win"),
+    (is_target_windows(t) && (arch == "aarch64")) => String.from("arm64-win"),
+    true => String.from("")
+  )
+});
+/// The global Yo cache root, mirroring `src/cache.yo`'s resolution order
+/// (`YO_CACHE_DIR` → `XDG_CACHE_HOME/yo` → `~/.cache/yo`).
+_yo_cache_root :: (fn() -> String)({
+  yo_cache_env := env.get(String.from("YO_CACHE_DIR"));
+  match(
+    yo_cache_env,
+    .Some(d) => d,
+    .None => {
+      xdg := env.get(String.from("XDG_CACHE_HOME"));
+      match(
+        xdg,
+        .Some(d) => d.concat(String.from("/yo")),
+        .None => {
+          home := home_dir();
+          match(
+            home,
+            .Some(h) => h.concat(String.from("/.cache/yo")),
+            .None => String.from(".yo-cache")
+          )
+        }
+      )
+    }
+  )
+});
+/// The solver binary's path inside the install directory.
+z3_binary_path :: (fn() -> String)({
+  stem := z3_host_asset_stem();
+  exe := cond(
+    is_target_windows(host_target()) => String.from("z3.exe"),
+    true => String.from("z3")
+  );
+  `${_yo_cache_root()}/solvers/z3-${Z3_VERSION}-${stem}/bin/${exe}`
+});
+/// The GitHub Releases download URL for the pinned asset.
+z3_download_url :: (fn() -> String)(
+  `https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/z3-${Z3_VERSION}-${z3_host_asset_stem()}.zip`
+);
+// ============================================================================
+// Sync file shims (the module_manager.yo comptime-file-IO idiom)
+// ============================================================================
+/// Whether `path` exists (libc `stat`; 512-byte statx buffer like
+/// module_manager's `_path_exists_sync`).
+_z3_exists_sync :: (fn(path : String) -> bool)({
+  cstr := path.to_cstr().ptr().unwrap();
+  buf := malloc(usize(512)).unwrap();
+  rc := unsafe(stat.stat((*char)(cstr), buf));
+  free(.Some(buf));
+  rc == int(0)
+});
+/// Read a whole file synchronously; `.None` on any failure (the caller
+/// decides what a missing/unreadable file means).
+_z3_read_file_sync :: (fn(path : String) -> Option(String))({
+  cstr := path.to_cstr().ptr().unwrap();
+  fd := unsafe(fcntl.open((*char)(cstr), int(fcntl.O_RDONLY)));
+  if(fd < int(0), {
+    return(Option(String).None);
+  });
+  result := ArrayList(u8).new();
+  buf := (*u8)(malloc(usize(4096)).unwrap());
+  while(runtime(true), {
+    // i64 immediately: `ssize_t` has no nameable constructor, but casting
+    // its RESULT is fine (module_manager.yo's note).
+    n := i64(unsafe(unistd.read(fd, (*void)(buf), usize(4096))));
+    cond(
+      (n < i64(0)) => {
+        free(.Some((*void)(buf)));
+        _ := unsafe(unistd.close(fd));
+        return(Option(String).None);
+      },
+      (n == i64(0)) => break,
+      true => {
+        (i : usize) = usize(0);
+        while(i < usize(n), {
+          result.push((buf.add(i)).*);
+          i = (i + usize(1));
+        });
+      }
+    );
+  });
+  free(.Some((*void)(buf)));
+  _ := unsafe(unistd.close(fd));
+  match(
+    String.from_utf8(result),
+    .Ok(s) => Option(String).Some(s),
+    .Err(_) => Option(String).None
+  )
+});
+/// Write a whole file synchronously (fopen "w": creates/truncates).
+/// `.false` on failure.
+_z3_write_file_sync :: (fn(path : String, contents : String) -> bool)({
+  pcstr := path.to_cstr().ptr().unwrap();
+  mcstr := String.from("w").to_cstr().ptr().unwrap();
+  f := unsafe(stdio.fopen((*char)(pcstr), (*char)(mcstr)));
+  match(
+    f,
+    .Some(fh) => {
+      b := contents.as_bytes();
+      bptr := match(
+        b.ptr(),
+        .Some(p) => p,
+        .None => (*u8)(malloc(usize(1)).unwrap())
+      );
+      wrote := unsafe(stdio.fwrite((*void)(bptr), usize(1), b.len(), fh));
+      _ := unsafe(stdio.fclose(fh));
+      wrote == b.len()
+    },
+    .None => false
+  )
+});
+/// Unlink a file (best effort — failures ignored; the temp dir recovers).
+_z3_unlink_sync :: (fn(path : String) -> unit)({
+  cstr := path.to_cstr().ptr().unwrap();
+  _ := unsafe(unistd.unlink((*char)(cstr)));
+  ()
+});
+/// Create `path` and every missing ancestor (mkdir -p; existing segments
+/// are fine). `mode` uses the exported `S_IRWXU` constant — `mode_t` is an
+/// opaque extern type with no nameable constructor (stat.yo's note).
+_z3_mkdir_p_sync :: (fn(path : String) -> unit)({
+  (i : usize) = usize(0);
+  b := path.as_bytes();
+  while(i < b.len(), {
+    match(
+      b.get(i),
+      .Some(c) => {
+        if((c == u8(47)) && (i > usize(0)), {
+          seg := path.substring(usize(0), i);
+          cstr := seg.to_cstr().ptr().unwrap();
+          _ := unsafe(stat.mkdir((*char)(cstr), stat.S_IRWXU));
+        });
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  cstr2 := path.to_cstr().ptr().unwrap();
+  _ := unsafe(stat.mkdir((*char)(cstr2), stat.S_IRWXU));
+  ()
+});
+/// Monotonic counter for temp-file names — unique within one process run,
+/// like the contract wrapper's `g_contract_old_counter`.
+(g_z3_tmp_counter : usize) = usize(0);
+/// A fresh temp path under the system temp dir (`<tmp>/yo-verify-<n>.<ext>`).
+_z3_temp_path :: (fn(ext : String) -> String)({
+  p := `${temp_dir()}/yo-verify-${g_z3_tmp_counter.to_string()}.${ext}`;
+  g_z3_tmp_counter = (g_z3_tmp_counter + usize(1));
+  p
+});
+// ============================================================================
+// Discovery & acquisition
+// ============================================================================
+/// Discovery order (plan §"Acquisition"): `YO_Z3_PATH` env override → the
+/// pinned install in the cache. `.None` when neither exists.
+discover_z3 :: (fn() -> Option(String))({
+  override := env.get(String.from("YO_Z3_PATH"));
+  match(
+    override,
+    .Some(p) => Option(String).Some(p),
+    .None => {
+      cached := z3_binary_path();
+      if(
+        _z3_exists_sync(cached.clone()),
+        Option(String).Some(cached),
+        Option(String).None
+      )
+    }
+  )
+});
+/// Download the pinned Z3 release asset into the solver cache and return
+/// the binary path. The ONLY async function in the harness: std/http has
+/// no sync form. Shape mirrors `src/version_cache.yo`'s release fetch —
+/// straight-line `e.io.await` calls, String-only values (the async backend
+/// mis-lowers captures of richer shapes; see
+/// issues/async-closure-value-struct-param-emits-invalid-c-cast.md).
+/// unzip extracts straight into the solvers root (`unzip -o` overwrites),
+/// so no rename/remove-dir dance is needed.
+_install_z3 :: (
+  fn(io : Io, exn : Exception) -> Impl(Future(String, IoExn))
+)(
+  io.async((e : IoExn) => {
+    stem := z3_host_asset_stem();
+    if(stem.len() == usize(0), {
+      e.exn.throw(
+        dyn(
+          `verify: no pinned Z3 release asset for this host (${host_target().triple}). Set YO_Z3_PATH to an existing z3 binary.`
+        )
+      );
+    });
+    solvers_root := `${_yo_cache_root()}/solvers`;
+    _z3_mkdir_p_sync(solvers_root.clone());
+    zip_path := _z3_temp_path(String.from("zip"));
+    url := z3_download_url();
+    opts := FetchOptions.new();
+    opts = opts.with_header(`User-Agent`, `yo-verifier`);
+    opts = opts.with_max_redirects(usize(5));
+    opts = opts.with_max_response_bytes(usize(268435456));
+    resp := e.io.await(fetch_with(url.clone(), opts, e.io), e);
+    if(resp.status_code >= i32(400), {
+      e.exn.throw(dyn(`verify: failed to download Z3 (HTTP ${resp.status_code.to_string()}) from ${url}`));
+    });
+    if(!_z3_write_file_sync(zip_path.clone(), resp.body), {
+      e.exn.throw(dyn(`verify: failed to write ${zip_path}`));
+    });
+    uc := Command.new(String.from("unzip"));
+    uc.arg(String.from("-o"));
+    uc.arg(zip_path.clone());
+    uc.arg(String.from("-d"));
+    uc.arg(solvers_root.clone());
+    uout := e.io.await(uc.output(e.io), e);
+    _z3_unlink_sync(zip_path.clone());
+    if(!uout.status.success(), {
+      e.exn.throw(
+        dyn(
+          `verify: 'unzip' failed to extract the Z3 archive. Install 'unzip' (or set YO_Z3_PATH to an existing z3 binary).`
+        )
+      );
+    });
+    bin := z3_binary_path();
+    if(!_z3_exists_sync(bin.clone()), {
+      e.exn.throw(
+        dyn(`verify: Z3 archive extracted but ${bin} is missing — unexpected archive layout from ${url}`)
+      );
+    });
+    bin
+  })
+);
+/// Resolve the solver: discovery first, install on miss.
+ensure_z3 :: (
+  fn(io : Io, exn : Exception) -> Impl(Future(String, IoExn))
+)(
+  io.async(
+    (e : IoExn) => match(
+      discover_z3(),
+      .Some(p) => p,
+      .None => e.io.await(_install_z3(e.io, e.exn), e)
+    )
+  )
+);
+// ============================================================================
+// The query protocol
+// ============================================================================
+/// Run one complete SMT-LIB script through a fresh `z3 -smt2 <file>`
+/// process and return its combined stdout (stderr redirected in). Errors
+/// carry the exit status and the captured output for the diagnostic.
+run_z3_script :: (fn(binary : String, script : String) -> Result(String, String))({
+  script_path := _z3_temp_path(String.from("smt2"));
+  out_path := _z3_temp_path(String.from("out"));
+  if(!_z3_write_file_sync(script_path.clone(), script), {
+    return(Result(String, String).Err(`verify: failed to write ${script_path}`));
+  });
+  cmd := `${binary} -smt2 ${script_path} > ${out_path} 2>&1`;
+  cmd_cstr := cmd.to_cstr().ptr().unwrap();
+  status := unsafe(stdlib.system(Option(*char).Some((*char)(cmd_cstr))));
+  out_opt := _z3_read_file_sync(out_path.clone());
+  _z3_unlink_sync(script_path.clone());
+  _z3_unlink_sync(out_path.clone());
+  out := match(
+    out_opt,
+    .Some(o) => o,
+    .None => String.new()
+  );
+  if(status < int(0), {
+    return(Result(String, String).Err(`verify: failed to spawn z3 (${status.to_string()})`));
+  });
+  // system(3) returns the WAIT status; the exit code is the high byte.
+  exit_code := (status / int(256));
+  // z3 exits nonzero when a post-check-sat EVIDENCE request is unavailable
+  // (get-value on unsat, get-unsat-core on sat) — it still prints the error
+  // AND the verdict, so a parseable verdict wins over the exit status.
+  if((exit_code != int(0)) && z3_check_sat_of(parse_z3_sexprs(out.clone())).is_none(), {
+    return(
+      Result(String, String).Err(`verify: z3 exited with status ${exit_code.to_string()}\n${out}`)
+    );
+  });
+  Result(String, String).Ok(out)
+});
+// ============================================================================
+// S-expression scanning (verdict parsing — pure, unit-testable)
+// ============================================================================
+/// A parsed S-expression: atom or list.
+Z3Sexpr :: ref(
+  enum(Atom(text : String), List(items : ArrayList(Self)))
+);
+/// Parse ALL top-level S-expressions in `text` (whitespace and `;` line
+/// comments tolerated). Unclosed lists are dropped rather than thrown —
+/// the caller decides what missing evidence means.
+parse_z3_sexprs :: (fn(text : String) -> ArrayList(Z3Sexpr))({
+  out := ArrayList(Z3Sexpr).new();
+  stack := ArrayList(ArrayList(Z3Sexpr)).new();
+  b := text.as_bytes();
+  (i : usize) = usize(0);
+  while(i < b.len(), {
+    c := match(b.get(i), .Some(x) => x, .None => u8(0));
+    cond(
+      ((c == u8(0x20)) || (c == u8(0x09)) || (c == u8(0x0A)) || (c == u8(0x0D))) => {
+        i = (i + usize(1));
+      },
+      (c == u8(0x3B)) => {
+        // ';' comment — skip to end of line (leave the \n for the next pass).
+        (j : usize) = i;
+        while(j < b.len(), {
+          cc := match(b.get(j), .Some(x) => x, .None => u8(0x0A));
+          if(cc == u8(0x0A), {
+            break;
+          });
+          j = (j + usize(1));
+        });
+        i = j;
+      },
+      (c == u8(0x28)) => {
+        frame := ArrayList(Z3Sexpr).new();
+        stack.push(frame);
+        i = (i + usize(1));
+      },
+      (c == u8(0x29)) => {
+        frame := match(
+          stack.pop(),
+          .Some(f) => f,
+          .None => ArrayList(Z3Sexpr).new()
+        );
+        list := Z3Sexpr.List(frame);
+        match(
+          stack.pop(),
+          .Some(parent) => {
+            parent.push(list);
+            stack.push(parent);
+          },
+          .None => {
+            out.push(list);
+          }
+        );
+        i = (i + usize(1));
+      },
+      true => {
+        // Atom: run of bytes that are not whitespace, parens, or comment.
+        start := i;
+        while(i < b.len(), {
+          cc := match(b.get(i), .Some(x) => x, .None => u8(0));
+          if((cc == u8(0x20)) || (cc == u8(0x09)) || (cc == u8(0x0A)) || (cc == u8(0x0D)) || (cc == u8(0x28)) || (cc == u8(0x29)) || (cc == u8(0x3B)), {
+            break;
+          });
+          i = (i + usize(1));
+        });
+        // substring takes (start, END), not (start, len).
+        atom := Z3Sexpr.Atom(text.substring(start, i));
+        match(
+          stack.pop(),
+          .Some(parent) => {
+            parent.push(atom);
+            stack.push(parent);
+          },
+          .None => {
+            out.push(atom);
+          }
+        );
+      }
+    );
+  });
+  out
+});
+/// Render one sexpr back to text (counter-example rendering).
+z3_sexpr_to_string :: (fn(s : Z3Sexpr) -> String)(
+  match(
+    s,
+    .Atom(t) => t.clone(),
+    .List(items) => {
+      sb := StringBuilder.new();
+      sb.write_byte(u8(0x28));
+      (i : usize) = usize(0);
+      while(i < items.len(), {
+        match(
+          items.get(i),
+          .Some(x) => {
+            if(i > usize(0), {
+              sb.write_byte(u8(0x20));
+            });
+            sb.write_string(z3_sexpr_to_string(x));
+          },
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+      sb.write_byte(u8(0x29));
+      sb.to_string()
+    }
+  )
+);
+/// The check-sat verdict of a response stream: the FIRST top-level atom
+/// among `unsat` / `sat` / `unknown`. `.None` when the stream has none
+/// (solver error — the caller reports the raw output).
+z3_check_sat_of :: (fn(forms : ArrayList(Z3Sexpr)) -> Option(String))({
+  (i : usize) = usize(0);
+  while(i < forms.len(), {
+    match(
+      forms.get(i),
+      .Some(form) => {
+        // Nested patterns do not parse — match twice.
+        match(
+          form,
+          .Atom(t) => {
+            if((t == "unsat") || (t == "sat") || (t == "unknown"), {
+              return(Option(String).Some(t.clone()));
+            });
+          },
+          _ => ()
+        );
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  Option(String).None
+});
+/// The text of `items[0]` when it is an atom (`.None` otherwise) — the
+/// nested-match helper for keyword-led response forms.
+_head_atom_text :: (fn(items : ArrayList(Z3Sexpr)) -> Option(String))(
+  match(
+    items.get(usize(0)),
+    .Some(head) => match(
+      head,
+      .Atom(t) => Option(String).Some(t.clone()),
+      _ => Option(String).None
+    ),
+    .None => Option(String).None
+  )
+);
+/// The unsat core: the first top-level BARE list of atoms (z3 prints it as
+/// `(name1 name2 ...)` right after unsat). Keyword-led forms (`(error …)`,
+/// `(model …)`, `(define-fun …)`) and the get-value response shape are
+/// skipped.
+z3_unsat_core_of :: (fn(forms : ArrayList(Z3Sexpr)) -> ArrayList(String))({
+  out := ArrayList(String).new();
+  (i : usize) = usize(0);
+  while(i < forms.len(), {
+    match(
+      forms.get(i),
+      .Some(form) => {
+        match(
+          form,
+          .List(items) => {
+            head_kw := match(
+              _head_atom_text(items),
+              .Some(t) => ((t == "error") || (t == "model") || (t == "define-fun")),
+              .None => false
+            );
+            if(!head_kw, {
+              all_atoms := true;
+              (j : usize) = usize(0);
+              while(j < items.len(), {
+                match(
+                  items.get(j),
+                  .Some(item) => {
+                    match(
+                      item,
+                      .Atom(_) => (),
+                      _ => {
+                        all_atoms = false;
+                      }
+                    );
+                  },
+                  .None => ()
+                );
+                if(!all_atoms, {
+                  break;
+                });
+                j = (j + usize(1));
+              });
+              if(all_atoms && (items.len() > usize(0)), {
+                (k : usize) = usize(0);
+                while(k < items.len(), {
+                  match(
+                    items.get(k),
+                    .Some(item2) => {
+                      match(
+                        item2,
+                        .Atom(t) => {
+                          out.push(t.clone());
+                        },
+                        _ => ()
+                      );
+                    },
+                    .None => ()
+                  );
+                  k = (k + usize(1));
+                });
+                return(out);
+              });
+            });
+          },
+          _ => ()
+        );
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  out
+});
+/// The `(get-value ...)` response: a top-level list of `(name value)`
+/// pairs, rendered as `name = value` strings in response order.
+z3_value_pairs_of :: (fn(forms : ArrayList(Z3Sexpr)) -> ArrayList(String))({
+  out := ArrayList(String).new();
+  (i : usize) = usize(0);
+  while(i < forms.len(), {
+    match(
+      forms.get(i),
+      .Some(form) => {
+        match(
+          form,
+          .List(pairs) => {
+            plausible := (pairs.len() > usize(0));
+            (j : usize) = usize(0);
+            while(j < pairs.len(), {
+              match(
+                pairs.get(j),
+                .Some(pair) => {
+                  match(
+                    pair,
+                    .List(kv) => {
+                      if(kv.len() != usize(2), {
+                        plausible = false;
+                      });
+                    },
+                    _ => {
+                      plausible = false;
+                    }
+                  );
+                },
+                .None => {
+                  plausible = false;
+                }
+              );
+              if(!plausible, {
+                break;
+              });
+              j = (j + usize(1));
+            });
+            if(plausible, {
+              (k : usize) = usize(0);
+              while(k < pairs.len(), {
+                match(
+                  pairs.get(k),
+                  .Some(pair2) => {
+                    match(
+                      pair2,
+                      .List(kv2) => {
+                        n := match(
+                          kv2.get(usize(0)),
+                          .Some(name_form) => match(
+                            name_form,
+                            .Atom(t) => t.clone(),
+                            _ => String.from("?")
+                          ),
+                          .None => String.from("?")
+                        );
+                        v := match(
+                          kv2.get(usize(1)),
+                          .Some(value_form) => z3_sexpr_to_string(value_form),
+                          .None => String.from("?")
+                        );
+                        out.push(`${n} = ${v}`);
+                      },
+                      _ => ()
+                    );
+                  },
+                  .None => ()
+                );
+                k = (k + usize(1));
+              });
+              return(out);
+            });
+          },
+          _ => ()
+        );
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  out
+});
+export(
+  Z3_VERSION,
+  z3_host_asset_stem,
+  z3_binary_path,
+  z3_download_url,
+  discover_z3,
+  ensure_z3,
+  run_z3_script,
+  _z3_exists_sync,
+  _z3_read_file_sync,
+  _z3_write_file_sync,
+  _z3_mkdir_p_sync,
+  Z3Sexpr,
+  parse_z3_sexprs,
+  z3_sexpr_to_string,
+  z3_check_sat_of,
+  z3_unsat_core_of,
+  z3_value_pairs_of
+);

--- a/tests/internal/verifier.test.yo
+++ b/tests/internal/verifier.test.yo
@@ -1,0 +1,383 @@
+//! Verifier harness unit tests (V2 of plans/backlog/FORMAL_VERIFICATION.md).
+//!
+//! Hermetic layers (no solver needed): term/encode goldens, name mangling,
+//! S-expression scanning, verdict mapping, cache-key stability.
+//! Real-solver tests run ONLY with YO_TEST_Z3=1 (CI's verify job installs
+//! the pinned Z3 and sets YO_Z3_PATH); without it they self-skip with a
+//! passing note so the rest of the suite stays hermetic.
+open(import("std/string"));
+open(import("std/fmt"));
+{ assert } :: import("std/assert");
+{ env } :: import("std/env");
+{ ArrayList } :: import("std/collections/array_list");
+{ VcSort, VcOp, VcTerm, VcQuantKind, VcQuery, new_vc_query, vc_eq, vc_and, vc_or, vc_not, vc_imp, vc_distinct } :: import("../../src/verifier/terms.yo");
+{ mangle_vc_name, encode_sort, encode_term, encode_content, encode_script, default_encode_options } :: import("../../src/verifier/encode.yo");
+{ Z3Sexpr, parse_z3_sexprs, z3_sexpr_to_string, z3_check_sat_of, z3_unsat_core_of, z3_value_pairs_of, run_z3_script, ensure_z3 } :: import("../../src/verifier/z3.yo");
+{ default_verify_run_config, verify_cache_key, verdict_of_response, VerifyVerdict, VerifyRunConfig, resolve_solver_sync, SolverResolution, verifier_harness_self_test } :: import("../../src/verifier/driver.yo");
+// ---------------------------------------------------------------------------
+// Small term-construction helpers (shared by the golden tests below)
+// ---------------------------------------------------------------------------
+_bv32_var :: (fn(name : String) -> VcTerm)(
+  VcTerm.Var(name : name, sort : VcSort.BvS(width : usize(32)))
+);
+_bv32_lit :: (fn(v : u64) -> VcTerm)(VcTerm.BvLit(value : v, width : usize(32)));
+_app2 :: (fn(op : VcOp, a : VcTerm, b : VcTerm) -> VcTerm)({
+  args := ArrayList(VcTerm).new();
+  args.push(a);
+  args.push(b);
+  VcTerm.App(op, args)
+});
+// ---------------------------------------------------------------------------
+// Sorts
+// ---------------------------------------------------------------------------
+test("encode_sort: bool and bitvector spellings", {
+  assert(encode_sort(VcSort.BoolS) == "Bool", "Bool");
+  assert(encode_sort(VcSort.BvS(width : usize(8))) == "(_ BitVec 8)", "bv8");
+  assert(encode_sort(VcSort.BvS(width : usize(64))) == "(_ BitVec 64)", "bv64");
+});
+// ---------------------------------------------------------------------------
+// Name mangling
+// ---------------------------------------------------------------------------
+test("mangle_vc_name: function-unique prefix + sanitized name", {
+  assert(mangle_vc_name(String.from("f"), String.from("result")) == "__yo_vf_result", "plain names pass through");
+  assert(mangle_vc_name(String.from("my fn"), String.from("a-b")) == "__yo_vmy_fn_a_b", "spaces/dashes become underscores");
+});
+test("mangle_vc_name: stable across calls (cache/golden requirement)", {
+  a := mangle_vc_name(String.from("divide"), String.from("result"));
+  b := mangle_vc_name(String.from("divide"), String.from("result"));
+  assert(a == b, "same input, same mangle");
+});
+// ---------------------------------------------------------------------------
+// Term encoding goldens
+// ---------------------------------------------------------------------------
+test("encode_term: literals and operators", {
+  assert(encode_term(_bv32_lit(u64(5))) == "(_ bv5 32)", "bv literal");
+  assert(encode_term(VcTerm.BoolLit(true)) == "true", "bool literal true");
+  assert(encode_term(VcTerm.BoolLit(false)) == "false", "bool literal false");
+  assert(
+    encode_term(_app2(VcOp.BvAdd, _bv32_lit(u64(1)), _bv32_lit(u64(1)))) == "(bvadd (_ bv1 32) (_ bv1 32))",
+    "bvadd application"
+  );
+  assert(
+    encode_term(vc_not(vc_eq(_bv32_var(String.from("x")), _bv32_lit(u64(2))))) == "(not (= x (_ bv2 32)))",
+    "not/equality nesting"
+  );
+});
+test("encode_term: indexed operators (casts)", {
+  assert(
+    encode_term(_app2(VcOp.SignExtendOp(extra : usize(32)), _bv32_var(String.from("x")), VcTerm.BoolLit(true))) ==
+      "((_ sign_extend 32) x true)",
+    "sign_extend shape (arity is the builder's concern in V2)"
+  );
+});
+test("encode_term: quantifier shape", {
+  names := ArrayList(String).new();
+  names.push(String.from("i"));
+  sorts := ArrayList(VcSort).new();
+  sorts.push(VcSort.BvS(width : usize(64)));
+  body := vc_eq(VcTerm.Var(name : String.from("i"), sort : VcSort.BvS(width : usize(64))), VcTerm.BvLit(value : u64(0), width : usize(64)));
+  q := VcTerm.Quant(VcQuantKind.Forall, names, sorts, body);
+  assert(
+    encode_term(q) == "(forall ((i (_ BitVec 64))) (= i (_ bv0 64)))",
+    "forall with typed binder"
+  );
+});
+// ---------------------------------------------------------------------------
+// Query encoding goldens (the canonical self-test query)
+// ---------------------------------------------------------------------------
+test("encode_content: declarations, named assumptions, negated goal, check-sat", {
+  q := new_vc_query(String.from("golden"));
+  q.declare(String.from("x"), VcSort.BvS(width : usize(32)));
+  q.assume_named(String.from("a1"), _app2(VcOp.EqOp, _bv32_var(String.from("x")), _app2(VcOp.BvAdd, _bv32_lit(u64(1)), _bv32_lit(u64(1)))));
+  q.goal = vc_eq(_bv32_var(String.from("x")), _bv32_lit(u64(2)));
+  expected :=
+    `(declare-fun x () (_ BitVec 32))
+(assert (! (= x (bvadd (_ bv1 32) (_ bv1 32))) :named a1))
+(assert (not (= x (_ bv2 32))))
+(check-sat)
+`;
+  assert(encode_content(q) == expected, "content golden");
+});
+test("encode_script: options, content, evidence directives in fixed order", {
+  q := new_vc_query(String.from("golden"));
+  q.declare(String.from("x"), VcSort.BvS(width : usize(32)));
+  q.assume(_app2(VcOp.EqOp, _bv32_var(String.from("x")), _app2(VcOp.BvAdd, _bv32_lit(u64(1)), _bv32_lit(u64(1)))));
+  q.goal = vc_eq(_bv32_var(String.from("x")), _bv32_lit(u64(3)));
+  opts := default_encode_options();
+  expected :=
+    `(set-logic ALL)
+(set-option :rlimit 5000000)
+(set-option :random-seed 0)
+(set-option :timeout 30000)
+(set-option :produce-unsat-cores true)
+(set-option :produce-models true)
+(declare-fun x () (_ BitVec 32))
+(assert (= x (bvadd (_ bv1 32) (_ bv1 32))))
+(assert (not (= x (_ bv3 32))))
+(check-sat)
+(get-unsat-core)
+(get-value (x))
+`;
+  assert(encode_script(q, opts) == expected, "script golden");
+});
+// ---------------------------------------------------------------------------
+// S-expression scanning
+// ---------------------------------------------------------------------------
+test("parse_z3_sexprs: atoms, lists, nesting, comments", {
+  forms := parse_z3_sexprs(String.from("unsat\n(a1 a2)\n; a comment\n((x #x00000002))"));
+  assert(forms.len() == usize(3), "three top-level forms");
+  assert(
+    match(
+      forms.get(usize(0)),
+      .Some(form) => match(
+        form,
+        .Atom(t) => (t == "unsat"),
+        _ => false
+      ),
+      .None => false
+    ),
+    "first form is the atom unsat"
+  );
+  core := z3_unsat_core_of(forms);
+  assert(core.len() == usize(2), "core has two names");
+  assert(
+    match(
+      core.get(usize(1)),
+      .Some(n) => (n == "a2"),
+      .None => false
+    ),
+    "core names parse"
+  );
+  vals := z3_value_pairs_of(forms);
+  assert(
+    match(
+      vals.get(usize(0)),
+      .Some(p) => (p == "x = #x00000002"),
+      .None => false
+    ),
+    "get-value pair renders as name = value"
+  );
+});
+test("parse_z3_sexprs: nested value sexprs render losslessly", {
+  forms := parse_z3_sexprs(String.from("sat\n((x (concat #x00000001 #x02)))"));
+  vals := z3_value_pairs_of(forms);
+  assert(
+    match(
+      vals.get(usize(0)),
+      .Some(p) => (p == "x = (concat #x00000001 #x02)"),
+      .None => false
+    ),
+    "concat value keeps its structure"
+  );
+});
+test("z3_check_sat_of: finds the verdict atom, skips non-verdict atoms", {
+  forms := parse_z3_sexprs(String.from("sat\n((x #x02))"));
+  assert(
+    match(
+      z3_check_sat_of(forms),
+      .Some(v) => (v == "sat"),
+      .None => false
+    ),
+    "sat detected"
+  );
+  forms2 := parse_z3_sexprs(String.from("unknown\n(:reason-unknown (incomplete quantifiers))"));
+  assert(
+    match(
+      z3_check_sat_of(forms2),
+      .Some(v) => (v == "unknown"),
+      .None => false
+    ),
+    "unknown detected"
+  );
+  forms3 := parse_z3_sexprs(String.from("(error \"line 1 column 1: unknown constant\")"));
+  assert(z3_check_sat_of(forms3).is_none(), "error stream has no verdict");
+});
+// ---------------------------------------------------------------------------
+// Verdict mapping (the mocked-runner seam: canned responses)
+// ---------------------------------------------------------------------------
+test("verdict_of_response: unsat ⇒ Proved with core", {
+  v := verdict_of_response(String.from("unsat\n(a1)\n"));
+  match(
+    v,
+    .Proved(core) => {
+      assert(
+        match(
+          core.get(usize(0)),
+          .Some(n) => (n == "a1"),
+          .None => false
+        ),
+        "core carries the clause name"
+      );
+    },
+    _ => {
+      assert(false, "expected Proved");
+    }
+  );
+});
+test("verdict_of_response: sat ⇒ Refuted with counter-example", {
+  v := verdict_of_response(String.from("sat\n((x #x00000002))\n"));
+  match(
+    v,
+    .Refuted(ce) => {
+      assert(ce.len() == usize(1), "one counter-example entry");
+      assert(
+        match(
+          ce.get(usize(0)),
+          .Some(p) => (p == "x = #x00000002"),
+          .None => false
+        ),
+        "entry renders as x = value"
+      );
+    },
+    _ => {
+      assert(false, "expected Refuted");
+    }
+  );
+});
+test("verdict_of_response: unknown ⇒ Unproven; garbage ⇒ SolverError", {
+  match(
+    verdict_of_response(String.from("unknown\n")),
+    .Unproven(_) => (),
+    _ => {
+      assert(false, "expected Unproven");
+    }
+  );
+  match(
+    verdict_of_response(String.new()),
+    .SolverError(_) => (),
+    _ => {
+      assert(false, "expected SolverError on empty output");
+    }
+  );
+});
+// ---------------------------------------------------------------------------
+// Cache keys
+// ---------------------------------------------------------------------------
+_golden_query :: (fn(goal_val : u64) -> VcQuery)({
+  q := new_vc_query(String.from("cache-key"));
+  q.declare(String.from("x"), VcSort.BvS(width : usize(32)));
+  q.assume(_app2(VcOp.EqOp, _bv32_var(String.from("x")), _app2(VcOp.BvAdd, _bv32_lit(u64(1)), _bv32_lit(u64(1)))));
+  q.goal = vc_eq(_bv32_var(String.from("x")), _bv32_lit(goal_val));
+  q
+});
+test("verify_cache_key: stable for identical input, sensitive to options and content", {
+  cfg := default_verify_run_config();
+  k1 := verify_cache_key(_golden_query(u64(2)), cfg);
+  k2 := verify_cache_key(_golden_query(u64(2)), cfg);
+  assert(k1 == k2, "same query + options ⇒ same key");
+  assert(k1.len() == usize(64), "sha256 hex length");
+  cfg2 := default_verify_run_config();
+  cfg2.encode_opts.rlimit = usize(1000);
+  k3 := verify_cache_key(_golden_query(u64(2)), cfg2);
+  assert(k1 != k3, "budget bump ⇒ different key");
+  k4 := verify_cache_key(_golden_query(u64(3)), cfg);
+  assert(k1 != k4, "goal change ⇒ different key");
+});
+// ---------------------------------------------------------------------------
+// Real-solver tests — YO_TEST_Z3=1 gated
+// ---------------------------------------------------------------------------
+test("real z3: harness self-test proves 1+1==2 and refutes 1+1==3 (YO_TEST_Z3=1)", {
+  enabled := match(
+    env.get(String.from("YO_TEST_Z3")),
+    .Some(v) => (v == "1"),
+    .None => false
+  );
+  if(!enabled, {
+    println(String.from("  (skipped: set YO_TEST_Z3=1 to run the real-solver tests)"));
+  }, {
+    cfg := default_verify_run_config();
+    binary := match(
+      resolve_solver_sync(cfg),
+      .Resolved(path) => path,
+      .InvalidPath(path) => {
+        assert(false, `explicit solver path '${path}' does not exist`);
+        String.new()
+      },
+      .Installable => {
+        // The sync harness cannot download; YO_Z3_PATH or a cached install
+        // must provide the solver for the real tests.
+        assert(false, "no solver found: set YO_Z3_PATH or install the pinned z3 into the cache");
+        String.new()
+      }
+    );
+    results := verifier_harness_self_test(cfg, binary.clone());
+    match(
+      results.get(usize(0)),
+      .Some(r1) => {
+        match(
+          r1.verdict,
+          .Proved(_) => (),
+          _ => {
+            assert(false, "1+1==2 must prove");
+          }
+        );
+      },
+      .None => {
+        assert(false, "missing first self-test result");
+      }
+    );
+    match(
+      results.get(usize(1)),
+      .Some(r2) => {
+        match(
+          r2.verdict,
+          .Refuted(ce) => {
+            assert(ce.len() > usize(0), "refutation must carry a counter-example");
+            println(`  counter-example: ${ce.get(usize(0)).unwrap()}`);
+          },
+          _ => {
+            assert(false, "1+1==3 must refute");
+          }
+        );
+      },
+      .None => {
+        assert(false, "missing second self-test result");
+      }
+    );
+  });
+});
+test("real z3: second run is a cache hit (YO_TEST_Z3=1)", {
+  enabled := match(
+    env.get(String.from("YO_TEST_Z3")),
+    .Some(v) => (v == "1"),
+    .None => false
+  );
+  if(!enabled, {
+    println(String.from("  (skipped: set YO_TEST_Z3=1 to run the real-solver tests)"));
+  }, {
+    cfg := default_verify_run_config();
+    cfg.no_cache = true;
+    binary := match(
+      resolve_solver_sync(cfg),
+      .Resolved(path) => path,
+      _ => {
+        assert(false, "no solver found: set YO_Z3_PATH or install the pinned z3");
+        String.new()
+      }
+    );
+    first := verifier_harness_self_test(cfg, binary.clone());
+    match(
+      first.get(usize(0)),
+      .Some(r) => {
+        assert(!r.cached, "no-cache run must not be cached");
+      },
+      .None => ()
+    );
+    cfg2 := default_verify_run_config();
+    second := verifier_harness_self_test(cfg2, binary.clone());
+    match(
+      second.get(usize(0)),
+      .Some(r2) => {
+        assert(r2.cached, "cached run must hit");
+        match(
+          r2.verdict,
+          .Proved(_) => (),
+          _ => {
+            assert(false, "cached verdict must still be Proved");
+          }
+        );
+      },
+      .None => ()
+    );
+  });
+});


### PR DESCRIPTION
Phase V2 of `plans/backlog/FORMAL_VERIFICATION.md` — **stacked on #475 (V1)**. Everything needed to talk to Z3, before any real VC.

## What landed

- **`src/verifier/terms.yo`** — the in-memory VC term IR: sorts (`bool`, exact-width bitvectors), the operator set (BV arithmetic/shifts/comparisons, indexed casts, `ite`), quantifiers (V5 surface, carried now so goldens are stable), and the obligation shape `VcQuery` (declarations + assumptions + goal — the runner checks Φ ∧ ¬P for unsat).
- **`src/verifier/encode.yo`** — deterministic SMT-LIB 2 emission (golden-string tested), the `__yo_v<fn>_<name>` mangling contract, and full scripts carrying the determinism options (`:rlimit`, `:random-seed 0`, timeout backstop) plus evidence directives (get-unsat-core, get-value).
- **`src/verifier/z3.yo`** — the pinned Z3 4.13.3 manifest, discovery (`YO_Z3_PATH` → `~/.cache/yo/solvers/…`), a one-time download install (version_cache's release-fetch shape), and the query protocol: **one fresh z3 process per query** (stronger isolation than push/pop), script + redirected output via FILE paths through libc `system(3)` — the `module_manager.yo` comptime-file-IO idiom, **synchronous on purpose**. Pure S-expression scanner + verdict parsing (check-sat, unsat cores, get-value pairs).
- **`src/verifier/driver.yo`** — verify modes (`runtime`/`verify`/`verify+`), run config, verdicts (Proved / Refuted+counter-example / Unproven / SolverError), the sha256-keyed verification cache (`~/.cache/yo/verify-cache`, terminal verdicts only), and the harness self-test.
- **`yo verify` subcommand** — flags `--verify-mode`, `--solver-path`, `--rlimit`, `--format text|json`, `--no-cache` (`--explain` reserved for V3); en+zh help.
- **`tests/internal/verifier.test.yo`** — 17 tests; the real-solver pair is `YO_TEST_Z3=1`-gated and self-skips otherwise.
- **`verify` CI job** in test.yml — installs the pinned Z3, a Z3-pin consistency guard (workflow ↔ `z3.yo`), runs the real-solver tests + `yo verify`, uploads the JSON report. Not a required check until V3.

## Validated end-to-end (local, pinned Z3 4.13.3)

```
verify: self-test: one_plus_one_eq_2: PROVED
verify: self-test: one_plus_one_eq_3: REFUTED  counter-example: x = #x00000002
verify: harness OK
```
plus the cached-run path and 17/17 internal tests; `yo check ./src` 270/270.

## Deviations (recorded in the plan doc)

1. The harness is **synchronous** — the async route hit a cluster of pre-existing capture-mode state-machine bugs (invalid C struct casts, `.io` member-projection loss in cond-branch arms, an ASan-confirmed use-after-free on resume), filed as `issues/async-closure-value-struct-param-emits-invalid-c-cast.md`. The only async path left is the one-time solver download.
2. One z3 process per query (spawn cost is ms-scale).
3. z3's nonzero exit on unavailable evidence (get-value on unsat) is tolerated when a verdict was parsed.

## Bugs surfaced and filed

- `issues/plain-recursive-enum-segfaults-the-evaluator.md` — a plain `enum` recursing into itself SIGSEGVs the type-size walk (should be a clean `ref(enum)` diagnostic).
- `issues/async-closure-value-struct-param-emits-invalid-c-cast.md` — the async cluster above, with repro shapes and the fix direction.