### PR TITLE
std/error: error_is and Context; file the two bugs that block ErrorChain

### DIFF
--- a/issues/blanket-inherent-method-on-a-dyn-receiver-dispatches-through-the-vtable.md
+++ b/issues/blanket-inherent-method-on-a-dyn-receiver-dispatches-through-the-vtable.md
@@ -1,0 +1,68 @@
+# A blanket inherent method reached through a `Dyn` receiver is dispatched through the VTABLE
+
+**Status:** OPEN
+**Found:** 2026-09-08, designing `Error.is(T)` for `plans/STD_API_STABILIZATION.md` §4 Core.
+
+## Symptom
+
+A blanket INHERENT method over a trait bound, called on a `Dyn(Trait)` value:
+
+```rust
+{ Error, AnyError } :: import("std/error");
+impl(
+  generic(E : Type),
+  where(E <: Error),
+  E,
+  is : (fn(self : Self, comptime(T) : Type) -> bool)(
+    match(downcast(self, T), .Some(_) => true, .None => false)
+  )
+);
+main :: (fn() -> unit)({
+  (base : AnyError) = dyn(MyErr(code : i32(7)));
+  println(`${base.is(MyErr)}`);
+});
+```
+
+`yo check` passes. The emitted C does not compile:
+
+```
+error: no member named 'is' in 'struct __yo_t0_vtable_s'
+ 2510 |   bool _tmp = (base).vtable->is((base).data);
+      |               ~~~~~~~~~~~~~  ^
+```
+
+## What is wrong
+
+The evaluator RESOLVES the call — the blanket impl's bound `E <: Error` is
+satisfied by `Dyn(Error)`, which is correct and useful. Codegen then assumes
+that any method call on a `Dyn` receiver is a TRAIT method and emits a vtable
+indirection. `is` is not a member of the `Error` trait, so there is no slot
+for it, and the emitted C names a struct member that does not exist.
+
+The right lowering is a DIRECT call to the monomorphised blanket method with
+the `Dyn` value as the receiver — the same thing that happens for any other
+concrete receiver type. Note the emitted call also correctly dropped the
+`comptime(T)` argument, so the only defect is the dispatch mechanism.
+
+## Why it matters
+
+This is the one shape that would let a `Dyn(Trait)` value carry convenience
+methods that are NOT part of the trait's vtable — Rust's `dyn Error` gets
+`is::<T>()`, `downcast_ref`, and `source`-chain helpers exactly that way. With
+this bug, every such helper has to be a free function, so `err.is(NotFound)`
+must be written `error_is(err, NotFound)`.
+
+`std/error.yo` takes the free-function route for that reason, with a comment
+pointing here.
+
+## Reproducer
+
+`issues/repros/` — the snippet above is self-contained apart from a `MyErr`
+struct implementing `ToString` and `Error`.
+
+## Note on severity
+
+It is an accepts-invalid: the failure is a C compile error, not a miscompile,
+so nothing silently misbehaves at runtime. But the diagnostic names a
+generated vtable struct and a source line in the emitted C, which points a
+reader at codegen rather than at their own call site.

