### PR TITLE
std/string: trim_*_matches, rsplit, push_rune, insert/remove/pop

### DIFF
--- a/std/string/string.yo
+++ b/std/string/string.yo
@@ -357,6 +357,24 @@ impl(
       }
     );
   }),
+  /// Append one rune, UTF-8 encoded — Rust's `String::push`.
+  ///
+  /// `push_byte` appends a single BYTE and will happily build invalid UTF-8;
+  /// this is the rune-level counterpart, so it is what you want for anything
+  /// outside ASCII.
+  push_rune : (fn(inout(self) : Self, r : rune) -> unit)({
+    match(
+      self._bytes,
+      .None => {
+        (new_al : ArrayList(u8)) = ArrayList(u8).with_capacity(usize(8));
+        utf8.encode_into(r, new_al);
+        self._bytes = .Some(new_al);
+      },
+      .Some(al) => {
+        utf8.encode_into(r, al);
+      }
+    );
+  }),
   /// Reserve capacity for at least `additional` more bytes.
   /// If the string is empty, creates a new buffer with the given capacity.
   reserve : (fn(inout(self) : Self, additional : usize) -> unit)({
@@ -1654,9 +1672,146 @@ impl(
       }
     );
   }),
+  /// `self` with every leading occurrence of `pat` removed — Rust's
+  /// `trim_start_matches`. Repeats, so `"aaab".trim_start_matches("a")` is
+  /// `"b"`, unlike the single-shot `strip_prefix`.
+  ///
+  /// A ZERO-WIDTH pattern (the empty string, a regex matching empty) strips
+  /// nothing and terminates rather than spinning.
+  trim_start_matches : (fn(generic(P : Type), self : Self, pat : P, where(P <: Pattern)) -> Self)({
+    (out : Self) = self.substring(usize(0), self.len());
+    while(runtime(true), {
+      before := out.len();
+      match(
+        out.strip_prefix(pat),
+        .Some(rest) => {
+          out = rest;
+        },
+        .None => {
+          break;
+        }
+      );
+      cond(
+        (out.len() == before) => {
+          break;
+        },
+        true => ()
+      );
+    });
+    out
+  }),
+  /// `self` with every trailing occurrence of `pat` removed — Rust's
+  /// `trim_end_matches`. Repeats, and terminates on a zero-width pattern.
+  trim_end_matches : (fn(generic(P : Type), self : Self, pat : P, where(P <: Pattern)) -> Self)({
+    (out : Self) = self.substring(usize(0), self.len());
+    while(runtime(true), {
+      before := out.len();
+      match(
+        out.strip_suffix(pat),
+        .Some(rest) => {
+          out = rest;
+        },
+        .None => {
+          break;
+        }
+      );
+      cond(
+        (out.len() == before) => {
+          break;
+        },
+        true => ()
+      );
+    });
+    out
+  }),
+  /// `self` with every leading AND trailing occurrence of `pat` removed —
+  /// Rust's `trim_matches`.
+  trim_matches : (fn(generic(P : Type), self : Self, pat : P, where(P <: Pattern)) -> Self)(
+    self.trim_start_matches(pat).trim_end_matches(pat)
+  ),
   split : (fn(generic(P : Type), self : Self, separator : P, where(P <: Pattern)) -> ArrayList(String))(
     separator.split_of(self)
   ),
+  /// `split`'s pieces from the RIGHT — Rust's `rsplit`.
+  ///
+  /// The pieces are the same ones `split` produces; only the ORDER is
+  /// reversed, so `"a.b.c".rsplit(".")` is `["c", "b", "a"]`. (Rust's returns
+  /// a lazy iterator; Yo's `split` already returns the whole list, so this
+  /// reverses it.)
+  rsplit : (fn(generic(P : Type), self : Self, separator : P, where(P <: Pattern)) -> ArrayList(String))({
+    parts := self.split(separator);
+    parts.reverse();
+    parts
+  }),
+  /// Insert `s` at BYTE index `idx`, shifting the rest right — Rust's
+  /// `insert_str`.
+  ///
+  /// PANICS when `idx` is past the end or is not a char boundary, as Rust
+  /// does; `len()` is bytes, so an index into the middle of a multi-byte rune
+  /// would otherwise produce invalid UTF-8.
+  insert_str : (fn(self : Self, idx : usize, s : Self) -> unit)({
+    if(idx > self.len(), {
+      __yo_panic("String.insert_str: index out of bounds");
+    });
+    if(!self.is_char_boundary(idx), {
+      __yo_panic("String.insert_str: index is not a char boundary");
+    });
+    head := self.substring(usize(0), idx);
+    tail := self.substring(idx, self.len());
+    self.clear();
+    self.push_string(head);
+    self.push_string(s);
+    self.push_string(tail);
+  }),
+  /// Insert one rune at BYTE index `idx` — Rust's `insert`. Same panics as
+  /// `insert_str`.
+  insert : (fn(self : Self, idx : usize, r : rune) -> unit)({
+    one := Self.new();
+    one.push_rune(r);
+    self.insert_str(idx, one);
+  }),
+  /// Remove and return the rune STARTING at byte index `idx` — Rust's
+  /// `remove`.
+  ///
+  /// PANICS when `idx` is out of bounds or not a char boundary.
+  remove : (fn(self : Self, idx : usize) -> rune)({
+    if(idx >= self.len(), {
+      __yo_panic("String.remove: index out of bounds");
+    });
+    r := match(
+      self.at(idx),
+      .Some(x) => x,
+      .None => __yo_panic("String.remove: index is not a char boundary")
+    );
+    head := self.substring(usize(0), idx);
+    tail := self.substring(idx + utf8.encoded_len(r), self.len());
+    self.clear();
+    self.push_string(head);
+    self.push_string(tail);
+    r
+  }),
+  /// Remove and return the LAST rune, or `.None` when empty — Rust's `pop`.
+  pop : (fn(self : Self) -> Option(rune))({
+    cond(
+      (self.len() == usize(0)) => return(Option(rune).None),
+      true => ()
+    );
+    // Walk back from the final byte to the boundary that starts the last rune.
+    // `floor_char_boundary` does exactly this, but it lives in a LATER impl
+    // block and a forward method reference across impl blocks is not resolved
+    // yet, so the walk is inlined here.
+    (start : usize) = (self.len() - usize(1));
+    while((start > usize(0)) && !self.is_char_boundary(start), {
+      start = (start - usize(1));
+    });
+    r := match(
+      self.at(start),
+      .Some(x) => x,
+      .None => return(Option(rune).None)
+    );
+    self.truncate(start);
+    Option(rune).Some(r)
+  }),
   /// Split at the FIRST occurrence of `separator`: `.Some((before; after))`
   /// with the separator itself removed, or `.None` when it never occurs.
   /// Rust's `str::split_once`. A zero-width separator (empty string pattern,

