### PR TITLE
std/encoding: JsonValue predicates, integer accessors, mutation, pointer, Eq/Clone/ToString

### DIFF
--- a/issues/fromstr-missing-on-seven-numeric-primitives.md
+++ b/issues/fromstr-missing-on-seven-numeric-primitives.md
@@ -1,0 +1,60 @@
+# `FromStr` is implemented for 6 of the 13 numeric primitives
+
+**Status: OPEN.** Found 2026-09-09 while writing `JsonValue.pointer`.
+
+## Symptom
+
+`s.parse(usize)` does not compile:
+
+```
+error[E0602]: Type usize does not implement required trait FromStr.
+     --> std/string/string.yo:3198:56
+     |
+3198 |   parse : (fn(self : Self, comptime(T) : Type, where(T <: FromStr)) -> Result(T, T.Err))(
+     |                                                        ^^
+```
+
+## Measurement
+
+`std/string/string.yo` has exactly six `FromStr` impls (lines 3115, 3124,
+3133, 3150, 3166, 3178):
+
+| implemented | missing |
+| --- | --- |
+| `i64`, `u64`, `i32`, `u32`, `f64`, `bool` | `usize`, `isize`, `i8`, `i16`, `u8`, `u16`, `f32` |
+
+Rust implements `FromStr` for **every** integer and float primitive, so
+`"12".parse::<usize>()` is the ordinary spelling there. In Yo the caller has to
+know which of the widths happens to be covered and convert:
+
+```rust
+match(token.parse(u64), .Ok(idx) => items.get(usize(idx)), .Err(_) => …)
+```
+
+`usize` is the width most likely to be parsed from text — it is what indexes
+every collection — so its absence is the sharpest of the seven.
+
+## Why it is not just a missing line
+
+The existing impls delegate to `_parse_i64_radix_res` / the `u64` scanner and
+then narrow. A `usize` impl must narrow to the target width and report
+`PosOverflow` when the value does not fit — `usize` is 64-bit on the targets in
+`plans/reference/TARGET_TRIPLES.md` today but is defined as pointer-width, so
+the impl has to go through the width-checked path rather than casting. The same
+holds for `i8`/`i16`/`u8`/`u16`, where overflow is reachable with three-digit
+input.
+
+`f32` needs the `f64` grammar plus a range check against the `f32` finite
+range (Rust returns `inf` for an overflowing `f32` literal rather than an
+error — the impl must match that, not reject it).
+
+## Fix sketch
+
+One generic impl is not possible today (there is no `Integer`-marker-bounded
+`FromStr` blanket that can name its own width), so this is seven impls plus a
+test per width covering: a value, the exact `MAX`, `MAX + 1` → `PosOverflow`,
+the exact `MIN`, `MIN - 1` → `NegOverflow` for the signed ones, an empty
+string, and a `+`/`-` sign.
+
+Related: D12 (`FromStr` parsing returns `Result`) is LANDED — this is a
+coverage gap in that decision, not a shape disagreement.

