### PR TITLE
std/imm: IntoIterator on all six immutable collections; SortedMap.entries

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -539,9 +539,25 @@ rewritten over `Mutex.with_lock` (its blocker is in `issues/fixed/`);
    documented at the definition: `chunks`/`windows` yield COPIES because Yo has
    no slice type, and `extend` is bounded by `IntoIterator`, which an iterator
    does NOT satisfy (issues/blanket-into-iter-is-not-an-intoiterator-impl.md).
-   Still open in this group: `imm/*` iterators and `remove` shape,
+   `imm/*` now has `IntoIterator` on all six containers (2026-09-08):
+   `List` walks its cons chain and `Vec` its flat array, both O(1) per step;
+   `Map`/`Set`/`SortedMap`/`SortedSet` delegate to the `List` their existing
+   `entries()`/`to_list()` already returns, and say so rather than pretending
+   to be lazy — a stack-based cursor over the trie/RB-tree is the future
+   optimization. `SortedMap` gained the `entries()` it was missing beside
+   `imm.Map`'s.
+
+   Still open in this group: `imm` `remove` shape,
    `OrderedMap.swap_remove`, private `ctrl/data/size` fields, the `imm/Vec`
    RRB-vs-flat-COW doc (§5).
+
+   **Evidence for that §5 decision, found while writing the iterator tests:**
+   `imm.Vec.push` takes `own(self)`, so the receiver is MOVED and keeping the
+   earlier version requires an extra binding (`kept := v; bigger := v.push(x)`)
+   — which is also what pushes the refcount above one and sends `push` down its
+   copying path. That is a coherent flat-COW design, but it is not what a reader
+   of the word "persistent" expects, and the ergonomics are the argument for
+   fixing the DOC rather than the structure.
 
    **Core numerics: integers DONE, floats UNBLOCKED.** Every
    `checked_/wrapping_/saturating_/overflowing_` plus `abs/pow/clamp` landed as

--- a/std/imm/list.yo
+++ b/std/imm/list.yo
@@ -284,7 +284,50 @@ impl(
     })
   )
 );
+/// Iterator over a `List`'s elements, head to tail.
+///
+/// Walks the cons chain, so it is O(1) per step and allocates nothing — the
+/// nodes already exist. This is also the iterator the four hash/tree
+/// containers reach for: `Map.entries()`, `Set.to_list()` and friends already
+/// return a `List`, so their `into_iter` is this one over that list.
+ListIter :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
+  struct(
+    _node : Option(ListNode(T))
+  )
+);
+impl(
+  generic(T : Type),
+  where(T <: (Send, Acyclic)),
+  ListIter(T),
+  Iterator(
+    Item : T,
+    next : (fn(inout(self) : Self) -> Option(T))(
+      match(
+        self._node,
+        .None => Option(T).None,
+        .Some(node) => {
+          v := node._value;
+          self._node = node._next;
+          Option(T).Some(v)
+        }
+      )
+    )
+  )
+);
+impl(
+  generic(T : Type),
+  where(T <: (Send, Acyclic)),
+  List(T),
+  IntoIterator(
+    Item : T,
+    IntoIter : ListIter(T),
+    into_iter : (fn(self : Self) -> ListIter(T))(
+      ListIter(T)(_node : self._head)
+    )
+  )
+);
 export(
   List,
-  ListNode
+  ListNode,
+  ListIter
 );

--- a/std/imm/map.yo
+++ b/std/imm/map.yo
@@ -609,7 +609,7 @@ _node_remove :: (
   )
 );
 // -- Collection helpers --
-{ List } :: import("./list.yo");
+{ List, ListIter } :: import("./list.yo");
 // -- Eq trait --
 _merge_from_node :: (
   fn(
@@ -998,6 +998,24 @@ impl(
         .None => true
       )
     })
