### PR TITLE
std/url + std/encoding: fallible component setters, and error offsets that name where the fault is

### DIFF
--- a/issues/derive-body-field-name-collides-with-a-builtin-type.md
+++ b/issues/derive-body-field-name-collides-with-a-builtin-type.md
@@ -1,0 +1,67 @@
+# An enum field named after a builtin type breaks `derive(Error)` / `derive(ToString)`
+
+**Status:** open (found 2026-09-09 while adding `EncodingError.UnpairedSurrogate`).
+
+## Symptom
+
+```
+error[E0603]: derive on "Bad" failed: error[E0603]: error[E0603]: Argument count mismatch: expected 1, got 0
+```
+
+with the generated body printed underneath (that print is the #518 fix doing
+its job — before it, this failure was swallowed and surfaced as a
+green-`check`-then-`abort()` stub).
+
+## Reproducer
+
+`issues/repros/derive-field-named-after-a-builtin-type.yo`:
+
+```rust
+Bad :: enum(Surrogate(unit : u16));
+derive(Bad, Error(.Surrogate => `unit ${unit}`));
+```
+
+Renaming the field to anything that is not a type name (`cu`, `code_unit`)
+makes it compile. The field TYPE is irrelevant; the field NAME is the trigger.
+
+## Root cause
+
+`derive(Error)` (and the structural `derive(ToString)`/`derive(Debug)`) splice
+their body into the CALL SITE's scope, and that body is **unhygienic** — the
+same property already documented for the `ToString`-in-scope requirement
+(`std/error.yo`) and in
+`issues/fixed/derive-tostring-debug-body-is-unhygienic-and-aborts.md`.
+
+The generated arm is
+
+```
+.Surrogate(unit) => ("unit ".to_string)().(+)((unit.to_string)())
+```
+
+`unit` binds the field in the match pattern, but the name resolution for
+`unit.to_string` reaches the BUILTIN `unit` type first, so `to_string` is the
+type's associated function and wants its receiver as an argument — hence
+"expected 1, got 0". Any builtin type name is a candidate: `unit`, and by the
+same route `str`, `bool`, `usize`, `i32`, … used as a field name.
+
+## Why it matters beyond the field name
+
+The diagnostic points at nothing the author wrote. It names an arity, not a
+name collision, and the offending token appears only inside the
+`auto-generated://` block. A reader has no way to get from the message to
+"rename your field".
+
+## Suggested fixes, in order of preference
+
+1. **Make the derived body hygienic**: bind each payload field to a generated
+   name (`__yo_derive_f0`) and rewrite the user's `${field}` references to it
+   during splicing. This is the real fix and also closes the
+   `ToString`-must-be-imported requirement.
+2. **Reject the collision at derive time** with a message that says so:
+   `derive(Error) on Bad: field "unit" shadows the builtin type "unit" — rename
+   it`. Cheap, and strictly better than the arity error.
+3. At minimum, document the restriction where `derive_rule(Error)` is defined.
+
+## Workaround in std today
+
+`EncodingError.UnpairedSurrogate` spells the field `code_unit`, not `unit`.

--- a/issues/derive-body-field-name-collides-with-a-builtin-type.md
+++ b/issues/derive-body-field-name-collides-with-a-builtin-type.md
@@ -23,6 +23,8 @@ derive(Bad, Error(.Surrogate => `unit ${unit}`));
 
 Renaming the field to anything that is not a type name (`cu`, `code_unit`)
 makes it compile. The field TYPE is irrelevant; the field NAME is the trigger.
+It is not an `open(...)` artifact either — the reproducer uses named imports
+only and still fails.
 
 ## Root cause
 

--- a/issues/repros/derive-field-named-after-a-builtin-type.yo
+++ b/issues/repros/derive-field-named-after-a-builtin-type.yo
@@ -2,7 +2,7 @@
 // the derived body is unhygienic, so `${unit}` resolves to the `unit` TYPE
 // rather than to the bound field, and `unit.to_string()` reports
 //   Argument count mismatch: expected 1, got 0
-open(import("std/string"));
+{ String } :: import("std/string");
 { Error } :: import("std/error");
 { ToString } :: import("std/fmt");
 Bad :: enum(Surrogate(unit : u16));