--- a/issues/mutual-recursion-between-a-fn-and-a-trait-impl-body.md
+++ b/issues/mutual-recursion-between-a-fn-and-a-trait-impl-body.md
@@ -1,0 +1,97 @@
+# Mutual recursion between a free fn and a trait-impl body silently produces an abort() stub
+
+**Status: OPEN.** Found 2026-09-09 while writing `Eq` for the recursive
+`JsonValue` tree.
+
+## Reproducer
+
+`issues/repros/mutual-recursion-through-a-trait-impl-operator.yo`:
+
+```rust
+{ ArrayList } :: import("std/collections/array_list");
+E :: enum(Leaf(v : i32), Node(kids : ArrayList(Self)));
+_kids_eq :: (fn(a : ArrayList(E), b : ArrayList(E)) -> bool)({
+  if(a.len() != b.len(), { return(false); });
+  i := usize(0);
+  while(i < a.len(), i = (i + usize(1)), {
+    if(a(i) != b(i), { return(false); });   // <-- needs E's Eq impl
+  });
+  true
+});
+impl(
+  E,
+  Eq(E)(
+    (==) : (fn(lhs : Self, rhs : Self) -> bool)(
+      match(
+        lhs,
+        .Leaf(x) => match(rhs, .Leaf(y) => (x == y), _ => false),
+        .Node(a) => match(rhs, .Node(b) => _kids_eq(a, b), _ => false)  // <-- needs _kids_eq
+      )
+    ),
+    (!=) : (fn(lhs : Self, rhs : Self) -> bool)(!(lhs == rhs))
+  )
+);
+```
+
+`_kids_eq` needs `E`'s `Eq` to compare two elements; `Eq`'s `(==)` needs
+`_kids_eq` to compare two child lists. Both directions are ordinary recursion,
+and the cycle terminates on the data.
+
+## Symptom
+
+`yo check` is **green**. Then:
+
+- `--optimize 2`: the binary links and dies on the first comparison —
+  `yo: FATAL: reached yo_id_5076, whose body failed to transpile — its
+  definition-time evaluation failed and was swallowed.`
+- `-O0`: it does not link — `error: call to 'yo_id_5076' declared with 'error'
+  attribute` (the GNU `error` attribute on the stub, which is only diagnosed
+  pre-optimization).
+
+So the existing FTT-stub safety net does catch it, but only at C-compile or run
+time; nothing reports it while type-checking.
+
+## What is and is not the trigger
+
+| shape | result |
+| --- | --- |
+| helper defined BEFORE the impl | stub |
+| helper defined AFTER the impl | stub — **ordering is not the trigger** |
+| ONE self-recursive free fn, impl delegates to it | **works** |
+
+The third row is why the std fix is a restructuring rather than a workaround:
+`JsonValue`'s `Eq` now delegates to a single self-recursive `_json_eq`, exactly
+as its `Clone` already delegates to a self-recursive `_json_clone`.
+
+## Mechanism
+
+Two plain `fn` definitions may reference each other because their SIGNATURES
+bind before their BODIES evaluate — the cyclic-definition error message says so
+explicitly ("Function definitions may reference each other"), and that is the
+two-phase forcing `plans/reference/LAZY_TOPLEVEL_BINDINGS.md` P0–P5 built.
+
+Impl FIELDS get no such phase. They are evaluated inside the impl field loop
+(`evaluate_impl_expression`), so forcing the `Eq` impl in order to resolve
+`a(i) != b(i)` evaluates `(==)`'s body immediately, which re-enters the
+`_kids_eq` binding that is already being forced. The resulting error lands in
+one of the evaluator's deliberate swallowing handlers (the def-time trial runs
+INSIDE the impl field loop), so the body is simply left untranspiled and
+codegen emits the `error`-attributed stub.
+
+## Fix sketch
+
+Give impl-field function definitions the same signature-first treatment plain
+`fn` definitions get: bind each field's function TYPE (from its written
+signature — every operator field in the reproducer has one) into the impl's
+registration before evaluating any field body. Then resolving `!=` during
+`_kids_eq` finds a signature, not a re-entered definition.
+
+That touches impl registration, which is the machinery behind every trait in
+the tree, so it wants its own PR with the byte-identity gate
+(`plans/reference/...` / the fixpoint) and a `comptime_expect_error` canary per
+genuinely-cyclic shape — a constant field that really does name itself must
+still be a cycle error, not silently accepted.
+
+Related: `issues/fixed/self-hosted-compile-swallows-undefined-call.md` (the
+same "swallowed, then a runnable no-op" class), and the entry-point FTT gate in
+`src/codegen/functions/generation.yo` that made this visible at all.

--- a/issues/repros/mutual-recursion-through-a-trait-impl-operator.yo
+++ b/issues/repros/mutual-recursion-through-a-trait-impl-operator.yo
@@ -1,0 +1,39 @@
+{ ArrayList } :: import("std/collections/array_list");
+E :: enum(Leaf(v : i32), Node(kids : ArrayList(Self)));
+_kids_eq :: (fn(a : ArrayList(E), b : ArrayList(E)) -> bool)({
+  if(a.len() != b.len(), {
+    return(false);
+  });
+  i := usize(0);
+  while(i < a.len(), i = (i + usize(1)), {
+    if(a(i) != b(i), {
+      return(false);
+    });
+  });
+  true
+});
+impl(
+  E,
+  Eq(E)(
+    (==) : (fn(lhs : Self, rhs : Self) -> bool)(
+      match(
+        lhs,
+        .Leaf(x) => match(rhs, .Leaf(y) => (x == y), _ => false),
+        .Node(a) => match(rhs, .Node(b) => _kids_eq(a, b), _ => false)
+      )
+    ),
+    (!=) : (fn(lhs : Self, rhs : Self) -> bool)(
+      !(lhs == rhs)
+    )
+  )
+);
+main :: (fn() -> unit)({
+  a := ArrayList(E).new();
+  a.push(E.Leaf(i32(1)));
+  x := E.Node(a);
+  b := ArrayList(E).new();
+  b.push(E.Leaf(i32(1)));
+  y := E.Node(b);
+  cond((x == y) => (), true => ());
+});
+export(main);

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -607,6 +607,46 @@ rewritten over `Mutex.with_lock` (its blocker is in `issues/fixed/`);
    claims to serve. Fixed by excluding `unit` from the builtin-inline operator
    routing so it uses the `Eq(unit)`/`Ord(unit)` impls that already existed
    (issues/fixed/unit-operand-renders-empty-so-binop-reports-ftt.md).
