### PR TITLE
std/sync: TryRecvError on try_recv; Semaphore.with_permit

### DIFF
--- a/issues/with-lock-and-with-permit-cannot-see-an-unwind.md
+++ b/issues/with-lock-and-with-permit-cannot-see-an-unwind.md
@@ -1,0 +1,60 @@
+# `Mutex.with_lock`'s "unlocks on unwind" claim is unreachable through its own signature
+
+**Status:** OPEN — doc/API accuracy, not a defect
+**Found:** 2026-09-08, trying to write the unwind test for the new
+`Semaphore.with_permit`.
+
+## The claim
+
+`std/sync/mutex.yo` says, of the `__MutexUnlocker` guard:
+
+> Allocated locally inside with_lock; Yo's drop-on-scope-exit and
+> drop-on-unwind machinery guarantees unlock under both normal return
+> and `unwind(...)`.
+
+The machinery does do that. The signature, however, makes the `unwind(...)`
+half unreachable.
+
+## Why
+
+`with_lock`'s body is an `Impl(Fn(inout(v) : T) -> R)` — a CLOSURE. Raising an
+effect requires the control-bound handler value to be in scope, and the
+compiler rejects capturing one into a closure:
+
+```
+error: Closures cannot capture a value of control-bound type. The captured
+value `boom` has type `fn() -> unit` which transitively contains a
+`ctl(...) -> ret` function. Closures can escape their enclosing frame, taking
+the captured control function with them — which would unwind to a dead install
+frame.
+```
+
+That rejection is correct and deliberate. Its consequence is that `body`
+cannot raise an effect, so nothing can unwind past `with_lock` from inside it,
+so the drop-on-unwind path is never taken. The comment describes a capability
+of the runtime rather than a behaviour of this function, which reads as a
+guarantee to anyone auditing lock safety.
+
+`Semaphore.with_permit` (added in the same batch) has exactly the same shape.
+Its doc states the accurate version and points here; a test asserting unwind
+safety cannot be written, and the semaphore test file says so at the place the
+test would have gone rather than leaving a silent hole.
+
+## The same point, already in the plan
+
+`plans/STD_API_STABILIZATION.md` §4 Concurrency asks that
+`async/mutex.with_lock` *"either takes an `io` (so its doc claim becomes true)
+or drops the claim"*. This is that item, generalised: it applies to the
+blocking `Mutex.with_lock` too, and to any future `with_*` helper taking a
+closure.
+
+## Options
+
+1. **Correct the comments** — cheapest, and honest. `with_permit` already does.
+2. **Take the effect as a parameter**, e.g.
+   `with_lock(body : Impl(Fn(inout(v) : T, exn : Exception) -> R))`, so the body
+   can throw and the claim becomes both true and testable. This is what §4 asks
+   of the async variant, and it is a breaking signature change.
+
+(1) should happen regardless; (2) is a design decision about whether these
+helpers are meant to be effect-transparent.

--- a/std/sync/channel.yo
+++ b/std/sync/channel.yo
@@ -25,6 +25,42 @@ pragma(Pragma.AllowUnsafe);
 { Cond } :: import("./cond");
 { AtomicBool, AtomicUsize, MemoryOrder } :: import("./atomic");
 { assert } :: import("../assert");
+{ ToString } :: import("../fmt/to_string.yo");
+open(import("../string"));
+/// Why a non-blocking receive came back empty-handed — Rust's
+/// `TryRecvError`.
+///
+/// `try_recv` used to answer `Option(T)`, which collapsed these two into one
+/// `.None`: a caller could not tell "nothing yet, try again" from "the sender
+/// is gone, stop trying", so every polling loop over a closed channel spun
+/// forever or exited early by guessing.
+TryRecvError :: enum(
+  /// The channel is open but has nothing buffered right now. Retry later.
+  Empty,
+  /// The channel is closed AND drained. No value will ever arrive; stop
+  /// polling.
+  Disconnected
+);
+export(TryRecvError);
+impl(
+  TryRecvError,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)(
+      match(
+        self,
+        .Empty => String.from("channel empty"),
+        .Disconnected => String.from("channel disconnected")
+      )
+    )
+  )
+);
+impl(
+  TryRecvError,
+  Eq(TryRecvError)(
+    (==) : ((lhs, rhs) -> __yo_op_eq(lhs, rhs)),
+    (!=) : ((lhs, rhs) -> __yo_op_neq(lhs, rhs))
+  )
+);
 /// Thread-safe bounded channel for passing values between threads.
 /// Uses atomic reference counting — implements `Send` and can be
 /// safely shared across threads without `Arc` wrapping.
