### PR TITLE
verifier: verify+ stripping (plan task 6) + check/compile integration

### DIFF
--- a/src/evaluator/builtins/contracts.yo
+++ b/src/evaluator/builtins/contracts.yo
@@ -19,6 +19,7 @@ open(import("std/fmt"));
   ast_expr_id,
   ast_expr_to_string,
   ast_expr_is_fn_call_of,
+  ast_expr_is_atom,
   BF_REQUIRES,
   BF_ENSURES,
   BF_INVARIANT,
@@ -501,7 +502,10 @@ VerifyTask :: ref(
     return_label : Option(String),
     table : ExprInfoTable,
     /// `"verify"` | `"verify+"` — only those modes register.
-    mode : String
+    mode : String,
+    /// The FuncVal itself — the `verify+` strip pass rewrites its boxed
+    /// body data in place (dropping asserts whose predicates proved).
+    func_val : EvalValue
   )
 );
 (g_verify_tasks : ArrayList(VerifyTask)) = ArrayList(VerifyTask).new();
@@ -593,6 +597,148 @@ take_verify_tasks :: (fn() -> ArrayList(VerifyTask))({
   g_verify_tasks = ArrayList(VerifyTask).new();
   out
 });
+/// The `verify+` strip pass (plan task 6): rewrite a wrapped function
+/// body IN PLACE, dropping the spliced `ensures failed` asserts whose
+/// corresponding obligation PROVED (the runtime check is dead weight —
+/// the proof replaces it). `proved[i]` is the verdict of `ensures#i`
+/// (index-aligned with the task's ensures order = the wrapper's splice
+/// order). The `requires failed` entry guards are KEPT: their proof
+/// obligation lives at CALL SITES (one per caller), and stripping a
+/// callee's guard because one caller proved it would be unsound.
+/// Returns the number of asserts stripped.
+strip_proved_ensures_asserts :: (
+  fn(func_val : EvalValue, proved : ArrayList(bool)) -> usize
+)(
+  match(
+    func_val,
+    .FuncVal(fvd, _) => {
+      body := fvd.*.body;
+      match(
+        body,
+        .FnCall(begin_id, begin_func, args, begin_infix, begin_tok) => {
+          kept := ArrayList(AstExpr).new();
+          (ens_idx : usize) = usize(0);
+          (stripped : usize) = usize(0);
+          (i : usize) = usize(0);
+          while(i < args.len(), {
+            drop := match(
+              args.get(i),
+              .Some(arg) => {
+                is_ens_assert := _is_contract_assert_call(arg, String.from("ensures failed:"));
+                if(is_ens_assert, {
+                  proved_here := match(
+                    proved.get(ens_idx),
+                    .Some(p) => p,
+                    .None => false
+                  );
+                  ens_idx = (ens_idx + usize(1));
+                  proved_here
+                }, false)
+              },
+              .None => false
+            );
+            if(!drop, {
+              match(
+                args.get(i),
+                .Some(arg) => {
+                  kept.push(arg);
+                },
+                .None => ()
+              );
+            }, {
+              stripped = (stripped + usize(1));
+            });
+            i = (i + usize(1));
+          });
+          if(stripped > usize(0), {
+            fvd.*.body = AstExpr.FnCall(begin_id, begin_func, kept, begin_infix, begin_tok);
+          });
+          stripped
+        },
+        .Atom(_, _) => usize(0)
+      )
+    },
+    _ => usize(0)
+  )
+);
+/// Whether `e` is a spliced contract assert call whose message atom starts
+/// with `prefix` — the wrapper's `_build_assert_call` shape: an
+/// `assert`/`comptime_assert` call of two args whose second is a string
+/// atom carrying the `<label>: <predicate>` message.
+_is_contract_assert_call :: (fn(e : AstExpr, prefix : String) -> bool)(
+  // The spliced message atom's token value is QUOTED
+  // (`_synth_string_token_value`), so the prefix includes the opening
+  // quote: `"ensures failed:`.
+  cond(
+    _assert_head_is(e, String.from("assert")) => _assert_msg_of(e).starts_with(`"${prefix}`),
+    _assert_head_is(e, String.from("comptime_assert")) => _assert_msg_of(e).starts_with(`"${prefix}`),
+    true => false
+  )
+);
+/// The member-callee cond (arm-body extraction — no braced single
+/// expressions).
+_callee_member_cond :: (
+  fn(dot_h : AstExpr, dot_args : ArrayList(AstExpr), name : String) -> bool
+)(
+  cond(
+    (ast_expr_token(dot_h).value == ".") => _dot_arg1_is(dot_args, name.clone()),
+    true => false
+  )
+);
+/// Whether a `.`-call's SECOND argument is a plain atom named `name`.
+_dot_arg1_is :: (fn(dot_args : ArrayList(AstExpr), name : String) -> bool)(
+  match(
+    dot_args.get(usize(1)),
+    .Some(second) => match(
+      second,
+      .Atom(_, st) => (st.value == name),
+      .FnCall(_, _, _, _, _) => false
+    ),
+    .None => false
+  )
+);
+/// Whether `e` is a call of `name` — either a bare callee atom
+/// (`comptime_assert`) or the wrapper's self-contained member callee
+/// `.(import("std/assert"), assert)` for the runtime `assert`
+/// (`_build_assert_callee`; the self-contained import survives the splice
+/// into any body scope).
+_assert_head_is :: (fn(e : AstExpr, name : String) -> bool)(
+  match(
+    e,
+    .FnCall(_, f, _, _, _) => _callee_named(f, name.clone()),
+    .Atom(_, _) => false
+  )
+);
+/// Whether a callee expression names `name` — bare atom or the
+/// `.(import("std/assert"), name)` member form.
+_callee_named :: (fn(f : AstExpr, name : String) -> bool)(
+  match(
+    f,
+    .Atom(_, ht) => (ht.value == name),
+    .FnCall(_, dot_h, dot_args, _, _) => _callee_member_cond(dot_h, dot_args, name.clone())
+  )
+);
+/// The message argument (arg 1) of an assert-shaped call when it is a
+/// plain string atom ("" otherwise).
+_assert_msg_of :: (fn(e : AstExpr) -> String)(
+  match(
+    e,
+    .FnCall(_, _, a, _, _) => _arg1_string_atom(a),
+    .Atom(_, _) => String.new()
+  )
+);
+/// Arg 1 of a call rendered as a string when it is a plain string atom
+/// ("" otherwise).
+_arg1_string_atom :: (fn(a : ArrayList(AstExpr)) -> String)(
+  match(
+    a.get(usize(1)),
+    .Some(m_arg) => cond(
+      ast_expr_is_atom(m_arg) => ast_expr_token(m_arg).value,
+      true => String.new()
+    ),
+    .None => String.new()
+  )
+);
 /// Splice the contract predicates into `body`.
 ///
 /// `return_label` (Phase V1) is the signature's labeled return