+
+   **Encoding — `JsonValue` batteries: DONE (2026-09-09).** The audit asked for
+   "`JsonValue` mutation (`insert`/`remove`/`object()`), `is_*`/`as_i64`/
+   `as_u64`, `pointer`, integer arms". All but the integer arms are in:
+   the six `is_*` predicates, `as_f64`/`as_i64`/`as_u64`, the `object()` /
+   `array()` empty constructors, `insert` (returning the REPLACED value, so it
+   is `serde_json`'s `Map::insert` and not a silent overwrite) / `remove` /
+   `push`, and RFC 6901 `pointer`. `JsonValue` also gains the three traits
+   finding 14 says it had none of: `ToString` (the compact text, = `Display`),
+   `Clone` (a deep tree — the payloads are `ArrayList`s, i.e. RC handles, so a
+   plain copy ALIASES the children) and `Eq`.
+   `insert`/`remove`/`push` PANIC on the wrong variant, matching the two
+   `Index` impls the file already had; in `serde_json` the variant check is
+   `as_object_mut()`, here it is the `is_object()` this PR adds.
+
+   Three things the tests pinned that are easy to get wrong: `Eq` compares
+   objects as MAPS (key order is not significant — `serde_json` behaves that
+   way under both its map backends), `as_i64` decides "integral" by an exact
+   round trip so NaN and ±infinity land in `.None` (2^63 is exactly
+   representable as a double, which makes `[-2^63, 2^63)` an exact bound), and
+   `pointer` must decode `~1` BEFORE `~0` or `~01` comes out as `/` instead of
+   the literal key `~1`.
+
+   **The integer arms are NOT done and are deliberately deferred**: a
+   `Number(i64)` variant beside `Number(f64)` changes the parser, both
+   stringifiers, `ToJson`/`FromJson` and every match over the enum — a breaking
+   change that belongs in a breaking window, not in an additive batch.
+   `as_i64`/`as_u64` give callers the integer they actually wanted meanwhile.
+
+   **Two bugs fell out.** `FromStr` turns out to be implemented for only 6 of
+   the 13 numeric primitives — `usize` has none, so `token.parse(usize)` does
+   not compile (issues/fromstr-missing-on-seven-numeric-primitives.md). And
+   writing `Eq` the obvious way — a `_kids_eq` helper comparing children with
+   `==`, called from the `Eq` body — produces an abort()-ing stub behind a
+   green `yo check`: the helper and the impl body are mutually recursive
+   through the impl, and impl fields get no signature-first binding phase the
+   way two plain `fn`s do
+   (issues/mutual-recursion-between-a-fn-and-a-trait-impl-body.md, with a
+   minimal reproducer). `Eq` is therefore ONE self-recursive `_json_eq`, which
+   is what `Clone` already did.
 5. **Freeze** — re-run the five measurements; a module freezes only when its
    group's list is empty.
 

--- a/std/encoding/json.yo
+++ b/std/encoding/json.yo
@@ -162,6 +162,211 @@ impl(
     )
   )
 );