@@ -157,12 +193,21 @@ impl(
   }),
   /// Try to receive a value without blocking.
   /// Returns .Some(value) if available, .None if empty.
-  try_recv : (fn(self : Self) -> Option(T))({
+  try_recv : (fn(self : Self) -> Result(T, TryRecvError))({
     self._mutex._raw_lock();
     cond(
       (self._len.load(MemoryOrder.Relaxed) == usize(0)) => {
+        // Empty vs Disconnected is the whole reason this returns a Result:
+        // a closed AND drained channel will never produce a value, and a
+        // polling caller has to be able to stop.
+        closed := self._closed.load(MemoryOrder.Relaxed);
         self._mutex._raw_unlock();
-        return(.None);
+        return(
+          cond(
+            closed => Result(T, TryRecvError).Err(TryRecvError.Disconnected),
+            true => Result(T, TryRecvError).Err(TryRecvError.Empty)
+          )
+        );
       },
       true => ()
     );
@@ -173,7 +218,7 @@ impl(
     self._len.store(self._len.load(MemoryOrder.Relaxed) - usize(1), MemoryOrder.Release);
     self._not_full.signal();
     self._mutex._raw_unlock();
-    return(.Some(val));
+    return(Result(T, TryRecvError).Ok(val));
   }),
   /// Close the channel. No more values can be sent.
   /// Pending recv() calls will return .None once the buffer is drained.

--- a/std/sync/semaphore.yo
+++ b/std/sync/semaphore.yo
@@ -49,6 +49,23 @@ Semaphore :: atomic(
     )
   )
 );
+// __SemaphoreReleaser — private object that releases one permit on Dispose.
+// Allocated locally inside with_permit; Yo's drop-on-scope-exit and
+// drop-on-unwind machinery guarantees the release under both a normal return
+// and `unwind(...)`. Mirrors __MutexUnlocker in ./mutex.yo.
+__SemaphoreReleaser :: ref(
+  struct(
+    _sem : Semaphore
+  )
+);
+impl(
+  __SemaphoreReleaser,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      self._sem.release();
+    })
+  )
+);
 impl(
   Semaphore,
   /// Create a semaphore holding `permits` permits.
@@ -99,6 +116,36 @@ impl(
     self._permits = (self._permits + i32(1));
     self._cv.signal();
     self._mutex._raw_unlock();
+  }),
+  /// Hold one permit for the duration of `body`, releasing it on the way out.
+  ///
+  /// The manual `acquire()` / `release()` pair is the one that leaks a permit
+  /// the first time an early exit is added to the block between them, and a
+  /// leaked permit is a deadlock the next time the pool fills. This is the
+  /// same guard shape `Mutex.with_lock` uses, for the same reason.
+  ///
+  /// The release rides a `Dispose` guard, so it happens on any scope exit the
+  /// language can produce here. It does NOT claim unwind safety: `body` is a
+  /// closure, and a closure cannot capture a control-bound value, so `body`
+  /// cannot raise an effect that unwinds past this call at all. Taking the
+  /// effect as a parameter is what would make such a claim testable — the same
+  /// point `plans/STD_API_STABILIZATION.md` §4 makes about
+  /// `async/mutex.with_lock`. See
+  /// issues/with-lock-and-with-permit-cannot-see-an-unwind.md.
+  ///
+  /// ```rust
+  /// pool.with_permit(() => fetch(url));
+  /// ```
+  with_permit : (
+    fn(
+      generic(R : Type),
+      self : Self,
+      body : Impl(Fn() -> R)
+    ) -> R
+  )({
+    self.acquire();
+    _guard := __SemaphoreReleaser(self);
+    body()
   }),
   /// The permits available at the instant of the call. Informational only —
   /// by the time the caller looks at it another thread may have taken one.

--- a/tests/sync/channel.test.yo
+++ b/tests/sync/channel.test.yo
@@ -2,7 +2,7 @@ pragma(Pragma.SkipWasm32Wasi); // no pthread support in standalone WASI
 { assert } :: import("std/assert");
 { arch, Arch } :: import("std/process");
 open(import("std/libc/stdio"));
