### PR TITLE
std/math: INFINITY, NEG_INFINITY and NAN — and the MSVC NaN spelling that fell out

### DIFF
--- a/issues/fixed/msvc-nan-spelling-escapes-the-non-finite-float-match.md
+++ b/issues/fixed/msvc-nan-spelling-escapes-the-non-finite-float-match.md
@@ -1,0 +1,88 @@
+# The MS CRT's `-nan(ind)` escapes the non-finite float match, emitting `-nan(ind).0`
+
+**Status: FIXED** (2026-09-09) — `src/codegen/exprs/comptime_value.yo`.
+
+## Symptom (Windows only)
+
+A comptime NaN constant reached the C compiler as:
+
+```c
+bool _file___D__a__temp_17067 = yo_id_10435(-nan(ind).0);
+```
+
+```
+tests/.yo_selftest_batch_139_0.bin.c:5652:78: error: use of undeclared identifier 'ind'; did you mean 'bind'?
+ 5652 |                             bool _file___D__a__temp_17067 = yo_id_10435(-nan(ind).0);
+      |                                                                              ^~~
+      |                                                                              bind
+C:\...\um\winsock2.h:1655:1: note: 'bind' declared here
+```
+
+macOS and Linux were green on the same commit. The suggestion of `bind` from
+`winsock2.h` is a coincidence of the payload's spelling, and a good reminder
+that a C-level diagnostic can point somewhere unrelated to the cause.
+
+## Root cause
+
+`generate_comptime_value`'s `.FloatLit(raw)` arm turns the three non-finite
+doubles into their C11 spellings (`HUGE_VAL`, `(-HUGE_VAL)`, `NAN`) before the
+"append `.0` if there is no radix point" rule can run — that rule is what
+produced `inf.0` in
+`issues/fixed/comptime-float-infinity-emits-invalid-c.md`.
+
+It recognised them by **string equality**:
+
+```rust
+((lowered == "nan") || (lowered == "-nan")) => …
+```
+
+But the raw comes from the HOST C library's `%g`, and the libraries disagree:
+
+| library | NaN renders as |
+| --- | --- |
+| glibc, Apple libc, musl | `nan`, `-nan` |
+| MS CRT | `-nan(ind)` (indefinite), `nan(snan)` (signalling) |
+
+So the equality test passed everywhere the developer looked and failed on the
+one platform that spells the payload.
+
+The value that reached it was `f64.NAN`, whose definition is `∞ - ∞`; on x86
+that produces the *indefinite* NaN with the sign bit set, which is exactly the
+case the MS CRT spells `-nan(ind)`.
+
+## Fix
+
+Match by PREFIX rather than equality, for both the infinities and the NaNs, and
+accept an explicit `+` sign:
+
+```rust
+non_finite := cond(
+  (lowered.starts_with("inf") || lowered.starts_with("+inf")) => …,
+  lowered.starts_with("-inf") => …,
+  ((lowered.starts_with("nan") || lowered.starts_with("+nan")) || lowered.starts_with("-nan")) => …,
+  true => String.from("")
+);
+```
+
+No finite raw can collide: `%g` renders one starting with a digit, `-`, `+` or
+`.`, never with `i` or `n` after an optional sign.
+
+The NaN's SIGN and PAYLOAD are dropped on purpose. C offers no portable
+constant expression for either, `NAN` is the canonical quiet NaN, and no
+operation except `copysign` / `signbit` can observe the difference.
+
+## Tests
+
+`tests/math.test.yo`'s two non-finite-constant tests are the reproducer — they
+pass on macOS and Linux and fail the whole `tests/` batch on Windows before
+this fix. There is no way to exercise the MSVC spelling from a macOS or Linux
+host, because the raw string comes from the HOST's `%g` at comptime and not
+from the target: the Windows CI leg IS the gate for this one.
+
+## Related, still open
+
+`f64.to_string()` on a non-finite value is likewise the host library's
+spelling, so the same `f64.NAN` prints `-nan` on macOS and `-nan(ind)` on
+Windows. Rust prints `NaN` everywhere. That is a std-level portability
+inconsistency in its own right — see
+`issues/float-to-string-is-platform-dependent-for-non-finite-values.md`.