--- a/tests/string/string.test.yo
+++ b/tests/string/string.test.yo
@@ -2300,3 +2300,105 @@ test("String parse_u64_radix", {
   assert(String.from("2").parse_u64_radix(u32(2)).is_none(), "digit not valid in radix");
   assert(String.from("100000000000000000000").parse_u64_radix(u32(10)).is_none(), "overflows u64");
 });
+// ===== trim_*_matches =====
+test("trim_start_matches removes EVERY leading occurrence", {
+  assert(`aaab`.trim_start_matches(`a`) == `b`, "repeats, unlike strip_prefix");
+  assert(`b`.trim_start_matches(`a`) == `b`, "no occurrence is a no-op");
+  assert(`aaa`.trim_start_matches(`a`) == ``, "stripping everything gives the empty string");
+  assert(`abab`.trim_start_matches(`ab`) == ``, "a multi-byte-long pattern");
+  assert(`xabab`.trim_start_matches(`ab`) == `xabab`, "an interior occurrence is not leading");
+});
+test("trim_end_matches removes EVERY trailing occurrence", {
+  assert(`baaa`.trim_end_matches(`a`) == `b`, "repeats, unlike strip_suffix");
+  assert(`b`.trim_end_matches(`a`) == `b`, "no occurrence is a no-op");
+  assert(`aaa`.trim_end_matches(`a`) == ``, "stripping everything");
+  assert(`ababx`.trim_end_matches(`ab`) == `ababx`, "an interior occurrence is not trailing");
+});
+test("trim_matches removes from both ends", {
+  assert(`aabaa`.trim_matches(`a`) == `b`, "both ends");
+  assert(`--x--`.trim_matches(`-`) == `x`, "a punctuation pattern");
+  assert(`aaa`.trim_matches(`a`) == ``, "everything");
+  assert(`xay`.trim_matches(`a`) == `xay`, "an interior occurrence survives");
+});
+test("a zero-width pattern terminates instead of spinning", {
+  assert(`abc`.trim_start_matches(``) == `abc`, "empty pattern strips nothing at the start");
+  assert(`abc`.trim_end_matches(``) == `abc`, "nor at the end");
+  assert(`abc`.trim_matches(``) == `abc`, "nor at both");
+});
+// ===== rsplit =====
+test("rsplit yields split's pieces in reverse order", {
+  parts := `a.b.c`.rsplit(`.`);
+  assert(parts.len() == usize(3), "three pieces");
+  assert(parts(usize(0)) == `c`, "the LAST piece comes first");
+  assert(parts(usize(1)) == `b`, "then the middle");
+  assert(parts(usize(2)) == `a`, "then the first");
+  fwd := `a.b.c`.split(`.`);
+  assert(fwd(usize(0)) == `a`, "and split is unchanged");
+});
+test("rsplit over edge cases", {
+  one := `abc`.rsplit(`.`);
+  assert(one.len() == usize(1), "no separator gives one piece");
+  assert(one(usize(0)) == `abc`, "the whole string");
+  empties := `a..b`.rsplit(`.`);
+  assert(empties.len() == usize(3), "adjacent separators keep the empty piece");
+  assert(empties(usize(1)) == ``, "which is in the middle after reversing");
+});
+// ===== push_rune / insert / remove / pop =====
+test("push_rune appends a UTF-8 encoded rune", {
+  s := String.new();
+  s.push_rune(rune(65));
+  s.push_rune(rune(0x00E9));
+  assert(s.len() == usize(3), "one ASCII byte plus a two-byte rune");
+  assert(s.chars().count() == usize(2), "but two runes");
+  assert(s.starts_with(`A`), "the ASCII rune came first");
+});
+test("insert_str shifts the tail right", {
+  s := String.from("hello");
+  s.insert_str(usize(0), `>>`);
+  assert(s == `>>hello`, "at the front");
+  s2 := String.from("hello");
+  s2.insert_str(usize(5), `!`);
+  assert(s2 == `hello!`, "at the end");
+  s3 := String.from("ho");
+  s3.insert_str(usize(1), `ell`);
+  assert(s3 == `hello`, "in the middle");
+});
+test("insert places a single rune", {
+  s := String.from("ac");
+  s.insert(usize(1), rune(98));
+  assert(s == `abc`, "an ASCII rune");
+  m := String.from("ab");
+  m.insert(usize(1), rune(0x00E9));
+  assert(m.len() == usize(4), "a two-byte rune grows the string by two bytes");
+  assert(m.chars().count() == usize(3), "and by one rune");
+});
+test("remove takes the rune at a byte index and returns it", {
+  s := String.from("abc");
+  assert(s.remove(usize(1)) == rune(98), "returns the removed rune");
+  assert(s == `ac`, "and closes the gap");
+  m := String.from("aéb");
+  assert(m.len() == usize(4), "é is two bytes");
+  assert(m.remove(usize(1)) == rune(0x00E9), "removing a multi-byte rune");
+  assert(m == `ab`, "removes ALL of its bytes");
+  assert(m.len() == usize(2), "so the byte length drops by two");
+});
+test("pop takes the last rune", {
+  s := String.from("abc");
+  assert(match(s.pop(), .Some(r) => (r == rune(99)), .None => false), "the last rune");
+  assert(s == `ab`, "and shortens the string");
+  m := String.from("aé");
+  assert(match(m.pop(), .Some(r) => (r == rune(0x00E9)), .None => false), "a multi-byte last rune");
+  assert(m == `a`, "removing both of its bytes");
+  assert(match(m.pop(), .Some(r) => (r == rune(97)), .None => false), "then the first");
+  assert(m.is_empty(), "leaving it empty");
+  assert(match(m.pop(), .Some(_) => false, .None => true), "popping an empty string is None");
+});
+test("insert/remove/pop round-trip", {
+  s := String.from("bd");
+  s.insert(usize(0), rune(97));
+  s.insert(usize(2), rune(99));
+  assert(s == `abcd`, "built up by insertion");
+  assert(s.remove(usize(2)) == rune(99), "removed the inserted middle");
+  assert(match(s.pop(), .Some(r) => (r == rune(100)), .None => false), "popped the tail");
+  assert(s == `ab`, "back to the two survivors");
+});