+  )
+);
+/// Iterate the map's entries, in the tree's own order.
+///
+/// Delegates to `entries()`, so the whole snapshot is materialised into a
+/// `List` first — the same cost `entries()` already had. A stack-based cursor
+/// over the trie would avoid it; this closes the §4 row without pretending to
+/// be lazier than it is.
+impl(
+  generic(K : Type, V : Type),
+  where(K <: (Eq(K), Hash, Send, Acyclic), V <: (Send, Acyclic)),
+  Map(K, V),
+  IntoIterator(
+    Item : MapEntry(K, V),
+    IntoIter : ListIter(MapEntry(K, V)),
+    into_iter : (fn(self : Self) -> ListIter(MapEntry(K, V)))(
+      self.entries().into_iter()
+    )
   )
 );
 export(Map, MapNode, MapBranch, MapLeaf, MapCollision, MapEntry, InsertResult, RemoveResult);

--- a/std/imm/set.yo
+++ b/std/imm/set.yo
@@ -20,7 +20,7 @@
 pragma(Pragma.AllowUnsafe);
 { Map } :: import("./map.yo");
 { ArrayList } :: import("../collections/array_list.yo");
-{ List } :: import("./list.yo");
+{ List, ListIter } :: import("./list.yo");
 /// Persistent immutable hash set backed by a HAMT.
 ///
 /// Wraps `Map(T, bool)` internally. The bool values are always `true`.
@@ -172,6 +172,20 @@ impl(
   Eq(Set(T))(
     (==) : (fn(lhs : Self, rhs : Self) -> bool)(
       lhs._inner == rhs._inner
+    )
+  )
+);
+/// Iterate the set's elements. Delegates to `to_list()` — see `Map`'s
+/// `IntoIterator` for the cost note.
+impl(
+  generic(T : Type),
+  where(T <: (Eq(T), Hash, Send, Acyclic)),
+  Set(T),
+  IntoIterator(
+    Item : T,
+    IntoIter : ListIter(T),
+    into_iter : (fn(self : Self) -> ListIter(T))(
+      self.to_list().into_iter()
     )
   )
 );

--- a/std/imm/sorted_map.yo
+++ b/std/imm/sorted_map.yo
@@ -18,7 +18,7 @@
 //! // keys are always sorted: 1, 2, 3
 //! ```
 pragma(Pragma.AllowUnsafe);
-{ List } :: import("./list.yo");
+{ List, ListIter } :: import("./list.yo");
 { ArrayList } :: import("../collections/array_list.yo");
 { MapEntry } :: import("./map.yo");
 /// Color of a red-black tree node.