--- a/issues/error-source-result-cannot-be-held-as-anyerror.md
+++ b/issues/error-source-result-cannot-be-held-as-anyerror.md
@@ -1,0 +1,86 @@
+# `Dyn(SelfTrait)` does not unify with `Dyn(ThatTrait)`, so `Error.source`'s result cannot be held
+
+**Status:** OPEN — blocks `ErrorChain` / `root_cause`
+**Found:** 2026-09-08, building §4 Core's error ergonomics.
+**Reproducer:** `issues/repros/error-source-selftrait-dyn.yo`
+
+## The trait
+
+`std/error.yo` declares, as it must:
+
+```rust
+Error :: trait(
+  (source : (fn(inout(self) : Self) -> Option(Dyn(SelfTrait)))) ?= (self -> .None),
+  where(Self <: ToString)
+);
+AnyError :: Dyn(Error);
+```
+
+`Dyn(SelfTrait)` is the only spelling available: `Dyn(Error)` inside `Error`'s
+own declaration is a definition cycle, and so is naming `AnyError`, which is
+`Dyn(Error)`.
+
+## Symptom — providing is fine, CONSUMING is not
+
+Overriding `source` with the more convenient `Option(AnyError)` is accepted:
+
+```rust
+impl(E2, Error(source : (fn(inout(self) : Self) -> Option(AnyError))(
+  Option(AnyError).Some(self.inner)
+)));
+```
+
+Calling it and holding the result at that same type is rejected:
+
+```rust
+(held : Option(AnyError)) = b.source();
+```
+```
+error[E0601]: Incompatible types:
+- Expected: <enum:enum_yo_id_7241>
+- Given   : <enum:enum_yo_id_7224>
+```
+
+and through an intermediate re-wrap the payloads are shown not to unify either:
+
+```
+Expected: dyn(Error + ToString)
+Got:      dyn((source : fn(self : Self : (ToString)) -> <enum:...>) + ToString)
+```
+
+So the trait's own `Dyn(SelfTrait)` is a STRUCTURAL dyn — whose `source` member
+is typed by the recursive `Option(Dyn(SelfTrait))` — and it never unifies with
+the NAMED `Dyn(Error)`, even though they denote the same thing. The asymmetry
+(an impl may declare `Option(AnyError)`, a caller may not receive it) suggests
+the impl-conformance check is laxer than assignment's.
+
+## What it costs
+
+`err.source()` is only usable INLINE — you can `match` on it and call
+`to_string()` on the payload. You cannot:
+
+- store it in a field or local typed `Option(AnyError)`;
+- call `.source()` on the payload, so you cannot walk more than one link;
+- therefore write `ErrorChain` (an iterator over the chain) or `root_cause`
+  at all.
+
+This is the real reason "nothing in the tree overrides `source`", which
+`plans/STD_API_STABILIZATION.md` §4 records as an observation: the feature is
+not merely unused, it is barely usable. `std/error.yo` ships `error_is` and
+`Context` (which DOES override `source`, and whose `to_string` renders the
+cause, so the message chain works even though the typed chain does not);
+`ErrorChain` and `root_cause` wait on this.
+
+## Candidate fixes
+
+1. **Canonicalise `Dyn(SelfTrait)` to `Dyn(<the enclosing trait>)`** when the
+   trait's own type value becomes available — i.e. resolve the self-reference
+   after the trait is registered, rather than leaving a structural stand-in.
+   This is the fix that makes the two spellings one type.
+2. Allow `Dyn(Error)` / a forward `AnyError` inside the declaration by
+   deferring the dyn's construction, which the lazy-bindings machinery may
+   already make possible.
+
+(1) looks right: the structural form carries no information the named one
+lacks, and every other self-reference in the language resolves to the named
+entity.

--- a/issues/repros/error-source-selftrait-dyn.yo
+++ b/issues/repros/error-source-selftrait-dyn.yo
@@ -1,0 +1,19 @@
+{ Error, AnyError } :: import("std/error");
+{ ToString } :: import("std/fmt/to_string");
+{ String } :: import("std/string");
+{ println } :: import("std/fmt");
+E1 :: struct(n : i32);
+impl(E1, ToString(to_string : (fn(inout(self) : Self) -> String)(`E1(${self.n})`)));
+impl(E1, Error());
+E2 :: struct(inner : AnyError);
+impl(E2, ToString(to_string : (fn(inout(self) : Self) -> String)(`E2`)));
+// PROVIDING an override typed Option(AnyError) is accepted.
+impl(E2, Error(source : (fn(inout(self) : Self) -> Option(AnyError))(Option(AnyError).Some(self.inner))));
+main :: (fn() -> unit)({
+  (a : AnyError) = dyn(E1(n : i32(1)));
+  (b : AnyError) = dyn(E2(inner : a));
+  // CONSUMING the result as an AnyError is rejected.
+  (held : Option(AnyError)) = b.source();
+  match(held, .Some(x) => println(x.to_string()), .None => println(`none`));
+});
+export(main);

--- a/std/error.yo
+++ b/std/error.yo
@@ -22,6 +22,76 @@ impl(String, Error());
 impl(ParseIntError, Error());
 impl(ParseFloatError, Error());
 impl(ParseBoolError, Error());