### PR DESCRIPTION
Stacked on #488. The remaining `String` rows from `plans/STD_API_STABILIZATION.md` §4 Text.

## Trimming

`trim_start_matches` / `trim_end_matches` / `trim_matches` **repeat**, where `strip_prefix`/`strip_suffix` are single-shot — so `"aaab".trim_start_matches("a")` is `"b"`. All three carry the same `Pattern` bound as `split`, so a rune, a `String` or a regex all work.

A **zero-width** pattern strips nothing and terminates rather than spinning: the loop breaks when the length stops changing, which is what makes `"abc".trim_matches("")` safe. Pinned by its own test.

## `rsplit`

Reverses `split`'s pieces. Rust's is a lazy right-to-left iterator; Yo's `split` already returns the whole list, so reversing it is the same answer, and the doc says so rather than implying laziness.

## Mutation

- `push_rune` — Rust's `String::push`, the rune-level counterpart of `push_byte`, which appends a single BYTE and will happily build invalid UTF-8.
- `insert_str` / `insert` / `remove` / `pop` — all byte-indexed like `substring` and `truncate`, and all panicking on a non-boundary index for the same reason `truncate` does: `len()` is **bytes**, so an index into the middle of a multi-byte rune would otherwise produce invalid UTF-8.

`remove` and `pop` return the rune they took, and both are pinned over a two-byte rune (`é`) so a byte-vs-rune confusion cannot pass: the tests assert the byte length drops by *two* and the rune count by *one*.

## One implementation note

`pop` inlines the backward boundary walk instead of calling `floor_char_boundary`, which does exactly this but lives in a **later** `impl` block — a forward method reference across impl blocks is not resolved yet (the lazy-bindings P3 work that remains). The comment says so at the site rather than leaving a reader wondering why the obvious call isn't there.

## Local verification

| gate | result |
| --- | --- |
| `tests/string/string.test.yo` | 289/289 |
| full suite | **3753/3753**, 0 failures |
| `check ./std` | 174/174 |
| `check ./src` | 266/266 |
| `yo build` (self-build) | rc=0 |
| cli scorecard | 81 PASS / 0 GOLDEN-DIFF |
| `fmt --check` std + tests | clean |

The self-build matters here: `std/string` is compiled into the compiler itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)