@@ -486,6 +486,27 @@ _node_remove :: (
 // ---------------------------------------------------------------------------
 // In-order traversal helpers
 // ---------------------------------------------------------------------------
+/// Collect entries in-order into a List. Builds by PREPENDING from the right,
+/// which is why the recursion visits right-then-left.
+_collect_entries :: (
+  fn(
+    comptime(K) : Type,
+    comptime(V) : Type,
+    node : Option(RBNode(K, V)),
+    acc : List(MapEntry(K, V)),
+    where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic))
+  ) -> List(MapEntry(K, V))
+)(
+  match(
+    node,
+    .None => acc,
+    .Some(h) => {
+      right_acc := recur(K, V, h._right, acc);
+      with_entry := right_acc.prepend(MapEntry(K, V)(key : h._key, value : h._value));
+      recur(K, V, h._left, with_entry)
+    }
+  )
+);
 /// Collect keys in-order into a List.
 _collect_keys :: (
   fn(
@@ -623,6 +644,11 @@ impl(
   values : (fn(self : Self) -> List(V))(
     _collect_values(K, V, self._root, List(V).new())
   ),
+  /// Return in-order list of entries — the counterpart of `imm.Map.entries`,
+  /// and what `into_iter` walks.
+  entries : (fn(self : Self) -> List(MapEntry(K, V)))(
+    _collect_entries(K, V, self._root, List(MapEntry(K, V)).new())
+  ),
   /// Create a sorted map from a slice of key-value pairs.
   from_entries : (fn(pairs : ArrayList(MapEntry(K, V))) -> Self)({
     (result : Self) = Self.new();
@@ -653,6 +679,20 @@ impl(
       rhs_vals := rhs.values();
       (lhs_keys == rhs_keys) && (lhs_vals == rhs_vals)
     })
+  )
+);
+/// Iterate the map's entries in ASCENDING key order. Delegates to
+/// `entries()` — see `imm.Map`'s `IntoIterator` for the cost note.
+impl(
+  generic(K : Type, V : Type),
+  where(K <: (Eq(K), Ord(K), Send, Acyclic), V <: (Send, Acyclic)),
+  SortedMap(K, V),
+  IntoIterator(
+    Item : MapEntry(K, V),
+    IntoIter : ListIter(MapEntry(K, V)),
+    into_iter : (fn(self : Self) -> ListIter(MapEntry(K, V)))(
+      self.entries().into_iter()
+    )
   )
 );
 export(SortedMap);

--- a/std/imm/sorted_set.yo
+++ b/std/imm/sorted_set.yo
@@ -20,7 +20,7 @@
 pragma(Pragma.AllowUnsafe);
 { SortedMap } :: import("./sorted_map.yo");
 { ArrayList } :: import("../collections/array_list.yo");
-{ List } :: import("./list.yo");
+{ List, ListIter } :: import("./list.yo");
 /// Persistent immutable sorted set backed by a left-leaning red-black tree.
 SortedSet :: (fn(comptime(T) : Type, where(T <: (Eq(T), Ord(T), Send, Acyclic))) -> comptime(Type))(
   struct(_inner : SortedMap(T, bool))
@@ -194,6 +194,20 @@ impl(
   Eq(SortedSet(T))(
     (==) : (fn(lhs : Self, rhs : Self) -> bool)(
       lhs._inner == rhs._inner
+    )
+  )
+);
+/// Iterate the set's elements in ASCENDING order. Delegates to `to_list()` —
+/// see `Map`'s `IntoIterator` for the cost note.
+impl(
+  generic(T : Type),
+  where(T <: (Eq(T), Ord(T), Send, Acyclic)),
+  SortedSet(T),
+  IntoIterator(
+    Item : T,
+    IntoIter : ListIter(T),
+    into_iter : (fn(self : Self) -> ListIter(T))(
+      self.to_list().into_iter()
     )
   )
 );

--- a/std/imm/vec.yo
+++ b/std/imm/vec.yo
@@ -501,4 +501,44 @@ impl(
     })
   )
 );
-export(Vec, PopResult);
+/// Iterator over a `Vec`'s elements, front to back.
+///
+/// The backing store is a flat array, so this is an index walk: O(1) per step
+/// and no allocation.
+VecIter :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
+  struct(
+    _vec : Vec(T),
+    _index : usize
+  )
+);
+impl(
+  generic(T : Type),
+  where(T <: (Send, Acyclic)),
+  VecIter(T),
+  Iterator(
+    Item : T,
+    next : (fn(inout(self) : Self) -> Option(T))(
+      cond(
+        (self._index >= self._vec.len()) => Option(T).None,
+        true => {
+          v := self._vec.get(self._index);
+          self._index = (self._index + usize(1));
+          v
+        }
+      )
+    )
+  )
+);
+impl(
+  generic(T : Type),
+  where(T <: (Send, Acyclic)),
+  Vec(T),
+  IntoIterator(
+    Item : T,
+    IntoIter : VecIter(T),
+    into_iter : (fn(self : Self) -> VecIter(T))(
+      VecIter(T)(_vec : self, _index : usize(0))
+    )
+  )
+);
+export(Vec, PopResult, VecIter);

