### PR TITLE
codegen: a tuple type gets a named C struct tag and a forward declaration

### DIFF
--- a/issues/fixed/tuple-type-has-no-forward-declaration.md
+++ b/issues/fixed/tuple-type-has-no-forward-declaration.md
@@ -1,0 +1,93 @@
+# A tuple type has no forward declaration, so `ArrayList(Tuple(..))` emits an unknown type name
+
+**Status: FIXED** (2026-09-09) — `src/codegen/types/generation.yo`.
+
+## Reproducer
+
+`issues/repros/arraylist-of-tuple-unknown-type-name.yo`:
+
+```rust
+{ ArrayList } :: import("std/collections/array_list");
+open(import("std/string"));
+main :: (fn() -> unit)({
+  xs := ArrayList(Tuple(String, String)).new();
+  xs.push((`a`, `b`));
+  p := xs(usize(0));
+  cond((p.0 == `a`) => (), true => ());
+});
+export(main);
+```
+
+```
+tup.c:389:3: error: unknown type name '__yo_t2'
+```
+
+`yo check` is green; this is a C-compile failure, so it is loud — but it makes
+`ArrayList(Tuple(K, V))` unusable, which is the natural return type for
+anything yielding pairs (`Url.query_pairs` is what hit it).
+
+## Root cause
+
+`generate_type_declarations` emits a forward declaration for every
+future-trait, struct and enum type:
+
+```c
+typedef struct __yo_t0_struct __yo_t0; // Forward declaration
+```
+
+Tuples got none — and could not have one, because `generate_tuple_declaration`
+emitted an ANONYMOUS struct:
+
+```c
+typedef struct { // Tuple(0 : String, 1 : String)
+  __yo_t3 _0;
+  __yo_t3 _1;
+} __yo_t2;
+```
+
+An anonymous struct has no tag to forward-declare. So when the ArrayList's own
+declaration — which holds a POINTER to its element type — was emitted first,
+it named a type C had not seen:
+
+```c
+struct __yo_t0_struct { //  : ArrayList(Tuple(0 : String, 1 : String))
+  __yo_ref_header_t header;
+  __yo_t2* _ptr;          // <- line 389
+  ...
+};
+...
+typedef struct { ... } __yo_t2;   // <- line 438
+```
+
+Ordering alone would not be a complete fix: a pointer cycle (`A` holding a
+`Tuple(*B)` while `B` holds an `*A`) has no valid order. C's rule is that a
+pointer to an incomplete type is fine *provided the name is declared*, and only
+a named struct tag can be declared ahead of its definition.
+
+## Fix
+
+Two lines of the same change:
+
+1. `generate_tuple_declaration` emits `struct <c_name>_struct { … };` — the
+   same shape `generate_struct_declaration` and `generate_enum_declaration`
+   already use — instead of an anonymous `typedef struct { … } <c_name>;`.
+2. `generate_type_declarations`'s forward pass gains an `is_tuple_type` arm
+   emitting `typedef struct <c_name>_struct <c_name>; // Forward declaration`.
+
+Every use site still names the typedef, so nothing else moves: compound
+literals (`(__yo_t2){ ._0 = …, ._1 = … }`), members, and pointer arithmetic are
+unchanged. The emitted C for every tuple changes shape, which is why the
+fixpoint gate is the acceptance test rather than byte identity against develop.
+
+## Tests
+
+`tests/basic.test.yo` — "a tuple element type inside a generic container
+declares its C name in time": an `ArrayList(Tuple(String, String))` pushed,
+indexed and read back, plus the one-level-deeper
+`ArrayList(Tuple(i32, ArrayList(i32)))`. On the pre-fix (v0.2.29) compiler the
+whole file fails to C-compile with two `unknown type name` errors.
+
+## Found by
+
+Writing `Url.query_pairs() -> ArrayList(Tuple(String, String))`
+(`plans/STD_API_STABILIZATION.md` §4 Encoding).

--- a/issues/repros/arraylist-of-tuple-unknown-type-name.yo
+++ b/issues/repros/arraylist-of-tuple-unknown-type-name.yo
@@ -1,0 +1,9 @@
+{ ArrayList } :: import("std/collections/array_list");
+open(import("std/string"));
+main :: (fn() -> unit)({
+  xs := ArrayList(Tuple(String, String)).new();
+  xs.push((`a`, `b`));
+  p := xs(usize(0));
+  cond((p.0 == `a`) => (), true => ());
+});
+export(main);