+/// Is `token` a valid RFC 6901 array index — `"0"`, or digits with no leading
+/// zero? The RFC is explicit that `"01"` is not an index, so it must not
+/// silently resolve to element 1.
+_is_rfc6901_index :: (fn(token : String) -> bool)({
+  b := token.as_bytes();
+  if(b.len() == usize(0), {
+    return(false);
+  });
+  i := usize(0);
+  while(i < b.len(), i = (i + usize(1)), {
+    c := b(i);
+    if((c < u8(48)) || (c > u8(57)), {
+      return(false);
+    });
+  });
+  (b.len() == usize(1)) || (b(usize(0)) != u8(48))
+});
+/// Variant predicates and the numeric / mutating batteries
+/// (`serde_json::Value`'s `is_*`, `as_i64`/`as_u64`, `Map::insert`/`remove`,
+/// `Value::pointer`).
+///
+/// `insert`, `remove` and `push` PANIC when the receiver is the wrong variant,
+/// the same contract the two `Index` impls above already have: in `serde_json`
+/// those live on `Map`/`Vec`, so the variant check happens when you call
+/// `as_object_mut()`. Here the check is `is_object()` / `is_array()`, which is
+/// why those predicates come first.
+impl(
+  JsonValue,
+  /// True for JSON `null`.
+  is_null : (fn(self : Self) -> bool)(
+    match(self, .Null => true, _ => false)
+  ),
+  /// True for a JSON boolean.
+  is_bool : (fn(self : Self) -> bool)(
+    match(self, .Bool(_) => true, _ => false)
+  ),
+  /// True for a JSON number.
+  is_number : (fn(self : Self) -> bool)(
+    match(self, .Number(_) => true, _ => false)
+  ),
+  /// True for a JSON string.
+  is_string : (fn(self : Self) -> bool)(
+    match(self, .Str(_) => true, _ => false)
+  ),
+  /// True for a JSON array.
+  is_array : (fn(self : Self) -> bool)(
+    match(self, .Array(_) => true, _ => false)
+  ),
+  /// True for a JSON object.
+  is_object : (fn(self : Self) -> bool)(
+    match(self, .Object(_, _) => true, _ => false)
+  ),
+  /// The numeric value as an `f64` — Rust's name for what `as_number`
+  /// already did. Both spellings are kept: `as_f64` sits beside `as_i64` /
+  /// `as_u64`, and `as_number` is what the rest of this module calls.
+  as_f64 : (fn(self : Self) -> Option(f64))(
+    self.as_number()
+  ),
+  /// The numeric value as an `i64`, or `.None` when it is not a number, not
+  /// integral, or outside `i64` — `serde_json::Value::as_i64`'s contract.
+  ///
+  /// JSON numbers are IEEE-754 doubles here (there is no separate integer
+  /// arm), so "integral" is decided by a round trip: `2^63` is exactly
+  /// representable as a double, which makes `[-2^63, 2^63)` an exact bound,
+  /// and NaN / ±infinity fail both comparisons and land in `.None`.
+  as_i64 : (fn(self : Self) -> Option(i64))(
+    match(
+      self,
+      .Number(n) => cond(
+        ((n >= f64(-9223372036854775808.0)) && (n < f64(9223372036854775808.0))) => {
+          t := i64(n);
+          cond((f64(t) == n) => Option(i64).Some(t), true => Option(i64).None)
+        },
+        true => Option(i64).None
+      ),
+      _ => Option(i64).None
+    )
+  ),
+  /// The numeric value as a `u64`, or `.None` when it is not a number, not
+  /// integral, negative, or outside `u64` — `serde_json::Value::as_u64`.
+  as_u64 : (fn(self : Self) -> Option(u64))(
+    match(
+      self,
+      .Number(n) => cond(
+        ((n >= f64(0.0)) && (n < f64(18446744073709551616.0))) => {
+          t := u64(n);
+          cond((f64(t) == n) => Option(u64).Some(t), true => Option(u64).None)
+        },
+        true => Option(u64).None
+      ),
+      _ => Option(u64).None
+    )
+  ),
+  /// An empty JSON object — `serde_json::Value::Object(Map::new())`.
+  object : (fn() -> Self)(
+    Self.Object(ArrayList(String).new(), ArrayList(JsonValue).new())
+  ),
+  /// An empty JSON array.
+  array : (fn() -> Self)(
+    Self.Array(ArrayList(JsonValue).new())
+  ),
+  /// Set `key` to `value`, returning the value it REPLACED (`.None` when the
+  /// key is new) — `serde_json`'s `Map::insert`. Insertion order is preserved
+  /// and a replacement keeps the key's original position.
+  ///
+  /// Panics when `self` is not an object.
+  insert : (fn(self : Self, key : String, value : JsonValue) -> Option(JsonValue))(
+    match(
+      self,
+      .Object(keys, values) => {
+        i := usize(0);
+        while(i < keys.len(), i = (i + usize(1)), {
+          if(keys(i) == key, {
+            old := values(i);
+            values(i) = value;
+            return(Option(JsonValue).Some(old));
+          });
+        });
+        keys.push(key);
+        values.push(value);
+        Option(JsonValue).None
+      },
+      _ => __yo_panic("JsonValue.insert: requires the .Object variant")
+    )
+  ),
+  /// Remove `key`, returning its value (`.None` when absent) —
+  /// `serde_json`'s `Map::remove`. The remaining keys keep their order.
+  ///
+  /// Panics when `self` is not an object.
+  remove : (fn(self : Self, key : String) -> Option(JsonValue))(
+    match(
+      self,
+      .Object(keys, values) => {
+        i := usize(0);
+        while(i < keys.len(), i = (i + usize(1)), {
+          if(keys(i) == key, {
+            keys.remove(i);
+            return(Option(JsonValue).Some(values.remove(i)));
+          });
+        });
+        Option(JsonValue).None
+      },
+      _ => __yo_panic("JsonValue.remove: requires the .Object variant")
+    )
+  ),
+  /// Append `value` to an array.
+  ///
+  /// Panics when `self` is not an array.
+  push : (fn(self : Self, value : JsonValue) -> unit)(
+    match(
+      self,
+      .Array(items) => items.push(value),
+      _ => __yo_panic("JsonValue.push: requires the .Array variant")
+    )
+  ),
+  /// Resolve an RFC 6901 JSON Pointer — `serde_json::Value::pointer`.
+  ///
+  /// `""` is the whole document. Otherwise the pointer must start with `/`
+  /// and each following token names an object key or an array index, with
+  /// `~1` decoding to `/` and `~0` to `~`. An array index must be `0` or a
+  /// digit string with no leading zero, as the RFC requires — `"01"` is not a
+  /// valid index and resolves to `.None`, not to element 1.
+  pointer : (fn(self : Self, path : String) -> Option(JsonValue))({
+    if(path.is_empty(), {
+      return(Option(JsonValue).Some(self));
+    });
+    if(!path.starts_with(`/`), {
+      return(Option(JsonValue).None);
+    });
+    // `"/a/b"`.split("/") is ["", "a", "b"] — drop the leading empty token.
+    tokens := path.split(`/`);
+    (current : JsonValue) = self;
+    ti := usize(1);
+    while(ti < tokens.len(), ti = (ti + usize(1)), {
+      raw := tokens(ti);
+      token := raw.replace(`~1`, `/`).replace(`~0`, `~`);
+      step := match(
+        current,
+        .Object(_, _) => current.get(token),
+        // `parse(u64)`, not `parse(usize)`: `FromStr` is implemented for
+        // i64/u64/i32/u32/f64/bool only — `usize` has none
+        // (issues/fromstr-missing-on-seven-numeric-primitives.md).
+        .Array(items) => cond(
+          _is_rfc6901_index(token) => match(
+            token.parse(u64),
+            .Ok(idx) => items.get(usize(idx)),
+            .Err(_) => Option(JsonValue).None
+          ),
+          true => Option(JsonValue).None
+        ),
+        _ => Option(JsonValue).None
+      );
+      match(
+        step,
+        .Some(next) => {
+          current = next;
+        },
+        .None => {
+          return(Option(JsonValue).None);
+        }
+      );
+    });
+    Option(JsonValue).Some(current)
+  })
+);
 /// Index trait — `v(key)` returns the child JsonValue for `key`, panicking
 /// if `v` is not an Object or the key is missing.
 impl(
@@ -1050,6 +1255,138 @@ json_stringify_pretty :: (fn(value : JsonValue, indent : usize) -> String)(
       _stringify_pretty_into(value, indent, usize(0), out);
       String.from_bytes(out)
     }
+  )
+);
+/// `ToString` — the COMPACT JSON text, matching `serde_json::Value`'s
+/// `Display`. The structural, Yo-shaped render is `Debug`'s job (D15), so
+/// these two do not collide.
+impl(
+  JsonValue,
+  ToString(
+    to_string : (fn(inout(self) : Self) -> String)(
+      json_stringify(self)
+    )
+  )
+);
+/// Deep-clone a value tree. `JsonValue` is a VALUE enum whose `Array` and
+/// `Object` payloads are `ArrayList`s — reference-counted handles — so a plain
+/// copy ALIASES the children, and `b := a; b.push(x)` would be visible through
+/// `a`. `Clone` is what makes an independent tree, and it recurses through a
+/// free function rather than `ArrayList.clone` so the `T <: Clone` bound does
+/// not have to be satisfied by the impl being defined.
+_json_clone :: (fn(v : JsonValue) -> JsonValue)(
+  match(
+    v,
+    .Null => JsonValue.Null,
+    .Bool(b) => JsonValue.Bool(b),
+    .Number(n) => JsonValue.Number(n),
+    .Str(s) => JsonValue.Str(s.clone()),
+    .Array(items) => {
+      out := ArrayList(JsonValue).new();
+      i := usize(0);
+      while(i < items.len(), i = (i + usize(1)), {
+        out.push(_json_clone(items(i)));
+      });
+      JsonValue.Array(out)
+    },
+    .Object(keys, values) => {
+      out_keys := ArrayList(String).new();
+      out_values := ArrayList(JsonValue).new();
+      i := usize(0);
+      while(i < keys.len(), i = (i + usize(1)), {
+        out_keys.push(keys(i).clone());
+        out_values.push(_json_clone(values(i)));
+      });
+      JsonValue.Object(out_keys, out_values)
+    }
+  )
+);
+impl(
+  JsonValue,
+  Clone(
+    clone : (fn(inout(self) : Self) -> Self)(
+      _json_clone(self)
+    )
+  )
+);
+/// Structural equality. Objects compare as MAPS, not positionally — the same
+/// key set with equal values, whatever order the keys were parsed in. That is
+/// `serde_json`'s behaviour under both its map backends (`BTreeMap` and, with
+/// `preserve_order`, `IndexMap`), and it is the only reading that survives a
+/// round trip through a format whose object order is not significant. With
+/// duplicate keys the first occurrence wins on each side.
+///
+/// Numbers compare as `f64`, so two `Number`s that are both NaN are NOT equal.
+///
+/// ONE self-recursive function, not a trio of helpers, for the same reason
+/// `_json_clone` is one: a helper that compares two children with `==` and an
+/// `Eq` body that calls that helper are mutually recursive THROUGH the impl,
+/// and impl fields get no signature-first binding phase, so the helper's
+/// definition-time evaluation fails, is swallowed, and codegen emits an
+/// abort()-ing stub behind a green `yo check`
+/// (issues/mutual-recursion-between-a-fn-and-a-trait-impl-body.md).
+_json_eq :: (fn(lhs : JsonValue, rhs : JsonValue) -> bool)(
+  match(
+    lhs,
+    .Null => match(rhs, .Null => true, _ => false),
+    .Bool(a) => match(rhs, .Bool(b) => (a == b), _ => false),
+    .Number(a) => match(rhs, .Number(b) => (a == b), _ => false),
+    .Str(a) => match(rhs, .Str(b) => (a == b), _ => false),
+    .Array(a) => match(
+      rhs,
+      .Array(b) => {
+        if(a.len() != b.len(), {
+          return(false);
+        });
+        i := usize(0);
+        while(i < a.len(), i = (i + usize(1)), {
+          if(!_json_eq(a(i), b(i)), {
+            return(false);
+          });
+        });
+        true
+      },
+      _ => false
+    ),
+    .Object(a_keys, a_values) => match(
+      rhs,
+      .Object(b_keys, b_values) => {
+        if(a_keys.len() != b_keys.len(), {
+          return(false);
+        });
+        i := usize(0);
+        while(i < a_keys.len(), i = (i + usize(1)), {
+          key := a_keys(i);
+          (found : bool) = false;
+          j := usize(0);
+          while(j < b_keys.len(), j = (j + usize(1)), {
+            if(b_keys(j) == key, {
+              if(!_json_eq(a_values(i), b_values(j)), {
+                return(false);
+              });
+              found = true;
+              j = b_keys.len();
+            });
+          });
+          if(!found, {
+            return(false);
+          });
+        });
+        true
+      },
+      _ => false
+    )
+  )
+);
+impl(
+  JsonValue,
+  Eq(JsonValue)(
+    (==) : (fn(lhs : Self, rhs : Self) -> bool)(
+      _json_eq(lhs, rhs)
+    ),
+    (!=) : (fn(lhs : Self, rhs : Self) -> bool)(
+      !_json_eq(lhs, rhs)
+    )
   )
 );
 export(json_stringify, json_stringify_pretty);

