### PR TITLE
codegen: a unit operand no longer reads as a failed transpile

### DIFF
--- a/issues/fixed/unit-operand-renders-empty-so-binop-reports-ftt.md
+++ b/issues/fixed/unit-operand-renders-empty-so-binop-reports-ftt.md
@@ -1,0 +1,120 @@
+# A `unit` operand renders as the empty string, so `_binop` reports "Failed to transpile"
+
+**Status: FIXED** (2026-09-09) — `src/codegen/exprs/generation.yo`,
+`_is_primitive_infix_operator` now excludes `unit`.
+
+## Symptom
+
+Any runtime comparison of two `unit` values fails to transpile. Standalone it
+is a fatal ICE; inside a derived `==` it is an `abort()`-ing stub.
+
+```rust
+main :: (fn() -> unit)({
+  a := ();
+  b := ();
+  r := (a == b);
+  cond(r => (), true => ());
+});
+export(main);
+```
+
+```
+yo: error: internal compiler error: Failed to transpile part of main's body —
+the emitted C for "__yo_user_main" contains an untranspiled expression, so the
+program would run without it
+```
+
+The emitted C, seen through a `unit`-returning helper (the entry-point gate is
+fatal only for `__yo_user_main`):
+
+```c
+static inline void yo_id_4199(uint8_t a, uint8_t b) {
+  bool _file____priv_temp_4073 = // Failed to transpile () == ();
+  bool r = _file____priv_temp_4073;
+```
+
+## The sharper case: `derive(Eq)` over a struct with a `unit` field
+
+```rust
+S :: struct(u : unit, n : i32);
+derive(S, Eq(S));
+main :: (fn() -> unit)({
+  a := S(u : (), n : i32(1));
+  b := S(u : (), n : i32(1));
+  r := (a == b);
+  cond(r => (), true => ());
+});
+export(main);
+```
+
+The derived `==` body contains the marker, so the whole function is rewritten
+to a stub. At `--optimize 2` the binary links and then dies:
+
+```
+yo: FATAL: reached fn_yo_id_4225, whose body failed to transpile — its
+definition-time evaluation failed and was swallowed.
+```
+
+At `-O0` it does not even link — the GNU `error` attribute on the stub fires:
+
+```
+error: call to 'fn_yo_id_4225' declared with 'error' attribute: yo: the body of
+fn_yo_id_4225 failed to transpile
+```
+
+This is exactly the case `std/prelude.yo`'s comment above `impl(unit, Eq(unit))`
+claims to serve — *"Without these, `derive(Eq)` (or Ord/Hash/Clone) over a
+struct with a `unit` field fails: the generated `lhs.u == rhs.u` has no `Eq` to
+resolve to."* The impls make the EVALUATOR happy; codegen then dropped the call
+on the floor. The mechanism was exported but never usable.
+
+## Root cause
+
+`unit` is a true zero-sized type (`issues/fixed/unit-should-be-a-true-zero-sized-type-like-rust.md`),
+so a `unit`-typed expression has **no C representation in expression position**
+and renders as the empty string.
+
+`_is_primitive_infix_operator` (`src/codegen/exprs/generation.yo`) routes
+`x op y` to the builtin-inline path whenever the LHS is a *primitive* type, and
+`is_primitive_type` answers `true` for `.Unit`. The inline path's `_binop`
+(`src/codegen/exprs/inline_fns.yo:73`) then guards:
+
+```rust
+if((lhs.len() == usize(0)) || (rhs.len() == usize(0)) || ...) {
+  return(`// Failed to transpile (${lhs}) ${op} (${rhs})`);
+});
+```
+
+That guard is correct and deliberate — `(() + ())` is invalid C, and an empty
+operand really does mean a dropped `ExprInfo` for every *other* primitive. It
+simply cannot distinguish "empty because the operand failed" from "empty
+because the operand is a ZST".
+
+## Fix
+
+Exclude `unit` at the routing decision rather than teaching `_binop` about
+types it cannot see:
+
+```rust
+.Some(lei) => (is_primitive_type(lei.ty) && !is_unit_type(lei.ty)),
+```
+
+`unit` has real `Eq(unit)` and `Ord(unit)` impls in the prelude, and the
+trait-method path emits a real call to them (a unit argument is passed as a
+literal `0` in the one-byte placeholder slot). So `==`, `!=`, `<`, `<=`, `>`
+and `>=` on `unit` all start working from the impls that already existed;
+nothing else changes, because `unit` was the only primitive whose operands
+render empty.
+
+## Tests
+
+`tests/unit_as_value_type.test.yo` — "unit operands compare through the
+prelude's Eq/Ord impls" and "derive(Eq)/derive(Ord) over a struct with a unit
+field". Both fail on the pre-fix binary (the first as the fatal ICE, the second
+as the runtime `FATAL: reached fn_… whose body failed to transpile`).
+
+## Found by
+
+Writing `impl(unit, Default(...))` for the std `Default` sweep
+(`plans/STD_API_STABILIZATION.md` §4 Core) and trying to assert
+`unit.default() == ()`.

--- a/src/codegen/exprs/generation.yo
+++ b/src/codegen/exprs/generation.yo
@@ -212,9 +212,21 @@ _is_primitive_infix_operator :: (fn(expr : AstExpr, context : FunctionGeneration
         // `&`-prefixed pointer operators had a pointer-LHS carve-out here;
         // pointer arithmetic now lowers through the add/sub/offset_from
         // method bodies' `__yo_ptr_*` builtins instead.)
+        // UNIT IS EXCLUDED even though it is primitive. A `unit`-typed
+        // operand has no C representation in expression position, so it
+        // renders as the EMPTY string — and `_binop`'s degraded-render guard
+        // (inline_fns.yo) rightly reads an empty operand as "this operand
+        // failed to transpile" and emits a `// Failed to transpile` comment.
+        // That turned every `unit == unit` into an untranspiled expression:
+        // fatal in `main`, and in a derived `==` an abort()-ing stub — so
+        // `derive(Eq)` over a struct with a `unit` field produced a binary
+        // that died on the first comparison
+        // (issues/fixed/unit-operand-renders-empty-so-binop-reports-ftt.md).
+        // The prelude's `impl(unit, Eq(unit))` / `Ord(unit)` are real
+        // functions, so the trait-method path emits a real call for them.
         .Some(lhs) => match(
           context.base.get_expr_info(lhs),
-          .Some(lei) => is_primitive_type(lei.ty),
+          .Some(lei) => (is_primitive_type(lei.ty) && !is_unit_type(lei.ty)),
           .None => false
         ),
         .None => false

