### PR TITLE
std: every error enum derives its messages instead of hand-writing two impls

### DIFF
--- a/.github/instructions/yo-design.instructions.md
+++ b/.github/instructions/yo-design.instructions.md
@@ -508,6 +508,23 @@ Rules that follow from it:
   error at the `dyn(...)` token (it used to fail inside the C compiler, naming a
   generated `__yo_wrap_…` symbol — see
   `issues/fixed/dyn-does-not-check-that-the-value-implements-the-traits.md`).
+- **Spell an error enum with `derive(Error)`, not two hand-written impls.**
+  One message per variant, in DECLARATION ORDER, emits `ToString` and `Error`
+  together; each message is checked against the variant it lands on, so a
+  renamed/added/removed/reordered variant is a compile error.
+
+  ```rust
+  derive(JsonError, Error(
+    .UnexpectedChar => `unexpected character at position ${pos}`,
+    .UnexpectedEnd  => `unexpected end of input`,
+    .Other          => `JSON error: ${msg}`
+  ));
+  ```
+
+  The message is ordinary Yo spliced into the arm that binds the payload, so
+  `${pos}` is the variant's own field — not a positional `{0}`. Write the two
+  impls by hand only when the render is not one message per variant (a struct
+  error, or a body that needs a local).
   `Error` carries `where(Self <: ToString)`, so `ToString` is required too.
 - **Never drop the payload on failure.** `Channel.send` returning
   `Result(unit, unit)` discarded the value the caller still owned; return it.

--- a/.github/skills/yo-async-effects/async-effects-recipes.md
+++ b/.github/skills/yo-async-effects/async-effects-recipes.md
@@ -237,8 +237,7 @@ open(import("std/error"));
 open(import("std/fmt"));
 
 DivError :: enum(DivByZero);