--- a/issues/float-to-string-is-platform-dependent-for-non-finite-values.md
+++ b/issues/float-to-string-is-platform-dependent-for-non-finite-values.md
@@ -1,0 +1,47 @@
+# `f64.to_string()` spells infinity and NaN differently per platform
+
+**Status: OPEN.** Found 2026-09-09 while fixing
+`issues/fixed/msvc-nan-spelling-escapes-the-non-finite-float-match.md`.
+
+## Symptom
+
+`to_string()` on a non-finite float hands back whatever the host C library's
+`%g` produced:
+
+| library | `f64.NAN.to_string()` | `f64.INFINITY.to_string()` |
+| --- | --- | --- |
+| glibc, Apple libc, musl | `nan` or `-nan` | `inf` |
+| MS CRT | `-nan(ind)`, or `nan(snan)` | `inf` |
+
+So a program that logs a NaN, writes one into JSON, or compares a rendered
+number against a fixture produces different output on Windows than on macOS or
+Linux — with no warning, and no way for the caller to normalise it without
+knowing every spelling.
+
+Rust prints `NaN`, `inf` and `-inf` on every platform, because `Display for
+f64` is implemented in Rust rather than delegated to the C library.
+
+## Why it is not just a formatting nit
+
+1. It is a silent cross-platform behaviour difference in `std`, which is
+   exactly the class the `## Stability` markers are meant to rule out.
+2. It already caused one compiler bug: the codegen's non-finite-float match
+   compared the raw against `"nan"` / `"-nan"` and emitted `-nan(ind).0` — not
+   valid C — on Windows (fixed, see above). Any other consumer of the raw
+   string has the same trap available to it.
+3. JSON has no non-finite literal, so `json_stringify` on a NaN currently emits
+   a bare `nan` / `-nan(ind)` token that no JSON parser accepts. Deciding the
+   spelling is a prerequisite for deciding what `json_stringify` should do
+   there (serde_json emits `null`).
+
+## Fix sketch
+
+Normalise in `to_string` rather than at each consumer: check `is_nan()` /
+`is_infinite()` first and return `NaN` / `inf` / `-inf` directly, only falling
+through to `%g` for finite values. That is a one-place change with a wide blast
+radius on golden output, so it wants its own PR and a sweep of any test or
+cli-case golden that currently contains a platform-spelled non-finite.
+
+Note the SEED GATE: `std` is compiled by the previous release, so a `std`-side
+change here is usable immediately (it is ordinary Yo, not a new runtime macro),
+but any test that pins the new spelling must land with it.

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -725,6 +725,20 @@ rewritten over `Mutex.with_lock` (its blocker is in `issues/fixed/`);
 
    `std/math` is now marked stable with ONE remaining gap: the `f32`
    transcendentals C has no single-precision entry point for.
+
+   **A second compiler bug fell out, Windows-only.** The codegen recognised a
+   non-finite float raw by string EQUALITY against `"nan"` / `"-nan"`, but the
+   raw is the HOST C library's `%g` output and the libraries disagree: the MS
+   CRT spells the indefinite NaN `-nan(ind)`. So `f64.NAN` emitted
+   `-nan(ind).0` on Windows and clang read the payload as an identifier
+   ("use of undeclared identifier 'ind'; did you mean 'bind'?") while macOS and
+   Linux stayed green. Matched by prefix now
+   (issues/fixed/msvc-nan-spelling-escapes-the-non-finite-float-match.md).
+   The same divergence is visible from Yo — `f64.NAN.to_string()` differs by
+   platform — which is filed separately as a std portability defect
+   (issues/float-to-string-is-platform-dependent-for-non-finite-values.md);
+   it also decides what `json_stringify` should do with a NaN, since JSON has
+   no non-finite literal.
 5. **Freeze** — re-run the five measurements; a module freezes only when its
    group's list is empty.
 

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -701,6 +701,30 @@ rewritten over `Mutex.with_lock` (its blocker is in `issues/fixed/`);
    worse than not having it (a blocking await inside a task nests the loop and
    deadlocks). The row wants an async-iteration abstraction first; it is a
    language/std design question, not a missing method.