@@ -814,5 +960,6 @@ export(
   resolve_verify_mode,
   register_verify_task,
   evaluated_for_verify,
-  take_verify_tasks
+  take_verify_tasks,
+  strip_proved_ensures_asserts
 );

--- a/src/evaluator/calls/function_type.yo
+++ b/src/evaluator/calls/function_type.yo
@@ -1271,7 +1271,8 @@ Result type: ${type_to_string(result_box)}`
             ensures_exprs : evd_enss,
             return_label : get_func_return_label(fn_val_id.clone()),
             table : ctx.expr_info_table,
-            mode : vmode
+            mode : vmode,
+            func_val : func_val
           )
         );
       }

--- a/src/main.yo
+++ b/src/main.yo
@@ -61,10 +61,11 @@ _(env : proc_env) :: import("std/env");
   SolverResolution,
   verifier_harness_self_test,
   verify_registered_functions,
+  verify_and_strip_tasks,
   VerifyResult,
   VerifyFnReport
 } :: import("./verifier/driver.yo");
-{ set_verify_mode_override, set_verify_target_paths } :: import("./evaluator/builtins/contracts.yo");
+{ set_verify_mode_override, set_verify_target_paths, take_verify_tasks } :: import("./evaluator/builtins/contracts.yo");
 { ensure_z3 } :: import("./verifier/z3.yo");
 { Z3_VERSION } :: import("./verifier/z3.yo");
 { json_stringify, JsonValue } :: import("std/encoding/json");
@@ -643,6 +644,58 @@ collect_check_files :: (
 ///
 /// The loading itself lives in `module_manager.yo` — `check` is one caller of
 /// that service, not its owner.
+/// V3 (plan task 6, the check/compile integration): drain the VerifyTask
+/// registry after an evaluation whose entry file was armed as a
+/// verification target, discharge the obligations, and apply the
+/// `verify+` strip pass. Prints one line per function report; the
+/// failure policy per the plan's verdict table: REFUTED is always a
+/// failure; unproven/solver-error/subset fail in `verify` mode and
+/// degrade to warnings in `verify+` (the runtime asserts stay). A
+/// missing solver is a FAILURE, not a skip: verify-mode codegen carries
+/// NO runtime asserts (the splice was suppressed), so shipping without
+/// the proofs would be unsound.
+_run_contract_verification :: (fn(io : Io, exn : Exception) -> bool)({
+  tasks := take_verify_tasks();
+  if((tasks.len() == usize(0)), {
+    return(true);
+  });
+  cfg := default_verify_run_config();
+  binary := match(
+    resolve_solver_sync(cfg),
+    .Resolved(p) => p,
+    .InvalidPath(p) => {
+      eprintln(`verify: solver path '${p}' does not exist`);
+      return(false);
+    },
+    .Installable => {
+      eprintln(
+        `verify: no Z3 solver found — this file's verify-mode contracts need proofs (their runtime asserts are suppressed). Run 'yo verify <file>' once to auto-install the pinned Z3, or point YO_Z3_PATH at one.`
+      );
+      return(false);
+    }
+  );
+  reports := verify_and_strip_tasks(cfg, binary, tasks);
+  (all_ok : bool) = true;
+  (ri : usize) = usize(0);
+  while(ri < reports.len(), {
+    match(
+      reports.get(ri),
+      .Some(rp) => {
+        _print_verify_fn_report(rp, false);
+        if(!(rp.outcome == "ok"), {
+          if((rp.outcome == "refuted") || (rp.mode == "verify"), {
+            all_ok = false;
+          }, {
+            eprintln(`           (verify+ fallback: the runtime assert stays)`);
+          });
+        });
+      },
+      .None => ()
+    );
+    ri = (ri + usize(1));
+  });
+  all_ok
+});
 check_single_file :: (
   fn(
     input_path : String,
@@ -651,6 +704,15 @@ check_single_file :: (
     exn : Exception
   ) -> bool
 )({
+  // V3: arm this file as THE verification target (both path spellings —
+  // Token.module_path is the path exactly as passed in, imported modules'
+  // tokens carry the resolved absolute form). Registration (and the
+  // assert-splice suppression) only fire for files whose own pragma — or
+  // the absence of one — resolves to verify/verify+.
+  targets := ArrayList(String).new();
+  targets.push(input_path.clone());
+  targets.push(mm_resolve_entry_abs(input_path.clone(), std_path.clone()));
+  set_verify_target_paths(targets);
   outcome := mm_load_file(input_path, std_path, true, io, exn);
   if(!(outcome.ok), {
     // The loader's handlers only stash the rendered diagnostic (the P1
@@ -661,8 +723,9 @@ check_single_file :: (
       .Some(rendered) => emit_rendered_text(rendered),
       .None => eprintln(`check: error in: ${input_path} (no diagnostic recorded)`)
     );
+    return(false);
   });
-  outcome.ok
+  _run_contract_verification(io, exn)
 });
 /// The argv entry following index `i` (the value of a `--flag value` pair), or
 /// "" if `i` is the last argument. Used by the `compile` flag parser.
@@ -2332,6 +2395,12 @@ run_compile :: (
     // collected functions — the prelude's, every imported module's, and the entry
     // module's. `mm_eval_entry_exprs` applies it from the published slot.
     entry_abs := mm_resolve_entry_abs(input_path.clone(), std_path.clone());
+    // V3: arm the entry file as the verification target (both path
+    // spellings) so verify/verify+ functions register during evaluation.
+    v_targets := ArrayList(String).new();
+    v_targets.push(input_path.clone());
+    v_targets.push(entry_abs.clone());
+    set_verify_target_paths(v_targets);
     outcome := mm_eval_entry_exprs(entry_abs, std_path.clone(), exprs, exn);
     if(!(outcome.ok), {
       // The eval failure's rendered diagnostic is in the loader's stash (its
@@ -2352,6 +2421,12 @@ run_compile :: (
     module_value := outcome.module_value;
     env := outcome.env;
     ctx := outcome.ctx;
+    // V3: contract verification runs BEFORE codegen (the verify+ strip
+    // rewrites function bodies in place); a failure exits 1 — the
+    // per-function lines are already printed by the helper.
+    if(!(_run_contract_verification(io, exn)), {
+      unsafe(exit(int(1)));
+    });
     // --skip-codegen: evaluate only (type-check), emit no C.
     if(skip_codegen, {
       return(());

--- a/src/main.yo
+++ b/src/main.yo
@@ -1978,6 +1978,10 @@ run_compile :: (
   // the test runner on its batch-compile children (see `set_evaluator_deadline`
   // in evaluator/exprs/_expr.yo for why this travels as a flag).
   (compile_timeout_ms : String) = String.new();
+  // V3: opt OUT of the post-eval contract verification (the test runner's
+  // batch compiles — a runtime harness; legs without Z3 could not compile
+  // verify-pragma fixtures otherwise).
+  (no_verify : bool) = false;
   (skip_cc : bool) = false;
   (skip_codegen : bool) = false;
   (debug_gc : bool) = false;
@@ -2034,6 +2038,10 @@ run_compile :: (
       (a_name == "--emcc-environment") => {
         emcc_environment = _opt_value(argv, ai, a_name.clone(), a_val.clone(), exn);
         ai = (ai + _opt_step(a_val));
+      },
+      (a_name == "--no-verify") => {
+        no_verify = true;
+        ai = (ai + usize(1));
       },
       (a_name == "--compile-timeout-ms") => {
         compile_timeout_ms = _opt_value(argv, ai, a_name.clone(), a_val.clone(), exn);
@@ -2396,11 +2404,14 @@ run_compile :: (
     // module's. `mm_eval_entry_exprs` applies it from the published slot.
     entry_abs := mm_resolve_entry_abs(input_path.clone(), std_path.clone());
     // V3: arm the entry file as the verification target (both path
-    // spellings) so verify/verify+ functions register during evaluation.
-    v_targets := ArrayList(String).new();
-    v_targets.push(input_path.clone());
-    v_targets.push(entry_abs.clone());
-    set_verify_target_paths(v_targets);
+    // spellings) so verify/verify+ functions register during evaluation —
+    // unless the caller opted out (--no-verify: the test runner's batches).
+    if(!(no_verify), {
+      v_targets := ArrayList(String).new();
+      v_targets.push(input_path.clone());
+      v_targets.push(entry_abs.clone());
+      set_verify_target_paths(v_targets);
+    });
     outcome := mm_eval_entry_exprs(entry_abs, std_path.clone(), exprs, exn);
     if(!(outcome.ok), {
       // The eval failure's rendered diagnostic is in the loader's stash (its
@@ -3433,6 +3444,12 @@ run_test :: (
         // indication of which file was responsible.
         ccmd.arg(String.from("--compile-timeout-ms"));
         ccmd.arg(String.from("600000"));
+        // The test runner is a RUNTIME harness: verification is a static
+        // gate (yo check / yo compile / yo verify), and legs without Z3
+        // could not run verify-pragma fixtures at all if the batch compile
+        // armed their targets (the splice suppression would leave the
+        // binary unasserted AND unsolvable). Opt the batch out.
+        ccmd.arg(String.from("--no-verify"));
         // WASI batch binaries embed the whole evaluator, whose `evaluate()`
         // has 693+ locals; emcc's defaults (64 KB stack, 16 MB initial
         // memory) cannot hold a frame that size. TS applies these in the TEST

--- a/src/verifier/driver.yo
+++ b/src/verifier/driver.yo
@@ -6,6 +6,7 @@
 //! miss spawn the solver. Cache hits are reported (`cached: proved`) so CI
 //! logs stay honest. Any input change — predicate text, callee contract
 //! set, solver pin, mode, options — invalidates the key.
+pragma(Pragma.AllowUnsafe);
 open(import("std/string"));
 open(import("std/fmt"));
 { ArrayList } :: import("std/collections/array_list");
@@ -16,7 +17,7 @@ open(import("std/fmt"));
 { VcQuery, VcSort, VcTerm, VcOp, new_vc_query, vc_eq } :: import("./terms.yo");
 { encode_content, encode_script, EncodeOptions, default_encode_options } :: import("./encode.yo");
 { VerifyFnInput, verify_function_body } :: import("./vc.yo");
-{ take_verify_tasks } :: import("../evaluator/builtins/contracts.yo");
+{ take_verify_tasks, VerifyTask, strip_proved_ensures_asserts } :: import("../evaluator/builtins/contracts.yo");
 {
   Z3_VERSION,
   ensure_z3,
@@ -443,8 +444,70 @@ VerifyFnReport :: ref(
 /// obligation runs through the same cache → encode → spawn → parse
 /// pipeline as the self-test. Subset errors abort that function's
 /// obligations list (there is nothing sound to check).
-verify_registered_functions :: (fn(cfg : VerifyRunConfig, binary : String) -> ArrayList(VerifyFnReport))({
-  tasks := take_verify_tasks();
+verify_registered_functions :: (fn(cfg : VerifyRunConfig, binary : String) -> ArrayList(VerifyFnReport))(
+  verify_and_strip_tasks(cfg, binary, take_verify_tasks())
+);
+/// The per-ensures-index PROVED table for the strip pass, parsed from the
+/// obligation names (`<fn_id>/ensures#N`). Indices beyond the parsed max
+/// default to NOT proved (conservative: keep the assert).
+_proved_ensures :: (fn(obligations : ArrayList(VerifyFnObligation)) -> ArrayList(bool))({
+  marks := ArrayList(bool).new();
+  (i : usize) = usize(0);
+  while(i < obligations.len(), {
+    match(
+      obligations.get(i),
+      .Some(obl) => {
+        match(
+          obl.verdict,
+          .Proved(_) => {
+            idx_opt := _ens_obligation_index(obl.name.clone());
+            match(
+              idx_opt,
+              .Some(n) => {
+                while(marks.len() <= n, {
+                  marks.push(false);
+                });
+                // ArrayList has no set(): write through the raw pointer
+                // (the bounds were just established above).
+                unsafe(((marks.ptr().unwrap()).add(n)).* = true);
+              },
+              .None => ()
+            );
+          },
+          _ => ()
+        );
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  marks
+});
+/// Parse the `N` of an obligation name ending in `/ensures#N` (`.None` for
+/// every other obligation kind — caller-side requires, AoRTE, asserts).
+_ens_obligation_index :: (fn(name : String) -> Option(usize))({
+  marker := String.from("/ensures#");
+  match(
+    name.index_of(marker.clone()),
+    .Some(at) => {
+      digits := name.substring(at + marker.len(), name.len());
+      match(
+        digits.parse_u64(),
+        .Some(n) => Option(usize).Some(usize(n)),
+        .None => Option(usize).None
+      )
+    },
+    .None => Option(usize).None
+  )
+});
+/// Verify an explicit task list (the check/compile integration drains
+/// first to decide whether a solver is needed at all). `verify+` tasks
+/// additionally get their PROVED `ensures` asserts stripped from the
+/// function body (plan task 6): the report's verdicts index-map onto the
+/// wrapper's splice order.
+verify_and_strip_tasks :: (
+  fn(cfg : VerifyRunConfig, binary : String, tasks : ArrayList(VerifyTask)) -> ArrayList(VerifyFnReport)
+)({
   reports := ArrayList(VerifyFnReport).new();
   (ti : usize) = usize(0);
   while(ti < tasks.len(), {
@@ -527,6 +590,14 @@ verify_registered_functions :: (fn(cfg : VerifyRunConfig, binary : String) -> Ar
               (worst == usize(1)) => String.from("unproven"),
               true => String.from("ok")
             );
+            // verify+ strip pass: `ensures#N` obligations that PROVED have
+            // their spliced asserts removed from the function body. A
+            // REFUTED function never reaches here (it is a compile error at
+            // the caller); unproven ones keep their asserts (the fallback).
+            if(t.mode == "verify+", {
+              _ := strip_proved_ensures_asserts(t.func_val, _proved_ensures(obligations));
+              ()
+            });
             reports.push(
               VerifyFnReport(
                 fn_id : t.fn_id.clone(),
@@ -624,5 +695,6 @@ export(
   VerifyFnObligation,
   VerifyFnReport,
   verify_registered_functions,
+  verify_and_strip_tasks,
   unmangle_for_display
 );

--- a/tests/internal/verifier_strip.test.yo
+++ b/tests/internal/verifier_strip.test.yo
@@ -1,0 +1,238 @@
+//! The `verify+` strip-pass tests (FORMAL_VERIFICATION.md V3 task 6):
+//! obligations that PROVED have their spliced `ensures failed` asserts
+//! removed from the function body before codegen; the `requires failed`
+//! entry guards STAY (their proof obligation lives at call sites).
+//!
+//! In-process model (verifier_negative's shape): the test imports the
+//! evaluator + verifier, arms the fixture as a verification target, loads
+//! it, and inspects the FuncVal's wrapped body directly. The first test
+//! exercises the strip MECHANISM without a solver; the second runs the
+//! full verify-and-strip pipeline under YO_TEST_Z3=1.
+open(import("std/string"));
+open(import("std/error"));
+{ ArrayList } :: import("std/collections/array_list");
+{ assert } :: import("std/assert");
+{ env } :: import("std/env");
+{
+  mm_load_file,
+  mm_preload_prelude,
+  mm_resolve_entry_abs,
+  resolve_std_path,
+  _take_load_error
+} :: import("../../src/module_manager.yo");
+{ clear_module_cache } :: import("../../src/evaluator/module_loader.yo");
+{
+  set_verify_mode_override,
+  set_verify_target_paths,
+  take_verify_tasks,
+  strip_proved_ensures_asserts
+} :: import("../../src/evaluator/builtins/contracts.yo");
+{
+  default_verify_run_config,
+  resolve_solver_sync,
+  verify_and_strip_tasks
+} :: import("../../src/verifier/driver.yo");
+{ EvalValue } :: import("../../src/value.yo");
+{ AstExpr, ast_expr_to_string, ast_expr_token } :: import("../../src/expr.yo");
+{ VerifyTask } :: import("../../src/evaluator/builtins/contracts.yo");
+
+_have_z3 :: (fn() -> bool)(
+  match(
+    env.get(String.from("YO_TEST_Z3")),
+    .Some(v) => (v == String.from("1")),
+    .None => false
+  )
+);
+/// Load the verify+ fixture with targets armed; returns the drained task
+/// list (the VerifyTask refs are shared — the strip mutates through them).
+_load_strip_tasks :: (fn(io : Io) -> ArrayList(VerifyTask))({
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `verifier_strip: unexpected throw: ${err}`);
+      }
+    )
+  );
+  std_path := resolve_std_path();
+  rel := String.from("./tests/spec/fixtures/valid/verifyplus_abs.yo");
+  targets := ArrayList(String).new();
+  targets.push(rel.clone());
+  targets.push(mm_resolve_entry_abs(rel.clone(), std_path.clone()));
+  _ := take_verify_tasks();
+  set_verify_mode_override(Option(String).None);
+  set_verify_target_paths(targets);
+  clear_module_cache();
+  mm_preload_prelude(std_path.clone(), true, io, exn);
+  outcome := mm_load_file(rel.clone(), std_path.clone(), true, io, exn);
+  match(
+    _take_load_error(),
+    .Some(rendered) => {
+      assert(outcome.ok, `fixture failed to evaluate: ${rendered}`);
+    },
+    .None => {
+      assert(outcome.ok, "fixture must evaluate cleanly");
+    }
+  );
+  tasks := take_verify_tasks();
+  assert(tasks.len() == usize(1), `expected exactly 1 task, got ${tasks.len().to_string()}`);
+  tasks
+});
+/// The task list's single FuncVal.
+_task_func_val :: (fn(tasks : ArrayList(VerifyTask)) -> EvalValue)(
+  match(
+    tasks.get(usize(0)),
+    .Some(t) => t.func_val,
+    .None => EvalValue.UnitVal
+  )
+);
+/// Count the spliced contract asserts of one label in a wrapped body.
+_count_contract_asserts :: (fn(func_val : EvalValue, label : String) -> usize)(
+  match(
+    func_val,
+    .FuncVal(fvd, _) => _count_labeled_asserts_in_body(fvd.*.body, label.clone()),
+    _ => usize(0)
+  )
+);
+_count_labeled_asserts_in_body :: (fn(body : AstExpr, label : String) -> usize)(
+  match(
+    body,
+    .FnCall(_, _, args, _, _) => _count_labeled_asserts(args, label.clone()),
+    .Atom(_, _) => usize(0)
+  )
+);
+_count_labeled_asserts :: (fn(args : ArrayList(AstExpr), label : String) -> usize)({
+  (n : usize) = usize(0);
+  (i : usize) = usize(0);
+  while(i < args.len(), {
+    match(
+      args.get(i),
+      .Some(arg) => {
+        if(_is_assert_with_label(arg, label.clone()), {
+          n = (n + usize(1));
+        });
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  n
+});
+/// Arg 1 of a call as a string when it is a plain atom ("" otherwise).
+_arg1_atom_value :: (fn(a : ArrayList(AstExpr)) -> String)(
+  match(
+    a.get(usize(1)),
+    .Some(m_arg) => match(
+      m_arg,
+      .Atom(_, mt) => mt.value,
+      .FnCall(_, _, _, _, _) => String.new()
+    ),
+    .None => String.new()
+  )
+);
+/// The recognizer (test-side mirror of the wrapper's `_build_assert_call`
+/// shape): an `assert`/`comptime_assert` call of two args whose message
+/// atom starts with `<label>:`.
+_is_assert_with_label :: (fn(e : AstExpr, label : String) -> bool)(
+  match(
+    e,
+    .FnCall(_, f, a, _, _) => {
+      is_assert := cond(
+        _callee_is_bare(f, String.from("assert")) => true,
+        _callee_is_bare(f, String.from("comptime_assert")) => true,
+        _callee_is_member(f, String.from("assert")) => true,
+        true => false
+      );
+      msg := _arg1_atom_value(a);
+      is_assert && msg.starts_with(`"${label}:`)
+    },
+    .Atom(_, _) => false
+  )
+);
+_callee_is_bare :: (fn(f : AstExpr, name : String) -> bool)(
+  match(
+    f,
+    .Atom(_, ht) => (ht.value == name),
+    .FnCall(_, _, _, _, _) => false
+  )
+);
+_callee_is_member :: (fn(f : AstExpr, name : String) -> bool)(
+  match(
+    f,
+    .Atom(_, _) => false,
+    .FnCall(_, dot_h, dot_args, _, _) => _callee_member_cond(dot_h, dot_args, name.clone())
+  )
+);
+_callee_member_cond :: (
+  fn(dot_h : AstExpr, dot_args : ArrayList(AstExpr), name : String) -> bool
+)(
+  cond(
+    (ast_expr_token(dot_h).value == ".") => _dot_arg1_is(dot_args, name.clone()),
+    true => false
+  )
+);
+_dot_arg1_is :: (fn(dot_args : ArrayList(AstExpr), name : String) -> bool)(
+  match(
+    dot_args.get(usize(1)),
+    .Some(second) => match(
+      second,
+      .Atom(_, st) => (st.value == name),
+      .FnCall(_, _, _, _, _) => false
+    ),
+    .None => false
+  )
+);
+
+test("strip drops proved ensures asserts and keeps the requires guard (mechanism, no solver)", {
+  // ONE load per test body: a second load would re-evaluate the std
+  // modules after the cache clear and trip the duplicate-registration
+  // corruption (the mm prelude-guard class). Both strip sub-cases run
+  // sequentially on the same FuncVal — the unproved pass first (it keeps
+  // the body intact), then the proved pass.
+  tasks := _load_strip_tasks(io);
+  fv := _task_func_val(tasks);
+  ne := _count_contract_asserts(fv, String.from("ensures failed"));
+  nr := _count_contract_asserts(fv, String.from("requires failed"));
+  assert(ne == usize(1), `pre-strip: one ensures assert (got ${ne.to_string()})`);
+  assert(nr == usize(1), `pre-strip: one requires guard (got ${nr.to_string()})`);
+  unproved := ArrayList(bool).new();
+  unproved.push(false);
+  stripped_u := strip_proved_ensures_asserts(fv, unproved);
+  assert(stripped_u == usize(0), "an unproved ensures keeps its assert");
+  assert(_count_contract_asserts(fv, String.from("ensures failed")) == usize(1), "post-strip (unproved): the ensures assert stays");
+  proved := ArrayList(bool).new();
+  proved.push(true);
+  stripped := strip_proved_ensures_asserts(fv, proved);
+  assert(stripped == usize(1), `exactly the ensures assert is stripped, got ${stripped.to_string()}`);
+  assert(_count_contract_asserts(fv, String.from("ensures failed")) == usize(0), "post-strip: no ensures assert");
+  assert(_count_contract_asserts(fv, String.from("requires failed")) == usize(1), "post-strip: the requires guard stays");
+});
+
+test("verify+ end-to-end: proved obligations strip the assert (real solver)", {
+  if(!_have_z3(), {
+    return(());
+  });
+  tasks := _load_strip_tasks(io);
+  fv := _task_func_val(tasks);
+  assert(_count_contract_asserts(fv, String.from("ensures failed")) == usize(1), "pre-strip: one ensures assert");
+  cfg := default_verify_run_config();
+  binary := match(
+    resolve_solver_sync(cfg),
+    .Resolved(p) => p,
+    _ => {
+      assert(false, "expected a resolved solver under YO_TEST_Z3=1");
+      String.new()
+    }
+  );
+  reports := verify_and_strip_tasks(cfg, binary, tasks);
+  match(
+    reports.get(usize(0)),
+    .Some(rp) => {
+      assert(rp.outcome == "ok", `the verify+ fixture proves, got ${rp.outcome}`);
+    },
+    .None => {
+      assert(false, "one report expected");
+    }
+  );
+  assert(_count_contract_asserts(fv, String.from("ensures failed")) == usize(0), "post-verify: the proved ensures assert is gone");
+  assert(_count_contract_asserts(fv, String.from("requires failed")) == usize(1), "post-verify: the requires guard stays");
+});

--- a/tests/spec/fixtures/valid/verifyplus_abs.yo
+++ b/tests/spec/fixtures/valid/verifyplus_abs.yo
@@ -1,0 +1,12 @@
+// verify+ fixture for the strip-pass tests
+// (tests/internal/verifier_strip.test.yo): GOOD contracts — every ensures
+// proves — so the strip pass removes the spliced `ensures failed` assert
+// while the `requires failed` entry guard must stay.
+pragma(Pragma.VerifyOrAssert);
+
+abs_vp :: (fn(x : i32, requires(x >= i32(-2147483647)), ensures(r >= i32(0))) -> (r : i32))(
+  cond(
+    (x < i32(0)) => (i32(0) - x),
+    true => x
+  )
+);


### PR DESCRIPTION
## Summary

Closes V3's remaining flagship piece on top of the merged V3 core (#497): **`verify+` proved-assert stripping** and the **check/compile pipeline integration** — proofs cost zero runtime, budget-exhausted fallbacks keep today's safety (plan §"The assert-splice interaction", V3 task 6).

- `VerifyTask` carries the FuncVal; `strip_proved_ensures_asserts` rewrites the wrapped body in place, dropping the spliced `ensures failed` asserts whose obligations **proved**. The `requires failed` entry guards stay (their proof obligations live at call sites — stripping a callee guard on one caller's proof would be unsound).
- `verify_and_strip_tasks` (driver) takes an explicit task list; for `verify+` tasks it derives the per-ensures PROVED table from obligation names and strips.
- **Integration**: `yo check` arms each file as the verification target and verifies after a clean load; `yo compile` arms the entry and verifies between evaluation and codegen (the strip rewrites bodies before emission). Failure policy per the plan's verdict table: refuted always fails; unproven/solver-error/subset fail in `verify` mode, warn in `verify+` (the assert stays). A **missing solver is a failure, not a skip** — verify-mode codegen carries no runtime asserts, so shipping without the proofs would be unsound. Projects with no verify-mode files register zero tasks and never touch Z3.

## Tests

- `tests/internal/verifier_strip.test.yo` (in-process model): the strip **mechanism** runs solver-free (unproved keeps the assert; proved strips it; the requires guard stays) and the full **verify+ pipeline** under `YO_TEST_Z3=1` (fixture proves → the ensures assert is gone, the guard remains).
- Regression: verifier_negative 5/5, verifier 17/17, `yo check ./src/main.yo` clean.

## Notes

- One load per test body: a second in-process load re-evaluates std after the cache clear and trips the duplicate-registration corruption (the mm prelude-guard class) — recorded in the test.
- Emission of the stripped bodies is validated by CI's self-hosted legs (the seed's compiled-in codegen predates the branch, per the established in-process model).

🤖 Generated with [Yo](https://github.com/shd101wyy/Yo)