-impl(DivError, ToString(to_string : ((self) -> `division by zero`)));
-impl(DivError, Error());
+derive(DivError, Error(.DivByZero => `division by zero`));
 
 safe_divide :: (fn(x : i32, y : i32, exn : Exception) -> i32)(
   cond(

--- a/.github/skills/yo-core-patterns/core-patterns-cheatsheet.md
+++ b/.github/skills/yo-core-patterns/core-patterns-cheatsheet.md
@@ -412,8 +412,10 @@ if((type_value_tag(my_type) != TypeTag.TUnit), { ... });
 open(import("std/error"));
 
 DivError :: enum(DivByZero);
-impl(DivError, ToString(to_string : ((self) -> `division by zero`)));
-impl(DivError, Error());
+// `derive(Error)` emits ToString AND Error from one message per variant, in
+// DECLARATION ORDER. Payload fields interpolate by name: for
+// `NotFound(path : String)` the message is `not found: ${path}`.
+derive(DivError, Error(.DivByZero => `division by zero`));
 
 safe_div :: (fn(a : i32, b : i32) -> Result(i32, DivError))(
   cond(

--- a/docs/en-US/DERIVE_TRAITS.md
+++ b/docs/en-US/DERIVE_TRAITS.md
@@ -2,7 +2,7 @@
 
 `derive` is a compile-time builtin that automatically generates trait implementations for struct and enum types. It works similarly to Rust's `#[derive(...)]` attribute but uses function call syntax.
 
-All six standard derivable traits (Eq, Hash, Clone, Ord, ToString, Default) are **self-hosted** — their derive rules are written in Yo using the `derive_rule` mechanism, not hardcoded in the compiler.
+Every derivable trait in `std` is **self-hosted** — the derive rules are written in Yo using the `derive_rule` mechanism, not hardcoded in the compiler. There are ten: `Eq`, `Hash`, `Clone`, `Ord`, `Default`, `ToString` and `Debug` (`std/prelude`, `std/fmt`), `Error` (`std/error`), and `ToJson` / `FromJson` (`std/encoding/json`).
 
 ## Basic Usage
 
@@ -109,6 +109,47 @@ d := (Config <: Default).default();
 Each field type must implement `Default`. Field types that are generic instantiations work too — `ArrayList(i32)`, `Option(T)` and so on — because the rule reaches each field's type through the struct's own field list rather than by naming it, so nothing needs to be in scope at the impl site.
 
 Pairs with `Option.unwrap_or_default` and `Result.unwrap_or_default`.
+
+### Debug
+
+Generates the same structural render as `ToString` — `TypeName(field1, field2, …)` for structs, `TypeName.Variant(…)` for enums — but under the `Debug` trait's `debug_string`, so a type can have a *developer* render and a *user-facing* `to_string` at the same time.
+
+```rust
+derive(Point, Debug);
+
+p := Point(i32(1), i32(2));
+// p.debug_string() returns "Point(1, 2)"
+```
+
+That split is the point: `derive(ToString)` produces a structural render, which is **not** a user-facing message, so an error type that derived `ToString` got `JsonError.UnexpectedEnd` where it wanted `unexpected end of input`. Reach for `Debug` when you want the structure, and for `Error` (below) or a hand-written `ToString` when you want prose.
+
+### Error
+
+Generates `ToString` **and** `Error` from one message per variant — `thiserror`'s `#[error("…")]`, in the syntax Yo already has. **Enums only**: a struct error has exactly one message, so write that `ToString` impl by hand.
+
+```rust
+JsonError :: enum(
+  UnexpectedChar(ch : u8, pos : usize),
+  UnexpectedEnd,
+  Other(msg : String)
+);
+derive(JsonError, Error(
+  .UnexpectedChar => `unexpected character at position ${pos}`,
+  .UnexpectedEnd  => `unexpected end of input`,
+  .Other          => `JSON error: ${msg}`
+));
+```
+
+The message is **ordinary Yo**, spliced into the match arm that binds the payload, so `${pos}` is the variant's own field rather than a positional `{0}`. A typo in a field name is an ordinary unresolved-name error.
+
+Two things to know:
+
+- **Messages go in declaration order**, and each is checked against the variant it lands on — so adding, removing, renaming or reordering a variant is a compile error, not a silently swapped message.
+- It emits both traits because `Error` requires `Self <: ToString`. That is why one `derive` replaces what used to be a `ToString` impl plus a separate `impl(T, Error());` line.
+
+### ToJson / FromJson
+
+Registered by `std/encoding/json`. `derive(T, ToJson)` generates a `JsonValue` encoder from the type's fields; `derive(T, FromJson)` generates the decoder. See `docs/en-US/JSON.md` for the field-name and `Option` conventions.
 
 ## Multiple Traits
 
@@ -259,10 +300,12 @@ When `derive(Type, Trait)` is called:
 
 ### Self-Hosted Standard Derives
 
-All six standard traits use the same `derive_rule` mechanism:
+Every derivable trait in `std` uses the same `derive_rule` mechanism, and each rule lives beside the trait it derives:
 
-- **Eq, Clone, Hash, Ord, Default** — derive rules defined in `std/prelude.yo`
-- **ToString** — derive rule defined in `std/fmt/to_string.yo` (where the ToString trait is defined)
+- **Eq, Clone, Hash, Ord, Default** — `std/prelude.yo`
+- **ToString, Debug** — `std/fmt/to_string.yo`. They share one `__derive_structural_body(T, method)` helper, so the structural render exists once and each trait wraps it.
+- **Error** — `std/error.yo`. The only rule that emits TWO trait bodies from one call, because `Error` requires `Self <: ToString`; it therefore builds the `impl(T, ToString(…), Error())` expression itself rather than going through `DeriveContext.make_impl`, which wraps exactly one.
+- **ToJson, FromJson** — `std/encoding/json.yo`
 
 These implementations use string-based code generation with `comptime_str` and `.to_expr()` to build impl blocks at compile time.
 

--- a/docs/en-US/DESIGN.md
+++ b/docs/en-US/DESIGN.md
@@ -2617,18 +2617,22 @@ The standard library defines an `Error` trait and `AnyError` type for dynamic er
 ```rust
 open(import("std/error"));
 
-// Error trait requires ToString. Custom error types implement both:
+// Error trait requires ToString. `derive(Error)` supplies both from one
+// message per variant, listed in declaration order:
 MathError :: enum(
   DivisionByZero,
   NegativeSqrt
 );
-impl(MathError, ToString(
-  to_string : ((self) -> match(self,
-    .DivisionByZero => `Division by zero`,
-    .NegativeSqrt => `Square root of a negative number`
-  ))
+derive(MathError, Error(
+  .DivisionByZero => `Division by zero`,
+  .NegativeSqrt => `Square root of a negative number`
 ));
-impl(MathError, Error());
+
+// The message is ordinary Yo, spliced into the arm that binds the payload, so
+// a variant's own fields interpolate by name:
+//   .NotFound(path : String)  =>  `not found: ${path}`
+// Writing the two impls by hand still works, and is the way to go when the
+// message is not a simple per-variant string.
 
 // AnyError is Dyn(Error) — any type implementing Error can be wrapped:
 (err : AnyError) = dyn(MathError.DivisionByZero);

--- a/docs/zh-CN/DERIVE_TRAITS.md
+++ b/docs/zh-CN/DERIVE_TRAITS.md
@@ -2,7 +2,7 @@
 
 `derive` 是一个编译期内建函数，可以自动为结构体和枚举类型生成特征实现。它的功能类似于 Rust 的 `#[derive(...)]` 属性，但使用函数调用语法。
 
-所有六个标准可派生特征（Eq、Hash、Clone、Ord、ToString、Default）都是**自宿主的**——它们的派生规则使用 `derive_rule` 机制直接在 Yo 中编写，而非在编译器中硬编码。
+`std` 中所有可派生特征都是**自宿主的**——派生规则使用 `derive_rule` 机制直接在 Yo 中编写，而非在编译器中硬编码。共有十个：`Eq`、`Hash`、`Clone`、`Ord`、`Default`、`ToString` 与 `Debug`（`std/prelude`、`std/fmt`），`Error`（`std/error`），以及 `ToJson` / `FromJson`（`std/encoding/json`）。
 
 ## 基本用法
 
@@ -109,6 +109,47 @@ d := (Config <: Default).default();
 每个字段类型都必须实现 `Default`。字段类型为泛型实例化（如 `ArrayList(i32)`、`Option(T)`）同样可用：派生规则通过结构体自身的字段列表取得字段类型，而非按名称引用，因此实现处无需任何额外的作用域引入。
 
 与 `Option.unwrap_or_default`、`Result.unwrap_or_default` 配合使用。
+
+### Debug
+
+生成与 `ToString` 相同的结构化渲染——结构体为 `TypeName(field1, field2, …)`，枚举为 `TypeName.Variant(…)`——但挂在 `Debug` 特征的 `debug_string` 上，于是一个类型可以同时拥有面向**开发者**的渲染和面向**用户**的 `to_string`。
+
+```rust
+derive(Point, Debug);
+
+p := Point(i32(1), i32(2));
+// p.debug_string() 返回 "Point(1, 2)"
+```
+
+这个拆分正是要点：`derive(ToString)` 产生的是结构化渲染，**不是**面向用户的消息，所以派生了 `ToString` 的错误类型只能得到 `JsonError.UnexpectedEnd`，而它想要的是 `unexpected end of input`。需要结构时用 `Debug`，需要文字消息时用下面的 `Error` 或手写 `ToString`。
+
+### Error
+
+从每个变体一条消息，同时生成 `ToString` **和** `Error`——相当于 `thiserror` 的 `#[error("…")]`，只是用 Yo 已有的语法写。**仅支持枚举**：结构体错误只有一条消息，直接手写那个 `ToString` impl 即可。
+
+```rust
+JsonError :: enum(
+  UnexpectedChar(ch : u8, pos : usize),
+  UnexpectedEnd,
+  Other(msg : String)
+);
+derive(JsonError, Error(
+  .UnexpectedChar => `unexpected character at position ${pos}`,
+  .UnexpectedEnd  => `unexpected end of input`,
+  .Other          => `JSON error: ${msg}`
+));
+```
+
+消息就是**普通的 Yo 代码**，会被拼接进绑定负载的那条 match 分支，因此 `${pos}` 是该变体自己的字段，而不是位置参数 `{0}`。字段名写错就是一个普通的「变量未找到」错误。
+
+两点需要知道：
+
+- **消息必须按声明顺序排列**，并且每条都会与它落在的变体逐一核对——因此新增、删除、重命名或重排变体都是编译错误，不会静默地把消息串位。
+- 它同时生成两个特征，是因为 `Error` 要求 `Self <: ToString`。这就是一次 `derive` 能替代原先「一个 `ToString` impl 加一行单独的 `impl(T, Error());`」的原因。
+
+### ToJson / FromJson
+
+由 `std/encoding/json` 注册。`derive(T, ToJson)` 依据类型的字段生成 `JsonValue` 编码器，`derive(T, FromJson)` 生成解码器。字段名与 `Option` 的约定见 `docs/zh-CN/JSON.md`。
 
 ## 多个特征
 
@@ -259,10 +300,12 @@ derive(generic(T1, T2), Pair(T1, T2), where((T1 <: MyEq(T1)), (T2 <: MyEq(T2))),
 
 ### 自宿主标准派生
 
-所有六个标准特征都使用相同的 `derive_rule` 机制：
+`std` 中每个可派生特征都使用相同的 `derive_rule` 机制，并且规则都与它所派生的特征放在一起：
 
-- **Eq、Clone、Hash、Ord、Default** — 派生规则定义在 `std/prelude.yo` 中
-- **ToString** — 派生规则定义在 `std/fmt/to_string.yo` 中（ToString 特征定义所在）
+- **Eq、Clone、Hash、Ord、Default** — `std/prelude.yo`
+- **ToString、Debug** — `std/fmt/to_string.yo`。两者共用一个 `__derive_structural_body(T, method)` 辅助函数，结构化渲染只存在一份，各自的特征只是把它包起来。
+- **Error** — `std/error.yo`。唯一一个一次调用生成**两个**特征体的规则，因为 `Error` 要求 `Self <: ToString`；也正因此它自己构造 `impl(T, ToString(…), Error())` 表达式，而不走只包一个特征体的 `DeriveContext.make_impl`。
+- **ToJson、FromJson** — `std/encoding/json.yo`
 
 这些实现使用基于字符串的代码生成，通过 `comptime_str` 和 `.to_expr()` 在编译期构建 impl 代码块。
 

--- a/docs/zh-CN/DESIGN.md
+++ b/docs/zh-CN/DESIGN.md
@@ -2589,18 +2589,21 @@ match(result,
 ```rust
 open(import("std/error"));
 
-// Error trait 要求实现 ToString。自定义错误类型需同时实现两者：
+// Error trait 要求实现 ToString。`derive(Error)` 只需按声明顺序为每个变体
+// 写一条消息，即可同时生成两者：
 MathError :: enum(
   DivisionByZero,
   NegativeSqrt
 );
-impl(MathError, ToString(
-  to_string : ((self) -> match(self,
-    .DivisionByZero => `Division by zero`,
-    .NegativeSqrt => `Square root of a negative number`
-  ))
+derive(MathError, Error(
+  .DivisionByZero => `Division by zero`,
+  .NegativeSqrt => `Square root of a negative number`
 ));
-impl(MathError, Error());
+
+// 消息就是普通的 Yo 代码，会被拼接进绑定负载的那条 match 分支，因此变体自己的
+// 字段可以按名字插值：
+//   .NotFound(path : String)  =>  `not found: ${path}`
+// 手写这两个 impl 依然可用；当消息不是简单的「每个变体一条字符串」时，就该那么写。
 
 // AnyError 是 Dyn(Error) — 任何实现了 Error 的类型都可以被包装：
 (err : AnyError) = dyn(MathError.DivisionByZero);

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -165,6 +165,12 @@ the work in §4 does not re-open them.
   `compile` both exit 0). That is a diagnostics bug, not a language limit —
   when it is fixed, the ordering constraint can be lifted without changing a
   single call site, since declaration order is a valid keyed list.
+  **All thirteen std error enums are migrated** — `JsonError` with the rule
+  itself, then `TimeoutError`, `CryptoError`, `TlsError`, `CsvError`,
+  `EncodingError`, `RegexError`, `IoError`, `NetError`, `UrlError`,
+  `DateTimeError`, `HttpParseError` and `HttpError` in the follow-up. Every
+  rendered message is unchanged and all thirteen now-redundant
+  `impl(T, Error());` lines are gone.
 - **D16 — `HashSet(T)` IS `HashMap(T, unit)`.** 498 of 929 lines of
   `hash_set.yo` are byte-identical to `hash_map.yo`, and the tombstone bug
   (§3) is present in both. `unit` is a true ZST as of v0.2.26, so the map's

--- a/std/async/index.yo
+++ b/std/async/index.yo
@@ -144,20 +144,13 @@ TimeoutError :: enum(
   /// unexpired, so it never produced a value.
   Aborted
 );
-impl(
+derive(
   TimeoutError,
-  ToString(
-    to_string : (
-      self ->
-        match(
-          self,
-          .Elapsed => `timeout: the deadline elapsed before the task finished`,
-          .Aborted => `timeout: the task was aborted before it produced a value`
-        )
-    )
+  Error(
+    .Elapsed => `timeout: the deadline elapsed before the task finished`,
+    .Aborted => `timeout: the task was aborted before it produced a value`
   )
 );
-impl(TimeoutError, Error());
 /// Await `handle` with a deadline: `.Ok(v)` if it finishes within `limit`,
 /// `.Err(TimeoutError.Elapsed)` if the deadline fires first (the handle is
 /// `abort()`ed), `.Err(TimeoutError.Aborted)` if the task was cancelled on

--- a/std/crypto/random.yo
+++ b/std/crypto/random.yo
@@ -27,20 +27,13 @@ CryptoError :: enum(
   /// Other platform-specific error.
   Other(msg : String)
 );
-impl(
+derive(
   CryptoError,
-  ToString(
-    to_string : (
-      self ->
-        match(
-          self,
-          .Unavailable => `crypto: platform random unavailable`,
-          .Other(msg) => `crypto error: ${msg}`
-        )
-    )
+  Error(
+    .Unavailable => `crypto: platform random unavailable`,
+    .Other => `crypto error: ${msg}`
   )
 );
-impl(CryptoError, Error());
 export(CryptoError);
 // ============================================================================
 // Platform externs

--- a/std/crypto/tls.yo
+++ b/std/crypto/tls.yo
@@ -77,24 +77,19 @@ TlsError :: enum(
   /// operation that needed data.
   Closed
 );
-impl(
-  TlsError,
-  ToString(
-    to_string : (fn(inout(self) : Self) -> String)(
-      match(
-        self,
-        .Connect(host) => `tls: could not connect to ${host}`,
-        .Handshake(detail) => `tls handshake failed: ${detail}`,
-        .Io(detail) => `tls i/o failed: ${detail}`,
-        .Closed => `tls session closed by peer`.to_string()
-      )
-    )
-  )
-);
 /// `_throw_tls` boxes a `TlsError` into an `AnyError` (`Dyn(Error)`), which
 /// requires the `Error` marker — D1's "an error type is a real enum
-/// implementing `Error()`".
-impl(TlsError, Error());
+/// implementing `Error()`" — so this derive supplies it alongside the
+/// messages.
+derive(
+  TlsError,
+  Error(
+    .Connect => `tls: could not connect to ${host}`,
+    .Handshake => `tls handshake failed: ${detail}`,
+    .Io => `tls i/o failed: ${detail}`,
+    .Closed => `tls session closed by peer`.to_string()
+  )
+);
 export(TlsError);
 /// Last backend error as text (empty queue → a fixed note).
 _ssl_err_string :: (fn() -> String)({

--- a/std/encoding/csv.yo
+++ b/std/encoding/csv.yo
@@ -35,22 +35,15 @@ CsvError :: enum(
   /// raised by `csv_parse_strict`). `record` is the 0-based record index.
   UnevenRecord(record : usize, expected : usize, found : usize)
 );
-impl(
+derive(
   CsvError,
-  ToString(
-    to_string : (
-      self ->
-        match(
-          self,
-          .UnexpectedAfterQuote(pos, byte) => `unexpected byte ${byte} after closing quote at byte ${pos}`,
-          .UnterminatedQuote(start) => `unterminated quoted field starting at byte ${start}`,
-          .BareCarriageReturn(pos) => `bare carriage return at byte ${pos}`,
-          .UnevenRecord(record, expected, found) => `record ${record} has ${found} fields, expected ${expected}`
-        )
-    )
+  Error(
+    .UnexpectedAfterQuote => `unexpected byte ${byte} after closing quote at byte ${pos}`,
+    .UnterminatedQuote => `unterminated quoted field starting at byte ${start}`,
+    .BareCarriageReturn => `bare carriage return at byte ${pos}`,
+    .UnevenRecord => `record ${record} has ${found} fields, expected ${expected}`
   )
 );
-impl(CsvError, Error());
 /// The record separator the writer emits.
 LineEnding :: enum(
   /// `\n`

--- a/std/encoding/error.yo
+++ b/std/encoding/error.yo
@@ -29,20 +29,13 @@ EncodingError :: enum(
   /// symbol whose low two bits are zero); Rust's `InvalidLastSymbol`.
   InvalidLastSymbol(ch : u8)
 );
-impl(
+derive(
   EncodingError,
-  ToString(
-    to_string : (
-      self ->
-        match(
-          self,
-          .InvalidChar(ch) => `encoding error: invalid character ${ch}`,
-          .OddLength => `encoding error: odd length`,
-          .InvalidLength => `encoding error: base64 length is 1 mod 4`,
-          .InvalidLastSymbol(ch) => `encoding error: non-canonical trailing bits in base64 symbol ${ch}`
-        )
-    )
+  Error(
+    .InvalidChar => `encoding error: invalid character ${ch}`,
+    .OddLength => `encoding error: odd length`,
+    .InvalidLength => `encoding error: base64 length is 1 mod 4`,
+    .InvalidLastSymbol => `encoding error: non-canonical trailing bits in base64 symbol ${ch}`
   )
 );
-impl(EncodingError, Error());
 export(EncodingError);

--- a/std/http/http.yo
+++ b/std/http/http.yo
@@ -251,25 +251,18 @@ HttpParseError :: enum(
   /// A header line without a `:`.
   InvalidHeaderLine(line : String)
 );
-impl(
+derive(
   HttpParseError,
-  ToString(
-    to_string : (
-      self ->
-        match(
-          self,
-          .Empty => `Empty message`,
-          .InvalidStatusLine(line) => `Invalid status line: ${line}`,
-          .InvalidStatusCode(text) => `Invalid status code: ${text}`,
-          .InvalidRequestLine(line) => `Invalid request line: ${line}`,
-          .UnknownMethod(name) => `Unknown method: ${name}`,
-          .UnsupportedVersion(version) => `Unsupported HTTP version: ${version}`,
-          .InvalidHeaderLine(line) => `Invalid header line: ${line}`
-        )
-    )
+  Error(
+    .Empty => `Empty message`,
+    .InvalidStatusLine => `Invalid status line: ${line}`,
+    .InvalidStatusCode => `Invalid status code: ${text}`,
+    .InvalidRequestLine => `Invalid request line: ${line}`,
+    .UnknownMethod => `Unknown method: ${name}`,
+    .UnsupportedVersion => `Unsupported HTTP version: ${version}`,
+    .InvalidHeaderLine => `Invalid header line: ${line}`
   )
 );
-impl(HttpParseError, Error());
 /// Parse a raw HTTP response string into an `HttpResponse`.
 parse_response :: (fn(raw : String) -> Result(HttpResponse, HttpParseError))({
   lines := raw.split(`\r\n`);
@@ -455,27 +448,20 @@ HttpError :: enum(
   /// An unclassified HTTP error.
   Other(msg : String)
 );
-impl(
+derive(
   HttpError,
-  ToString(
-    to_string : (
-      self ->
-        match(
-          self,
-          .ConnectionFailed(msg) => `HTTP connection failed: ${msg}`,
-          .InvalidUrl(msg) => `Invalid URL: ${msg}`,
-          .Timeout => `HTTP request timed out`,
-          .TooManyRedirects => `Too many redirects`,
-          .UnsupportedScheme(scheme) => `Unsupported scheme: ${scheme}`,
-          .ResponseTooLarge => `Response too large`,
-          .MalformedChunkedBody(msg) => `Malformed chunked body: ${msg}`,
-          .MalformedContentLength(msg) => `Malformed Content-Length: ${msg}`,
-          .Other(msg) => `HTTP error: ${msg}`
-        )
-    )
+  Error(
+    .ConnectionFailed => `HTTP connection failed: ${msg}`,
+    .InvalidUrl => `Invalid URL: ${msg}`,
+    .Timeout => `HTTP request timed out`,
+    .TooManyRedirects => `Too many redirects`,
+    .UnsupportedScheme => `Unsupported scheme: ${scheme}`,
+    .ResponseTooLarge => `Response too large`,
+    .MalformedChunkedBody => `Malformed chunked body: ${msg}`,
+    .MalformedContentLength => `Malformed Content-Length: ${msg}`,
+    .Other => `HTTP error: ${msg}`
   )
 );
-impl(HttpError, Error());
 export(HttpError);
 export(HttpMethod, HttpHeader, HttpRequest, HttpResponse);
 export(HttpParseError, parse_response, parse_request, http_status_text);

--- a/std/net/errors.yo
+++ b/std/net/errors.yo
@@ -55,31 +55,22 @@ impl(
     )
   )
 );
-impl(
+derive(
   NetError,
-  ToString(
-    to_string : (
-      self -> {
-        s := match(
-          self,
-          .ConnectionRefused => String.from("connection refused"),
-          .ConnectionReset => String.from("connection reset by peer"),
-          .ConnectionAborted => String.from("connection aborted"),
-          .AddrInUse => String.from("address already in use"),
-          .AddrNotAvailable => String.from("address not available"),
-          .TimedOut => String.from("operation timed out"),
-          .HostUnreachable => String.from("host unreachable"),
-          .NetworkUnreachable => String.from("network unreachable"),
-          .DNSFailed(msg) => `DNS lookup failed: ${msg}`,
-          .Io(err) => err.to_string(),
-          .Other(msg) => msg
-        );
-        return(s);
-      }
-    )
+  Error(
+    .ConnectionRefused => String.from("connection refused"),
+    .ConnectionReset => String.from("connection reset by peer"),
+    .ConnectionAborted => String.from("connection aborted"),
+    .AddrInUse => String.from("address already in use"),
+    .AddrNotAvailable => String.from("address not available"),
+    .TimedOut => String.from("operation timed out"),
+    .HostUnreachable => String.from("host unreachable"),
+    .NetworkUnreachable => String.from("network unreachable"),
+    .DNSFailed => `DNS lookup failed: ${msg}`,
+    .Io => err.to_string(),
+    .Other => msg
   )
 );
-impl(NetError, Error());
 impl(
   NetError,
   /// Check a raw syscall result and throw on error.

--- a/std/regex/error.yo
+++ b/std/regex/error.yo
@@ -67,36 +67,23 @@ RegexError :: enum(
   /// The same flag character given more than once.
   DuplicateFlag(flag : u8)
 );
-impl(
+derive(
   RegexError,
-  ToString(
-    to_string : (
-      self ->
-        match(
-          self,
-          .UnexpectedEnd(pos) => `regex error: unexpected end of pattern at byte ${pos}`,
-          .TrailingBackslash(pos) => `regex error: pattern ends with a trailing backslash at byte ${pos}`,
-          .UnterminatedCharClass(pos) => `regex error: unterminated character class, expected ']' at byte ${pos}`,
-          .UnterminatedGroup(pos) => `regex error: unterminated group, expected ')' at byte ${pos}`,
-          .UnmatchedCloseParen(pos) => `regex error: unmatched ')' at byte ${pos}`,
-          .InvalidQuantifier(pos) => `regex error: invalid '{m,n}' quantifier at byte ${pos}`,
-          .QuantifierOutOfOrder(min, max, pos) =>
-            `regex error: quantifier '{${min},${max}}' has max below min at byte ${pos}`,
-          .InvalidBackreference(group, pos) =>
-            `regex error: backreference to group ${group} exceeds the number of groups at byte ${pos}`,
-          .InvalidNamedBackreference(pos) =>
-            `regex error: malformed named backreference, expected '\\k<name>' at byte ${pos}`,
-          .UnknownGroupName(name, pos) =>
-            `regex error: unknown named group '${name}' in backreference at byte ${pos}`,
-          .InvalidUnicodeProperty(pos) =>
-            `regex error: malformed unicode property, expected '\\p{name}' at byte ${pos}`,
-          .UnknownUnicodeProperty(name, pos) =>
-            `regex error: unknown unicode property '${name}' at byte ${pos}`,
-          .InvalidFlag(flag) => `regex error: invalid flag '${_flag_char(flag)}'`,
-          .DuplicateFlag(flag) => `regex error: duplicate flag '${_flag_char(flag)}'`
-        )
-    )
+  Error(
+    .UnexpectedEnd => `regex error: unexpected end of pattern at byte ${pos}`,
+    .TrailingBackslash => `regex error: pattern ends with a trailing backslash at byte ${pos}`,
+    .UnterminatedCharClass => `regex error: unterminated character class, expected ']' at byte ${pos}`,
+    .UnterminatedGroup => `regex error: unterminated group, expected ')' at byte ${pos}`,
+    .UnmatchedCloseParen => `regex error: unmatched ')' at byte ${pos}`,
+    .InvalidQuantifier => `regex error: invalid '{m,n}' quantifier at byte ${pos}`,
+    .QuantifierOutOfOrder => `regex error: quantifier '{${min},${max}}' has max below min at byte ${pos}`,
+    .InvalidBackreference => `regex error: backreference to group ${group} exceeds the number of groups at byte ${pos}`,
+    .InvalidNamedBackreference => `regex error: malformed named backreference, expected '\\k<name>' at byte ${pos}`,
+    .UnknownGroupName => `regex error: unknown named group '${name}' in backreference at byte ${pos}`,
+    .InvalidUnicodeProperty => `regex error: malformed unicode property, expected '\\p{name}' at byte ${pos}`,
+    .UnknownUnicodeProperty => `regex error: unknown unicode property '${name}' at byte ${pos}`,
+    .InvalidFlag => `regex error: invalid flag '${_flag_char(flag)}'`,
+    .DuplicateFlag => `regex error: duplicate flag '${_flag_char(flag)}'`
   )
 );
-impl(RegexError, Error());
 export(RegexError);

--- a/std/sys/errors.yo
+++ b/std/sys/errors.yo
@@ -181,55 +181,46 @@ impl(
     )
   )
 );
-impl(
+derive(
   IoError,
-  ToString(
-    to_string : (
-      self -> {
-        s := match(
-          self,
-          .NotFound => String.from("file or directory not found"),
-          .PermissionDenied => String.from("permission denied"),
-          .AlreadyExists => String.from("file or directory already exists"),
-          .NotADirectory => String.from("not a directory"),
-          .IsADirectory => String.from("is a directory"),
-          .DirectoryNotEmpty => String.from("directory not empty"),
-          .BrokenPipe => String.from("broken pipe"),
-          .WouldBlock => String.from("operation would block"),
-          .InvalidInput => String.from("invalid input"),
-          .Interrupted => String.from("operation interrupted"),
-          .TooManyOpenFiles => String.from("too many open files"),
-          .FileTooLarge => String.from("file too large"),
-          .NoSpace => String.from("no space left on device"),
-          .ReadOnlyFilesystem => String.from("read-only filesystem"),
-          .CrossDeviceLink => String.from("cross-device link"),
-          .TooManyLinks => String.from("too many links"),
-          .NameTooLong => String.from("name too long"),
-          .NotSupported => String.from("operation not supported"),
-          .TimedOut => String.from("operation timed out"),
-          .Busy => String.from("resource busy"),
-          .BadFileDescriptor => String.from("bad file descriptor"),
-          .IoError => String.from("I/O error"),
-          .ConnectionRefused => String.from("connection refused"),
-          .ConnectionReset => String.from("connection reset by peer"),
-          .ConnectionAborted => String.from("connection aborted"),
-          .NotConnected => String.from("socket not connected"),
-          .AddressInUse => String.from("address already in use"),
-          .AddressNotAvailable => String.from("address not available"),
-          .NetworkUnreachable => String.from("network unreachable"),
-          .HostUnreachable => String.from("host unreachable"),
-          .NetworkDown => String.from("network is down"),
-          .AlreadyConnected => String.from("socket already connected"),
-          .InvalidData => String.from("stream contained malformed data"),
-          .WriteZero => String.from("write returned zero bytes"),
-          .Other(code) => `unknown I/O error (os error ${code})`.to_string()
-        );
-        return(s);
-      }
-    )
+  Error(
+    .NotFound => String.from("file or directory not found"),
+    .PermissionDenied => String.from("permission denied"),
+    .AlreadyExists => String.from("file or directory already exists"),
+    .NotADirectory => String.from("not a directory"),
+    .IsADirectory => String.from("is a directory"),
+    .DirectoryNotEmpty => String.from("directory not empty"),
+    .BrokenPipe => String.from("broken pipe"),
+    .WouldBlock => String.from("operation would block"),
+    .InvalidInput => String.from("invalid input"),
+    .Interrupted => String.from("operation interrupted"),
+    .TooManyOpenFiles => String.from("too many open files"),
+    .FileTooLarge => String.from("file too large"),
+    .NoSpace => String.from("no space left on device"),
+    .ReadOnlyFilesystem => String.from("read-only filesystem"),
+    .CrossDeviceLink => String.from("cross-device link"),
+    .TooManyLinks => String.from("too many links"),
+    .NameTooLong => String.from("name too long"),
+    .NotSupported => String.from("operation not supported"),
+    .TimedOut => String.from("operation timed out"),
+    .Busy => String.from("resource busy"),
+    .BadFileDescriptor => String.from("bad file descriptor"),
+    .IoError => String.from("I/O error"),
+    .ConnectionRefused => String.from("connection refused"),
+    .ConnectionReset => String.from("connection reset by peer"),
+    .ConnectionAborted => String.from("connection aborted"),
+    .NotConnected => String.from("socket not connected"),
+    .AddressInUse => String.from("address already in use"),
+    .AddressNotAvailable => String.from("address not available"),
+    .NetworkUnreachable => String.from("network unreachable"),
+    .HostUnreachable => String.from("host unreachable"),
+    .NetworkDown => String.from("network is down"),
+    .AlreadyConnected => String.from("socket already connected"),
+    .InvalidData => String.from("stream contained malformed data"),
+    .WriteZero => String.from("write returned zero bytes"),
+    .Other => `unknown I/O error (os error ${code})`.to_string()
   )
 );
-impl(IoError, Error());
 impl(
   IoError,
   // Check a raw result code, throwing on error via Exception effect.

--- a/std/time/datetime.yo
+++ b/std/time/datetime.yo
@@ -347,22 +347,17 @@ DateTimeError :: enum(
   /// names it ("month", "day", "hour", "minute", "second", "offset").
   OutOfRange(field : str)
 );
-impl(
-  DateTimeError,
-  ToString(
-    to_string : (fn(inout(self) : Self) -> String)(
-      match(
-        self,
-        .InvalidFormat(index) => `invalid RFC 3339 date-time at byte ${index.to_string()}`,
-        .OutOfRange(field) => `date-time component out of range: ${String.from(field)}`
-      )
-    )
-  )
-);
 /// D1's "an error type is a real enum implementing `Error()`". Nothing in std
 /// boxes a `DateTimeError` into an `AnyError` today, but `dyn()` now enforces
-/// the bound, so the marker is what makes the first `throw` of one compile.
-impl(DateTimeError, Error());
+/// the bound, so the `Error` half of this derive is what makes the first
+/// `throw` of one compile.
+derive(
+  DateTimeError,
+  Error(
+    .InvalidFormat => `invalid RFC 3339 date-time at byte ${index.to_string()}`,
+    .OutOfRange => `date-time component out of range: ${String.from(field)}`
+  )
+);
 export(DateTimeError);
 /// Days in `month` of `year` (leap-aware). 0 for an invalid month.
 _days_in :: (fn(year : i32, month : u8) -> u8)(

--- a/std/url/index.yo
+++ b/std/url/index.yo
@@ -24,23 +24,16 @@ UrlError :: enum(
   InvalidCharacter(pos : usize),
   Other(msg : String)
 );
-impl(
+derive(
   UrlError,
-  ToString(
-    to_string : (
-      self ->
-        match(
-          self,
-          .EmptyInput => `URL error: empty input`,
-          .MissingScheme => `URL error: missing scheme`,
-          .InvalidPort => `URL error: invalid port`,
-          .InvalidCharacter(pos) => `URL error: invalid character at position ${pos}`,
-          .Other(msg) => `URL error: ${msg}`
-        )
-    )
+  Error(
+    .EmptyInput => `URL error: empty input`,
+    .MissingScheme => `URL error: missing scheme`,
+    .InvalidPort => `URL error: invalid port`,
+    .InvalidCharacter => `URL error: invalid character at position ${pos}`,
+    .Other => `URL error: ${msg}`
   )
 );
-impl(UrlError, Error());
 // ============================================================================
 // Url
 // ============================================================================

--- a/tests/cli-cases/init-build-test/expected_tree
+++ b/tests/cli-cases/init-build-test/expected_tree
@@ -1,7 +1,7 @@
 ./.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./.agents/skills/yo-async-effects/async-effects-recipes.md	78e6a7cccea15e5209ce4ecaef1fc6e43a2bd8e39fccb19183a055f1b177f150
+./.agents/skills/yo-async-effects/async-effects-recipes.md	74b67f0959e93ebc71e4695ee45a175a658c709dec75b15696fc5f137dd68415
 ./.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
-./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	7e56b6b15031efe5ade34352914c64dcb96b08b9f73111ac3eb1941ea015ccf7
+./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	a0992b8044f9fe58d78d5919d72a6d4cb937202ec2f909f0ea53d86187b708b1
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54

--- a/tests/cli-cases/init-cwd/expected_tree
+++ b/tests/cli-cases/init-cwd/expected_tree
@@ -1,7 +1,7 @@
 ./.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./.agents/skills/yo-async-effects/async-effects-recipes.md	78e6a7cccea15e5209ce4ecaef1fc6e43a2bd8e39fccb19183a055f1b177f150
+./.agents/skills/yo-async-effects/async-effects-recipes.md	74b67f0959e93ebc71e4695ee45a175a658c709dec75b15696fc5f137dd68415
 ./.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
-./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	7e56b6b15031efe5ade34352914c64dcb96b08b9f73111ac3eb1941ea015ccf7
+./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	a0992b8044f9fe58d78d5919d72a6d4cb937202ec2f909f0ea53d86187b708b1
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54

--- a/tests/cli-cases/init-existing/expected_tree
+++ b/tests/cli-cases/init-existing/expected_tree
@@ -1,7 +1,7 @@
 ./probe/.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./probe/.agents/skills/yo-async-effects/async-effects-recipes.md	78e6a7cccea15e5209ce4ecaef1fc6e43a2bd8e39fccb19183a055f1b177f150
+./probe/.agents/skills/yo-async-effects/async-effects-recipes.md	74b67f0959e93ebc71e4695ee45a175a658c709dec75b15696fc5f137dd68415
 ./probe/.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
-./probe/.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	7e56b6b15031efe5ade34352914c64dcb96b08b9f73111ac3eb1941ea015ccf7
+./probe/.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	a0992b8044f9fe58d78d5919d72a6d4cb937202ec2f909f0ea53d86187b708b1
 ./probe/.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./probe/.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./probe/.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54

--- a/tests/cli-cases/init/expected_tree
+++ b/tests/cli-cases/init/expected_tree
@@ -1,7 +1,7 @@
 ./probe/.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./probe/.agents/skills/yo-async-effects/async-effects-recipes.md	78e6a7cccea15e5209ce4ecaef1fc6e43a2bd8e39fccb19183a055f1b177f150
+./probe/.agents/skills/yo-async-effects/async-effects-recipes.md	74b67f0959e93ebc71e4695ee45a175a658c709dec75b15696fc5f137dd68415
 ./probe/.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
-./probe/.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	7e56b6b15031efe5ade34352914c64dcb96b08b9f73111ac3eb1941ea015ccf7
+./probe/.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	a0992b8044f9fe58d78d5919d72a6d4cb937202ec2f909f0ea53d86187b708b1
 ./probe/.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./probe/.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./probe/.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54

--- a/tests/cli-cases/skills-install-zh/expected_tree
+++ b/tests/cli-cases/skills-install-zh/expected_tree
@@ -1,7 +1,7 @@
 ./.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./.agents/skills/yo-async-effects/async-effects-recipes.md	78e6a7cccea15e5209ce4ecaef1fc6e43a2bd8e39fccb19183a055f1b177f150
+./.agents/skills/yo-async-effects/async-effects-recipes.md	74b67f0959e93ebc71e4695ee45a175a658c709dec75b15696fc5f137dd68415
 ./.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
-./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	7e56b6b15031efe5ade34352914c64dcb96b08b9f73111ac3eb1941ea015ccf7
+./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	a0992b8044f9fe58d78d5919d72a6d4cb937202ec2f909f0ea53d86187b708b1
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54

--- a/tests/cli-cases/skills-install/expected_tree
+++ b/tests/cli-cases/skills-install/expected_tree
@@ -1,7 +1,7 @@
 ./.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./.agents/skills/yo-async-effects/async-effects-recipes.md	78e6a7cccea15e5209ce4ecaef1fc6e43a2bd8e39fccb19183a055f1b177f150
+./.agents/skills/yo-async-effects/async-effects-recipes.md	74b67f0959e93ebc71e4695ee45a175a658c709dec75b15696fc5f137dd68415
 ./.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
-./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	7e56b6b15031efe5ade34352914c64dcb96b08b9f73111ac3eb1941ea015ccf7
+./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	a0992b8044f9fe58d78d5919d72a6d4cb937202ec2f909f0ea53d86187b708b1
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54


### PR DESCRIPTION
**Stacked on #513** (`std-derive-error`) — that PR adds the `derive(Error)`
rule; this one uses it everywhere. Will be retargeted to `develop` before
#513's branch is deleted.

The twelve remaining std error enums move from a hand-written `ToString` impl
plus a bare `impl(T, Error());` to a single `derive(T, Error(...))`:
`TimeoutError`, `CryptoError`, `TlsError`, `CsvError`, `EncodingError`,
`RegexError`, `IoError`, `NetError`, `UrlError`, `DateTimeError`,
`HttpParseError`, `HttpError`. `JsonError` came with the rule in #513.

239 lines deleted, 180 added.

### Every rendered message is unchanged, and that is checked, not asserted

The migration was mechanical and verified as such: each existing
`match(self, …)` was split with a balanced-paren splitter, checked arm-for-arm
against the enum's **declaration order**, and the message expression carried
across **verbatim** — including the ones that are not bare templates:

- `String.from("…")` in `IoError` / `NetError`,
- `err.to_string()` for `NetError.Io`,
- the bare `msg` passthrough for `NetError.Other`,
- `` `…`.to_string() `` where the old explicit `-> String` return type needed it.

Every payload binding in the old positional patterns already matched the
declared field name — which is what `derive(Error)` binds by — so no message
changed which field it interpolates.

Two orphaned doc comments (the `DateTimeError` and `TlsError` notes explaining
why the `Error` marker is there) moved onto the derive rather than being
deleted: the marker is still what makes `dyn()` accept them, it is just no
longer a separate line.

### Docs and agent guidance follow the code

`docs/{en-US,zh-CN}/DESIGN.md`'s `MathError` example, the two skill
cheatsheets, and a new rule in `.github/instructions/yo-design.instructions.md`
saying to reach for `derive(Error)` first and hand-write only when the render
is not one message per variant.

Editing two bundled skill files moves six cli-case tree goldens (`init*`,
`skills-install*`) — re-recorded with the in-repo binary, and the diff is only
the two files' hashes.

### Gate

| gate | result |
| --- | --- |
| `yo check ./std` with the **v0.2.29 seed** | 174/174 |
| Full suite (`./tests`, minus `internal` + `cli-cases`) | **3873 passed, 0 failed** |
| Codegen-bootstrap corpus (156 goldens) | **PASS 156, GOLDEN-DIFF 0** — includes `dyn_error_throw_ioerror`, whose golden IS the derived `IoError` message |
| CLI golden scorecard, re-run after the record | **PASS 88, GOLDEN-DIFF 0, NO-GOLDEN 0** |
| Bootstrap fixpoint | posted below |

Runtime coverage of the derived messages is not incidental: `tests/url/url.test.yo`
asserts all five `UrlError` messages verbatim, `tests/net/errors.test.yo` and
`tests/regex/regex.test.yo` assert theirs, `tests/http/http.test.yo` matches on
`HttpError`'s, and the `IoError` message is a byte-compared codegen golden.