-{ Channel } :: import("std/sync/channel");
+{ Channel, TryRecvError } :: import("std/sync/channel");
 { Thread, ThreadPool, spawn } :: import("std/thread");
 { sleep_blocking } :: import("std/time/sleep");
 { Duration } :: import("std/time/duration");
@@ -67,13 +67,37 @@ test("Channel try_recv returns value when available", {
   ch := Channel(i32).new(usize(5));
   ch.send(i32(77));
   val := ch.try_recv();
-  assert(val.is_some(), "try_recv should return value");
+  assert(val.is_ok(), "try_recv should return a value");
   assert(val.unwrap() == i32(77), "try_recv should return 77");
 });
-test("Channel try_recv returns None when empty", {
+test("Channel try_recv on an OPEN empty channel is Empty, not Disconnected", {
   ch := Channel(i32).new(usize(5));
-  val := ch.try_recv();
-  assert(val.is_none(), "try_recv should return None on empty channel");
+  assert(
+    match(ch.try_recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Empty)),
+    "an open channel with nothing buffered says Empty — retry later"
+  );
+});
+test("Channel try_recv on a CLOSED drained channel is Disconnected", {
+  ch := Channel(i32).new(usize(5));
+  ch.close();
+  assert(
+    match(ch.try_recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Disconnected)),
+    "a closed, drained channel says Disconnected — stop polling"
+  );
+});
+test("TryRecvError distinguishes the two cases a poller must act on", {
+  // The whole reason try_recv is a Result: the old Option collapsed these,
+  // so a polling loop could not tell "not yet" from "never".
+  ch := Channel(i32).new(usize(2));
+  first := ch.try_recv();
+  ch.send(i32(5));
+  second := ch.try_recv();
+  ch.close();
+  third := ch.try_recv();
+  assert(match(first, .Err(e) => (e == TryRecvError.Empty), .Ok(_) => false), "before any send: Empty");
+  assert(match(second, .Ok(v) => (v == i32(5)), .Err(_) => false), "after a send: the value");
+  assert(match(third, .Err(e) => (e == TryRecvError.Disconnected), .Ok(_) => false), "after close: Disconnected");
+  assert(TryRecvError.Empty != TryRecvError.Disconnected, "and the two are distinguishable");
 });
 // ============================================================================
 // Close semantics
@@ -138,10 +162,13 @@ test("Channel try_recv drains remaining values after close", {
   ch.send(i32(100));
   ch.close();
   val := ch.try_recv();
-  assert(val.is_some(), "try_recv should return buffered value after close");
+  assert(val.is_ok(), "try_recv should return buffered value after close");
   assert(val.unwrap() == i32(100), "value should be 100");
   val2 := ch.try_recv();
-  assert(val2.is_none(), "try_recv should return None when closed and empty");
+  assert(
+    match(val2, .Ok(_) => false, .Err(e) => (e == TryRecvError.Disconnected)),
+    "once drained AND closed it is Disconnected, not merely Empty"
+  );
 });
 // ============================================================================
 // Edge cases
