### PR TITLE
std: a `## Stability` marker on the six modules that lacked one

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -647,6 +647,28 @@ rewritten over `Mutex.with_lock` (its blocker is in `issues/fixed/`);
    (issues/mutual-recursion-between-a-fn-and-a-trait-impl-body.md, with a
    minimal reproducer). `Eq` is therefore ONE self-recursive `_json_eq`, which
    is what `Clone` already did.
+   **`## Stability` markers: DONE (2026-09-09).** §1's last row counted eight
+   modules without one. `std/http/server` got its marker when the server was
+   last touched; the remaining six now have one — `std/async/index`,
+   `std/async/channel`, `std/async/mutex`, `std/sync/barrier`,
+   `std/sync/semaphore` and `std/gc` (which also gains the module doc it never
+   had: what the cycle collector is FOR, and that `tracked_count` counts cycle
+   CANDIDATES, since an `Acyclic` type never reaches the collector).
+
+   Writing them settled two rows and surfaced one divergence:
+
+   - `async/mutex.with_lock` **already takes an `io`**, so the §4 row ("either
+     takes an `io` so its doc claim becomes true, or drops the claim") is
+     satisfied as written — the claim is true today. No change needed.
+   - `sync/barrier` and `sync/semaphore` are marked **stable**: both follow a
+     named model exactly (the generation barrier; Java/`tokio` counting
+     semaphore), and the two properties most likely to be read as provisional
+     — unfair acquisition, an uncapped permit count — are deliberate and
+     already documented.
+   - **`async/channel.try_recv` still returns `Option(T)`** where
+     `sync/channel`'s now returns `Result(T, TryRecvError)` (#495). The
+     marker names it as the thing that will move; aligning it is a follow-up,
+     not a doc change.
 5. **Freeze** — re-run the five measurements; a module freezes only when its
    group's list is empty.
 

--- a/std/async/channel.yo
+++ b/std/async/channel.yo
@@ -23,6 +23,21 @@
 //! }), io);
 //! v := io.await(ch.recv(io), io); // .Some(42)
 //! ```
+//!
+//! ## Stability
+//!
+//! unstable, in two specific ways:
+//!
+//! - `try_recv` still returns `Option(T)`, where `std/sync/channel`'s now
+//!   returns `Result(T, TryRecvError)` so a polling caller can tell "nothing
+//!   buffered yet" from "closed and drained". This one will be aligned with
+//!   the blocking channel's shape; `recv`'s `Option(T)` (where `.None` means
+//!   closed) is under the same question.
+//! - the 1 ms timer tick above is an implementation choice a waker-based
+//!   rewrite would remove, which changes handoff latency but no signature.
+//!
+//! `new`, `send`, `try_send`, `close`, `is_closed` and `len` are intended to
+//! keep their names and meanings.
 { ArrayList } :: import("../collections/array_list");
 { assert } :: import("../assert");
 IO_timer :: import("../sys/timer");

--- a/std/async/index.yo
+++ b/std/async/index.yo
@@ -21,6 +21,18 @@
 //! For the async-safe `Channel` and `Mutex` (usable INSIDE tasks without
 //! parking the event loop the way `std/sync`'s blocking primitives do), see
 //! `std/async/channel` and `std/async/mutex`.
+//!
+//! ## Stability
+//!
+//! unstable — the NAMES and signatures (`yield`, `join_all`, `race`, `any`,
+//! `timeout`, `TimeoutError`) are intended to keep their meanings, but the
+//! MECHANISM under them is expected to change: every combinator drives the
+//! loop by polling, re-checking on a 1 ms timer tick, so a handle that
+//! completes just after a check waits out the rest of the tick. A waker-based
+//! rewrite is planned (`plans/STD_API_STABILIZATION.md` §4 Concurrency) and
+//! would change the latency and the CPU cost of waiting, not the API. The
+//! `JoinHandle`-not-`Future` argument type is a consequence of that design and
+//! may relax with it.
 pragma(Pragma.AllowUnsafe);
 { ArrayList } :: import("../collections/array_list");
 { assert } :: import("../assert");

--- a/std/async/mutex.yo
+++ b/std/async/mutex.yo
@@ -19,6 +19,15 @@
 //! m.set(m.get() + i64(1));
 //! m.unlock();
 //! ```
+//!
+//! ## Stability
+//!
+//! unstable — `new`, `lock`, `with_lock`, `try_lock`, `unlock`, `is_locked`,
+//! `get` and `set` are intended to keep their names and meanings, but the 1 ms
+//! tick that contended acquisition re-checks on is an implementation choice a
+//! waker-based rewrite would remove (`plans/STD_API_STABILIZATION.md` §4
+//! Concurrency). Unfairness is by design, not provisional: build FIFO ordering
+//! on top if you need it.
 { assert } :: import("../assert");
 IO_timer :: import("../sys/timer");
 

--- a/std/gc.yo
+++ b/std/gc.yo
@@ -1,4 +1,31 @@
 //! Garbage collection interface for cycle collection.
+//!
+//! Yo is reference-counted, so ordinary values are reclaimed the moment their
+//! last reference goes away and nothing here is needed for them. What
+//! reference counting cannot reclaim is a CYCLE, and this module is the manual
+//! handle on the collector that can: `collect()` runs it, `tracked_count()`
+//! reports how many objects it is currently watching.
+//!
+//! Only types that can participate in a cycle are tracked at all — a type
+//! proven `Acyclic` never reaches the collector — so `tracked_count()` is a
+//! count of cycle CANDIDATES, not of live objects.
+//!
+//! ```rust
+//! { collect, tracked_count } :: import "std/gc";
+//!
+//! collect();
+//! println(tracked_count().to_string());
+//! ```
+//!
+//! ## Stability
+//!
+//! unstable — `collect` is intended to keep its name and meaning (run the
+//! cycle collector now, synchronously). `tracked_count` exposes the
+//! collector's own bookkeeping and exists because the cycle tests need to
+//! observe it; it is not a memory-accounting API, and a collector redesign may
+//! change what "tracked" counts or drop the function. Nothing here is a
+//! substitute for breaking cycles with a weak reference where the ownership
+//! actually is a cycle.
 pragma(Pragma.AllowUnsafe);
 extern(
   "Yo",

--- a/std/sync/barrier.yo
+++ b/std/sync/barrier.yo
@@ -19,6 +19,15 @@
 //! t1.join();
 //! t2.join();
 //! ```
+//!
+//! ## Stability
+//!
+//! stable — `new`, `wait`, `parties`, `generation` and `waiting` follow the
+//! generation model `std::sync::Barrier` and `pthread_barrier_t` both carry,
+//! and `wait`'s single `true` is Rust's `BarrierWaitResult::is_leader` without
+//! the wrapper struct. `generation` and `waiting` are observability, so they
+//! are honest about being a SNAPSHOT: by the time you read either, another
+//! party may have arrived.
 pragma(Pragma.AllowUnsafe);
 { Mutex } :: import("./mutex");
 { Cond } :: import("./cond");

--- a/std/sync/semaphore.yo
+++ b/std/sync/semaphore.yo
@@ -30,6 +30,15 @@
 //! });
 //! t.join();
 //! ```
+//!
+//! ## Stability
+//!
+//! stable — `new`, `acquire`, `try_acquire`, `release`, `with_permit` and
+//! `available_permits` follow Java's and `tokio`'s counting-semaphore surface.
+//! The two properties most likely to be mistaken for provisional are
+//! deliberate and documented above: acquisition is NOT fair, and the permit
+//! count is not capped, which is what makes this usable as a signalling
+//! device rather than only as a lock. `available_permits` is a snapshot.
 pragma(Pragma.AllowUnsafe);
 { Mutex } :: import("./mutex");
 { Cond } :: import("./cond");


### PR DESCRIPTION
§1's last audit row counted **eight** modules with no `## Stability` section — the thing `yo doc` renders and readers use to tell a settled name from a provisional one. `std/http/server` picked one up when the server was last touched; the other six get one here: `std/async/index`, `std/async/channel`, `std/async/mutex`, `std/sync/barrier`, `std/sync/semaphore`, `std/gc`.

Each says **what is expected to move and what is not**, rather than a bare stable/unstable word:

- The three `async` modules are unstable in their **mechanism**, not their names — every one of them re-checks a blocked operation on a 1 ms timer tick, which a waker-based rewrite would remove. That changes latency and CPU cost, not a signature.
- `sync/barrier` and `sync/semaphore` are **stable**: each follows a named model exactly (the generation barrier that `std::sync::Barrier` and `pthread_barrier_t` share; Java's and `tokio`'s counting semaphore), and the two properties most likely to be misread as provisional — unfair acquisition, an uncapped permit count — are deliberate and already documented.
- `std/gc` also gains **the module doc it never had**. It had one line. It now says what the cycle collector is for (reference counting reclaims everything except a cycle) and that `tracked_count` counts cycle *candidates* rather than live objects, because a type proven `Acyclic` never reaches the collector at all.

## Two audit rows settled while writing them

- **`async/mutex.with_lock` already takes an `io`**, so §4's *"either takes an `io` so its doc claim becomes true, or drops the claim"* is satisfied as written. The claim is true today; no change needed.
- **`async/channel.try_recv` still returns `Option(T)`** where `sync/channel`'s now returns `Result(T, TryRecvError)` (#495). The marker names that divergence as the thing that will move. Aligning it is a follow-up — a signature change, not a doc change.

Both recorded in `plans/STD_API_STABILIZATION.md`.

## Local gates (macOS arm64)

| gate | result |
| --- | --- |
| `yo fmt --check` on all six | clean |
| `yo check ./std` | 174/174 |
| full suite + CLI + fixpoint | queued; results in a comment before merge |

Doc-comment-only in `std/*.yo`, so no behaviour changes — but they are `.yo` files, so this is not on the docs-only fast path and gets the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)