--- a/tests/unit_as_value_type.test.yo
+++ b/tests/unit_as_value_type.test.yo
@@ -352,3 +352,35 @@ test("a generic struct at T = unit erases the field; Array(unit, N) constructs, 
   e := arr(usize(1));
   assert(sizeof(Array(unit, usize(3))) == usize(1), "Array(unit, 3) is the dummy byte");
 });
+// `unit` OPERANDS. A unit-typed operand has no C representation in expression
+// position, so it renders as the EMPTY string — and `_binop`'s degraded-render
+// guard reads an empty operand as "this operand failed to transpile". Every
+// `unit == unit` therefore became a `// Failed to transpile` comment: fatal in
+// `main`, and inside a DERIVED `==` an abort()-ing stub, so `derive(Eq)` over a
+// struct with a `unit` field produced a binary that died on the first
+// comparison (it also failed to C-compile at -O0, where the GNU `error`
+// attribute on the stub fires). The prelude's `impl(unit, Eq(unit))` /
+// `Ord(unit)` are real functions, so codegen now routes unit operands to the
+// trait-method path instead of the builtin-inline one.
+// See issues/fixed/unit-operand-renders-empty-so-binop-reports-ftt.md.
+_EqUnitField :: struct(u : unit, n : i32);
+derive(_EqUnitField, Eq(_EqUnitField));
+derive(_EqUnitField, Ord(_EqUnitField), Eq(_EqUnitField));
+test("unit operands compare through the prelude's Eq/Ord impls", {
+  a := ();
+  b := ();
+  assert(a == b, "unit values are equal");
+  assert(!(a != b), "unit values are never unequal");
+  assert(a <= b, "unit <= unit");
+  assert(a >= b, "unit >= unit");
+  assert(!(a < b), "unit is never < unit");
+  assert(!(a > b), "unit is never > unit");
+});
+test("derive(Eq)/derive(Ord) over a struct with a unit field", {
+  x := _EqUnitField(u : (), n : i32(1));
+  y := _EqUnitField(u : (), n : i32(1));
+  z := _EqUnitField(u : (), n : i32(2));
+  assert(x == y, "the unit field does not break structural equality");
+  assert(x != z, "the non-unit field still distinguishes");
+  assert(x < z, "derived Ord over a unit field orders by the non-unit field");
+});