@@ -320,7 +347,7 @@ test("Channel pool task sends multiple values", {
   sum := i32(0);
   count := i32(0);
   val := ch.try_recv();
-  while(runtime(val.is_some()), {
+  while(runtime(val.is_ok()), {
     sum = (sum + val.unwrap());
     count = (count + i32(1));
     val = ch.try_recv();

--- a/tests/sync/semaphore.test.yo
+++ b/tests/sync/semaphore.test.yo
@@ -312,3 +312,30 @@ test("Semaphore of one permit serializes a read-modify-write", {
   t4.join();
   assert(counter.load(MemoryOrder.Acquire) == i32(100), "no update may be lost under a 1-permit semaphore");
 });
+// ============================================================================
+// with_permit
+// ============================================================================
+test("with_permit takes a permit for the body and gives it back", {
+  sem := Semaphore.new(i32(2));
+  inside := sem.with_permit(() => sem.available_permits());
+  assert(inside == i32(1), "one permit was held while the body ran");
+  assert(sem.available_permits() == i32(2), "and released on the way out");
+});
+test("with_permit returns the body's value", {
+  sem := Semaphore.new(i32(1));
+  assert(sem.with_permit(() => i32(42)) == i32(42), "an i32");
+  assert(sem.with_permit(() => true) == true, "and a bool — R is generic");
+});
+// NOTE there is deliberately no "releases when the body unwinds" test: the
+// body is an `Impl(Fn() -> R)` closure, and the compiler rejects capturing a
+// control-bound value into a closure ("Closures cannot capture a value of
+// control-bound type ... would unwind to a dead install frame"). So the body
+// CANNOT raise an effect, and that path is unreachable through this signature.
+// `with_permit`'s doc says exactly that rather than claiming unwind safety it
+// cannot demonstrate. See issues/with-lock-and-with-permit-cannot-see-an-unwind.md.
+test("with_permit nests down to zero and back", {
+  sem := Semaphore.new(i32(2));
+  deepest := sem.with_permit(() => sem.with_permit(() => sem.available_permits()));
+  assert(deepest == i32(0), "both permits were held at the innermost point");
+  assert(sem.available_permits() == i32(2), "and both came back");
+});


### PR DESCRIPTION
Independent of every other open PR — touches `std/sync/channel.yo` and `std/sync/semaphore.yo` only.

Two §4 Concurrency rows.

## `try_recv` now returns `Result(T, TryRecvError)`

The old `Option(T)` collapsed the two answers a polling caller has to act on **differently**: `.None` meant both *"nothing buffered yet, retry"* and *"closed and drained, no value will ever arrive"*. A loop over a closed channel could only spin forever or exit by guessing.

`TryRecvError` is `Empty` | `Disconnected`, Rust's split. One test pins all three states in sequence — `Empty` before any send, the value after one, `Disconnected` after close.

This is a breaking return-type change, sanctioned by the §4 list. In-tree callers were `tests/sync/channel.test.yo` only; `std/async/channel.yo` has its own separate `try_recv`, untouched here.

## `Semaphore.with_permit`

The `with_lock`-shaped guard for permits. The manual `acquire()`/`release()` pair leaks a permit the first time an early exit is added between them, and a leaked permit is a deadlock the next time the pool fills.

### Writing its test found that an existing claim is unreachable

`Mutex.with_lock`'s comment says its guard *"guarantees unlock under both normal return and `unwind(...)`"*. The machinery does — the signature does not let you get there:

```
error: Closures cannot capture a value of control-bound type. The captured
value `boom` has type `fn() -> unit` which transitively contains a
`ctl(...) -> ret` function. Closures can escape their enclosing frame ...
```

That rejection is correct and deliberate. Its consequence is that the body of a `with_*` helper **cannot raise an effect**, so nothing can unwind past the call from inside it, and the drop-on-unwind path is never taken. The comment describes a capability of the runtime, not a behaviour of the function — which reads as a guarantee to anyone auditing lock safety.

So `with_permit`'s doc states the accurate version instead of copying the claim, the semaphore test file explains why the unwind test is absent **at the place it would have gone** rather than leaving a silent hole, and the whole thing is filed as `issues/with-lock-and-with-permit-cannot-see-an-unwind.md`.

That issue is §4's own complaint about `async/mutex.with_lock` — *"either takes an `io` (so its doc claim becomes true) or drops the claim"* — generalised to the blocking variant, with both options laid out.

## Deliberately not here

`Mutex.try_lock`, `RwLock.try_*` and `Condvar.wait_timeout` each need a new `__yo_*` sync macro in the emitted C runtime (`src/codegen/types/generation.yo`), and `std/` must build under the **seed** — so the compiler half has to ship in a release before std can use it. Same sequencing `std/math`'s `INFINITY` is waiting on. Adding them without the runtime would be a link error, and faking them with a side channel would not be the mutex's own state.

## Local verification

| gate | result |
| --- | --- |
| `tests/sync/channel.test.yo` | 29/29 |
| `tests/sync/semaphore.test.yo` | 13/13 |
| full suite | **3752/3752**, 0 failures |
| `check ./std` | 174/174 |
| `check ./src` | 266/266 |
| `yo build` (self-build) | rc=0 |
| cli scorecard | 85 PASS / 0 GOLDEN-DIFF |

🤖 Generated with [Claude Code](https://claude.com/claude-code)