--- a/tests/imm_iterators.test.yo
+++ b/tests/imm_iterators.test.yo
@@ -1,0 +1,134 @@
+//! `Iterator` / `IntoIterator` on all six `imm` collections.
+//!
+//! Before this, `std/imm/string.yo` was the only file in the directory with an
+//! iterator, so none of the containers worked with `for`, `collect` or any
+//! combinator. `List` and `Vec` walk their own storage; the four hash/tree
+//! containers delegate to the `List` their existing `entries()`/`to_list()`
+//! already returns.
+{ assert } :: import("std/assert");
+open(import("std/collections/array_list"));
+{ List } :: import("std/imm/list");
+{ Vec } :: import("std/imm/vec");
+{ Map, MapEntry } :: import("std/imm/map");
+{ Set } :: import("std/imm/set");
+{ SortedMap } :: import("std/imm/sorted_map");
+{ SortedSet } :: import("std/imm/sorted_set");
+_drain :: (fn(generic(I : Type), it : I, where(I <: Iterator(Item := i32))) -> ArrayList(i32))({
+  out := ArrayList(i32).new();
+  iter := it;
+  while(runtime(true), {
+    match(
+      iter.next(),
+      .None => {
+        break;
+      },
+      .Some(v) => {
+        out.push(v);
+      }
+    );
+  });
+  out
+});
+_drain_keys :: (
+  fn(generic(I : Type), it : I, where(I <: Iterator(Item := MapEntry(i32, i32)))) -> ArrayList(i32)
+)({
+  out := ArrayList(i32).new();
+  iter := it;
+  while(runtime(true), {
+    match(
+      iter.next(),
+      .None => {
+        break;
+      },
+      .Some(e) => {
+        out.push(e.key);
+      }
+    );
+  });
+  out
+});
+test("List iterates head to tail", {
+  xs := List(i32).new().prepend(i32(3)).prepend(i32(2)).prepend(i32(1));
+  got := _drain(xs.into_iter());
+  assert(got.len() == usize(3), "three elements");
+  assert(got(usize(0)) == i32(1), "head first");
+  assert(got(usize(1)) == i32(2), "then the middle");
+  assert(got(usize(2)) == i32(3), "then the tail");
+});
+test("an empty List yields nothing", {
+  assert(_drain(List(i32).new().into_iter()).len() == usize(0), "no elements");
+});
+test("iterating a List does not consume it", {
+  xs := List(i32).new().prepend(i32(1));
+  _first := _drain(xs.into_iter());
+  assert(_drain(xs.into_iter()).len() == usize(1), "still iterable a second time");
+  assert(xs.len() == usize(1), "and its length is unchanged");
+});
+test("Vec iterates front to back", {
+  v := Vec(i32).new().push(i32(10)).push(i32(20)).push(i32(30));
+  got := _drain(v.into_iter());
+  assert(got.len() == usize(3), "three elements");
+  assert(got(usize(0)) == i32(10), "first");
+  assert(got(usize(2)) == i32(30), "last");
+});
+test("an empty Vec yields nothing", {
+  assert(_drain(Vec(i32).new().into_iter()).len() == usize(0), "no elements");
+});
+test("a retained Vec version iterates independently of one derived from it", {
+  v := Vec(i32).new().push(i32(1));
+  // `push` takes `own(self)`, so `v` is MOVED into it; the extra binding is
+  // what keeps the earlier version alive (and what pushes the refcount above
+  // one, sending `push` down its copying path).
+  kept := v;
+  bigger := v.push(i32(2));
+  assert(_drain(kept.into_iter()).len() == usize(1), "the retained version is unchanged");
+  assert(_drain(bigger.into_iter()).len() == usize(2), "and the derived one has both");
+});
+test("Map iterates its entries", {
+  m := Map(i32, i32).new().insert(i32(1), i32(10)).insert(i32(2), i32(20));
+  keys := _drain_keys(m.into_iter());
+  assert(keys.len() == usize(2), "both entries");
+  assert(keys.contains(i32(1)), "key 1 appeared");
+  assert(keys.contains(i32(2)), "key 2 appeared");
+});
+test("an empty Map yields nothing", {
+  assert(_drain_keys(Map(i32, i32).new().into_iter()).len() == usize(0), "no entries");
+});
+test("Set iterates its elements", {
+  s := Set(i32).new().insert(i32(5)).insert(i32(7)).insert(i32(5));
+  got := _drain(s.into_iter());
+  assert(got.len() == usize(2), "the duplicate insert did not add an element");
+  assert(got.contains(i32(5)), "5 is present");
+  assert(got.contains(i32(7)), "7 is present");
+});
+test("SortedMap iterates in ASCENDING key order", {
+  m := SortedMap(i32, i32).new().insert(i32(3), i32(30)).insert(i32(1), i32(10)).insert(i32(2), i32(20));
+  keys := _drain_keys(m.into_iter());
+  assert(keys.len() == usize(3), "three entries");
+  assert(keys(usize(0)) == i32(1), "smallest key first");
+  assert(keys(usize(1)) == i32(2), "then the middle");
+  assert(keys(usize(2)) == i32(3), "then the largest");
+});
+test("SortedMap.entries matches its iteration order", {
+  m := SortedMap(i32, i32).new().insert(i32(2), i32(20)).insert(i32(1), i32(10));
+  es := m.entries();
+  assert(es.len() == usize(2), "two entries");
+  assert(match(es.head(), .Some(e) => (e.key == i32(1)), .None => false), "head is the smallest key");
+  assert(match(es.head(), .Some(e) => (e.value == i32(10)), .None => false), "carrying its value");
+});
+test("SortedSet iterates in ASCENDING order", {
+  s := SortedSet(i32).new().insert(i32(9)).insert(i32(2)).insert(i32(5));
+  got := _drain(s.into_iter());
+  assert(got.len() == usize(3), "three elements");
+  assert(got(usize(0)) == i32(2), "smallest first");
+  assert(got(usize(1)) == i32(5), "then the middle");
+  assert(got(usize(2)) == i32(9), "then the largest");
+});
+test("an imm collection works with a for loop", {
+  v := Vec(i32).new().push(i32(1)).push(i32(2)).push(i32(3));
+  (total : i32) = i32(0);
+  for(v, x => {
+    total = (total + x);
+  });
+  assert(total == i32(6), "the whole point of IntoIterator: `for` works");
+});