+/// True when the type-erased `err` is really a `T` — Rust's `dyn Error::is`.
+///
+/// A FREE function rather than a method because a blanket inherent method over
+/// `E <: Error` resolves on a `Dyn(Error)` receiver and then miscompiles: codegen
+/// treats every method call on a `Dyn` value as a trait method and emits a
+/// vtable indirection for a slot that does not exist. See
+/// issues/blanket-inherent-method-on-a-dyn-receiver-dispatches-through-the-vtable.md;
+/// when that is fixed this becomes `err.is(T)`.
+///
+/// ```rust
+/// cond(
+///   error_is(err, NotFound) => recover(),
+///   true => rethrow(err)
+/// );
+/// ```
+///
+/// To use the value and not just test for it, reach for the `downcast(err, T)`
+/// builtin this is written over — it returns `Option(T)`.
+error_is :: (fn(err : AnyError, comptime(T) : Type) -> bool)(
+  match(
+    downcast(err, T),
+    .Some(_) => true,
+    .None => false
+  )
+);
+export(error_is);
+/// An error that adds a message to the one underneath it — Rust's
+/// `anyhow::Context` / `.context(...)`.
+///
+/// This is the type that makes `Error.source` worth having: nothing else in
+/// the tree overrides it, so before this every error chain was one link long.
+/// `to_string` renders the whole chain, innermost last:
+///
+/// ```rust
+/// e := Context.new(`while loading the config`, dyn(io_err));
+/// println(e.to_string());   // while loading the config: no such file
+/// ```
+Context :: struct(
+  /// What was being attempted.
+  message : String,
+  /// The error that caused it.
+  cause : AnyError
+);
+export(Context);
+impl(
+  Context,
+  /// Wrap `cause` with `message`.
+  new : (fn(message : String, cause : AnyError) -> Self)(
+    Self(message : message, cause : cause)
+  )
+);
+impl(
+  Context,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)({
+      out := self.message.clone();
+      out.push_str(": ");
+      out.push_string(self.cause.to_string());
+      out
+    })
+  )
+);
+impl(
+  Context,
+  Error(
+    source : (fn(inout(self) : Self) -> Option(AnyError))(
+      Option(AnyError).Some(self.cause)
+    )
+  )
+);
 /// Non-resumable exception handling effect record.
 /// Use `throw` to raise an `AnyError` and abort the current computation.
 /// `throw` is `ctl(...)` — handler body may contain `unwind`, and the

--- a/tests/error_ergonomics.test.yo
+++ b/tests/error_ergonomics.test.yo
@@ -1,0 +1,64 @@
+//! `std/error`'s §4 Core ergonomics: `error_is` and `Context`.
+//!
+//! `ErrorChain`/`root_cause` are absent on purpose — `Error.source`'s result
+//! cannot be held at `Option(AnyError)`, so the chain cannot be walked past
+//! one link. See issues/error-source-result-cannot-be-held-as-anyerror.md.
+{ assert } :: import("std/assert");
+{ Error, AnyError, error_is, Context } :: import("std/error");
+{ ToString } :: import("std/fmt/to_string");
+open(import("std/string"));
+NotFound :: struct(path : String);
+impl(
+  NotFound,
+  ToString(to_string : (fn(inout(self) : Self) -> String)(`no such file: ${self.path}`))
+);
+impl(NotFound, Error());
+Denied :: struct(who : String);
+impl(
+  Denied,
+  ToString(to_string : (fn(inout(self) : Self) -> String)(`denied for ${self.who}`))
+);
+impl(Denied, Error());
+test("error_is identifies the concrete type behind an AnyError", {
+  (e : AnyError) = dyn(NotFound(path : `/tmp/x`));
+  assert(error_is(e, NotFound), "the type it really is");
+  assert(!error_is(e, Denied), "and not another error type");
+});
+test("error_is over a second error type", {
+  (e : AnyError) = dyn(Denied(who : `nobody`));
+  assert(error_is(e, Denied), "identified");
+  assert(!error_is(e, NotFound), "not confused with the first");
+});
+test("downcast recovers the value, which is what error_is tests for", {
+  (e : AnyError) = dyn(NotFound(path : `/etc/hosts`));
+  assert(match(downcast(e, NotFound), .Some(nf) => (nf.path == `/etc/hosts`), .None => false), "the payload survives");
+  assert(match(downcast(e, Denied), .Some(_) => false, .None => true), "and the wrong type gives None");
+});
+test("Context renders its message ahead of the cause", {
+  (inner : AnyError) = dyn(NotFound(path : `cfg.toml`));
+  c := Context.new(`while loading the config`, inner);
+  assert(c.to_string() == `while loading the config: no such file: cfg.toml`, "message, colon, cause");
+});
+test("Context nests, and each layer adds a prefix", {
+  (inner : AnyError) = dyn(NotFound(path : `a`));
+  (one : AnyError) = dyn(Context.new(`reading`, inner));
+  two := Context.new(`starting up`, one);
+  assert(two.to_string() == `starting up: reading: no such file: a`, "the whole chain renders innermost last");
+});
+test("Context overrides source, and the cause is reachable inline", {
+  (inner : AnyError) = dyn(Denied(who : `root`));
+  (c : AnyError) = dyn(Context.new(`connecting`, inner));
+  // Inline only: the result cannot be stored at Option(AnyError) — see the
+  // module doc and the issue it points at.
+  assert(match(c.source(), .Some(s) => (s.to_string() == `denied for root`), .None => false), "source yields the cause");
+});
+test("an error that does NOT override source reports none", {
+  (e : AnyError) = dyn(NotFound(path : `x`));
+  assert(match(e.source(), .Some(_) => false, .None => true), "the trait default is .None");
+});
+test("error_is sees Context itself, not its cause", {
+  (inner : AnyError) = dyn(NotFound(path : `x`));
+  (c : AnyError) = dyn(Context.new(`ctx`, inner));
+  assert(error_is(c, Context), "the outer type");
+  assert(!error_is(c, NotFound), "error_is does NOT look through the chain, as in Rust");
+});