--- a/src/codegen/types/generation.yo
+++ b/src/codegen/types/generation.yo
@@ -246,7 +246,14 @@ generate_tuple_declaration :: (fn(tuple_type : TypeValue, c_name : String, conte
   match(
     tuple_type,
     .Tuple({ field_types }) => {
-      context.emitter.emit_declaration_string_line(`typedef struct { // ${type_to_string(tuple_type)}`);
+      // A NAMED struct tag, not an anonymous `typedef struct {...} T;`, so the
+      // forward-declaration pass in `generate_type_declarations` can declare
+      // the name ahead of any struct that holds a POINTER to this tuple. It
+      // could not before, and an `ArrayList(Tuple(String, String))` emitted
+      // `__yo_t2* _ptr;` above the `typedef ... __yo_t2;` that named it —
+      // "unknown type name '__yo_t2'"
+      // (issues/fixed/tuple-type-has-no-forward-declaration.md).
+      context.emitter.emit_declaration_string_line(`struct ${c_name}_struct { // ${type_to_string(tuple_type)}`);
       n := field_types.len();
       (i : usize) = usize(0);
       (emitted : bool) = false;
@@ -269,7 +276,7 @@ generate_tuple_declaration :: (fn(tuple_type : TypeValue, c_name : String, conte
       if(!emitted, {
         _emit_zst_dummy(context);
       });
-      context.emitter.emit_declaration_string_line(`} ${c_name};`);
+      context.emitter.emit_declaration_line("};");
       context.emitter.emit_declaration_line("");
     },
     _ => ()
@@ -1610,6 +1617,18 @@ generate_type_declarations :: (fn(context : CodeGenContext) -> unit)({
                   l.push_str("; // Forward declaration");
                   em.emit_declaration_string_line(l);
                 });
+              },
+              // A tuple is a plain value struct, but it can still be reached
+              // THROUGH A POINTER from a struct emitted earlier — an
+              // `ArrayList(Tuple(..))`'s `_ptr` is exactly that — so it needs
+              // its name declared up here like any other struct.
+              is_tuple_type(ty) => {
+                l := String.from("typedef struct ");
+                l.push_string(cn.clone());
+                l.push_str("_struct ");
+                l.push_string(cn.clone());
+                l.push_str("; // Forward declaration");
+                em.emit_declaration_string_line(l);
               },
               true => ()
             )

--- a/tests/basic.test.yo
+++ b/tests/basic.test.yo
@@ -2582,3 +2582,33 @@ test("a local shadows a C-interop type name", {
 test("the C type still resolves where it is NOT shadowed", {
   assert(_ct_takes_long(long(3)) == long(3), "long names the type in a signature");
 });
+// A tuple reached THROUGH A POINTER from a struct emitted earlier — an
+// `ArrayList(Tuple(..))`'s `_ptr` is exactly that shape — needs its C type
+// NAME declared before that struct. Tuples were emitted as an anonymous
+// `typedef struct {...} __yo_tN;`, which cannot be forward-declared, so the
+// element pointer referred to a name C had not seen yet:
+//
+//   struct __yo_t0_struct { ... __yo_t2* _ptr; ... };   <- line 386
+//   typedef struct { ... } __yo_t2;                      <- line 438
+//   error: unknown type name '__yo_t2'
+//
+// See issues/fixed/tuple-type-has-no-forward-declaration.md.
+test("a tuple element type inside a generic container declares its C name in time", {
+  open(import("std/collections/array_list"));
+  open(import("std/string"));
+  xs := ArrayList(Tuple(String, String)).new();
+  xs.push((`k`, `v`));
+  xs.push((`a`, `b`));
+  assert(xs.len() == usize(2), "two pairs");
+  p := xs(usize(0));
+  assert(p.0 == `k`, "first element of the first pair");
+  assert(p.1 == `v`, "second element of the first pair");
+  assert(xs(usize(1)).0 == `a`, "the second pair too");
+  // The same shape one level deeper: a tuple whose element is itself a
+  // container, in a container.
+  ys := ArrayList(Tuple(i32, ArrayList(i32))).new();
+  inner := ArrayList(i32).new();
+  inner.push(i32(7));
+  ys.push((i32(1), inner));
+  assert(ys(usize(0)).1(usize(0)) == i32(7), "a container inside a tuple inside a container");
+});


### PR DESCRIPTION
## Symptom

`ArrayList(Tuple(String, String))` does not compile:

```
tup.c:389:3: error: unknown type name '__yo_t2'
```

`yo check` is green — this is a C-compile failure, so it is loud — but it makes `ArrayList(Tuple(K, V))` unusable, which is the natural return type for anything yielding pairs.

## Root cause

`generate_type_declarations` emits a forward declaration for every future-trait, struct and enum type:

```c
typedef struct __yo_t0_struct __yo_t0; // Forward declaration
```

Tuples got none — and **could not have one**, because `generate_tuple_declaration` emitted an *anonymous* struct, which has no tag to declare ahead of its definition. So when a struct holding a **pointer** to the tuple was emitted first — an `ArrayList(Tuple(..))`'s `_ptr` is exactly that shape — it named a type C had not seen yet:

```c
struct __yo_t0_struct { //  : ArrayList(Tuple(0 : String, 1 : String))
  __yo_ref_header_t header;
  __yo_t2* _ptr;                   // line 389
  ...
};
...
typedef struct { ... } __yo_t2;    // line 438
```

Reordering alone would not be a complete fix: a pointer cycle (`A` holding a `Tuple(*B)` while `B` holds an `*A`) has no valid order. C's rule is that a pointer to an incomplete type is fine **provided the name is declared**, and only a named struct tag can be declared ahead of its definition.

## Fix

1. `generate_tuple_declaration` emits `struct <c_name>_struct { … };` — the same shape `generate_struct_declaration` and `generate_enum_declaration` already use.
2. The forward pass gains an `is_tuple_type` arm.

Every use site still names the typedef, so nothing else moves: compound literals (`(__yo_t2){ ._0 = …, ._1 = … }`), member access and pointer arithmetic are unchanged. The emitted C for every tuple changes **shape**, which is why the fixpoint is the acceptance test here rather than byte identity against develop.

## Test

`tests/basic.test.yo` — "a tuple element type inside a generic container declares its C name in time". On the v0.2.29 compiler the whole file fails to C-compile with two `unknown type name` errors, taking its entire batch with it; with the fix, 47/47.

## Local gates (macOS arm64)

| gate | result |
| --- | --- |
| `yo fmt --check ./src` | clean |
| `yo check ./src` | 270/270 |
| `yo build` | rc=0 |
| repro `.yo` | 2 C errors before → 0 after, runs |
| `tests/basic.test.yo` | **47 passed** (1 new) |
| full suite + CLI + fixpoint | running; results in a comment before merge |

## Found by

Writing `Url.query_pairs() -> ArrayList(Tuple(String, String))` for the §4 Encoding row.

`issues/fixed/tuple-type-has-no-forward-declaration.md` + `issues/repros/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)