### PR DESCRIPTION
## What

A `unit`-typed operand has no C representation in expression position, so it renders as the **empty string**. `_binop`'s degraded-render guard (`src/codegen/exprs/inline_fns.yo:73`) reads an empty operand as *"this operand failed to transpile"* — correctly, for every other primitive — so every `unit == unit` became a `// Failed to transpile` comment.

Standalone that is the fatal entry-point gate:

```rust
main :: (fn() -> unit)({
  a := ();
  b := ();
  r := (a == b);
  cond(r => (), true => ());
});
export(main);
```

```
yo: error: internal compiler error: Failed to transpile part of main's body
```

Inside a **derived `==`** it is worse: the body carries the marker, so the whole function is rewritten to a stub. `derive(Eq)` over a struct with a `unit` field produced a binary that died on its first comparison at `--optimize 2`

```
yo: FATAL: reached fn_yo_id_4225, whose body failed to transpile
```

and did not even link at `-O0`, where the GNU `error` attribute on the stub fires. That is precisely the case the prelude's comment above `impl(unit, Eq(unit))` claims to serve — *"Without these, `derive(Eq)` over a struct with a `unit` field fails"*. The impls made the **evaluator** happy while codegen dropped the call on the floor: an exported mechanism that was never usable.

## Fix

At the routing decision, not in `_binop`, which only sees rendered strings and cannot tell a ZST from a failure:

```rust
.Some(lei) => (is_primitive_type(lei.ty) && !is_unit_type(lei.ty)),
```

`unit` has real `Eq(unit)` and `Ord(unit)` impls in the prelude, and the trait-method path emits a real call to them (a unit argument is passed as a literal `0` in the one-byte placeholder slot). So `==`, `!=`, `<`, `<=`, `>` and `>=` on `unit` all start working from impls that already existed. `unit` was the only primitive whose operands render empty, so nothing else moves — the fixpoint confirms it.

## Tests

`tests/unit_as_value_type.test.yo` gains two tests. Both are **red on the pre-fix binary**: the first as the fatal ICE (which voids the whole batch — `yo: error: test: batch compile failed`), the second as the runtime `FATAL: reached fn_… whose body failed to transpile`.

## Local gates (macOS arm64)

| gate | result |
| --- | --- |
| `yo fmt --check ./src` | clean |
| `yo check ./src` | 270/270 |
| `yo build` | rc=0 |
| full suite (`./tests`, minus internal/cli-cases) | **3815 passed, 0 failed** |
| CLI golden scorecard | **PASS 88, GOLDEN-DIFF 0, NO-GOLDEN 0** |
| `fixpoint_only.sh` | **FIXPOINT_HOLDS** (stage2 hollow=0, STAGE3_RC=0) |

## Found by

Writing `impl(unit, Default(...))` for the std `Default` sweep (`plans/STD_API_STABILIZATION.md` §4 Core) and trying to assert `unit.default() == ()`.

`issues/fixed/unit-operand-renders-empty-so-binop-reports-ftt.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)