--- a/tests/encoding/json.test.yo
+++ b/tests/encoding/json.test.yo
@@ -567,3 +567,85 @@ test("JsonValue Default is null", {
   assert(match(v, .Null => true, _ => false), "default JsonValue is .Null");
   assert(json_stringify(v) == `null`, "the default value stringifies as null");
 });
+test("JsonValue variant predicates", {
+  n := JsonValue.Null;
+  b := JsonValue.Bool(true);
+  num := JsonValue.Number(f64(1.5));
+  s := JsonValue.Str(`x`);
+  a := JsonValue.array();
+  o := JsonValue.object();
+  assert(n.is_null() && !n.is_bool(), "Null");
+  assert(b.is_bool() && !b.is_number(), "Bool");
+  assert(num.is_number() && !num.is_string(), "Number");
+  assert(s.is_string() && !s.is_array(), "Str");
+  assert(a.is_array() && !a.is_object(), "Array");
+  assert(o.is_object() && !o.is_null(), "Object");
+});
+test("JsonValue.as_i64 / as_u64 accept only integral in-range numbers", {
+  assert(JsonValue.Number(f64(42.0)).as_i64().unwrap() == i64(42), "42 is an i64");
+  assert(JsonValue.Number(f64(-7.0)).as_i64().unwrap() == i64(-7), "-7 is an i64");
+  assert(JsonValue.Number(f64(1.5)).as_i64().is_none(), "1.5 is not integral");
+  assert(JsonValue.Number(f64(9.3e18)).as_i64().is_none(), "above i64::MAX");
+  assert(JsonValue.Number(f64(42.0)).as_u64().unwrap() == u64(42), "42 is a u64");
+  assert(JsonValue.Number(f64(-1.0)).as_u64().is_none(), "-1 is not a u64");
+  assert(JsonValue.Str(`42`).as_i64().is_none(), "a string is not a number");
+  assert(JsonValue.Number(f64(2.5)).as_f64().unwrap() == f64(2.5), "as_f64 is as_number");
+});
+test("JsonValue object mutation: insert replaces in place, remove keeps order", {
+  o := JsonValue.object();
+  assert(o.insert(`a`, JsonValue.Number(f64(1.0))).is_none(), "a is new");
+  assert(o.insert(`b`, JsonValue.Number(f64(2.0))).is_none(), "b is new");
+  prev := o.insert(`a`, JsonValue.Number(f64(3.0)));
+  assert(prev.unwrap().as_f64().unwrap() == f64(1.0), "insert returns the replaced value");
+  assert(json_stringify(o) == `{"a":3,"b":2}`, "a keeps its original position");
+  gone := o.remove(`a`);
+  assert(gone.unwrap().as_f64().unwrap() == f64(3.0), "remove returns the value");
+  assert(o.remove(`a`).is_none(), "removing twice is None");
+  assert(json_stringify(o) == `{"b":2}`, "the survivor keeps its order");
+});
+test("JsonValue array mutation", {
+  a := JsonValue.array();
+  a.push(JsonValue.Number(f64(1.0)));
+  a.push(JsonValue.Str(`two`));
+  assert(json_stringify(a) == `[1,"two"]`, "push appends");
+  assert(a.at(usize(1)).unwrap().as_string().unwrap() == `two`, "at reads back");
+});
+test("JsonValue.pointer resolves RFC 6901 paths", {
+  v := json_parse("{\"a\":{\"b\":[10,20]},\"x~y\":1,\"p/q\":2,\"\":3,\"~1\":4}").unwrap();
+  assert(v.pointer(``).unwrap() == v, "the empty pointer is the whole document");
+  assert(v.pointer(`/a/b/1`).unwrap().as_i64().unwrap() == i64(20), "object then array");
+  assert(v.pointer(`/x~0y`).unwrap().as_i64().unwrap() == i64(1), "~0 decodes to ~");
+  assert(v.pointer(`/p~1q`).unwrap().as_i64().unwrap() == i64(2), "~1 decodes to /");
+  assert(v.pointer(`/`).unwrap().as_i64().unwrap() == i64(3), "the empty key");
+  assert(v.pointer(`/a/b/2`).is_none(), "index past the end");
+  assert(v.pointer(`/a/b/01`).is_none(), "a leading zero is not an index (RFC 6901)");
+  assert(v.pointer(`/a/missing`).is_none(), "missing key");
+  assert(v.pointer(`a/b`).is_none(), "a pointer must start with /");
+  assert(v.pointer(`/a/b/x`).is_none(), "a non-numeric token cannot index an array");
+  // Escape ORDER matters: `~1` must decode before `~0`, or `~01` would come
+  // out as `/` instead of the literal key `~1`.
+  assert(v.pointer(`/~01`).unwrap().as_i64().unwrap() == i64(4), "~01 decodes to the literal ~1");
+});
+test("JsonValue Eq compares objects as maps, not positionally", {
+  a := json_parse("{\"x\":1,\"y\":[2,{\"z\":null}]}").unwrap();
+  b := json_parse("{\"y\":[2,{\"z\":null}],\"x\":1}").unwrap();
+  assert(a == b, "key order is not significant");
+  c := json_parse("{\"x\":1,\"y\":[2,{\"z\":true}]}").unwrap();
+  assert(a != c, "a nested difference is caught");
+  d := json_parse("{\"x\":1}").unwrap();
+  assert(a != d, "a missing key is caught");
+  assert(JsonValue.Null == JsonValue.Null, "Null == Null");
+  assert(JsonValue.Null != JsonValue.Bool(false), "Null != false");
+});
+test("JsonValue Clone makes an independent tree", {
+  a := json_parse("{\"xs\":[1]}").unwrap();
+  b := a.clone();
+  assert(a == b, "the clone starts equal");
+  b.pointer(`/xs`).unwrap().push(JsonValue.Number(f64(2.0)));
+  assert(json_stringify(a) == `{"xs":[1]}`, "the original is untouched");
+  assert(json_stringify(b) == `{"xs":[1,2]}`, "the clone grew");
+});
+test("JsonValue ToString is the compact JSON text", {
+  v := json_parse("{\"a\": [1, 2]}").unwrap();
+  assert(v.to_string() == `{"a":[1,2]}`, "ToString == json_stringify");
+});