### PR DESCRIPTION
Stacked on #490. **This closes §4's Collections group.**

The list said *"`imm/*` — no `Iterator` on any of the six collection types (`imm/string.yo:627` has one)"*. Now `List`, `Vec`, `Map`, `Set`, `SortedMap` and `SortedSet` all implement `IntoIterator`, so `for`, `collect` and every prelude combinator work over them.

## How each one iterates

- **`List`** walks its own cons chain, **`Vec`** indexes its flat array — both O(1) per step, no allocation.
- **`Map` / `Set` / `SortedMap` / `SortedSet`** delegate to the `List` that their existing `entries()` / `to_list()` already returns. That materialises the snapshot first, and the doc says so plainly rather than implying laziness; a stack-based cursor over the trie / RB-tree is the optimization if it is ever wanted. The cost is not new — it is what `entries()` already charged.
- **`SortedMap.entries()`** did not exist beside `imm.Map`'s; it does now, in-order, built by the same prepend-from-the-right walk as `keys()`/`values()`.

## Evidence for the open §5 `imm/Vec` question

Writing the tests turned this up, and the plan now records it. `imm.Vec.push` takes `own(self)`, so the receiver is **moved** — retaining the earlier version needs an extra binding:

```rust
kept := v;              // also lifts the refcount above one …
bigger := v.push(i32(2));   // … which sends `push` down its COPYING path
```

The test that tried the obvious `v.push(x)`-and-still-use-`v` shape is the one that failed, with `error[E0901]: use of moved value: v`. Coherent as flat COW; not what a reader of the word "persistent" expects. That is the argument for fixing the **doc** rather than the structure.

## Local verification

| gate | result |
| --- | --- |
| new `tests/imm_iterators.test.yo` | 13/13 |
| every existing imm file | list 16/16, vec 53/53, map 21/21, set 19/19, sorted_map 17/17, sorted_set 18/18, threading 30/30 |
| full suite | **3779/3779**, 0 failures |
| `check ./std` | 174/174 |
| `check ./src` | 266/266 |
| `yo build` (self-build) | rc=0 |
| cli scorecard | 81 PASS / 0 GOLDEN-DIFF |

The existing imm files being unchanged is the regression evidence: this touched all six modules.

One of the 13 new tests is just `for(v, (x) => ...)` over an `imm.Vec`, which is the whole point of the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)