### PR TITLE
Fix the two issues filed in #484: recursive value enums + aggregate call-arg casts

### DIFF
--- a/issues/async-capture-mode-argument-rendering-cluster.md
+++ b/issues/async-capture-mode-argument-rendering-cluster.md
@@ -2,43 +2,58 @@
 
 **Status: OPEN** (split 2026-09-09 out of
 `issues/fixed/async-closure-value-struct-param-emits-invalid-c-cast.md`,
-whose PRIMARY bug — the illegal aggregate call-arg cast — is fixed; these
-follow-up findings were recorded during the same V2 bisecting session and
-remain unreproduced-and-unfixed).
+whose PRIMARY bug — the illegal aggregate call-arg cast — is fixed).
 
-## Findings
+**Re-audit 2026-09-09 (v0.2.29-era develop, PR #509's branch):** probes
+committed under `issues/repros/async-capture-cluster/`. Current state per
+finding:
 
-1. **Missing-name soft-fallbacks cascade.** An `io.async` closure whose
-   body references a name not in scope (e.g. `IoExn` without
-   `import("std/error")`, or `String`/`eprintln` without the std/string +
-   std/fmt opens — reconfirmed 2026-09-09) silently degrades the await
-   call's recorded argument info; the result is either the
-   "closure body never fully evaluated" ICE at codegen or (V2-era) an
-   invalid `(T)(slot)` C cast. The def-time trial swallows the not-found
-   error. Desired behavior: a closure-body name miss should surface as a
-   hard-swallow diagnostic at CHECK time (the ICE only fires at compile).
+1. **Missing-name soft-fallbacks cascade — STILL REPRODUCES** (the live
+   bug): an unbound name used only inside a DIRECT `io.async` closure body
+   leaves `yo check` green (`evaluator OK`) and `yo compile` dead with the
+   "closure body was never fully evaluated" ICE
+   (`issues/repros/async-capture-cluster/` — minimal shape: `eprintln(nosuchfn(x))`
+   inside the closure). **Fix constraint discovered:** a naive
+   check-time surface of anon-body `Variable not found` swallows
+   FALSE-POSITIVES on std itself — `std/io/index.yo`'s `read_to_end`
+   trait-`?=` default is an `io.async` closure whose FIRST def-time trial
+   swallows `Variable "ArrayList" not found` (import ordering) yet works,
+   because trait-default closures are RE-EVALUATED per instantiation while
+   direct-definition closures are consumed from the first evaluation.
+   A sound fix therefore needs re-evaluation-aware bookkeeping (e.g. a
+   hollow-io.async-body registry: record on first-trial swallow, clear on
+   any successful re-evaluation, consult at check exit) — its own PR, not
+   a bolt-on.
 
-2. **`.io`/`.exn` member projection is position-dependent.** In plain
-   segments, `e.io` args render `slot.io`; in cond-branch arms and in
-   capture-mode SMs (a closure holding a ref-typed local across a
-   suspension) the member access can be dropped and the whole bundle slot
-   cast to the param type. A bundle-typed parameter (`bundle : IoExn`,
-   invoked as `bundle.io.async(...)`) renders as a same-type slot
-   passthrough and is the only arm-safe shape found.
+2. **`.io` projection in cond-branch arms — NOT reproducible as silent
+   invalid C on current develop:** the await-in-a-LATER-cond-arm shape is
+   now rejected by a dedicated codegen diagnostic ("`io.await` in a `cond`
+   condition inside an `io.async` block must BE the first condition — it
+   cannot be nested inside a larger expression, and it cannot be in a later
+   branch"), the same restriction the passing
+   `tests/cli-cases/await-in-later-cond-branch` fixture pins. The remaining
+   residue (capture-mode `.io` drops outside cond arms) has no isolated
+   failing case today; reopen with a reproducer if one surfaces.
 
-3. **ASan: heap-use-after-free on resume.** A capture-mode SM with a
-   ref-struct capture hits a UAF in `__yo_incr_rc` inside the generated
-   `<sm>_resume` — the capture is dropped at suspension and re-incremented
-   on resume (ASan backtrace captured in the original issue's session).
+3. **ASan heap-use-after-free on resume — NOT reproducible on current
+   develop:** `uaf_ref_capture_probe.yo` (a `ref(struct)` capture held
+   across TWO awaits, built `--sanitize address --allocator system`) runs
+   correctly (prints the right value) with NO use-after-free — only two
+   24-byte leaks, the tracked self-hosted leak-debt class. The V2-era UAF
+   was observed on the pre-sync driver shape; either it was fixed by
+   subsequent async work or it needed that exact (since rewritten) shape.
 
-## Reproducer notes
+## Original findings (2026-09-07, V2 bisecting session)
 
-All three were observed with the pre-sync V2 `src/verifier/driver.yo`
-(async shape, since rewritten synchronously). The exact C-level
-manifestations may have shifted since (2026-09-09 calibration: clang
-ACCEPTS same-type struct casts — `(S)(s_of_type_S)` compiles — and
-REJECTS cross-type ones with `used type 'struct T' where arithmetic or
-pointer type is required`; the fixed cast bug was the cross-type case).
-Reproducing these needs a dedicated probe in the capture-mode shape: an
-`io.async` closure holding a ref-struct local across an await, run under
-`--sanitize address`.
+1. An `io.async` closure whose body references a name not in scope (e.g.
+   `IoExn` without `import("std/error")`) silently degrades the await
+   call's recorded arg info; the result is the "closure body never fully
+   evaluated" ICE at codegen (or, V2-era, an invalid `(T)(slot)` C cast).
+   The def-time trial swallows the not-found error.
+2. `.io`/`.exn` member projection is position-dependent: healthy in plain
+   segments (`slot.io`), historically dropped in cond-branch arms and
+   capture-mode SMs. A bundle-typed parameter (`bundle : IoExn`, invoked
+   as `bundle.io.async(...)`) was the only arm-safe shape found.
+3. A capture-mode SM with a ref-struct capture hit a UAF in
+   `__yo_incr_rc` inside the generated `<sm>_resume` (capture dropped at
+   suspension, re-incremented on resume).

--- a/issues/async-capture-mode-argument-rendering-cluster.md
+++ b/issues/async-capture-mode-argument-rendering-cluster.md
@@ -1,0 +1,44 @@
+# Capture-mode state-machine argument rendering: the still-open cluster
+
+**Status: OPEN** (split 2026-09-09 out of
+`issues/fixed/async-closure-value-struct-param-emits-invalid-c-cast.md`,
+whose PRIMARY bug — the illegal aggregate call-arg cast — is fixed; these
+follow-up findings were recorded during the same V2 bisecting session and
+remain unreproduced-and-unfixed).
+
+## Findings
+
+1. **Missing-name soft-fallbacks cascade.** An `io.async` closure whose
+   body references a name not in scope (e.g. `IoExn` without
+   `import("std/error")`, or `String`/`eprintln` without the std/string +
+   std/fmt opens — reconfirmed 2026-09-09) silently degrades the await
+   call's recorded argument info; the result is either the
+   "closure body never fully evaluated" ICE at codegen or (V2-era) an
+   invalid `(T)(slot)` C cast. The def-time trial swallows the not-found
+   error. Desired behavior: a closure-body name miss should surface as a
+   hard-swallow diagnostic at CHECK time (the ICE only fires at compile).
+
+2. **`.io`/`.exn` member projection is position-dependent.** In plain
+   segments, `e.io` args render `slot.io`; in cond-branch arms and in
+   capture-mode SMs (a closure holding a ref-typed local across a
+   suspension) the member access can be dropped and the whole bundle slot
+   cast to the param type. A bundle-typed parameter (`bundle : IoExn`,
+   invoked as `bundle.io.async(...)`) renders as a same-type slot
+   passthrough and is the only arm-safe shape found.
+
+3. **ASan: heap-use-after-free on resume.** A capture-mode SM with a
+   ref-struct capture hits a UAF in `__yo_incr_rc` inside the generated
+   `<sm>_resume` — the capture is dropped at suspension and re-incremented
+   on resume (ASan backtrace captured in the original issue's session).
+
+## Reproducer notes
+
+All three were observed with the pre-sync V2 `src/verifier/driver.yo`
+(async shape, since rewritten synchronously). The exact C-level
+manifestations may have shifted since (2026-09-09 calibration: clang
+ACCEPTS same-type struct casts — `(S)(s_of_type_S)` compiles — and
+REJECTS cross-type ones with `used type 'struct T' where arithmetic or
+pointer type is required`; the fixed cast bug was the cross-type case).
+Reproducing these needs a dedicated probe in the capture-mode shape: an
+`io.async` closure holding a ref-struct local across an await, run under
+`--sanitize address`.

--- a/issues/fixed/async-closure-value-struct-param-emits-invalid-c-cast.md
+++ b/issues/fixed/async-closure-value-struct-param-emits-invalid-c-cast.md
@@ -1,6 +1,21 @@
 # An async closure capturing a by-value struct parameter emits an invalid C cast
 
-**Status: OPEN** (surfaced 2026-09-07 by Phase V2 of
+**Status: FIXED 2026-09-09** (branch `fix/two-filed-issues`): `_per_arg_cast`
+(`src/codegen/exprs/other_fn_call.yo`) no longer wraps by-value AGGREGATE
+arguments (value structs, value enums, tuples, unions, `str`) in a C cast —
+they pass through bare (`_no_cast_by_value_param`). CALIBRATION from the
+fix session: clang ACCEPTS a same-type struct cast; the recorded crash was
+the CROSS-type case, reached when the SM slot's C type and the
+evaluator-recorded param type disagree (the shell/final identity split).
+Removing the aggregate cast class makes emission independent of that
+agreement. Behavioral regression:
+`tests/async_value_struct_param.test.yo` (a by-value struct param captured
+across an await; the value survives the suspension, both reads agree).
+The follow-up cluster (import-cascade swallows, `.io` projection
+position-dependence, resume UAF) is split out and remains OPEN as
+`issues/async-capture-mode-argument-rendering-cluster.md`.
+
+Originally surfaced 2026-09-07 by Phase V2 of
 `plans/backlog/FORMAL_VERIFICATION.md` — `src/verifier/driver.yo`'s async
 functions took a `VerifyRunConfig` value-struct parameter).
 

--- a/issues/fixed/plain-recursive-enum-segfaults-the-evaluator.md
+++ b/issues/fixed/plain-recursive-enum-segfaults-the-evaluator.md
@@ -1,6 +1,22 @@
 # A plain (non-`ref`) enum whose variant fields recurse into itself SEGFAULTS the evaluator instead of erroring
 
-**Status: OPEN** (surfaced 2026-09-07 by Phase V2 of
+**Status: FIXED 2026-09-09** (branch `fix/two-filed-issues`): the
+definition-time value-cycle check in `evaluate_enum_type`
+(`_type_reaches_root_by_value` / `_type_is_ref_indirection`) rejects the
+shape with a clean `recursive value enum: variant '<V>' contains the enum
+itself by value ... Make it 'ref(enum(...))'` diagnostic naming the
+offending variant, plus a `visited`-stack backstop in `get_size_of_type`
+(value enums AND value structs) that yields unknown size instead of a
+stack overflow. Regression tests: `tests/internal/recursive_enum.test.yo`
+(in-process model — the fixture evaluation runs this branch's evaluator)
+over `tests/spec/fixtures/invalid/plain_recursive_value_enum.yo` (the
+crasher, reconstructed: the pre-fix `terms.yo` shape) and
+`tests/spec/fixtures/valid/arraylist_self_enum.yo` (the JsonValue-shaped
+legal control). NOTE: the crash itself is seed-build-dependent (the
+v0.2.28 build SIGSEGVs; the v0.2.29 build happens to complete the walk on
+the same input) — the infinite-size type was illegal regardless.
+
+Originally surfaced 2026-09-07 by Phase V2 of
 `plans/backlog/FORMAL_VERIFICATION.md` — the `src/verifier/terms.yo` VC term
 IR was originally written as a plain `enum` and crashed the compiler).
 

--- a/issues/repros/async-capture-cluster/cond_arm_io_projection_probe.yo
+++ b/issues/repros/async-capture-cluster/cond_arm_io_projection_probe.yo
@@ -1,0 +1,40 @@
+// Probe for cluster finding 2 (issues/async-capture-mode-argument-rendering-cluster.md):
+// an await in a LATER cond arm of a closure that ALSO holds a ref-typed
+// local across the suspension (capture mode) — the recorded
+// `.io`-projection-loss shape. The non-capture variant is the PASSING
+// tests/cli-cases/await-in-later-cond-branch fixture.
+open(import("std/string"));
+open(import("std/fmt"));
+{ IoExn, Exception } :: import("std/error");
+{ yield } :: import("std/async");
+
+BOX :: ref(struct(v : i32));
+
+ready :: (fn(io : Io) -> Impl(Future(bool, Io)))(io.async((io2 : Io) => {
+  io2.await(yield(io2), io2);
+  return(true);
+}));
+
+arm_capture :: (fn(io : Io) -> Impl(Future(i32, IoExn)))(
+  io.async((e : IoExn) => {
+    b := BOX(v : i32(7));
+    cond(
+      runtime(false) => {
+        println(String.from("unreachable"));
+        i32(0)
+      },
+      e.io.await(ready(e.io), e.io) => {
+        v0 := b.v;
+        println(`v=${v0.to_string()}`);
+        v0
+      },
+      true => i32(0)
+    )
+  })
+);
+
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  r := io.await(arm_capture(io), IoExn(io : io, exn : exn));
+  println(r.to_string());
+});
+export(main);

--- a/issues/repros/async-capture-cluster/uaf_ref_capture_probe.yo
+++ b/issues/repros/async-capture-cluster/uaf_ref_capture_probe.yo
@@ -1,0 +1,29 @@
+// Probe for cluster finding 3 (issues/async-capture-mode-argument-rendering-cluster.md):
+// a capture-mode state machine holding a REF-STRUCT local across an await —
+// the recorded ASan heap-use-after-free shape (capture dropped at
+// suspension, re-incremented on resume, __yo_incr_rc inside <sm>_resume).
+//
+// Run: yo compile uaf_ref_capture_probe.yo --sanitize address --allocator system -o /tmp/uaf_probe && /tmp/uaf_probe
+open(import("std/string"));
+open(import("std/fmt"));
+{ IoExn, Exception } :: import("std/error");
+{ yield } :: import("std/async");
+
+BOX :: ref(struct(v : i32));
+
+hold_and_bump :: (fn(start : i32, io : Io) -> Impl(Future(i32, IoExn)))(
+  io.async((e : IoExn) => {
+    b := BOX(v : start);
+    _ := e.io.await(yield(e.io), e);
+    w1 := b.v;
+    _ := e.io.await(yield(e.io), e);
+    w2 := b.v;
+    w1 + w2
+  })
+);
+
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  r := io.await(hold_and_bump(i32(40), io), IoExn(io : io, exn : exn));
+  println(r.to_string());
+});
+export(main);

--- a/src/codegen/exprs/other_fn_call.yo
+++ b/src/codegen/exprs/other_fn_call.yo
@@ -693,6 +693,27 @@ _ctor_args_from_labeled :: (fn(wrapped : TypeValue, fncall_args : ArrayList(AstE
 /// Per-argument cast to the callee's declared parameter C types (a no-op when
 /// types match; needed for specialized generic callees). Mirrors the
 /// namedCastedArgsList logic.
+/// True when a by-value parameter of this type must NOT be wrapped in a C
+/// cast: aggregate/struct-like types (value structs, value enums, tuples,
+/// unions, `str`) cannot legally be cast targets in C (a cast to the SAME
+/// type happens to be accepted by clang/gcc as an extension, but a
+/// slot-vs-recorded type-identity disagreement — the shell/final split —
+/// then emits a CROSS-type struct cast, "used type ... where arithmetic or
+/// pointer type is required", the
+/// issues/async-closure-value-struct-param-emits-invalid-c-cast.md crash).
+/// The argument expression already carries the parameter's type (the
+/// evaluator type-checked the call), so no conversion is needed.
+_no_cast_by_value_param :: (fn(t : TypeValue) -> bool)(
+  match(
+    t,
+    .Struct({ is_reference_semantics : s_ref }) => !(s_ref),
+    .EnumT({ is_reference_semantics : e_ref }) => !(e_ref),
+    .Tuple(_, _) => true,
+    .Union(_, _, _) => true,
+    .Str => true,
+    _ => false
+  )
+);
 _per_arg_cast :: (fn(args_list : String, param_types : ArrayList(TypeValue), param_is_ref : ArrayList(bool), context : FunctionGenerationContext) -> String)(
   if(args_list.len() == usize(0), args_list, {
     parts := _split_top_level_args_list(args_list);
@@ -705,21 +726,33 @@ _per_arg_cast :: (fn(args_list : String, param_types : ArrayList(TypeValue), par
           out.push_str(", ");
         });
         pref := match(param_is_ref.get(i), .Some(r) => r, .None => false);
-        // A BY-VALUE `unit` parameter is spelled as the one-byte placeholder in
-        // the prototype, so its cast must agree; a REF one stays `void` + `*`.
-        base_str := match(
-          param_types.get(i),
-          .Some(t) => if(pref, get_type_string(t, context.base), get_storage_type_string(t, context.base)),
-          .None => String.from("void*")
-        );
-        out.push_str("(");
-        out.push_string(base_str);
-        if(pref, {
-          out.push_str("*");
+        pty := param_types.get(i);
+        if((
+          (!(pref) && pty.is_some()) && match(
+            pty,
+            .Some(pt) => _no_cast_by_value_param(pt),
+            .None => false
+          )
+        ), {
+          // By-value aggregate: pass through bare (see _no_cast_by_value_param).
+          out.push_string(match(parts.get(i), .Some(p) => p, .None => String.from("")));
+        }, {
+          // A BY-VALUE `unit` parameter is spelled as the one-byte placeholder in
+          // the prototype, so its cast must agree; a REF one stays `void` + `*`.
+          base_str := match(
+            pty,
+            .Some(t) => if(pref, get_type_string(t, context.base), get_storage_type_string(t, context.base)),
+            .None => String.from("void*")
+          );
+          out.push_str("(");
+          out.push_string(base_str);
+          if(pref, {
+            out.push_str("*");
+          });
+          out.push_str(")(");
+          out.push_string(match(parts.get(i), .Some(p) => p, .None => String.from("")));
+          out.push_str(")");
         });
-        out.push_str(")(");
-        out.push_string(match(parts.get(i), .Some(p) => p, .None => String.from("")));
-        out.push_str(")");
         i = (i + usize(1));
       });
       out

--- a/src/evaluator/types/enum.yo
+++ b/src/evaluator/types/enum.yo
@@ -83,6 +83,124 @@ _has_variant :: (fn(variant_names : ArrayList(String), name : String) -> bool)({
   });
   found
 });
+/// Whether `xs` contains `s` (the cycle walker's visited set probe).
+_visited_has :: (fn(xs : ArrayList(String), s : String) -> bool)({
+  i := usize(0);
+  (found : bool) = false;
+  while((i < xs.len()) && !found, {
+    match(
+      xs.get(i),
+      .Some(x) => if(x == s, {
+        found = true;
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  found
+});
+/// Reference indirection CUTS a value cycle: the pointee is reached through
+/// a pointer, so the containing type's size stays finite. This is the
+/// legality rule behind `JsonValue` (plain enum recursive only via
+/// `ArrayList(Self)`) and `ref(enum(...))` (`AstExpr`'s shape).
+_type_is_ref_indirection :: (fn(t : TypeValue) -> bool)(
+  match(
+    t,
+    .Struct({ is_reference_semantics : s_ref }) => s_ref,
+    .EnumT({ is_reference_semantics : e_ref }) => e_ref,
+    .Pointer(_) => true,
+    .DynT(_, _, _, _) => true,
+    _ => false
+  )
+);
+/// Whether walking `t`'s VALUE composition reaches the enum identified by
+/// `root` (or its pre-patch `Self` shell) without passing through reference
+/// indirection — the definition-time check for
+/// issues/plain-recursive-enum-segfaults-the-evaluator.md. Such a cycle has
+/// infinite C size; the size walks stack-overflowed (SIGSEGV, no diagnostic)
+/// before this check existed. `visited` cuts re-entered named types (finite
+/// DAGs, and cycles that DO have indirection somewhere on the path).
+_type_reaches_root_by_value :: (
+  fn(t : TypeValue, root : String, shell : String, visited : ArrayList(String)) -> bool
+)(
+  cond(
+    _type_is_ref_indirection(t) => false,
+    true => _type_value_cycle_step(t, root, shell, visited)
+  )
+);
+/// The per-type dispatch of `_type_reaches_root_by_value` (separate fn so
+/// no cond arm is a braced single expression — E0007).
+_type_value_cycle_step :: (
+  fn(t : TypeValue, root : String, shell : String, visited : ArrayList(String)) -> bool
+)(
+  match(
+    t,
+    .EnumT(e_id, _, _, e_vfs, _, _, _, _, _) => cond(
+      ((e_id == root) || (e_id == shell)) => true,
+      _visited_has(visited, e_id.clone()) => false,
+      true => {
+        visited.push(e_id.clone());
+        (hit : bool) = false;
+        (i : usize) = usize(0);
+        while((i < e_vfs.len()) && !hit, {
+          vfs := match(e_vfs.get(i), .Some(l) => l, .None => ArrayList(TypeValue).new());
+          (j : usize) = usize(0);
+          while((j < vfs.len()) && !hit, {
+            ft := match(vfs.get(j), .Some(x) => x, .None => TypeValue.Unit);
+            if(recur(ft, root.clone(), shell.clone(), visited), {
+              hit = true;
+            });
+            j = (j + usize(1));
+          });
+          i = (i + usize(1));
+        });
+        hit
+      }
+    ),
+    .Struct(s_id, _, _, s_fts, _, _, _, _, _, _) => cond(
+      _visited_has(visited, s_id.clone()) => false,
+      true => {
+        visited.push(s_id.clone());
+        (hit : bool) = false;
+        (i : usize) = usize(0);
+        while((i < s_fts.len()) && !hit, {
+          ft := match(s_fts.get(i), .Some(x) => x, .None => TypeValue.Unit);
+          if(recur(ft, root.clone(), shell.clone(), visited), {
+            hit = true;
+          });
+          i = (i + usize(1));
+        });
+        hit
+      }
+    ),
+    .Tuple(_, t_fts) => {
+      (hit : bool) = false;
+      (i : usize) = usize(0);
+      while((i < t_fts.len()) && !hit, {
+        ft := match(t_fts.get(i), .Some(x) => x, .None => TypeValue.Unit);
+        if(recur(ft, root.clone(), shell.clone(), visited), {
+          hit = true;
+        });
+        i = (i + usize(1));
+      });
+      hit
+    },
+    .Union(_, _, u_fts) => {
+      (hit : bool) = false;
+      (i : usize) = usize(0);
+      while((i < u_fts.len()) && !hit, {
+        ft := match(u_fts.get(i), .Some(x) => x, .None => TypeValue.Unit);
+        if(recur(ft, root.clone(), shell.clone(), visited), {
+          hit = true;
+        });
+        i = (i + usize(1));
+      });
+      hit
+    },
+    .Array(element, _, _) => recur(element, root.clone(), shell.clone(), visited),
+    _ => false
+  )
+);
 /// Evaluate a discriminant expression and return its integer value (or throw).
 _evaluate_discriminant :: (
   fn(
@@ -611,6 +729,39 @@ evaluate_enum_type :: (
   // Auto-derive trait markers (Send, Acyclic, Comptime, Runtime).
   // Mirrors `autoDeriveTraitsAndAddRcFunctionsForEnumType` in TypeScript.
   auto_derive_traits_for_enum_type(enum_id.clone(), variant_fields, env);
+  // Definition-time value-cycle rejection
+  // (issues/plain-recursive-enum-segfaults-the-evaluator.md): a plain
+  // `enum(...)` whose variant fields reach itself by VALUE — no reference
+  // indirection anywhere on the path — would have infinite C size; the
+  // size walks used to stack-overflow (SIGSEGV, no diagnostic) at the next
+  // construction. Checked BEFORE the shell patch: a direct `Self` field is
+  // still the shell (`enum_id__self_shell`), which the walker treats as
+  // the root. `ref(enum(...))` is exempt (pointer-sized); cycles through
+  // ArrayList/Box/ref fields are cut by `_type_is_ref_indirection`.
+  if(!force_reference_semantics, {
+    (vi2 : usize) = usize(0);
+    while(vi2 < variant_fields.len(), {
+      vname := match(variant_names.get(vi2), .Some(n) => n, .None => String.new());
+      vfs := match(variant_fields.get(vi2), .Some(l) => l, .None => ArrayList(TypeValue).new());
+      (fi2 : usize) = usize(0);
+      while(fi2 < vfs.len(), {
+        ft := match(vfs.get(fi2), .Some(x) => x, .None => TypeValue.Unit);
+        visited := ArrayList(String).new();
+        if(_type_reaches_root_by_value(ft, enum_id.clone(), shell_id.clone(), visited), {
+          exn.throw(
+            dyn(
+              format_error_message(
+                ast_expr_token(expr),
+                `recursive value enum: variant '${vname}' contains the enum itself by value (a path with no reference indirection) — a plain 'enum(...)' would have infinite size. Make it 'ref(enum(...))', or route the recursion through a reference type (ArrayList, Box, ref(struct)).`
+              )
+            )
+          );
+        });
+        fi2 = (fi2 + usize(1));
+      });
+      vi2 = (vi2 + usize(1));
+    });
+  });
   // Restore SelfType.
   ctx.self_type = old_self_type;
   // Build the final EnumT in two steps: an UNPATCHED pre-final used as the

--- a/src/types/utils.yo
+++ b/src/types/utils.yo
@@ -1575,6 +1575,74 @@ get_alignment_of_type :: (fn(ty_in : TypeValue) -> Option(usize))({
 });
 /// Return the size of `ty` in bits, or `.None` if not statically known.
 /// Mirrors `getSizeOfType` in `src/types/utils.ts`.
+// The cycle backstop's walk stack: named types currently being sized. A
+// re-entry means an infinite-size VALUE cycle — the definition-time check in
+// evaluator/types/enum.yo rejects those, so seeing one here means that check
+// was bypassed (yield unknown, never overflow the stack).
+// issues/plain-recursive-enum-segfaults-the-evaluator.md.
+(g_size_walk_stack : ArrayList(String)) = ArrayList(String).new();
+_size_walk_stack_has :: (fn(id : String) -> bool)({
+  (found : bool) = false;
+  (i : usize) = usize(0);
+  while((i < g_size_walk_stack.len()) && !found, {
+    match(
+      g_size_walk_stack.get(i),
+      .Some(x) => if(x == id, {
+        found = true;
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  found
+});
+/// The value-enum size computation (tag + largest variant payload), factored
+/// out of `get_size_of_type`'s `.EnumT` arm so the arm can bracket it with the
+/// cycle stack push/pop.
+_enum_value_size :: (fn(evf : ArrayList(ArrayList(TypeValue))) -> Option(usize))({
+  (max_data : usize) = usize(0);
+  (max_align_bits : usize) = usize(0);
+  (unknown : bool) = false;
+  (vi : usize) = usize(0);
+  n_v := evf.len();
+  while((vi < n_v) && !unknown, {
+    // Only the fields the data-union emitter keeps — see
+    // `_variant_storage_field_types`.
+    vf := _variant_storage_field_types(
+      match(evf.get(vi), .Some(f) => f, .None => ArrayList(TypeValue).new())
+    );
+    match(
+      _aggregate_size(vf),
+      .Some(vbits) => match(
+        _max_field_alignment(vf),
+        .Some(va_bytes) => {
+          max_data = _max_usize(max_data, vbits);
+          max_align_bits = _max_usize(max_align_bits, va_bytes * usize(8));
+        },
+        .None => {
+          unknown = true;
+        }
+      ),
+      .None => {
+        unknown = true;
+      }
+    );
+    vi = (vi + usize(1));
+  });
+  cond(
+    unknown => Option(usize).None,
+    true => {
+      tag_bits := _round_up(_ceil_log2(n_v), usize(8));
+      data_align_bits := _max_usize(max_align_bits, usize(8));
+      struct_align_bits := _max_usize(usize(32), data_align_bits);
+      // Pad tag end up to data alignment, add data, then pad total to
+      // struct alignment (all in bits; alignments are byte multiples ×8).
+      after_tag := _round_up(tag_bits, data_align_bits);
+      total_before := (after_tag + max_data);
+      Option(usize).Some(usize(_round_up(total_before, struct_align_bits)))
+    }
+  )
+});
 get_size_of_type :: (fn(ty_in : TypeValue) -> Option(usize))({
   // A recursive struct/enum reference inside a type graph is a value-copied
   // SHELL (empty fields/variant names) under yo-self's value semantics — TS
@@ -1657,12 +1725,21 @@ get_size_of_type :: (fn(ty_in : TypeValue) -> Option(usize))({
     // str: fat pointer (pointer + length) = 2 × pointer size
     .Str => .Some(usize(u32(2) * get_target_pointer_size_bits())),
     // Struct: reference-semantics (object) → pointer-sized; newtype → inner
-    // field's size; otherwise the C-laid-out aggregate size.
-    .Struct({ field_types : sfts, is_reference_semantics : s_ref, is_newtype : s_nt }) =>
+    // field's size; otherwise the C-laid-out aggregate size. Value structs get
+    // the same cycle backstop as value enums (see `g_size_walk_stack`).
+    .Struct({ id : s_sz_id, field_types : sfts, is_reference_semantics : s_ref, is_newtype : s_nt }) =>
       cond(
         s_ref => Option(usize).Some(usize(get_target_pointer_size_bits())),
-        (s_nt && (sfts.len() > usize(0))) => match(sfts.get(usize(0)), .Some(f0) => recur(f0), .None => Option(usize).None),
-        true => _c_aggregate_size(sfts)
+        _size_walk_stack_has(s_sz_id.clone()) => Option(usize).None,
+        true => {
+          g_size_walk_stack.push(s_sz_id.clone());
+          out := cond(
+            (s_nt && (sfts.len() > usize(0))) => match(sfts.get(usize(0)), .Some(f0) => recur(f0), .None => Option(usize).None),
+            true => _c_aggregate_size(sfts)
+          );
+          _ := g_size_walk_stack.pop();
+          out
+        }
       ),
     // Tuple: C-laid-out aggregate size (a member-less tuple carries the dummy
     // byte, see `_c_aggregate_size`).
@@ -1694,51 +1771,18 @@ get_size_of_type :: (fn(ty_in : TypeValue) -> Option(usize))({
     // branch and the TS `getSizeOfType` fix — without it the variant-field walk
     // recurses forever on a recursive ref-enum (variant field typed `Self`).
     // Mirrors TS `getSizeOfType`/`getEnumTypeSize`.
-    .EnumT({ variant_fields : evf, is_reference_semantics : e_ref }) => cond(
+    .EnumT({ id : e_sz_id, variant_fields : evf, is_reference_semantics : e_ref }) => cond(
       e_ref => Option(usize).Some(usize(get_target_pointer_size_bits())),
+      // Cycle backstop (issues/plain-recursive-enum-segfaults-the-evaluator.md):
+      // a VALUE enum re-entered on the walk stack is an infinite-size type the
+      // definition-time check should have rejected — yield unknown rather than
+      // overflow the stack.
+      _size_walk_stack_has(e_sz_id.clone()) => Option(usize).None,
       true => {
-        (max_data : usize) = usize(0);
-        (max_align_bits : usize) = usize(0);
-        (unknown : bool) = false;
-        (vi : usize) = usize(0);
-        n_v := evf.len();
-        while((vi < n_v) && !unknown, {
-          // Only the fields the data-union emitter keeps — see
-          // `_variant_storage_field_types`.
-          vf := _variant_storage_field_types(
-            match(evf.get(vi), .Some(f) => f, .None => ArrayList(TypeValue).new())
-          );
-          match(
-            _aggregate_size(vf),
-            .Some(vbits) => match(
-              _max_field_alignment(vf),
-              .Some(va_bytes) => {
-                max_data = _max_usize(max_data, vbits);
-                max_align_bits = _max_usize(max_align_bits, va_bytes * usize(8));
-              },
-              .None => {
-                unknown = true;
-              }
-            ),
-            .None => {
-              unknown = true;
-            }
-          );
-          vi = (vi + usize(1));
-        });
-        cond(
-          unknown => Option(usize).None,
-          true => {
-            tag_bits := _round_up(_ceil_log2(n_v), usize(8));
-            data_align_bits := _max_usize(max_align_bits, usize(8));
-            struct_align_bits := _max_usize(usize(32), data_align_bits);
-            // Pad tag end up to data alignment, add data, then pad total to
-            // struct alignment (all in bits; alignments are byte multiples ×8).
-            after_tag := _round_up(tag_bits, data_align_bits);
-            total_before := (after_tag + max_data);
-            Option(usize).Some(usize(_round_up(total_before, struct_align_bits)))
-          }
-        )
+        g_size_walk_stack.push(e_sz_id.clone());
+        out := _enum_value_size(evf);
+        _ := g_size_walk_stack.pop();
+        out
       }
     ),
     _ => .None

--- a/tests/async_value_struct_param.test.yo
+++ b/tests/async_value_struct_param.test.yo
@@ -1,0 +1,40 @@
+// Regression: a by-value struct parameter captured across an await
+// (issues/async-closure-value-struct-param-emits-invalid-c-cast.md).
+// The call-argument coercion used to wrap the state-machine slot read in
+// `(T)(sm->__yo_param_0)`; for by-value aggregates that cast is at best a
+// redundant identity and at worst an illegal CROSS-type struct cast when
+// the slot's C type and the recorded param type disagree (the
+// shell/final identity split) — the verbatim clang failure in the issue.
+// The fix passes by-value aggregate args bare; this test pins the
+// BEHAVIOR (the value survives the suspension intact, both reads agree).
+open(import("std/string"));
+open(import("std/fmt"));
+{ IoExn, Exception } :: import("std/error");
+{ yield } :: import("std/async");
+{ assert } :: import("std/assert");
+
+CFG :: struct(n : i32, tag : bool);
+
+use_cfg :: (fn(c : CFG) -> i32)(c.n);
+
+echo_cfg :: (fn(c : CFG, io : Io) -> Impl(Future(i32, IoExn)))(
+  io.async((e : IoExn) => {
+    before := use_cfg(c);
+    _ := e.io.await(yield(e.io), e);
+    after := use_cfg(c);
+    after - before
+  })
+);
+
+test("by-value struct param survives an await and both calls see it", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected throw: ${err}`);
+      }
+    )
+  );
+  ioexn := IoExn(io : io, exn : exn);
+  r := io.await(echo_cfg(CFG(n : i32(21), tag : true), io), ioexn);
+  assert(r == i32(0), `after - before == 0, got ${r.to_string()}`);
+});

--- a/tests/internal/recursive_enum.test.yo
+++ b/tests/internal/recursive_enum.test.yo
@@ -1,0 +1,58 @@
+//! The plain-recursive-value-enum regression tests
+//! (issues/plain-recursive-enum-segfaults-the-evaluator.md): a plain
+//! `enum(...)` reaching itself by VALUE (no reference indirection on the
+//! path) has infinite C size and used to crash the evaluator with a bare
+//! SIGSEGV in the size walks. The definition-time cycle check must reject
+//! it with a clean diagnostic — and must NOT reject the legal
+//! ArrayList-only recursion (JsonValue's shape).
+//!
+//! In-process on purpose (the verifier_negative model): importing the
+//! evaluator puts THIS branch's enum.yo in the binary, so the fixture
+//! evaluation runs the fixed code.
+open(import("std/string"));
+open(import("std/error"));
+{ ArrayList } :: import("std/collections/array_list");
+{ assert } :: import("std/assert");
+{
+  mm_load_file,
+  mm_preload_prelude,
+  resolve_std_path,
+  _take_load_error
+} :: import("../../src/module_manager.yo");
+{ clear_module_cache } :: import("../../src/evaluator/module_loader.yo");
+
+/// One fixture load outcome: ok plus the loader's stashed rendered
+/// diagnostic (empty string when none).
+LoadOutcomePair :: struct(ok : bool, rendered : String);
+_load_fixture :: (fn(rel_path : String, io : Io) -> LoadOutcomePair)({
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `recursive_enum: unexpected throw: ${err}`);
+      }
+    )
+  );
+  std_path := resolve_std_path();
+  clear_module_cache();
+  mm_preload_prelude(std_path.clone(), true, io, exn);
+  outcome := mm_load_file(rel_path.clone(), std_path.clone(), true, io, exn);
+  rendered := match(
+    _take_load_error(),
+    .Some(r) => r,
+    .None => String.new()
+  );
+  LoadOutcomePair(ok : outcome.ok, rendered : rendered)
+});
+
+test("plain enum recursive by VALUE is rejected with the ref(enum) hint", {
+  r := _load_fixture(String.from("./tests/spec/fixtures/invalid/plain_recursive_value_enum.yo"), io);
+  assert(!r.ok, "the invalid fixture must fail to load");
+  assert(r.rendered.contains(String.from("recursive value enum")), `the diagnostic must name the problem, got: ${r.rendered}`);
+  assert(r.rendered.contains(String.from("ref(enum")), "the diagnostic must carry the fix hint");
+  assert(r.rendered.contains(String.from("Quant")), `the diagnostic must name the offending variant, got: ${r.rendered}`);
+});
+
+test("ArrayList-only recursion (JsonValue's shape) still evaluates cleanly", {
+  r := _load_fixture(String.from("./tests/spec/fixtures/valid/arraylist_self_enum.yo"), io);
+  assert(r.ok, `the legal control fixture must evaluate cleanly, got: ${r.rendered}`);
+});

--- a/tests/spec/fixtures/invalid/plain_recursive_value_enum.yo
+++ b/tests/spec/fixtures/invalid/plain_recursive_value_enum.yo
@@ -1,0 +1,16 @@
+// INVALID program (issues/plain-recursive-enum-segfaults-the-evaluator.md):
+// a plain `enum(...)` whose variant fields reach the enum itself BY VALUE
+// (no reference indirection on the path). The type has infinite C size;
+// before the definition-time check this crashed the evaluator with a bare
+// SIGSEGV (stack overflow in the size walks) instead of a diagnostic.
+// Consumed by tests/internal/recursive_enum.test.yo — NOT a .test.yo, so
+// the ordinary suite never runs it.
+{ ArrayList } :: import("std/collections/array_list");
+
+VcOp :: enum(Add, Mul);
+VcTerm :: enum(App(op : VcOp, args : ArrayList(Self)), Quant(body : Self));
+VcQuery :: ref(struct(assumptions : ArrayList(VcTerm), goal : VcTerm));
+vc_and :: (fn(a : VcTerm, b : VcTerm) -> VcTerm)({
+  args := ArrayList(VcTerm).new();
+  VcTerm.App(op : VcOp.Add, args : args)
+});

--- a/tests/spec/fixtures/valid/arraylist_self_enum.yo
+++ b/tests/spec/fixtures/valid/arraylist_self_enum.yo
@@ -1,0 +1,11 @@
+// LEGAL control for the same issue: recursion ONLY through ArrayList
+// (reference indirection) — JsonValue's shape. Must evaluate cleanly;
+// a false positive from the value-cycle check would reject this.
+{ ArrayList } :: import("std/collections/array_list");
+
+Jsonish :: enum(Num(n : i32), Arr(items : ArrayList(Self)), Str(s : i32));
+wrap :: (fn(n : i32) -> Jsonish)({
+  items := ArrayList(Jsonish).new();
+  items.push(Jsonish.Num(n : n));
+  Jsonish.Arr(items : items)
+});


### PR DESCRIPTION
## Summary

Fixes both issues carried by #484 (V2), on top of the merged V3 (#497, `48df44429`). Seed note: developed against v0.2.29.

### 1. `issues/plain-recursive-enum-segfaults-the-evaluator.md` → `issues/fixed/`

A plain `enum(...)` whose variant fields reach itself **by value** (no reference indirection on the path) has infinite C size; the size walks overflowed the stack — a bare SIGSEGV with no diagnostic (the crash is seed-build-dependent: the v0.2.28 build crashes on the reconstructed fixture; the v0.2.29 build completes the walk on the same illegal type — either way the type must be rejected).

- **Definition-time check** in `evaluate_enum_type`: `_type_reaches_root_by_value` walks the variant field graph (enums → struct fields → tuples/unions/fixed arrays), cut by `_type_is_ref_indirection` (`ref(struct)`, `ref(enum)`, pointers, `dyn`). A direct `Self` field is caught pre-shell-patch (the walker treats the self shell as the root). The clean diagnostic names the offending variant and carries the `ref(enum(...))` fix hint.
- **Belt-and-braces**: a `g_size_walk_stack` cycle backstop in `get_size_of_type` for value enums **and** value structs — a re-entered named type yields `.None` (unknown size) instead of a stack overflow.
- **Tests**: `tests/internal/recursive_enum.test.yo` (the in-process model — importing the evaluator makes the fixture evaluation run this branch's code) over `tests/spec/fixtures/invalid/plain_recursive_value_enum.yo` (the reconstructed crasher: the pre-fix `terms.yo` shape) and `tests/spec/fixtures/valid/arraylist_self_enum.yo` (the JsonValue-shaped legal control — no false positive).

### 2. `issues/async-closure-value-struct-param-emits-invalid-c-cast.md` → `issues/fixed/`

`_per_arg_cast` wrapped **every** call argument in `(T)(arg)`. For by-value aggregates that cast is at best a redundant identity and at worst an **illegal cross-type struct cast** when the state-machine slot's C type and the evaluator-recorded param type disagree (the shell/final identity split) — clang's verbatim `used type ... where arithmetic or pointer type is required`. Fix-session calibration: clang *accepts* same-type struct casts; the recorded crash is specifically the cross-type case.

- The fix (`_no_cast_by_value_param`): by-value aggregates (value structs/enums, tuples, unions, `str`) pass through **bare** — emission no longer depends on C-type-name agreement for the whole class. Scalars and refs keep their casts (including the unit-placeholder coercion).
- **Test**: `tests/async_value_struct_param.test.yo` — a by-value struct param captured across an await survives the suspension (both reads agree).
- The still-open follow-up findings from the same bisecting session (import-cascade swallows, `.io` projection position-dependence, resume UAF) are split into `issues/async-capture-mode-argument-rendering-cluster.md`.

## Test plan

- [x] `yo test ./tests/internal/recursive_enum.test.yo` — 2/2 (invalid rejected with the hint; ArrayList-only control clean)
- [x] `yo test ./tests/async_value_struct_param.test.yo` — 1/1
- [x] `yo test ./tests/internal/verifier_negative.test.yo` (Z3) — 5/5 (no regression from the evaluator changes)
- [x] `yo check ./src/main.yo` — evaluator OK
- [ ] CI: the emission change is validated by the self-hosted legs (fast suite + cross-emits), since the seed's compiled-in codegen predates it