--- a/issues/repros/derive-field-named-after-a-builtin-type.yo
+++ b/issues/repros/derive-field-named-after-a-builtin-type.yo
@@ -1,0 +1,15 @@
+// An enum field named after a BUILTIN TYPE breaks derive(Error)/derive(ToString):
+// the derived body is unhygienic, so `${unit}` resolves to the `unit` TYPE
+// rather than to the bound field, and `unit.to_string()` reports
+//   Argument count mismatch: expected 1, got 0
+open(import("std/string"));
+{ Error } :: import("std/error");
+{ ToString } :: import("std/fmt");
+Bad :: enum(Surrogate(unit : u16));
+derive(Bad, Error(.Surrogate => `unit ${unit}`));
+main :: (fn() -> unit)({
+  b := Bad.Surrogate(unit : u16(7));
+  s := b.to_string();
+  ()
+});
+export(main);

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -435,7 +435,7 @@ remove_entry/get_key_value` (all 5). `Deque.front`/`back`. `BTreeMap` —
 no `Iterator` on any of the six collection types (`imm/string.yo:627` has one).
 Text — every listed `String` method, `next_back`, `is_ascii_*` renames. Encoding
 — `Url.join/query_pairs/path_segments`, `JsonValue` mutation/`as_i64`/`pointer`,
-`EncodingError` offsets, regex naming, `glob()`. I/O — `OpenOptions`, `Watcher`
+regex naming, `glob()`. I/O — `OpenOptions`, `Watcher`
 `Dispose`, `SystemTime`/`UNIX_EPOCH`, `SocketAddr` `Eq`/`Hash`,
 `TcpStream.local_addr` (it is on `TcpListener`), `TcpListener.incoming`. Core — **all of it**: every `checked_/wrapping_/
 saturating_/overflowing_`, `abs/pow/clamp/count_ones/leading_zeros`, every
@@ -486,9 +486,58 @@ bytes while `FormatSpec` pads by runes; `Alignment` exported.
 **Encoding.** Verified against the code 2026-09-09 — LANDED:
 `Url.join`/`query_pairs`/`path_segments`; `JsonValue` mutation
 (`insert`/`remove`/`object()`), `is_*`/`as_i64`/`as_u64`, `pointer`, integer
-arms; TOML values; `GlobPattern` + filesystem `glob()`. STILL OPEN:
-`Url.set_*`; `EncodingError` with offsets; module-prefix stutter
-(`json_parse` → `json.parse` …). regex Rust-shaped names **LANDED 2026-09-09** —
+arms; TOML values; `GlobPattern` + filesystem `glob()`. STILL OPEN: module-prefix
+stutter (`json_parse` → `json.parse` …). `Url.set_*` and `EncodingError`
+offsets **LANDED 2026-09-09** — described below.
+
+**`Url.set_*` — LANDED 2026-09-09, and every setter is FALLIBLE.**
+
+`set_scheme`, `set_host`, `set_port`, `set_path`, `set_query`, `set_fragment`,
+`set_userinfo`. All but `set_port` return `Result(unit, UrlError)`, and that is
+not ceremony: `Url.parse` rejects any byte outside RFC 3986 §2 as a SECURITY
+boundary — a raw CRLF in a path flows through `Url.path()` into
+`HttpRequest`'s request line and splits one HTTP request into two — so a setter
+that skipped the check would be a hole straight past the parser. The offset of
+the first offending byte comes back in `UrlError.InvalidCharacter(pos)`, the
+same shape and the same convention `parse` already uses, so a caller handles
+one error whether the URL came from text or from a setter.
+
+Each setter also rejects the delimiters that would RELOCATE its component,
+and the sets differ per component because the grammar does: a `/` is legal in
+a path and a query but ends a host; a `?` is legal in a query but starts one
+inside a path; the fragment is last, so nothing can follow it and every URI
+byte is legal there. A forbidden byte does not corrupt the value — it silently
+changes what the next parse reads — which is why these reject rather than
+percent-escape: escaping would change what the caller asked for without saying
+so.
+
+Three shapes get their own guard because `to_string` would otherwise render
+something that re-parses differently: a bare IPv6 host (its colons read as a
+port, which is why RFC 3986 §3.2.2 has the brackets), a relative path while a
+host is set (`http://host` + `x` renders `http://hostx`), and a path beginning
+`//` with no host (renders `scheme://…` and re-parses as an authority).
+`set_port` is infallible because every `u16` is a legal port, including 0.
+
+**`EncodingError` offsets — LANDED 2026-09-09.** Every variant that can name a
+position now carries `pos`, plus a `pos() -> Option(usize)` accessor.
+`InvalidChar(ch, pos)`, `InvalidLastSymbol(ch, pos)`, `OddLength(len)`,
+`InvalidLength(len)`. Without the offset a caller decoding a 4 KiB blob learned
+only that one byte somewhere was wrong — not enough to report, highlight or
+skip past, and the character alone does not say WHICH occurrence of it.
+(Rust's `base64::DecodeError` carries the same offset for the same reason.)
+
+The new `UnpairedSurrogate(code_unit, pos)` replaces a wrong value, not just a
+thin one: all three surrogate faults in `utf16_to_utf8` reported
+`InvalidChar(u8(0))` — an offending character of NUL — because a UTF-16 code
+unit is 16 bits and `InvalidChar`'s `ch` is a `u8`, so the variant could not
+carry it at all. Its `pos` is an index in CODE UNITS, not bytes, because that
+is what the input is.
+
+The field is spelled `code_unit` rather than `unit` because a field named after
+a builtin type breaks the unhygienic derived body with a confusing
+`Argument count mismatch: expected 1, got 0` — filed as
+`issues/derive-body-field-name-collides-with-a-builtin-type.md` with a
+reproducer. regex Rust-shaped names **LANDED 2026-09-09** —
 `test` → `is_match`, `exec` → `find`, `match_all` → `find_all`, and the
 two-argument `new(pattern, flags)` split into a one-argument `new(pattern)`
 (what `compile` used to be, now deleted) plus `new_with_flags(pattern, flags)`,
@@ -960,9 +1009,9 @@ cooperative-scheduling contract.
    (issues/fixed/tuple-type-has-no-forward-declaration.md).
 
    Still open in Encoding: TOML floats/arrays/dates/inline tables/escapes/
-   comments/serializer, `EncodingError` offsets, regex Rust-shaped names,
-   `GlobPattern.new -> Result` + filesystem `glob()`, the module-prefix stutter,
-   and `Url.set_*`.
+   comments/serializer, and the module-prefix stutter. (regex Rust-shaped
+   names, `GlobPattern.new -> Result` + filesystem `glob()`, `Url.set_*` and
+   `EncodingError` offsets all landed 2026-09-09.)
 
    **`FromStr` renamed to `FromString` (2026-09-09).** The trait's parameter is
    a `String`, and its own doc comment said so one line above the signature —

--- a/plans/STD_API_STABILIZATION_FINDINGS.md
+++ b/plans/STD_API_STABILIZATION_FINDINGS.md
@@ -68,7 +68,7 @@ Companion to `plans/STD_API_STABILIZATION.md` (the decisions and the ranked list
 20. Two builders, three vocabularies: StringBuilder(write_*), fmt.Writer(write_* chainable + numerics), String(push_*) → one builder + trait.
 21. fmt.Writer byte-at-a-time appends (writer.yo:41,48,64); write_padded pads by BYTES (:145) vs FormatSpec by runes (spec.yo:71).
 22. StringBuilder.to_string copies byte-at-a-time (119-141) and CONSUMES (non-consuming name) → into_string + non-consuming ToString; clear:144 reallocates.
-23. EncodingError thin: utf16 throws InvalidChar(u8(0)) for unpaired surrogate (utf16.yo ~72,80,92), no offset → InvalidChar(byte, index), UnpairedSurrogate(index, unit), InvalidLength(len).
+23. ~~EncodingError thin: utf16 throws InvalidChar(u8(0)) for unpaired surrogate (utf16.yo ~72,80,92), no offset~~ **FIXED 2026-09-09**: `InvalidChar(ch, pos)`, `InvalidLastSymbol(ch, pos)`, `OddLength(len)`, `InvalidLength(len)`, new `UnpairedSurrogate(code_unit, pos)` (code-unit index, not bytes), plus a `pos() -> Option(usize)` accessor. The `u8(0)` was unrepresentable, not merely thin — a 16-bit code unit does not fit `InvalidChar.ch`.
 24. GlobPattern.new doesn't compile/validate (glob.yo:191); `[a-z]` ranges NOT implemented (133-150: literal compare); no filesystem globbing, MatchOptions, matches_path.
 
 ## P2

--- a/std/encoding/base64.yo
+++ b/std/encoding/base64.yo
@@ -64,7 +64,7 @@ export(base64_encode, base64_encode_url);
 // ============================================================================
 // Decoding
 // ============================================================================
-_decode_char_res :: (fn(c : u8, alpha : str) -> Result(u8, EncodingError))({
+_decode_char_res :: (fn(c : u8, alpha : str, pos : usize) -> Result(u8, EncodingError))({
   i := usize(0);
   while(i < usize(64), i = (i + usize(1)), {
     cond(
@@ -74,7 +74,7 @@ _decode_char_res :: (fn(c : u8, alpha : str) -> Result(u8, EncodingError))({
       true => ()
     );
   });
-  .Err(EncodingError.InvalidChar(c))
+  .Err(EncodingError.InvalidChar(ch : c, pos : pos))
 });
 _decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), EncodingError))({
   // Strip trailing padding
@@ -84,7 +84,7 @@ _decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), Encodi
   // error, not a zero byte (issues/fixed/base64-decode-accepted-impossible-lengths-and-trailing-bits.md).
   cond(
     ((len % usize(4)) == usize(1)) => {
-      return(.Err(EncodingError.InvalidLength));
+      return(.Err(EncodingError.InvalidLength(len : len)));
     },
     true => ()
   );
@@ -92,7 +92,7 @@ _decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), Encodi
   i := usize(0);
   while(i < len, i = (i + usize(4)), {
     c0 := match(
-      _decode_char_res(s.byte_at(i), alpha),
+      _decode_char_res(s.byte_at(i), alpha, i),
       .Ok(v) => v,
       .Err(e) => {
         return(.Err(e));
@@ -100,7 +100,7 @@ _decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), Encodi
     );
     c1 := cond(
       ((i + usize(1)) < len) => match(
-        _decode_char_res(s.byte_at(i + usize(1)), alpha),
+        _decode_char_res(s.byte_at(i + usize(1)), alpha, i + usize(1)),
         .Ok(v) => v,
         .Err(e) => {
           return(.Err(e));
@@ -112,7 +112,7 @@ _decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), Encodi
     cond(
       ((i + usize(2)) < len) => {
         c2 := match(
-          _decode_char_res(s.byte_at(i + usize(2)), alpha),
+          _decode_char_res(s.byte_at(i + usize(2)), alpha, i + usize(2)),
           .Ok(v) => v,
           .Err(e) => {
             return(.Err(e));
@@ -122,7 +122,7 @@ _decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), Encodi
         cond(
           ((i + usize(3)) < len) => {
             c3 := match(
-              _decode_char_res(s.byte_at(i + usize(3)), alpha),
+              _decode_char_res(s.byte_at(i + usize(3)), alpha, i + usize(3)),
               .Ok(v) => v,
               .Err(e) => {
                 return(.Err(e));
@@ -136,7 +136,7 @@ _decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), Encodi
             // encoding (Rust rejects it as InvalidLastSymbol).
             cond(
               ((c2 & u8(3)) != u8(0)) => {
-                return(.Err(EncodingError.InvalidLastSymbol(s.byte_at(i + usize(2)))));
+                return(.Err(EncodingError.InvalidLastSymbol(ch : s.byte_at(i + usize(2)), pos : (i + usize(2)))));
               },
               true => ()
             );
@@ -148,7 +148,7 @@ _decode_with_res :: (fn(s : String, alpha : str) -> Result(ArrayList(u8), Encodi
         // second must be zero.
         cond(
           ((c1 & u8(15)) != u8(0)) => {
-            return(.Err(EncodingError.InvalidLastSymbol(s.byte_at(i + usize(1)))));
+            return(.Err(EncodingError.InvalidLastSymbol(ch : s.byte_at(i + usize(1)), pos : (i + usize(1)))));
           },
           true => ()
         );

--- a/std/encoding/error.yo
+++ b/std/encoding/error.yo
@@ -7,7 +7,7 @@
 //! ```rust
 //! { EncodingError } :: import "std/encoding/error";
 //!
-//! exn.throw(dyn(EncodingError.OddLength));
+//! exn.throw(dyn(EncodingError.OddLength(len : usize(5))));
 //! ```
 import("../string");
 { Error } :: import("../error");
@@ -16,26 +16,63 @@ import("../string");
 // Error type
 // ============================================================================
 /// Encoding/decoding error type.
+///
+/// Every variant that can name a position carries `pos`, the BYTE OFFSET into
+/// the input where the fault is. Without it a caller decoding a 4 KiB blob
+/// learns only that one byte somewhere was wrong, which is not enough to
+/// report, highlight, or skip past — the character alone does not say WHICH
+/// occurrence of it (Rust's `base64::DecodeError` carries the same offset for
+/// exactly this reason).
 EncodingError :: enum(
-  /// Invalid character encountered during decoding.
-  InvalidChar(ch : u8),
-  /// Input string has odd length (hex requires even length).
-  OddLength,
+  /// Invalid character encountered during decoding, and where it was.
+  InvalidChar(ch : u8, pos : usize),
+  /// Input string has odd length (hex requires even length); `len` is the
+  /// length seen, so the caller need not re-measure.
+  OddLength(len : usize),
   /// base64 input whose length is 1 mod 4 (after padding): one sextet
   /// cannot encode a byte, so no encoder produces it.
-  InvalidLength,
+  InvalidLength(len : usize),
   /// base64 input whose final symbol carries bits that no byte can occupy
   /// (a 2-symbol group must end in one of `AQgw`, a 3-symbol group in a
   /// symbol whose low two bits are zero); Rust's `InvalidLastSymbol`.
-  InvalidLastSymbol(ch : u8)
+  InvalidLastSymbol(ch : u8, pos : usize),
+  /// A UTF-16 surrogate with no partner: a high surrogate at the end of the
+  /// input or followed by a non-low unit, or a bare low surrogate. `pos` is an
+  /// index in CODE UNITS, not bytes, because that is what the input is.
+  ///
+  /// The field is `code_unit` rather than `unit` because a field named after a
+  /// builtin type breaks the unhygienic derived body — see
+  /// issues/derive-body-field-name-collides-with-a-builtin-type.md.
+  ///
+  /// A separate variant because `InvalidChar` cannot carry it: a UTF-16 code
+  /// unit is 16 bits and `ch` is a `u8`, so the surrogate decoders were all
+  /// reporting `InvalidChar(0)` — an offending character of NUL, which is not
+  /// what was wrong and told the caller nothing.
+  UnpairedSurrogate(code_unit : u16, pos : usize)
 );
 derive(
   EncodingError,
   Error(
-    .InvalidChar => `encoding error: invalid character ${ch}`,
-    .OddLength => `encoding error: odd length`,
-    .InvalidLength => `encoding error: base64 length is 1 mod 4`,
-    .InvalidLastSymbol => `encoding error: non-canonical trailing bits in base64 symbol ${ch}`
+    .InvalidChar => `encoding error: invalid character ${ch} at offset ${pos}`,
+    .OddLength => `encoding error: odd length ${len}`,
+    .InvalidLength => `encoding error: base64 length ${len} is 1 mod 4`,
+    .InvalidLastSymbol => `encoding error: non-canonical trailing bits in base64 symbol ${ch} at offset ${pos}`,
+    .UnpairedSurrogate => `encoding error: unpaired UTF-16 surrogate ${code_unit} at code-unit index ${pos}`
+  )
+);
+impl(
+  EncodingError,
+  /// The byte offset the fault was found at, for the variants that have one.
+  /// `.None` for a whole-input length complaint, which has no single position.
+  pos : (fn(self : Self) -> Option(usize))(
+    match(
+      self,
+      .InvalidChar({ pos }) => .Some(pos),
+      .InvalidLastSymbol({ pos }) => .Some(pos),
+      .UnpairedSurrogate({ pos }) => .Some(pos),
+      .OddLength => .None,
+      .InvalidLength => .None
+    )
   )
 );
 export(EncodingError);

--- a/std/encoding/hex.yo
+++ b/std/encoding/hex.yo
@@ -39,8 +39,10 @@ export(hex_encode);
 // ============================================================================
 // Decoding
 // ============================================================================
-/// Nibble value of one hex digit, or which character was wrong (D13).
-_hex_nibble_res :: (fn(c : u8) -> Result(u8, EncodingError))(
+/// Nibble value of one hex digit, or which character was wrong AND where
+/// (D13). The offset is passed in rather than derived, because this sees one
+/// byte and the caller is the one that knows where it came from.
+_hex_nibble_res :: (fn(c : u8, pos : usize) -> Result(u8, EncodingError))(
   cond(
     ((c >= u8(48)) && (c <= u8(57))) => .Ok(c - u8(48)),
     // '0'-'9'
@@ -48,7 +50,7 @@ _hex_nibble_res :: (fn(c : u8) -> Result(u8, EncodingError))(
     // 'a'-'f'
     ((c >= u8(65)) && (c <= u8(70))) => .Ok((c - u8(65)) + u8(10)),
     // 'A'-'F'
-    true => .Err(EncodingError.InvalidChar(c))
+    true => .Err(EncodingError.InvalidChar(ch : c, pos : pos))
   )
 );
 /// Decode a hexadecimal string to bytes (D13 — a pure transform returns a
@@ -56,7 +58,7 @@ _hex_nibble_res :: (fn(c : u8) -> Result(u8, EncodingError))(
 hex_decode :: (fn(s : String) -> Result(ArrayList(u8), EncodingError))({
   cond(
     ((s.len() % usize(2)) != usize(0)) => {
-      return(.Err(EncodingError.OddLength));
+      return(.Err(EncodingError.OddLength(len : s.len())));
     },
     true => ()
   );
@@ -64,14 +66,14 @@ hex_decode :: (fn(s : String) -> Result(ArrayList(u8), EncodingError))({
   i := usize(0);
   while(i < s.len(), i = (i + usize(2)), {
     hi := match(
-      _hex_nibble_res(s.byte_at(i)),
+      _hex_nibble_res(s.byte_at(i), i),
       .Ok(v) => v,
       .Err(e) => {
         return(.Err(e));
       }
     );
     lo := match(
-      _hex_nibble_res(s.byte_at(i + usize(1))),
+      _hex_nibble_res(s.byte_at(i + usize(1)), i + usize(1)),
       .Ok(v) => v,
       .Err(e) => {
         return(.Err(e));

--- a/std/encoding/utf16.yo
+++ b/std/encoding/utf16.yo
@@ -53,7 +53,10 @@ export(utf8_to_utf16);
 /// returns a `Result`; `utf16_to_utf8_exn` is the effect-carrying wrapper).
 ///
 /// Decodes surrogate pairs back into supplementary code points.
-/// `.Err(EncodingError.InvalidChar)` on an unpaired surrogate.
+/// `.Err(EncodingError.UnpairedSurrogate)` on an unpaired surrogate, carrying
+/// the offending code unit and its index — it used to report
+/// `InvalidChar(u8(0))`, an offending character of NUL, because a 16-bit code
+/// unit does not fit in `InvalidChar`'s `u8`.
 utf16_to_utf8 :: (fn(data : ArrayList(u16)) -> Result(String, EncodingError))({
   out := ArrayList(u8).new();
   i := usize(0);
@@ -64,14 +67,15 @@ utf16_to_utf8 :: (fn(data : ArrayList(u16)) -> Result(String, EncodingError))({
       ((w >= u32(0xD800)) && (w <= u32(0xDBFF))) => {
         cond(
           ((i + usize(1)) >= data.len()) => {
-            return(.Err(EncodingError.InvalidChar(u8(0))));
+            return(.Err(EncodingError.UnpairedSurrogate(code_unit : u16(w), pos : i)));
           },
           true => ()
         );
         w2 := u32(data(i + usize(1)));
         cond(
           ((w2 < u32(0xDC00)) || (w2 > u32(0xDFFF))) => {
-            return(.Err(EncodingError.InvalidChar(u8(0))));
+            // The HIGH surrogate is the one at fault: it promised a partner.
+            return(.Err(EncodingError.UnpairedSurrogate(code_unit : u16(w), pos : i)));
           },
           true => ()
         );
@@ -84,7 +88,7 @@ utf16_to_utf8 :: (fn(data : ArrayList(u16)) -> Result(String, EncodingError))({
       // 3-byte CESU-8 sequence — invalid UTF-8 — despite this function's
       // documented "rejects unpaired surrogates" contract.
       ((w >= u32(0xDC00)) && (w <= u32(0xDFFF))) => {
-        return(.Err(EncodingError.InvalidChar(u8(0))));
+        return(.Err(EncodingError.UnpairedSurrogate(code_unit : u16(w), pos : i)));
       },
       true => {
         // A BMP scalar: nothing is ever substituted here.

--- a/std/url/index.yo
+++ b/std/url/index.yo
@@ -490,6 +490,153 @@ impl(
   userinfo : (fn(self : Self) -> Option(String))(
     self._userinfo
   ),
+  // --- Setters (RFC 3986 component replacement) ---
+  //
+  // Every setter VALIDATES and returns `Result(unit, UrlError)`. That is not
+  // ceremony: `Url.parse` rejects any byte outside RFC 3986 §2 as a SECURITY
+  // boundary — a raw CRLF in a path flows through `Url.path()` into
+  // `HttpRequest`'s request line and splits one HTTP request into two — and a
+  // setter that skipped the check would be a hole straight past the parser.
+  // Each also rejects the delimiters that would relocate the component: a `?`
+  // written into a path silently becomes a query on the next parse.
+  /// Replace the scheme. Must be `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`.
+  set_scheme : (fn(self : Self, scheme : String) -> Result(unit, UrlError))(
+    cond(
+      !_is_scheme(scheme) => .Err(UrlError.Other(`invalid scheme: ${scheme}`)),
+      true => {
+        self._scheme = scheme;
+        .Ok(())
+      }
+    )
+  ),
+  /// Replace the host, or remove it with `.None`.
+  ///
+  /// An IPv6 literal must be bracketed (`[::1]`) — that is how RFC 3986 §3.2.2
+  /// keeps the host's colons apart from the port's. `/`, `?`, `#` and `@` are
+  /// rejected because each of them ENDS the host in the grammar, so accepting
+  /// one would mean the next parse read a different URL than the one built.
+  ///
+  /// The `.None` case removes the whole authority, so a following `to_string`
+  /// renders the opaque `scheme:path` form.
+  set_host : (fn(self : Self, host : Option(String)) -> Result(unit, UrlError))(
+    match(
+      host,
+      .None => {
+        self._host = Option(String).None;
+        .Ok(())
+      },
+      .Some(h) =>
+        match(
+          _validate_component(h, `host`, `/?#@`),
+          .Err(e) => .Err(e),
+          .Ok(_) =>
+            cond(
+              h.is_empty() => .Err(UrlError.Other(`host may not be empty — use .None to remove it`)),
+              // A bare V6 literal has colons that would read as a port.
+              (h.contains(`:`) && !(h.starts_with(`[`) && h.ends_with(`]`))) =>
+                .Err(UrlError.Other(`an IPv6 host must be bracketed, as in [::1]`)),
+              true => {
+                self._host = Option(String).Some(h);
+                .Ok(())
+              }
+            )
+        )
+    )
+  ),
+  /// Replace the port, or remove it with `.None`. Infallible: every `u16` is a
+  /// legal port, including 0.
+  set_port : (fn(self : Self, port : Option(u16)) -> unit)({
+    self._port = port;
+  }),
+  /// Replace the path.
+  ///
+  /// With a host present the path must be empty or start with `/`, because
+  /// `to_string` writes `scheme://host` immediately followed by the path —
+  /// a path of `x` would render `http://hostx`. With NO host the path must not
+  /// start with `//`, which would render `scheme://...` and re-parse as an
+  /// authority: a different URL than the one built.
+  set_path : (fn(self : Self, path : String) -> Result(unit, UrlError))(
+    match(
+      _validate_component(path, `path`, `?#`),
+      .Err(e) => .Err(e),
+      .Ok(_) =>
+        cond(
+          (self._host.is_some() && (!path.is_empty() && !path.starts_with(`/`))) =>
+            .Err(UrlError.Other(`a path must start with '/' when a host is present`)),
+          (self._host.is_none() && path.starts_with(`//`)) =>
+            .Err(UrlError.Other(`a path may not start with '//' when there is no host`)),
+          true => {
+            self._path = path;
+            .Ok(())
+          }
+        )
+    )
+  ),
+  /// Replace the query (WITHOUT the leading `?`), or remove it with `.None`.
+  set_query : (fn(self : Self, query : Option(String)) -> Result(unit, UrlError))(
+    match(
+      query,
+      .None => {
+        self._query = Option(String).None;
+        .Ok(())
+      },
+      .Some(q) =>
+        match(
+          _validate_component(q, `query`, `#`),
+          .Err(e) => .Err(e),
+          .Ok(_) => {
+            self._query = Option(String).Some(q);
+            .Ok(())
+          }
+        )
+    )
+  ),
+  /// Replace the fragment (WITHOUT the leading `#`), or remove it with
+  /// `.None`. The fragment is LAST in the grammar, so nothing can follow it and
+  /// there is no delimiter to guard — every URI byte is legal here, including
+  /// `/`, `?` and `#`.
+  set_fragment : (fn(self : Self, fragment : Option(String)) -> Result(unit, UrlError))(
+    match(
+      fragment,
+      .None => {
+        self._fragment = Option(String).None;
+        .Ok(())
+      },
+      .Some(f) =>
+        match(
+          _validate_component(f, `fragment`, ``),
+          .Err(e) => .Err(e),
+          .Ok(_) => {
+            self._fragment = Option(String).Some(f);
+            .Ok(())
+          }
+        )
+    )
+  ),
+  /// Replace the userinfo (WITHOUT the trailing `@`), or remove it with
+  /// `.None`.
+  ///
+  /// A `@` inside userinfo is rejected: the authority splits at the LAST `@`,
+  /// so `set_userinfo("a@b")` on `//host` would re-parse with userinfo `a` and
+  /// host `b` — the classic credential-confusion shape.
+  set_userinfo : (fn(self : Self, userinfo : Option(String)) -> Result(unit, UrlError))(
+    match(
+      userinfo,
+      .None => {
+        self._userinfo = Option(String).None;
+        .Ok(())
+      },
+      .Some(u) =>
+        match(
+          _validate_component(u, `userinfo`, `/?#@`),
+          .Err(e) => .Err(e),
+          .Ok(_) => {
+            self._userinfo = Option(String).Some(u);
+            .Ok(())
+          }
+        )
+    )
+  ),
   // Returns the host:port as a String, or just host if no port
   host_port : (fn(self : Self) -> Option(String))(
     match(
@@ -552,6 +699,49 @@ _UrlRef :: struct(
   query : Option(String),
   fragment : Option(String)
 );
+/// Check every byte of a component against RFC 3986 §2, reporting the byte
+/// OFFSET of the first offender in `UrlError.InvalidCharacter` — the same
+/// error and the same offset convention `Url.parse` uses, so a caller handles
+/// one shape whether the URL came from text or from a setter.
+///
+/// `forbidden` additionally rejects the bytes that END this component in the
+/// grammar. They differ per component and getting them wrong is the whole
+/// point: a `/` is legal in a path and a query but ends a host; a `?` is legal
+/// in a query but starts one inside a path. A forbidden byte does not corrupt
+/// the value, it silently RELOCATES it on the next parse — which is why this
+/// rejects rather than escapes: escaping would change what the caller asked
+/// for, without saying so.
+_validate_component :: (
+  fn(s : String, what : String, forbidden : String) -> Result(unit, UrlError)
+)({
+  forbidden_b := forbidden.as_bytes();
+  (i : usize) = usize(0);
+  while(runtime(i < s.len()), {
+    b := s.byte_at(i);
+    cond(
+      !_is_uri_byte(b) => {
+        return(Result(unit, UrlError).Err(UrlError.InvalidCharacter(pos : i)));
+      },
+      true => ()
+    );
+    (j : usize) = usize(0);
+    while(runtime(j < forbidden_b.len()), {
+      cond(
+        (forbidden_b(j) == b) => {
+          return(
+            Result(unit, UrlError).Err(
+              UrlError.Other(`byte ${b} at offset ${i} ends a ${what} in the RFC 3986 grammar — percent-encode it`)
+            )
+          );
+        },
+        true => ()
+      );
+      j = (j + usize(1));
+    });
+    i = (i + usize(1));
+  });
+  Result(unit, UrlError).Ok(())
+});
 /// Is `s` a valid RFC 3986 scheme — `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`?
 /// Needed because `foo:bar` is an absolute URI while `foo bar:baz` and
 /// `1a:b` are not, and a relative path may legally contain a colon after the

--- a/tests/encoding/base64.test.yo
+++ b/tests/encoding/base64.test.yo
@@ -153,7 +153,7 @@ test("whitespace inside base64 text is rejected, like any other non-alphabet byt
     match(
       base64_decode(String.from("Zm9v YmFy")),
       .Ok(_) => false,
-      .Err(e) => match(e, .InvalidLength => true, _ => false)
+      .Err(e) => match(e, .InvalidLength({ len }) => (len == usize(9)), _ => false)
     ),
     "a 9-symbol input is InvalidLength, whatever else is wrong with it"
   );
@@ -163,7 +163,7 @@ test("whitespace inside base64 text is rejected, like any other non-alphabet byt
     match(
       base64_decode(String.from("Zm9v YmFyIQ==")),
       .Ok(_) => false,
-      .Err(e) => match(e, .InvalidChar(c) => (c == u8(32)), _ => false)
+      .Err(e) => match(e, .InvalidChar({ ch }) => (ch == u8(32)), _ => false)
     ),
     "the space is reported as InvalidChar(0x20)"
   );
@@ -215,4 +215,59 @@ test("base64_decode still accepts the canonical short groups, padded or not", {
   assert((c.len() == usize(2)) && ((c(usize(0)) == u8(65)) && (c(usize(1)) == u8(66))), "QUI= is AB");
   d := base64_decode(String.from("QUI")).unwrap();
   assert(d.len() == usize(2), "QUI is AB without padding");
+});
+// ===== Offsets =====
+test("base64_decode reports WHERE the bad symbol was", {
+  // "Zm9v YmFyIQ==" strips to 11 symbols, so the scan runs; the space is at
+  // index 4 of the input.
+  assert(
+    match(
+      base64_decode(String.from("Zm9v YmFyIQ==")),
+      .Ok(_) => false,
+      .Err(e) => match(e, .InvalidChar({ ch, pos }) => ((ch == u8(32)) && (pos == usize(4))), _ => false)
+    ),
+    "the offending symbol and its offset"
+  );
+  // A bad symbol in each of the four positions of a group reports its own
+  // index — each is decoded separately and passes its own position.
+  assert(
+    match(
+      base64_decode(String.from("Zm9vYm!yIQ==")),
+      .Ok(_) => false,
+      .Err(e) => match(e, .InvalidChar({ pos }) => (pos == usize(6)), _ => false)
+    ),
+    "third symbol of the second group"
+  );
+  // InvalidLastSymbol carries the offset of the symbol whose bits are wrong.
+  // "QR==" strips to "QR": R's low four bits are 0001, which no byte can
+  // occupy, and R is at index 1.
+  assert(
+    match(
+      base64_decode(String.from("QR==")),
+      .Ok(_) => false,
+      .Err(e) => match(e, .InvalidLastSymbol({ ch, pos }) => ((ch == u8(82)) && (pos == usize(1))), _ => false)
+    ),
+    "the two-symbol group's trailing symbol and its offset"
+  );
+  // "QUJ=" strips to "QUJ": J's low two bits are 01, and J is at index 2.
+  assert(
+    match(
+      base64_decode(String.from("QUJ=")),
+      .Ok(_) => false,
+      .Err(e) => match(e, .InvalidLastSymbol({ ch, pos }) => ((ch == u8(74)) && (pos == usize(2))), _ => false)
+    ),
+    "the three-symbol group's trailing symbol and its offset"
+  );
+  // InvalidLength is a whole-input complaint, so pos() is .None while the
+  // variant still carries the length that was wrong.
+  assert(
+    match(
+      base64_decode(String.from("Zm9v YmFy")),
+      .Ok(_) => false,
+      .Err(e) => (
+        e.pos().is_none() && match(e, .InvalidLength({ len }) => (len == usize(9)), _ => false)
+      )
+    ),
+    "a length complaint has no position but does carry the length"
+  );
 });

--- a/tests/encoding/hex.test.yo
+++ b/tests/encoding/hex.test.yo
@@ -65,15 +65,15 @@ test("hex_decode reports WHICH error (D13)", {
     match(
       hex_decode(`abc`),
       .Ok(_) => false,
-      .Err(e) => match(e, .OddLength => true, _ => false)
+      .Err(e) => match(e, .OddLength({ len }) => (len == usize(3)), _ => false)
     ),
-    "odd length is OddLength"
+    "odd length is OddLength carrying the length seen"
   );
   assert(
     match(
       hex_decode(`xxyz`),
       .Ok(_) => false,
-      .Err(e) => match(e, .InvalidChar(c) => (c == u8(120)), _ => false)
+      .Err(e) => match(e, .InvalidChar({ ch }) => (ch == u8(120)), _ => false)
     ),
     "a bad digit is InvalidChar carrying the offending byte 'x'"
   );
@@ -105,4 +105,37 @@ test("hex roundtrip", {
   assert(decoded(usize(2)) == u8(0x6C), "roundtrip byte 2");
   assert(decoded(usize(3)) == u8(0x6C), "roundtrip byte 3");
   assert(decoded(usize(4)) == u8(0x6F), "roundtrip byte 4");
+});
+test("hex_decode reports WHERE the bad digit was", {
+  // The offset is the point of the change: without it a caller decoding a
+  // 4 KiB blob learns only that one byte somewhere was wrong, which is not
+  // enough to report, highlight, or skip past.
+  assert(
+    match(
+      hex_decode(`00ff2g11`),
+      .Ok(_) => false,
+      // The 'g' is the 6th byte of the input, index 5.
+      .Err(e) => match(e, .InvalidChar({ ch, pos }) => ((ch == u8(103)) && (pos == usize(5))), _ => false)
+    ),
+    "the offending byte and its offset"
+  );
+  // A bad digit in the HIGH nibble of a pair reports its own index, not the
+  // pair's — the two nibbles are read separately and each passes its position.
+  assert(
+    match(
+      hex_decode(`00zf`),
+      .Ok(_) => false,
+      .Err(e) => match(e, .InvalidChar({ pos }) => (pos == usize(2)), _ => false)
+    ),
+    "a high-nibble fault reports its own index"
+  );
+  // And `pos()` gives it without matching, for the variants that have one.
+  assert(
+    match(hex_decode(`0z`), .Ok(_) => false, .Err(e) => (e.pos().unwrap() == usize(1))),
+    "EncodingError.pos() reads the offset"
+  );
+  assert(
+    match(hex_decode(`abc`), .Ok(_) => false, .Err(e) => e.pos().is_none()),
+    "a whole-input length complaint has no single position"
+  );
 });

--- a/tests/encoding/utf16.test.yo
+++ b/tests/encoding/utf16.test.yo
@@ -4,7 +4,7 @@
 { ArrayList } :: import("std/collections/array_list");
 { Error, AnyError, Exception } :: import("std/error");
 { EncodingError } :: import("std/encoding/error");
-open(import("std/fmt"));
+{ eprintln } :: import("std/fmt");
 // Helper: build a str from raw bytes via ArrayList(u8) -> String -> as_str()
 // Since Yo doesn't support \x escapes in string literals, we construct
 // multi-byte UTF-8 strings from bytes.

--- a/tests/encoding/utf16.test.yo
+++ b/tests/encoding/utf16.test.yo
@@ -3,6 +3,8 @@
 { utf8_to_utf16, utf16_to_utf8, utf16_to_utf8_exn } :: import("std/encoding/utf16");
 { ArrayList } :: import("std/collections/array_list");
 { Error, AnyError, Exception } :: import("std/error");
+{ EncodingError } :: import("std/encoding/error");
+open(import("std/fmt"));
 // Helper: build a str from raw bytes via ArrayList(u8) -> String -> as_str()
 // Since Yo doesn't support \x escapes in string literals, we construct
 // multi-byte UTF-8 strings from bytes.
@@ -156,4 +158,78 @@ test("utf16_to_utf8_exn still throws for callers inside an effect scope", {
 });
 test("utf16_to_utf8 rejects an unpaired low surrogate", {
   assert(_lone_low_surrogate_rejected(), "an unpaired low surrogate should throw");
+});
+// ============================================================================
+// UnpairedSurrogate carries the code unit and its index
+// ============================================================================
+test("utf16_to_utf8 names the unpaired surrogate and where it was", {
+  // Every one of these used to report `InvalidChar(u8(0))` — an offending
+  // character of NUL, which is not what was wrong and told the caller
+  // nothing. A UTF-16 code unit is 16 bits and InvalidChar's `ch` is a u8, so
+  // the variant could not carry it at all.
+  //
+  // A high surrogate at the END of the input: it promised a partner.
+  data := ArrayList(u16).new();
+  data.push(u16(65)); // 'A'
+  data.push(u16(0xD83D));
+  assert(
+    match(
+      utf16_to_utf8(data),
+      .Ok(_) => false,
+      .Err(e) =>
+        match(
+          e,
+          .UnpairedSurrogate({ code_unit, pos }) => ((code_unit == u16(0xD83D)) && (pos == usize(1))),
+          _ => false
+        )
+    ),
+    "a trailing high surrogate is named, at index 1"
+  );
+  // A high surrogate followed by something that is not a low surrogate. The
+  // HIGH one is at fault, so it is the one reported.
+  d2 := ArrayList(u16).new();
+  d2.push(u16(0xD83D));
+  d2.push(u16(65)); // 'A', not a low surrogate
+  assert(
+    match(
+      utf16_to_utf8(d2),
+      .Ok(_) => false,
+      .Err(e) =>
+        match(
+          e,
+          .UnpairedSurrogate({ code_unit, pos }) => ((code_unit == u16(0xD83D)) && (pos == usize(0))),
+          _ => false
+        )
+    ),
+    "a high surrogate with the wrong partner is named, at index 0"
+  );
+  // A bare LOW surrogate.
+  d3 := ArrayList(u16).new();
+  d3.push(u16(65));
+  d3.push(u16(66));
+  d3.push(u16(0xDE00));
+  assert(
+    match(
+      utf16_to_utf8(d3),
+      .Ok(_) => false,
+      .Err(e) =>
+        match(
+          e,
+          .UnpairedSurrogate({ code_unit, pos }) => ((code_unit == u16(0xDE00)) && (pos == usize(2))),
+          _ => false
+        )
+    ),
+    "a bare low surrogate is named, at index 2"
+  );
+  // `pos()` reads it without matching. The index is in CODE UNITS, not bytes,
+  // because that is what the input is.
+  assert(
+    match(utf16_to_utf8(d3), .Ok(_) => false, .Err(e) => (e.pos().unwrap() == usize(2))),
+    "pos() gives the code-unit index"
+  );
+  // And a valid pair still decodes, so the guard has not become too eager.
+  ok := ArrayList(u16).new();
+  ok.push(u16(0xD83D));
+  ok.push(u16(0xDE00));
+  assert(utf16_to_utf8(ok).is_ok(), "a real surrogate pair still decodes");
 });

--- a/tests/url/url.test.yo
+++ b/tests/url/url.test.yo
@@ -375,3 +375,117 @@ test("Url.path_segments splits the path and is None without an authority", {
   // `mailto:` has an opaque path, not a /-separated hierarchy.
   assert(Url.parse(`mailto:a@b.com`).unwrap().path_segments().is_none(), "a URL that cannot be a base has no segments");
 });
+// ============================================================================
+// Setters
+// ============================================================================
+test("Url setters replace each component and round-trip through to_string", {
+  u := Url.parse(String.from("http://example.com/a?x=1#f")).unwrap();
+  assert(u.set_scheme(`https`).is_ok(), "scheme replaced");
+  assert(u.set_host(Option(String).Some(`other.example`)).is_ok(), "host replaced");
+  u.set_port(Option(u16).Some(u16(8443)));
+  assert(u.set_path(`/b/c`).is_ok(), "path replaced");
+  assert(u.set_query(Option(String).Some(`y=2`)).is_ok(), "query replaced");
+  assert(u.set_fragment(Option(String).Some(`g`)).is_ok(), "fragment replaced");
+  assert(u.to_string() == `https://other.example:8443/b/c?y=2#g`, `rendered ${u.to_string()}`);
+  // And it re-parses to the same thing, which is the property that matters.
+  again := Url.parse(u.to_string()).unwrap();
+  assert(again.scheme() == `https`, "scheme survives the round-trip");
+  assert(again.port().unwrap() == u16(8443), "port survives");
+  assert(again.path() == `/b/c`, "path survives");
+  assert(again.query().unwrap() == `y=2`, "query survives");
+  assert(again.fragment().unwrap() == `g`, "fragment survives");
+});
+test("Url setters remove optional components with .None", {
+  u := Url.parse(String.from("http://user@example.com:99/a?x=1#f")).unwrap();
+  assert(u.set_query(Option(String).None).is_ok(), "query removed");
+  assert(u.set_fragment(Option(String).None).is_ok(), "fragment removed");
+  assert(u.set_userinfo(Option(String).None).is_ok(), "userinfo removed");
+  u.set_port(Option(u16).None);
+  assert(u.to_string() == `http://example.com/a`, `rendered ${u.to_string()}`);
+  assert(u.query().is_none(), "query is gone");
+  // Dropping the host renders the opaque scheme:path form.
+  assert(u.set_host(Option(String).None).is_ok(), "host removed");
+  assert(u.to_string() == `http:/a`, `opaque form: ${u.to_string()}`);
+});
+test("Url.set_port takes every u16 including 0", {
+  u := Url.parse(String.from("http://example.com/")).unwrap();
+  u.set_port(Option(u16).Some(u16(0)));
+  assert(u.to_string() == `http://example.com:0/`, `port 0: ${u.to_string()}`);
+  u.set_port(Option(u16).Some(u16(65535)));
+  assert(u.port().unwrap() == u16(65535), "the top port");
+});
+test("Url setters reject a raw CRLF — the request-splitting vector", {
+  // This is the whole reason the setters validate. A raw CRLF in a path flows
+  // through Url.path() into HttpRequest's request line and splits one request
+  // into two; Url.parse has always rejected it, and a setter that did not
+  // would be a hole straight past the parser.
+  u := Url.parse(String.from("http://example.com/a")).unwrap();
+  crlf := `/a\r\nX-Injected: 1`;
+  match(
+    u.set_path(crlf),
+    .Ok(_) => assert(false, "a raw CRLF must be rejected"),
+    .Err(e) =>
+      match(
+        e,
+        .InvalidCharacter(pos) => assert(pos == usize(2), `the offset names the CR, got ${pos}`),
+        _ => assert(false, "expected InvalidCharacter")
+      )
+  );
+  assert(u.path() == `/a`, "and the path is unchanged after a rejected set");
+  // A raw space, a control byte and a non-ASCII byte are all rejected too.
+  assert(u.set_path(`/a b`).is_err(), "a raw space is not a URI byte");
+  assert(u.set_query(Option(String).Some(`a=\t`)).is_err(), "a tab is not either");
+  assert(u.set_fragment(Option(String).Some(`é`)).is_err(), "nor a raw UTF-8 byte");
+});
+test("Url setters reject the delimiters that would relocate the component", {
+  u := Url.parse(String.from("http://example.com/a")).unwrap();
+  // A `?` inside a path silently becomes a query on the next parse.
+  assert(u.set_path(`/a?x=1`).is_err(), "a ? ends a path");
+  assert(u.set_path(`/a#f`).is_err(), "and so does a #");
+  // A `#` inside a query starts a fragment.
+  assert(u.set_query(Option(String).Some(`x=1#f`)).is_err(), "a # ends a query");
+  // But a `/` and a `?` are LEGAL in a query, and everything is legal in a
+  // fragment — nothing follows it in the grammar.
+  assert(u.set_query(Option(String).Some(`a=/b?c`)).is_ok(), "/ and ? are legal in a query");
+  assert(u.set_fragment(Option(String).Some(`a/b?c#d`)).is_ok(), "a fragment has no delimiter to guard");
+  // A `/` is legal in a path (it is the separator) but ends a host.
+  assert(u.set_path(`/a/b/c`).is_ok(), "/ is a path separator");
+  assert(u.set_host(Option(String).Some(`a.example/x`)).is_err(), "a / ends a host");
+  assert(u.set_host(Option(String).Some(`a.example@b`)).is_err(), "an @ ends a host");
+  // The credential-confusion shape: the authority splits at the LAST @.
+  assert(u.set_userinfo(Option(String).Some(`a@b`)).is_err(), "an @ in userinfo is rejected");
+  assert(u.set_userinfo(Option(String).Some(`user:pw`)).is_ok(), "but a colon is fine");
+});
+test("Url.set_host requires brackets for an IPv6 literal", {
+  u := Url.parse(String.from("http://example.com/")).unwrap();
+  assert(u.set_host(Option(String).Some(`[::1]`)).is_ok(), "bracketed V6 accepted");
+  assert(u.to_string() == `http://[::1]/`, `rendered ${u.to_string()}`);
+  // A bare V6 literal's colons would read as a port on the next parse.
+  assert(u.set_host(Option(String).Some(`::1`)).is_err(), "bare V6 rejected");
+  assert(u.set_host(Option(String).Some(`2001:db8::1`)).is_err(), "and a longer one");
+  assert(u.set_host(Option(String).Some(``)).is_err(), "an empty host is .None, not ''");
+});
+test("Url.set_path guards the shapes to_string would render ambiguously", {
+  // With a host, `to_string` writes scheme://host immediately followed by the
+  // path — a path of `x` would render `http://hostx`.
+  u := Url.parse(String.from("http://example.com/a")).unwrap();
+  assert(u.set_path(`x`).is_err(), "a relative path with a host is rejected");
+  assert(u.set_path(``).is_ok(), "but an empty path is fine");
+  assert(u.to_string() == `http://example.com`, `rendered ${u.to_string()}`);
+  // With NO host, a path starting with `//` would render scheme://... and
+  // re-parse as an authority: a different URL than the one built.
+  o := Url.parse(String.from("mailto:user@example.com")).unwrap();
+  assert(o.host().is_none(), "an opaque URI has no host");
+  assert(o.set_path(`//evil.example/x`).is_err(), "// with no host is rejected");
+  assert(o.set_path(`/ok`).is_ok(), "a single slash is fine");
+});
+test("Url.set_scheme takes only an RFC 3986 scheme", {
+  u := Url.parse(String.from("http://example.com/")).unwrap();
+  assert(u.set_scheme(`https`).is_ok(), "letters");
+  assert(u.set_scheme(`x-y.z+1`).is_ok(), "letters, digits, - . + after the first byte");
+  assert(u.set_scheme(`1http`).is_err(), "a scheme must start with a letter");
+  assert(u.set_scheme(``).is_err(), "and must not be empty");
+  assert(u.set_scheme(`ht tp`).is_err(), "no space");
+  assert(u.set_scheme(`ht:tp`).is_err(), "no colon");
+  assert(u.scheme() == `x-y.z+1`, "the last successful set stands");
+});


### PR DESCRIPTION
Closes the Encoding row's `Url.set_*` and `EncodingError` offsets
(`STD_API_STABILIZATION_FINDINGS.md` row 23).

## `Url.set_*` — every setter is FALLIBLE, and that is the point

`set_scheme`, `set_host`, `set_port`, `set_path`, `set_query`, `set_fragment`,
`set_userinfo`. All but `set_port` return `Result(unit, UrlError)`.

`Url.parse` rejects any byte outside RFC 3986 §2 as a **security boundary** — a
raw CRLF in a path flows through `Url.path()` into `HttpRequest`'s request line
and splits one HTTP request into two — so a setter that skipped the check would
be a hole straight past the parser. The offset of the first offending byte
comes back in `UrlError.InvalidCharacter(pos)`: the same shape and the same
convention `parse` uses, so a caller handles **one** error whether the URL came
from text or from a setter.

Each setter also rejects the delimiters that would **relocate** its component,
and the sets differ per component because the grammar does: a `/` is legal in a
path and a query but ends a host; a `?` is legal in a query but starts one
inside a path; the fragment is last, so nothing can follow it and every URI
byte is legal there. These reject rather than percent-escape — a forbidden byte
does not corrupt the value, it silently changes what the next parse reads, and
escaping would change what the caller asked for without saying so.

Three shapes get their own guard because `to_string` would otherwise render
something that re-parses differently:

- **a bare IPv6 host** — its colons read as a port, which is why RFC 3986
  §3.2.2 has the brackets;
- **a relative path while a host is set** — `http://host` + `x` renders
  `http://hostx`;
- **a path beginning `//` with no host** — renders `scheme://…` and re-parses
  as an authority.

`set_port` is infallible: every `u16` is a legal port, including 0.

## `EncodingError` offsets

Every variant that can name a position carries `pos`, plus a
`pos() -> Option(usize)` accessor: `InvalidChar(ch, pos)`,
`InvalidLastSymbol(ch, pos)`, `OddLength(len)`, `InvalidLength(len)`.

Without the offset a caller decoding a 4 KiB blob learned only that one byte
somewhere was wrong — not enough to report, highlight or skip past, and the
character alone does not say *which* occurrence of it. Rust's
`base64::DecodeError` carries the same offset for the same reason.

## `UnpairedSurrogate` replaces a WRONG value, not just a thin one

All three surrogate faults in `utf16_to_utf8` reported `InvalidChar(u8(0))` —
an offending character of **NUL** — because a UTF-16 code unit is 16 bits and
`InvalidChar`'s `ch` is a `u8`, so the variant could not carry it at all. The
new `UnpairedSurrogate(code_unit, pos)` can. Its `pos` is an index in **code
units**, not bytes, because that is what the input is. Where a high surrogate
has the wrong partner, the *high* one is reported: it is the unit that promised
a partner.

## A compiler bug found on the way — filed, not worked around

The field is spelled `code_unit` rather than `unit` because **a field named
after a builtin type breaks the unhygienic derived body**:

```
error[E0603]: derive on "Bad" failed: error[E0603]: Argument count mismatch: expected 1, got 0
```

`unit` binds in the match pattern, but resolution for `unit.to_string` reaches
the **builtin `unit` type** first, so `to_string` is the type's associated
function and wants its receiver as an argument. The diagnostic names an arity,
not a name collision, and the offending token appears only inside the
`auto-generated://` block — a reader cannot get from the message to "rename
your field".

Write-up and reproducer in
`issues/derive-body-field-name-collides-with-a-builtin-type.md` and
`issues/repros/derive-field-named-after-a-builtin-type.yo`, with the hygienic
fix and a cheaper reject-at-derive-time alternative both spelled out. The
reproducer uses named imports only, so the collision is not an `open(...)`
artifact. That the failure is visible at all is #518's doing — it used to be
swallowed into a green `check` and an `abort()` stub.

## Coverage

| file | result |
| --- | --- |
| `tests/url/url.test.yo` | **42/42** (+8) |
| `tests/encoding/hex.test.yo` | **10/10** (+1) |
| `tests/encoding/base64.test.yo` | **21/21** (+1) |
| `tests/encoding/utf16.test.yo` | **15/15** (+1) |

The URL tests cover every component set and removed, a to_string/parse
round-trip, port 0 and 65535, the CRLF vector with its asserted offset, the
per-component delimiter sets both ways, the bracketed and bare IPv6 hosts, the
two ambiguous-render path shapes, and the scheme grammar. The base64 test
covers all four positions of a group and both `InvalidLastSymbol` shapes; the
utf16 test covers all three surrogate faults.

## Local gate (all green)

| gate | result |
| --- | --- |
| `yo build` with `YO_STD=<worktree>/std` | rc=0 |
| full suite (`tests`, minus `internal`/`cli-cases`) | **3910 passed, 0 failed** (incl. the `tests/dyn` canary) |
| CLI golden scorecard | PASS **90**, GOLDEN-DIFF 0, NO-GOLDEN 0, SKIP 1 |
| `gates_fast.sh` (7 gates) | rc=0 — `check ./std` **173/173**, `check ./src` **271/271**, corpus PASS 156 |
| `fixpoint_only.sh` | **FIXPOINT_HOLDS**, stage2 hollow=0 |

Note: `yo test` here was run with a **tree-built** compiler, not the seed —
v0.2.29 predates the tuple forward-declaration fix (#507) and cannot compile
`ArrayList(Tuple(..))` behind a pointer, which `Url.query_pairs` returns.

Conflicts with #522/#524 in `plans/STD_API_STABILIZATION.md` only (each appends
to a neighbouring paragraph); resolved by keeping every hunk at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)