### PR TITLE
std/async: try_recv returns Result(T, TryRecvError), matching the blocking channel

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -813,6 +813,13 @@ rewritten over `Mutex.with_lock` (its blocker is in `issues/fixed/`);
    `Result` — a D12 violation independent of the name, and an error-type design
    question rather than a rename
    (issues/httpmethod-from-string-returns-option-not-result.md).
+   - **`async/channel.try_recv` returned `Option(T)`** where `sync/channel`'s
+     returns `Result(T, TryRecvError)` (#495). ALIGNED in the follow-up: the
+     async channel now returns the SAME `TryRecvError`, imported from
+     `std/sync/channel` rather than redeclared, so the two channels report one
+     distinction with one vocabulary. A closed channel with buffered values
+     still yields them — `Disconnected` means closed AND drained, which is the
+     case the old `.None` could not express and which the new test pins.
 5. **Freeze** — re-run the five measurements; a module freezes only when its
    group's list is empty.
 

--- a/std/async/channel.yo
+++ b/std/async/channel.yo
@@ -26,19 +26,18 @@
 //!
 //! ## Stability
 //!
-//! unstable, in two specific ways:
+//! unstable — `recv` answers `Option(T)`, where `.None` means the channel
+//! closed, and whether that should be a `Result` the way `try_recv`'s answer
+//! now is remains open. The 1 ms timer tick above is an implementation choice
+//! a waker-based rewrite would remove, which changes handoff latency but no
+//! signature.
 //!
-//! - `try_recv` still returns `Option(T)`, where `std/sync/channel`'s now
-//!   returns `Result(T, TryRecvError)` so a polling caller can tell "nothing
-//!   buffered yet" from "closed and drained". This one will be aligned with
-//!   the blocking channel's shape; `recv`'s `Option(T)` (where `.None` means
-//!   closed) is under the same question.
-//! - the 1 ms timer tick above is an implementation choice a waker-based
-//!   rewrite would remove, which changes handoff latency but no signature.
-//!
-//! `new`, `send`, `try_send`, `close`, `is_closed` and `len` are intended to
-//! keep their names and meanings.
+//! `new`, `send`, `try_send`, `try_recv`, `close`, `is_closed` and `len` are
+//! intended to keep their names and meanings.
 { ArrayList } :: import("../collections/array_list");
+// The SAME `TryRecvError` the blocking channel reports, so a caller that
+// polls both does not need two vocabularies for one distinction.
+{ TryRecvError } :: import("../sync/channel");
 { assert } :: import("../assert");
 IO_timer :: import("../sys/timer");
 
@@ -131,15 +130,26 @@ impl(
       }
     )
   ),
-  /// Try to receive without suspending: `.None` when the buffer is empty
-  /// (closed or not).
-  try_recv : (fn(self : Self) -> Option(T))(
+  /// Try to receive without suspending — `.Ok(value)`, or the reason there is
+  /// none.
+  ///
+  /// This used to answer `Option(T)`, which collapsed the two answers a
+  /// polling caller must act on differently: `.None` meant both "nothing
+  /// buffered yet, retry" and "closed and drained, no value will ever
+  /// arrive". `TryRecvError` is the SAME type `std/sync/channel.try_recv`
+  /// returns, so the two channels now report the same distinction with the
+  /// same vocabulary.
+  ///
+  /// A closed channel with buffered values still yields them: `Disconnected`
+  /// means closed AND drained.
+  try_recv : (fn(self : Self) -> Result(T, TryRecvError))(
     cond(
       (self._buf.len() > usize(0)) => {
         v := self._buf.remove(usize(0));
-        Option(T).Some(v)
+        Result(T, TryRecvError).Ok(v)
       },
-      true => Option(T).None
+      self._closed => Result(T, TryRecvError).Err(TryRecvError.Disconnected),
+      true => Result(T, TryRecvError).Err(TryRecvError.Empty)
     )
   ),
   /// Close the channel: pending and future `send`s fail with `.Err`;
@@ -156,4 +166,4 @@ impl(
     self._buf.len()
   )
 );
-export(Channel);
+export(Channel, TryRecvError);