### PR DESCRIPTION
Independent of the #488→#492 chain — touches only `std/error.yo`.

§4 Core asked for `Error.is(T)`, a documented `downcast`, `ErrorChain` and `Context(msg, source)`. **Two land; the other two are blocked by compiler bugs that building them surfaced**, both filed with reproducers rather than worked around.

## `error_is(err, T)` — and why it is a free function

A blanket inherent method over `E <: Error` *does* resolve on a `Dyn(Error)` receiver. Codegen then emits a vtable indirection for a slot that does not exist:

```
error: no member named 'is' in 'struct __yo_t0_vtable_s'
  bool _tmp = (base).vtable->is((base).data);
```

That is the one shape that would let a `Dyn(Trait)` value carry helpers *outside* the trait's vtable — exactly how Rust's `dyn Error` gets `is::<T>()`. Filed as `issues/blanket-inherent-method-on-a-dyn-receiver-dispatches-through-the-vtable.md`; when it is fixed, this becomes `err.is(T)` with no change to the semantics.

## `Context` — the type that makes `source` worth having

Before it, nothing in the tree overrode `Error.source`, so every chain was one link long. `to_string` renders message-then-cause, so nesting reads:

```
starting up: reading: no such file: a
```

## `ErrorChain` and `root_cause` are deliberately absent

Not for lack of trying. `Error.source` is declared `Option(Dyn(SelfTrait))` — the only spelling available, since `Dyn(Error)` inside `Error`'s own declaration is a definition cycle, and so is naming `AnyError`. That structural dyn **never unifies with the named `Dyn(Error)`**:

```rust
impl(E2, Error(source : (fn(inout(self) : Self) -> Option(AnyError))(...)));  // accepted
(held : Option(AnyError)) = b.source();                                       // REJECTED
```
```
error[E0601]: Incompatible types:
- Expected: <enum:enum_yo_id_7241>
- Given   : <enum:enum_yo_id_7224>
```

Providing an override at that type is fine; *receiving* the result is not. So `err.source()` is usable only inline, and the chain cannot be walked past one link — which makes `ErrorChain` and `root_cause` unwritable today.

**This answers a question the plan had only observed.** §4 records that "nothing in the tree overrides `source`". The reason is not neglect: the typed chain is barely usable. Filed as `issues/error-source-result-cannot-be-held-as-anyerror.md`, with a five-line reproducer in `issues/repros/` and the fix I believe is right — canonicalise `Dyn(SelfTrait)` to the named trait's dyn once the trait is registered, since the structural form carries no information the named one lacks.

## Tests

8 cases covering what ships, including:
- the inline-only `source` call, with a comment pointing at the issue so the odd shape is not mistaken for style;
- that `error_is` does **not** look through the chain — `error_is(ctx, NotFound)` is false where `error_is(ctx, Context)` is true, matching Rust, where `is` tests the outermost error;
- `downcast` recovering the payload, which is what `error_is` is written over.

## Local verification

| gate | result |
| --- | --- |
| `tests/error_ergonomics.test.yo` | 8/8 |
| full suite | **3732/3732**, 0 failures |
| `check ./std` | 173/173 |
| `check ./src` | 266/266 |
| `yo build` (self-build) | rc=0 |
| cli scorecard | 85 PASS / 0 GOLDEN-DIFF |
| `fmt --check` std + tests | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)