+   **`f64`/`f32` non-finite constants: DONE (2026-09-09), unblocked by the
+   v0.2.29 seed.** `INFINITY`, `NEG_INFINITY` and `NAN` are the last three
+   names `std/math` was missing. They had to wait for a seed because the
+   v0.2.28 compiler emitted a non-finite float constant as the invalid C
+   literal `inf.0` (issues/fixed/comptime-float-infinity-emits-invalid-c.md,
+   fixed in #487 and therefore first present in a seed at v0.2.29), and `std/`
+   must build under the seed.
+
+   None of the three has a token, so each is spelled as the thing that produces
+   it: an OVERFLOWING literal (`f64(1.0e400)`) for the infinities and `∞ - ∞`
+   for the NaN. Both alternatives were tried and rejected against the actual
+   compiler: `0.0 / 0.0` is refused outright ("Division by zero in comptime
+   float operation: __yo_comptime_f64_div"), and `x * y - x * y` is fused into
+   an FMA by `-ffp-contract=on` and evaluates to `-inf` rather than NaN.
+
+   The tests do not stop at `is_infinite()`/`is_nan()`. They assert
+   `INFINITY > MAX`, `NEG_INFINITY < MIN`, `NEG_INFINITY == -INFINITY`, that
+   NaN is unequal to ITSELF (the reason `is_nan()` exists), and that arithmetic
+   on the constants behaves — `inf + 1`, `inf * -1`, `1 / inf`, NaN
+   propagation. That last group is the one that would have caught `inf.0`:
+   a constant that never reaches the C compiler correctly cannot be added to.
+
+   `std/math` is now marked stable with ONE remaining gap: the `f32`
+   transcendentals C has no single-precision entry point for.
 5. **Freeze** — re-run the five measurements; a module freezes only when its
    group's list is empty.
 

--- a/src/codegen/exprs/comptime_value.yo
+++ b/src/codegen/exprs/comptime_value.yo
@@ -233,11 +233,27 @@ generate_comptime_value :: (fn(value : EvalValue, ty : TypeValue, context : Code
       // available today. `HUGE_VAL`/`HUGE_VALF`/`NAN` are the C11 <math.h>
       // spellings (7.12/4, 7.12/5); `(1.0/0.0)` is NOT a substitute, being a
       // division by zero in a context that may require a constant expression.
+      // Matched by PREFIX, not equality, because the spelling is the HOST C
+      // library's and they disagree: glibc and Apple libc print `nan` /
+      // `-nan`, while the MS CRT prints `-nan(ind)` for the indefinite NaN
+      // (and `nan(snan)` for a signalling one). An equality test passed on
+      // macOS and Linux and emitted `-nan(ind).0` on Windows — not C at all,
+      // and clang read the payload as an identifier: "use of undeclared
+      // identifier 'ind'; did you mean 'bind'?"
+      // (issues/fixed/msvc-nan-spelling-escapes-the-non-finite-float-match.md).
+      // No finite raw can collide: `%g` renders one starting with a digit,
+      // `-`, `+` or `.`, never with `i` or `n` after an optional sign.
+      //
+      // A NaN's SIGN and PAYLOAD are dropped on purpose. C offers no portable
+      // constant expression for either, `NAN` is the canonical quiet NaN, and
+      // no operation except `copysign`/`signbit` can observe the difference.
       lowered := raw.clone().to_lowercase();
       non_finite := cond(
-        ((lowered == "inf") || (lowered == "infinity")) => if(_is_f32(ty), String.from("HUGE_VALF"), String.from("HUGE_VAL")),
-        ((lowered == "-inf") || (lowered == "-infinity")) => if(_is_f32(ty), String.from("(-HUGE_VALF)"), String.from("(-HUGE_VAL)")),
-        ((lowered == "nan") || (lowered == "-nan")) => if(_is_f32(ty), String.from("NAN"), String.from("((double)NAN)")),
+        (lowered.starts_with("inf") || lowered.starts_with("+inf")) => if(_is_f32(ty), String.from("HUGE_VALF"), String.from("HUGE_VAL")),
+        lowered.starts_with("-inf") => if(_is_f32(ty), String.from("(-HUGE_VALF)"), String.from("(-HUGE_VAL)")),
+        (
+          (lowered.starts_with("nan") || lowered.starts_with("+nan")) || lowered.starts_with("-nan")
+        ) => if(_is_f32(ty), String.from("NAN"), String.from("((double)NAN)")),
         true => String.from("")
       );
       // No `add_c_include` here: `emit_c_includes` has already run by the time

--- a/std/math.yo
+++ b/std/math.yo
@@ -31,18 +31,22 @@
 //! makes them real comptime constants with no header dependency, and they are
 //! exact: each is the shortest decimal that round-trips to the same double.
 //!
-//! `INFINITY`, `NEG_INFINITY` and `NAN` are NOT here yet. The only comptime
-//! spelling of them is an overflowing literal (`f64(1.0e400)`), which the
-//! v0.2.28 seed still miscompiles to `inf.0`
-//! (issues/fixed/comptime-float-infinity-emits-invalid-c.md) — `std/` has to
-//! build under the seed, so they wait for the next seed bump. `is_nan`,
-//! `is_infinite` and `is_finite` are here and work today.
+//! `INFINITY`, `NEG_INFINITY` and `NAN` are here as of the v0.2.29 seed. They
+//! have no token of their own, so each is spelled as the thing that produces
+//! it: an OVERFLOWING literal (`f64(1.0e400)`) for the infinities, and
+//! `∞ - ∞` for the NaN. Two alternatives were tried and rejected — `0.0 / 0.0`
+//! is refused outright ("Division by zero in comptime float operation"), and
+//! `x * y - x * y` is fused into an FMA by `-ffp-contract=on` and evaluates to
+//! `-inf`. They had to wait for a seed because the v0.2.28 compiler emitted a
+//! non-finite float constant as the invalid C literal `inf.0`
+//! (issues/fixed/comptime-float-infinity-emits-invalid-c.md), and `std/` must
+//! build under the seed.
+//!
 //! ## Stability
 //!
 //! stable — the method and constant names follow Rust's `f64`/`f32` inherent
-//! surface, and the two deliberate gaps (`INFINITY`/`NEG_INFINITY`/`NAN`, and
-//! the `f32` transcendentals C has no single-precision entry point for) are
-//! additive when they arrive.
+//! surface, and the one remaining gap (the `f32` transcendentals C has no
+//! single-precision entry point for) is additive when it arrives.
 pragma(Pragma.AllowUnsafe);
 {
   sqrt : _c_sqrt,
@@ -128,7 +132,19 @@ impl(
   /// The most negative finite double — `-MAX`, NOT the smallest positive.
   MIN : f64(-1.7976931348623157e308),
   /// The smallest positive NORMAL double. Subnormals go lower.
-  MIN_POSITIVE : f64(2.2250738585072014e-308)
+  MIN_POSITIVE : f64(2.2250738585072014e-308),
+  /// Positive infinity. The only comptime spelling of a non-finite double is
+  /// an OVERFLOWING literal — there is no `inf` token — so `1.0e400` is
+  /// deliberate, not a typo. Codegen emits it as C's `HUGE_VAL`.
+  INFINITY : f64(1.0e400),
+  /// Negative infinity.
+  NEG_INFINITY : f64(-1.0e400),
+  /// A quiet NaN. `∞ - ∞` rather than `0.0 / 0.0`, which would be a
+  /// division by zero the comptime evaluator refuses, and rather than
+  /// `x * y - x * y`, which `-ffp-contract=on` fuses into an FMA and turns
+  /// into `-inf`. NaN compares unequal to EVERYTHING, itself included — use
+  /// `is_nan()`, never `== f64.NAN`.
+  NAN : (f64(1.0e400) - f64(1.0e400))
 );
 /// The same constants at `f32` precision.
 impl(
@@ -144,7 +160,10 @@ impl(
   EPSILON : f32(1.1920929e-7),
   MAX : f32(3.4028235e38),
   MIN : f32(-3.4028235e38),
-  MIN_POSITIVE : f32(1.1754944e-38)
+  MIN_POSITIVE : f32(1.1754944e-38),
+  INFINITY : f32(1.0e400),
+  NEG_INFINITY : f32(-1.0e400),
+  NAN : (f32(1.0e400) - f32(1.0e400))
 );
 impl(
   f64,

--- a/tests/math.test.yo
+++ b/tests/math.test.yo
@@ -127,3 +127,36 @@ test("f32 surface", {
   assert(f32(0.0).copysign(f32(-1.0)).is_sign_negative(), "negative zero");
   assert(f32(1.0).is_finite(), "is_finite");
 });
+test("f64 non-finite constants", {
+  assert(f64.INFINITY.is_infinite(), "INFINITY is infinite");
+  assert(!f64.INFINITY.is_finite(), "INFINITY is not finite");
+  assert(!f64.INFINITY.is_nan(), "INFINITY is not NaN");
+  assert(f64.INFINITY > f64.MAX, "INFINITY is above the largest finite double");
+  assert(f64.NEG_INFINITY.is_infinite(), "NEG_INFINITY is infinite");
+  assert(f64.NEG_INFINITY < f64.MIN, "NEG_INFINITY is below the most negative finite double");
+  assert(f64.NEG_INFINITY == -f64.INFINITY, "NEG_INFINITY is -INFINITY");
+  assert(f64.NAN.is_nan(), "NAN is NaN");
+  assert(!f64.NAN.is_finite(), "NAN is not finite");
+  assert(!f64.NAN.is_infinite(), "NAN is not infinite");
+  // NaN compares unequal to everything, itself included — this is the reason
+  // `is_nan()` exists and the reason the doc says never to write `== f64.NAN`.
+  assert(!(f64.NAN == f64.NAN), "NAN is not equal to itself");
+  assert(f64.NAN != f64.NAN, "NAN is unequal to itself");
+  // The constants reach the C compiler as HUGE_VAL / NAN, so arithmetic on
+  // them has to behave: this is what `inf.0` used to break.
+  assert((f64.INFINITY + f64(1.0)).is_infinite(), "inf + 1 is inf");
+  assert((f64.INFINITY * f64(-1.0)) == f64.NEG_INFINITY, "inf * -1 is -inf");
+  assert((f64(1.0) / f64.INFINITY) == f64(0.0), "1 / inf is 0");
+  assert((f64.NAN + f64(1.0)).is_nan(), "NaN propagates through addition");
+  assert(f64.INFINITY.is_sign_positive(), "INFINITY is positive");
+  assert(f64.NEG_INFINITY.is_sign_negative(), "NEG_INFINITY is negative");
+});
+test("f32 non-finite constants", {
+  assert(f32.INFINITY.is_infinite(), "f32 INFINITY is infinite");
+  assert(f32.INFINITY > f32.MAX, "f32 INFINITY is above the largest finite float");
+  assert(f32.NEG_INFINITY.is_infinite(), "f32 NEG_INFINITY is infinite");
+  assert(f32.NEG_INFINITY < f32.MIN, "f32 NEG_INFINITY is below the most negative float");
+  assert(f32.NAN.is_nan(), "f32 NAN is NaN");
+  assert(!(f32.NAN == f32.NAN), "f32 NAN is not equal to itself");
+  assert((f32.INFINITY + f32(1.0)).is_infinite(), "f32 inf + 1 is inf");
+});


### PR DESCRIPTION
The last three names `std/math` was missing — **unblocked by the v0.2.29 seed**, which landed a few hours ago.

They had to wait for a seed because the v0.2.28 compiler emitted a non-finite float constant as the invalid C literal `inf.0` (`issues/fixed/comptime-float-infinity-emits-invalid-c.md`, fixed in #487 and therefore first present in a seed at v0.2.29), and `std/` must build under the seed. Verified against the real v0.2.29 bundle, not the local dev binary.

## The spelling, and the two rejected alternatives

None of the three has a token of its own, so each is spelled as the thing that produces it:

```rust
INFINITY : f64(1.0e400),
NEG_INFINITY : f64(-1.0e400),
NAN : (f64(1.0e400) - f64(1.0e400)),
```

Both alternatives were tried against the actual compiler and rejected:

- `0.0 / 0.0` — refused outright: `Division by zero in comptime float operation: __yo_comptime_f64_div`.
- `x * y - x * y` — `-ffp-contract=on` fuses it into an FMA, and it evaluates to `-inf`, not NaN.

The doc says all of this at the definition, so the `1.0e400` does not read as a typo.

## Tests

They do not stop at `is_infinite()` / `is_nan()`, which would pass even for a constant that never reached C correctly. They assert `INFINITY > MAX`, `NEG_INFINITY < MIN`, `NEG_INFINITY == -INFINITY`, that **NaN is unequal to itself** — the whole reason `is_nan()` exists, and why the doc says never to write `== f64.NAN` — and that arithmetic on the constants behaves: `inf + 1`, `inf * -1`, `1 / inf`, NaN propagation. That last group is what would have caught `inf.0`.

Same coverage at `f32`.

## Stability

`std/math`'s `## Stability` marker drops these from its list of deliberate gaps. The one that remains is the `f32` transcendentals C has no single-precision entry point for.

## Local gates (macOS arm64)

| gate | result |
| --- | --- |
| `yo fmt --check` | clean |
| `yo check ./std` (v0.2.29 seed) | 174/174 |
| `yo build` (v0.2.29 seed) | rc=0 |
| `tests/math.test.yo` | **12 passed** (10 + 2 new) |
| full suite + CLI + fixpoint | queued; results in a comment before merge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)