### PR DESCRIPTION
**Stacked on #500.** Base will be retargeted to `develop` once #500 lands (before its branch is deleted — deleting a parent branch auto-closes the child PR, which is how #499 was lost).

## What

The audit's Encoding row asked for *"`JsonValue` mutation (`insert`/`remove`/`object()`), `is_*`/`as_i64`/`as_u64`, `pointer`, integer arms"*. Everything but the integer arms lands here:

- the six `is_*` predicates — I hit their absence writing a test for `JsonValue.default()` in #500, where `v.is_null()` did not exist;
- `as_f64` (Rust's name for the existing `as_number`), `as_i64`, `as_u64`;
- `object()` / `array()` empty constructors;
- `insert`, returning the value it **replaced** — `serde_json`'s `Map::insert`, not a silent overwrite — plus `remove` and `push`;
- RFC 6901 `pointer`.

Plus the three traits finding 14 says `JsonValue` had none of: `ToString` (the compact text, matching `Display`), `Clone` (a **deep** tree — the `Array`/`Object` payloads are `ArrayList`s, i.e. RC handles, so a plain copy aliases the children and `b := a; b.push(x)` is visible through `a`), and `Eq`.

`insert`/`remove`/`push` panic on the wrong variant, the same contract the file's two `Index` impls already had. In `serde_json` that check is `as_object_mut()`; here it is the `is_object()` this PR adds.

## Three details the tests pin

- **`Eq` compares objects as MAPS** — same key set, equal values, order insignificant. That is `serde_json`'s behaviour under both its map backends (`BTreeMap`, and `IndexMap` under `preserve_order`), and the only reading that survives a round trip through a format whose object order is not significant.
- **`as_i64` decides "integral" by an exact round trip**, so NaN and ±infinity land in `.None`. 2^63 is exactly representable as a double, which makes `[-2^63, 2^63)` an exact bound.
- **`pointer` decodes `~1` before `~0`** — the other order turns `~01` into `/` instead of the literal key `~1`. There is a test for exactly that.

## Deliberately deferred: the integer arms

A `Number(i64)` variant beside `Number(f64)` changes the parser, both stringifiers, `ToJson`/`FromJson` and every match over the enum — a breaking change that belongs in a breaking window, not in an additive batch. `as_i64`/`as_u64` give callers the integer they actually wanted meanwhile.

## Two bugs filed with reproducers rather than worked around

- **`FromStr` is implemented for only 6 of the 13 numeric primitives** — `usize` has none, so `token.parse(usize)` does not compile. `pointer` parses a `u64` and narrows. `issues/fromstr-missing-on-seven-numeric-primitives.md` (fixed in the PR stacked on this one).
- **Mutual recursion between a free fn and a trait-impl body silently produces an `abort()` stub.** Writing `Eq` the obvious way — a `_kids_eq` helper comparing children with `==`, called from the `Eq` body — is green under `yo check`, then dies on the first comparison at `--optimize 2` and does not link at `-O0`. The helper and the impl body are mutually recursive *through the impl*, and impl fields get no signature-first binding phase the way two plain `fn`s do. Ordering is **not** the trigger (tested both ways); a single self-recursive function is. `Eq` therefore delegates to one self-recursive `_json_eq`, exactly as `Clone` delegates to `_json_clone`. `issues/mutual-recursion-between-a-fn-and-a-trait-impl-body.md` + `issues/repros/`.

## Local gates (macOS arm64)

| gate | result |
| --- | --- |
| `yo fmt --check ./std` / `./tests` | clean |
| `yo check ./std` | 174/174 |
| `yo build` | rc=0 |
| `tests/encoding/json.test.yo` | **68 passed** (8 new) |
| `tests/path.test.yo` | 89 passed |
| full suite | 3845 passed / 1 failed — the `Path` expectation fixed in #500, which this branch did not yet carry at the time; rebased onto it and both files re-run clean |
| CLI golden scorecard | **PASS 88, GOLDEN-DIFF 0, NO-GOLDEN 0** |
| `fixpoint_only.sh` | **FIXPOINT_HOLDS** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)