### PR TITLE
std/string: DoubleEndedIterator on all four string iterators; lines() strips the CR of a CRLF

### DIFF
--- a/std/string/string.yo
+++ b/std/string/string.yo
@@ -2035,9 +2035,27 @@ impl(
 * Rune iterator for `String` — yields decoded Unicode runes.
 * Used by `chars()` and `into_iter()`.
 */
+/// Byte index of the rune boundary immediately BEFORE `at` — the start of the
+/// rune that ENDS at `at`.
+///
+/// `at` must itself be a boundary and greater than zero. Used by the
+/// `next_back` half of the string iterators: UTF-8 is self-synchronising, so
+/// walking back over continuation bytes finds the previous rune's first byte
+/// without any table.
+_prev_rune_start :: (fn(s : String, at : usize) -> usize)({
+  (i : usize) = (at - usize(1));
+  while((i > usize(0)) && !s.is_char_boundary(i), {
+    i = (i - usize(1));
+  });
+  i
+});
 StringChars :: struct(
   _string : String,
-  _byte_index : usize
+  _byte_index : usize,
+  /// Exclusive BACK cursor, moved by `next_back`. The two ends have met when
+  /// `_end <= _byte_index`, which is what makes forward and backward
+  /// iteration composable on one iterator.
+  _end : usize
 );
 impl(
   StringChars,
@@ -2048,7 +2066,7 @@ impl(
         self._string._bytes,
         .None => .None,
         .Some(al) => cond(
-          (self._byte_index >= al.len()) => .None,
+          (self._byte_index >= self._end) => .None,
           true => {
             first_byte_opt := al.get(self._byte_index);
             match(
@@ -2067,13 +2085,34 @@ impl(
     )
   )
 );
+/// `chars()` from the back — this is what makes `s.chars().rev()` work, via
+/// the prelude's blanket `rev` over `DoubleEndedIterator` (promised by D4).
+impl(
+  StringChars,
+  DoubleEndedIterator(
+    Item : rune,
+    next_back : (fn(inout(self) : Self) -> Option(rune))(
+      cond(
+        (self._end <= self._byte_index) => Option(rune).None,
+        true => {
+          start := _prev_rune_start(self._string, self._end);
+          r := self._string._decode_rune_at(start);
+          self._end = start;
+          r
+        }
+      )
+    )
+  )
+);
 /**
 * Byte iterator for `String` — yields raw UTF-8 bytes.
 * Used by `bytes()`.
 */
 StringBytes :: struct(
   _string : String,
-  _index : usize
+  _index : usize,
+  /// Exclusive BACK cursor — see `StringChars._end`.
+  _end : usize
 );
 impl(
   StringBytes,
@@ -2084,13 +2123,32 @@ impl(
         self._string._bytes,
         .None => .None,
         .Some(al) => cond(
-          (self._index >= al.len()) => .None,
+          (self._index >= self._end) => .None,
           true => {
             byte_opt := al.get(self._index);
             self._index = (self._index + usize(1));
             byte_opt
           }
         )
+      )
+    )
+  )
+);
+impl(
+  StringBytes,
+  DoubleEndedIterator(
+    Item : u8,
+    next_back : (fn(inout(self) : Self) -> Option(u8))(
+      cond(
+        (self._end <= self._index) => Option(u8).None,
+        true => {
+          self._end = (self._end - usize(1));
+          match(
+            self._string._bytes,
+            .None => Option(u8).None,
+            .Some(al) => al.get(self._end)
+          )
+        }
       )
     )
   )
@@ -2105,7 +2163,9 @@ impl(
 */
 StringCharIndices :: struct(
   _string : String,
-  _byte_index : usize
+  _byte_index : usize,
+  /// Exclusive BACK cursor — see `StringChars._end`.
+  _end : usize
 );
 impl(
   StringCharIndices,
@@ -2116,7 +2176,7 @@ impl(
         self._string._bytes,
         .None => .None,
         .Some(al) => cond(
-          (self._byte_index >= al.len()) => .None,
+          (self._byte_index >= self._end) => .None,
           true => {
             offset := self._byte_index;
             first_byte_opt := al.get(offset);
@@ -2140,24 +2200,44 @@ impl(
   )
 );
 impl(
+  StringCharIndices,
+  DoubleEndedIterator(
+    Item : IterPair(usize, rune),
+    next_back : (fn(inout(self) : Self) -> Option(IterPair(usize, rune)))(
+      cond(
+        (self._end <= self._byte_index) => Option(IterPair(usize, rune)).None,
+        true => {
+          start := _prev_rune_start(self._string, self._end);
+          self._end = start;
+          match(
+            self._string._decode_rune_at(start),
+            .Some(r) => Option(IterPair(usize, rune)).Some(IterPair(usize, rune)(_0 : start, _1 : r)),
+            .None => Option(IterPair(usize, rune)).None
+          )
+        }
+      )
+    )
+  )
+);
+impl(
   String,
   /**
   * Returns a rune iterator over the string's Unicode characters
   */
   chars : (fn(self : Self) -> StringChars)(
-    StringChars(_string : self, _byte_index : usize(0))
+    StringChars(_string : self, _byte_index : usize(0), _end : self.len())
   ),
   /**
   * Returns a byte iterator over the string's raw UTF-8 bytes
   */
   bytes : (fn(self : Self) -> StringBytes)(
-    StringBytes(_string : self, _index : usize(0))
+    StringBytes(_string : self, _index : usize(0), _end : self.len())
   ),
   /**
   * Consume the string and return a rune iterator (default iteration)
   */
   into_iter : (fn(self : Self) -> StringChars)(
-    StringChars(_string : self, _byte_index : usize(0))
+    StringChars(_string : self, _byte_index : usize(0), _end : self.len())
   )
 );
 /// === Rune-aware indexing (D4 vocabulary) ===
@@ -2188,7 +2268,7 @@ impl(
   /// the replacement for the `while(i < s.len()) { s.at(i) }` shape, which
   /// now visits continuation bytes and hands back `.None` at each of them.
   char_indices : (fn(self : Self) -> StringCharIndices)(
-    StringCharIndices(_string : self, _byte_index : usize(0))
+    StringCharIndices(_string : self, _byte_index : usize(0), _end : self.len())
   ),
   /// The largest byte offset `<= index` that sits on a rune boundary.
   ///
@@ -2292,8 +2372,49 @@ impl(
 */
 StringLines :: struct(
   _string : String,
-  _byte_index : usize
+  _byte_index : usize,
+  /// Exclusive BACK cursor — see `StringChars._end`.
+  _end : usize
 );
+/// A line's content, with ONE trailing `\r` dropped.
+///
+/// `lines()` splits on `\n` and must not leave the carriage return of a
+/// Windows `\r\n` at the end of the line — Rust's `str::lines` strips it, and
+/// a reader that forgot to would silently compare unequal against every
+/// literal. Only one `\r` goes: `"a\r\r\n"` really does end with a `\r`.
+_line_slice :: (fn(al : ArrayList(u8), start : usize, stop : usize) -> String)({
+  (cut : usize) = stop;
+  cond(
+    (cut > start) => match(
+      al.get(cut - usize(1)),
+      .Some(last) => cond(
+        (last == u8(13)) => {
+          cut = (cut - usize(1));
+        },
+        true => ()
+      ),
+      .None => ()
+    ),
+    true => ()
+  );
+  cond(
+    (cut <= start) => String(_bytes : .None),
+    true => {
+      buf := ArrayList(u8).with_capacity(cut - start);
+      (j : usize) = start;
+      while(j < cut, j = (j + usize(1)), {
+        match(
+          al.get(j),
+          .Some(b) => {
+            buf.push(b);
+          },
+          .None => ()
+        );
+      });
+      String(_bytes : .Some(buf))
+    }
+  )
+});
 impl(
   StringLines,
   Iterator(
@@ -2303,13 +2424,13 @@ impl(
         self._string._bytes,
         .None => .None,
         .Some(al) => {
-          total := al.len();
+          stop := self._end;
           cond(
-            (self._byte_index >= total) => .None,
+            (self._byte_index >= stop) => .None,
             true => {
               start := self._byte_index;
               i := start;
-              while(i < total, i = (i + usize(1)), {
+              while(i < stop, i = (i + usize(1)), {
                 byte_opt := al.get(i);
                 match(
                   byte_opt,
@@ -2324,29 +2445,62 @@ impl(
                   .None => ()
                 );
               });
-              line_buf := ArrayList(u8).with_capacity(i - start);
-              j := start;
-              while(j < i, j = (j + usize(1)), {
-                byte_opt := al.get(j);
-                match(
-                  byte_opt,
-                  .Some(b) => {
-                    line_buf.push(b);
-                  },
-                  .None => ()
-                );
-              });
               self._byte_index = cond(
-                (i < total) => (i + usize(1)),
-                true => total
+                (i < stop) => (i + usize(1)),
+                true => stop
               );
-              cond(
-                (line_buf.len() == usize(0)) => .Some(String(_bytes : .None)),
-                true => .Some(String(_bytes : .Some(line_buf)))
-              )
+              .Some(_line_slice(al, start, i))
             }
           )
         }
+      )
+    )
+  )
+);
+/// `lines()` from the back.
+///
+/// The mirror of `next`'s rule that a trailing `\n` TERMINATES the last line
+/// rather than starting an empty one after it: the first thing `next_back`
+/// does is step over one such newline.
+impl(
+  StringLines,
+  DoubleEndedIterator(
+    Item : String,
+    next_back : (fn(inout(self) : Self) -> Option(String))(
+      match(
+        self._string._bytes,
+        .None => .None,
+        .Some(al) => cond(
+          (self._end <= self._byte_index) => Option(String).None,
+          true => {
+            (stop : usize) = self._end;
+            cond(
+              match(al.get(stop - usize(1)), .Some(b) => (b == u8(10)), .None => false) => {
+                stop = (stop - usize(1));
+              },
+              true => ()
+            );
+            // Scan back for the newline that ends the PREVIOUS line; the line
+            // we are yielding starts just after it.
+            (line_start : usize) = self._byte_index;
+            (k : usize) = stop;
+            while(k > self._byte_index, {
+              k = (k - usize(1));
+              cond(
+                match(al.get(k), .Some(b) => (b == u8(10)), .None => false) => {
+                  line_start = (k + usize(1));
+                  break;
+                },
+                true => ()
+              );
+            });
+            self._end = cond(
+              (line_start > self._byte_index) => (line_start - usize(1)),
+              true => self._byte_index
+            );
+            Option(String).Some(_line_slice(al, line_start, stop))
+          }
+        )
       )
     )
   )
@@ -2367,7 +2521,7 @@ impl(
   * ```
   */
   lines : (fn(self : Self) -> StringLines)(
-    StringLines(_string : self, _byte_index : usize(0))
+    StringLines(_string : self, _byte_index : usize(0), _end : self.len())
   ),
   /**
   * Returns a new string containing `n` copies of `self`.

--- a/tests/string/string_double_ended.test.yo
+++ b/tests/string/string_double_ended.test.yo
@@ -1,0 +1,139 @@
+//! `DoubleEndedIterator` on the four `String` iterators, and `lines()`'s
+//! `\r\n` handling.
+//!
+//! D4 promised `chars().rev()`; that works through the prelude's blanket `rev`
+//! over `DoubleEndedIterator`, so these tests exercise `next_back` both
+//! directly and through `rev`.
+{ assert } :: import("std/assert");
+open(import("std/string"));
+open(import("std/collections/array_list"));
+_runes :: (fn(generic(I : Type), it : I, where(I <: Iterator(Item := rune))) -> ArrayList(rune))({
+  out := ArrayList(rune).new();
+  iter := it;
+  while(runtime(true), {
+    match(
+      iter.next(),
+      .None => {
+        break;
+      },
+      .Some(r) => {
+        out.push(r);
+      }
+    );
+  });
+  out
+});
+_lines :: (fn(generic(I : Type), it : I, where(I <: Iterator(Item := String))) -> ArrayList(String))({
+  out := ArrayList(String).new();
+  iter := it;
+  while(runtime(true), {
+    match(
+      iter.next(),
+      .None => {
+        break;
+      },
+      .Some(s) => {
+        out.push(s);
+      }
+    );
+  });
+  out
+});
+test("chars().rev() yields the runes backwards", {
+  got := _runes(`abc`.chars().rev());
+  assert(got.len() == usize(3), "three runes");
+  assert(got(usize(0)) == rune(99), "the last rune comes first");
+  assert(got(usize(1)) == rune(98), "then the middle");
+  assert(got(usize(2)) == rune(97), "then the first");
+});
+test("chars().rev() over multi-byte runes", {
+  got := _runes(`aéb`.chars().rev());
+  assert(got.len() == usize(3), "three runes from four bytes");
+  assert(got(usize(0)) == rune(98), "b");
+  assert(got(usize(1)) == rune(0x00E9), "é — walked back over its continuation byte");
+  assert(got(usize(2)) == rune(97), "a");
+});
+test("chars next and next_back meet in the middle", {
+  it := `abcd`.chars();
+  assert(match(it.next(), .Some(r) => (r == rune(97)), .None => false), "front: a");
+  assert(match(it.next_back(), .Some(r) => (r == rune(100)), .None => false), "back: d");
+  assert(match(it.next(), .Some(r) => (r == rune(98)), .None => false), "front: b");
+  assert(match(it.next_back(), .Some(r) => (r == rune(99)), .None => false), "back: c");
+  assert(match(it.next(), .Some(_) => false, .None => true), "the ends have met, so next is None");
+  assert(match(it.next_back(), .Some(_) => false, .None => true), "and so is next_back");
+});
+test("chars next_back on an empty string", {
+  it := ``.chars();
+  assert(match(it.next_back(), .Some(_) => false, .None => true), "nothing to take");
+});
+test("bytes next_back walks raw bytes", {
+  it := `aé`.bytes();
+  assert(it.next_back().is_some(), "the last continuation byte");
+  assert(match(it.next(), .Some(b) => (b == u8(97)), .None => false), "front is still 'a'");
+  assert(it.next_back().is_some(), "the lead byte of é");
+  assert(match(it.next(), .Some(_) => false, .None => true), "then the ends meet");
+});
+test("char_indices next_back reports the rune's OWN start offset", {
+  it := `aéb`.char_indices();
+  match(
+    it.next_back(),
+    .Some(p) => {
+      assert(p._0 == usize(3), "b starts at byte 3");
+      assert(p._1 == rune(98), "and is 'b'");
+    },
+    .None => assert(false, "expected a pair")
+  );
+  match(
+    it.next_back(),
+    .Some(p) => {
+      assert(p._0 == usize(1), "é starts at byte 1, not 2");
+      assert(p._1 == rune(0x00E9), "and is 'é'");
+    },
+    .None => assert(false, "expected a pair")
+  );
+});
+test("lines strips the carriage return of a CRLF", {
+  got := _lines(`a\r\nb\r\n`.lines());
+  assert(got.len() == usize(2), "two lines, no trailing empty one");
+  assert(got(usize(0)) == `a`, "the CR is gone from the first line");
+  assert(got(usize(1)) == `b`, "and from the second");
+});
+test("lines keeps a LONE carriage return that is not part of a CRLF", {
+  got := _lines(`a\r\r\n`.lines());
+  assert(got.len() == usize(1), "one line");
+  assert(got(usize(0)) == `a\r`, "only ONE trailing CR is stripped");
+});
+test("lines over LF-only input is unchanged", {
+  got := _lines(`a\nb`.lines());
+  assert(got.len() == usize(2), "two lines");
+  assert(got(usize(0)) == `a`, "first");
+  assert(got(usize(1)) == `b`, "second, unterminated");
+  trailing := _lines(`a\n`.lines());
+  assert(trailing.len() == usize(1), "a trailing newline TERMINATES rather than adding an empty line");
+});
+test("lines().rev() yields the lines backwards", {
+  got := _lines(`a\nb\nc`.lines().rev());
+  assert(got.len() == usize(3), "three lines");
+  assert(got(usize(0)) == `c`, "the last line first");
+  assert(got(usize(1)) == `b`, "then the middle");
+  assert(got(usize(2)) == `a`, "then the first");
+});
+test("lines().rev() with a trailing newline and CRLF", {
+  got := _lines(`a\r\nb\r\n`.lines().rev());
+  assert(got.len() == usize(2), "the trailing newline adds no empty line from the back either");
+  assert(got(usize(0)) == `b`, "b first, CR stripped");
+  assert(got(usize(1)) == `a`, "then a");
+});
+test("lines next and next_back meet in the middle", {
+  it := `a\nb\nc\nd`.lines();
+  assert(match(it.next(), .Some(s) => (s == `a`), .None => false), "front: a");
+  assert(match(it.next_back(), .Some(s) => (s == `d`), .None => false), "back: d");
+  assert(match(it.next(), .Some(s) => (s == `b`), .None => false), "front: b");
+  assert(match(it.next_back(), .Some(s) => (s == `c`), .None => false), "back: c");
+  assert(match(it.next(), .Some(_) => false, .None => true), "the ends have met");
+  assert(match(it.next_back(), .Some(_) => false, .None => true), "from both directions");
+});
+test("lines next_back on an empty string", {
+  it := ``.lines();
+  assert(match(it.next_back(), .Some(_) => false, .None => true), "nothing to take");
+});


### PR DESCRIPTION
Stacked on #489. Two more §4 Text rows — and with these the Text group's `String` list is empty.

## `chars().rev()` — D4 promised it, it did not exist

None of the string iterators implemented `DoubleEndedIterator`, so the prelude's blanket `rev` had nothing to attach to. Each of `StringChars`, `StringBytes`, `StringCharIndices` and `StringLines` now gains an exclusive `_end` back cursor and a `next_back`.

The two ends have met when `_end <= <front cursor>`, so forward and backward iteration **compose on one iterator** rather than being two separate modes. Pinned for `chars` and `lines` by tests that alternate `next`/`next_back` and then check both directions report `.None`:

```rust
it := `abcd`.chars();
it.next();       // a
it.next_back();  // d
it.next();       // b
it.next_back();  // c
it.next();       // .None — the ends have met
```

`next_back` for the rune iterators walks back over continuation bytes to find the previous rune's first byte — UTF-8 is self-synchronising, so that is a four-line loop with no table (`_prev_rune_start`). `char_indices().next_back()` reports the rune's **own** start offset rather than where the walk began: the test pins `é` at byte 1 of `"aéb"`, not 2.

## `lines()` now strips the CR of a CRLF

Rust's `str::lines` does; this did not. A Windows `\r\n` file left the carriage return on the end of every line, where it silently compares unequal against every literal — the kind of bug that shows up as "why doesn't my config parser match".

Exactly **one** `\r` goes, so `"a\r\r\n"` still yields `"a\r"`. That is pinned, because "strip all trailing CRs" is the tempting wrong version.

`lines().next_back()` mirrors `next`'s rule that a trailing newline *terminates* the last line rather than starting an empty one after it, so `"a\r\nb\r\n".lines().rev()` is `["b", "a"]` and not `["", "b", "a"]`.

## Local verification

| gate | result |
| --- | --- |
| new `tests/string/string_double_ended.test.yo` | 13/13 |
| `tests/string/string.test.yo` | 289/289 |
| `repeat_join_lines` / `string_char_api` / `string_byte_index` | 12/12, 21/21, 20/20 |
| full suite | **3766/3766**, 0 failures |
| `check ./std` | 174/174 |
| `check ./src` | 266/266 |
| `yo build` (self-build) | rc=0 |
| cli scorecard | 81 PASS / 0 GOLDEN-DIFF |

The existing string files matter here: this changed the shape of four iterator structs and rewrote `lines()`'s body, so their being unchanged is the regression evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)