--- a/tests/async/channel.test.yo
+++ b/tests/async/channel.test.yo
@@ -11,7 +11,10 @@ pragma(Pragma.AllowUnsafe);
 test("Test channel try ops", {
   ch := Channel(i32).new(usize(2));
   assert(ch.len() == usize(0), "new channel should be empty");
-  assert(match(ch.try_recv(), .Some(_) => false, .None => true), "try_recv on empty should be .None");
+  assert(
+    match(ch.try_recv(), .Ok(_) => false, .Err(e) => match(e, .Empty => true, _ => false)),
+    "try_recv on an OPEN empty channel is Empty, not Disconnected"
+  );
   s1 := ch.try_send(i32(1));
   s2 := ch.try_send(i32(2));
   assert(match(s1, .Ok(_) => true, .Err(_) => false), "first try_send should fit");
@@ -20,8 +23,28 @@ test("Test channel try ops", {
   assert(match(s3, .Ok(_) => false, .Err(v) => (v == i32(3))), "over-capacity try_send should hand the value back");
   r1 := ch.try_recv();
   r2 := ch.try_recv();
-  assert(match(r1, .Some(v) => (v == i32(1)), .None => false), "FIFO: first out is 1");
-  assert(match(r2, .Some(v) => (v == i32(2)), .None => false), "FIFO: second out is 2");
+  assert(match(r1, .Ok(v) => (v == i32(1)), .Err(_) => false), "FIFO: first out is 1");
+  assert(match(r2, .Ok(v) => (v == i32(2)), .Err(_) => false), "FIFO: second out is 2");
+});
+// A CLOSED channel is Disconnected only once it is also DRAINED — the two
+// answers `Option(T)` used to collapse into one `.None`, which is why this
+// returns a `Result` now (the same `TryRecvError` `std/sync/channel` reports).
+test("async try_recv separates Empty from Disconnected", {
+  ch := Channel(i32).new(usize(2));
+  _s := ch.try_send(i32(7));
+  ch.close();
+  buffered := ch.try_recv();
+  assert(match(buffered, .Ok(v) => (v == i32(7)), .Err(_) => false), "a closed channel still yields what it buffered");
+  drained := ch.try_recv();
+  assert(
+    match(drained, .Ok(_) => false, .Err(e) => match(e, .Disconnected => true, _ => false)),
+    "closed AND drained is Disconnected"
+  );
+  open_empty := Channel(i32).new(usize(1));
+  assert(
+    match(open_empty.try_recv(), .Ok(_) => false, .Err(e) => match(e, .Empty => true, _ => false)),
+    "an open empty channel is Empty"
+  );
 });
 // ---------------------------------------------------------------------------
 // 2. async producer → awaiting consumer, buffer smaller than the stream


### PR DESCRIPTION
**Stacked on #505.** Base retargets to `develop` once #505 lands.

## What

`std/sync/channel.try_recv` moved to `Result(T, TryRecvError)` in #495, because `Option(T)` collapsed the two answers a polling caller must act on differently: `.None` meant both *"nothing buffered yet, retry"* and *"closed and drained, no value will ever arrive"*.

The **async** channel was left behind, so the two channels reported the same distinction in two vocabularies. #505's stability marker had to write that divergence down as a known defect; this closes it.

It now returns the **same** `TryRecvError`, imported from `std/sync/channel` rather than redeclared, and re-exported so a caller of only the async channel can name it.

## The test that the old shape could not express

```rust
ch := Channel(i32).new(usize(2));
_s := ch.try_send(i32(7));
ch.close();
// A closed channel still yields what it buffered:
assert(ch.try_recv() is Ok(7));
// Only the call AFTER that is Disconnected:
assert(ch.try_recv() is Err(Disconnected));
```

With `Option(T)` both of those last two states were `.None`.

## Stability marker

Drops the divergence and keeps the one question that remains: whether `recv`'s `Option(T)` — where `.None` means closed — should become a `Result` for the same reason.

## Local gates (macOS arm64)

| gate | result |
| --- | --- |
| `yo fmt --check` | clean |
| `yo check ./std` | 174/174 |
| `yo build` (v0.2.29 seed) | rc=0 |
| `tests/async/channel.test.yo` | **5 passed** (1 new) |
| full suite + CLI + fixpoint | queued; results in a comment before merge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)