### PR TITLE
codegen/match: hoist self-referential pattern-binding initializers (C11 6.2.1p4)

### DIFF
--- a/issues/match-binding-shadows-scrutinee-self-referential-initializer.md
+++ b/issues/match-binding-shadows-scrutinee-self-referential-initializer.md
@@ -1,0 +1,105 @@
+# Match-arm binding shadowing the scrutinee emits a self-referential C initializer (UB)
+
+- **Status**: open (fix implemented, see below)
+- **Found**: 2026-09-09, during V3 of `plans/backlog/FORMAL_VERIFICATION.md` (match/datatype encoding)
+- **Severity**: high — undefined behavior in generated C; nondeterministic garbage pointers, premature frees, rc=139 SIGSEGV
+- **Surface**: any Yo `match` whose arm pattern binds a name that is also the scrutinee's name (or, generally, any name referenced by the binding's initializer)
+
+## Reproducer
+
+```rust
+V :: ref(
+  enum(
+    Leaf(v : i32),
+    Node(name : String, t : Self),
+    Other
+  )
+);
+
+walk :: (fn(t : V) -> i32)(
+  match(
+    t,
+    .Leaf(v) => v,
+    // `t` shadows the parameter `t`.
+    .Node(_, t) => walk(t),
+    .Other => i32(-1)
+  )
+);
+```
+
+The emitted C (v0.2.29 seed) is:
+
+```c
+static inline int32_t yo_id_N(__yo_t0* t) {
+  switch (t->tag) {
+  case __YO_T0_NODE: {
+    __yo_t0* t = t->data.Node.t;   // <-- self-referential
+    ...
+```
+
+## Root cause
+
+In C, a declaration's point of declaration is **after the completion of its
+declarator and before its initializer** (C11 6.2.1p4). So in
+`__yo_t0* t = t->data.Node.t;` the `t` in the initializer refers to the NEW,
+not-yet-initialized `t`, not the outer parameter. The expression therefore
+reads an uninitialized stack slot — undefined behavior. The Yo codegen
+emitted this form whenever an arm's pattern binding had the same sanitized
+C name as the identifier chain in the binding's initializer (in practice:
+the scrutinee).
+
+Whether the program crashes depends entirely on clang's stack-slot
+assignment for that particular function — which is why this presented as
+*nondeterministic* corruption:
+
+- The V3 verifier's `_collect_declared` (a 6-arm recursive walk over
+  `VcTerm`, parameters `t : VcTerm`) crashed at `switch (t->tag)` reading
+  address `0x38` (NULL + the box tag offset). Under gdb the "scrutinee"
+  was a stale stack pointer into an ancestor frame; `Test.t` read as a
+  valid pointer in one run and garbage in another at identical addresses.
+- `yo test tests/internal/verifier_match.test.yo` and the standalone
+  `tmp/matchdrv.yo` driver both reproduced rc=139, with and without ASan
+  (the read stays inside the same stack page, so ASan sees a plain SEGV).
+
+## Disassembly proof
+
+In the miscompiled function, clang assigned the parameter `t` to frame
+slot `0x200` (prologue `mov %rdi,0x200(%rbx)`), but the shadowing
+declaration's initializer code loads the base from the NEW binding's slot
+(`mov 0x150(%rbx),%rax` in the `.Test` arm, slot `0x148` in the `.Proj`
+arm) — a slot no code in the function ever stores to before that point.
+The non-shadowing `.Ctor` arm (`cargs = t->data.Ctor.args`) loads the
+correct slot `0x200`. Three arms, same initializer shape, two different
+base slots — the self-referential ones are UB.
+
+## Affected emission sites (`src/codegen/exprs/match.yo`)
+
+1. tagged-union positional destructuring `.Variant(a, b)` → `T a = m->data.V.f;`
+2. tagged-union labeled destructuring `.Variant({a : x})`
+3. nullable-pointer payload bind `.(p) => ...`
+4. `=> rename` whole-match bind `.Variant => name`
+5. (defensive) subject materialization `T subject_temp = <matched>;`
+
+## Fix
+
+`_emit_pattern_binding_decl` (match.yo): when the binding's name appears in
+the initializer, hoist the initializer into a fresh temp first:
+
+```c
+__yo_t0* __yo_pat_init_1 = t->data.Node.t;  // outer t still in scope
+__yo_t0* t = __yo_pat_init_1;               // harmless copy
+```
+
+The substring test is deliberately conservative (the initializer's only
+identifiers are the matched-value code and type tags; a false positive
+costs one temp that -O2 folds away).
+
+## Notes
+
+- The Yo-level code (`match` arm binding shadowing a parameter) is legal
+  Yo; only the C emission was wrong.
+- Yo source cannot express the bug directly (no null for ref enums) — the
+  NULL/garbage only exists at the C level, which is why the crash traces
+  looked like RC/UAF corruption and defied memory-oriented debugging.
+- `:=` rebinding does not have this shape (same-scope C redeclaration
+  would be a compile error, so that path never emitted it).

--- a/src/codegen/exprs/match.yo
+++ b/src/codegen/exprs/match.yo
@@ -39,6 +39,59 @@ open(import("std/string"));
 _is_word_byte :: (fn(b : u8) -> bool)(
   ((b >= u8(97)) && (b <= u8(122))) || (((b >= u8(65)) && (b <= u8(90))) || (((b >= u8(48)) && (b <= u8(57))) || (b == u8(95))))
 );
+/// Emit `<T> bind = init;` — through a fresh temp when `bind`'s own name
+/// appears in `init`. A C declaration's initializer is evaluated with the
+/// NEW binding ALREADY in scope (C11 6.2.1p4: the declarator completes
+/// before the initializer), so `T t = t->data.Node.t;` — what a Yo arm
+/// `.Node(_, t) => ...` against scrutinee `t` used to emit — reads the
+/// UNINITIALIZED new `t`, not the scrutinee: undefined behavior that
+/// surfaced as nondeterministic garbage pointers, freed-tree walks and
+/// rc=139 in the V3 verifier
+/// (issues/match-binding-shadows-scrutinee-self-referential-initializer.md).
+/// Hoisting the initializer into a fresh temp first makes the binding's
+/// own initializer reference only that temp; the copy is then harmless.
+/// The substring test is deliberately conservative: `init`'s only variable
+/// references are the matched-value code and type tags, and a false
+/// positive costs one extra temp that -O2 folds away. The temp name is
+/// derived from the binding name — two same-named bindings can never share
+/// a C scope (arms are separate case blocks; nesting goes deeper), and
+/// `__yo_`-prefixed user identifiers are excluded by the same convention
+/// every other minted name relies on.
+_emit_pattern_binding_decl :: (
+  fn(context : FunctionGenerationContext, indent : String, bind : String, ty : TypeValue, init_code : String) -> unit
+)({
+  em := context.base.emitter;
+  tstr := get_type_string(ty, context.base);
+  if(init_code.contains(bind.clone()), {
+    tmp := String.from("__yo_pat_");
+    tmp.push_string(bind.clone());
+    l1 := indent.clone();
+    l1.push_string(tstr.clone());
+    l1.push_str(" ");
+    l1.push_string(tmp.clone());
+    l1.push_str(" = ");
+    l1.push_string(init_code.clone());
+    l1.push_str(";");
+    em.emit_string_line(l1);
+    l2 := indent.clone();
+    l2.push_string(tstr);
+    l2.push_str(" ");
+    l2.push_string(bind.clone());
+    l2.push_str(" = ");
+    l2.push_string(tmp);
+    l2.push_str(";");
+    em.emit_string_line(l2);
+  }, {
+    l := indent.clone();
+    l.push_string(tstr);
+    l.push_str(" ");
+    l.push_string(bind.clone());
+    l.push_str(" = ");
+    l.push_string(init_code.clone());
+    l.push_str(";");
+    em.emit_string_line(l);
+  })
+});
 /// True when position `idx` lies INSIDE a double-quoted C string literal in
 /// `s` (parity walk with `\\`-escape skipping). Mirrors the TS fix
 /// (codeContainsReturnStatement, src/codegen/utils/index.ts): the word
@@ -655,14 +708,7 @@ _gen_nullable_ptr_match :: (fn(expr : AstExpr, indent : String, context : Functi
           pargs.get(usize(0)),
           .Some(dvar) => if(ast_expr_is_atom(dvar), {
             dvn := sanitize_for_c_identifier(ast_expr_token(dvar).value, false);
-            decl := body_indent.clone();
-            decl.push_string(get_type_string(nullable_inner, context.base));
-            decl.push_str(" ");
-            decl.push_string(dvn);
-            decl.push_str(" = ");
-            decl.push_string(matched_value_code.clone());
-            decl.push_str(";");
-            em.emit_string_line(decl);
+            _emit_pattern_binding_decl(context, body_indent.clone(), dvn.clone(), nullable_inner, matched_value_code.clone());
             // Shadow-register the binding like _emit_destructure_binds does
             // for tagged-union arms: the arm body must resolve `q` to THIS
             // local C declaration. Without it, a GENERIC-IMPL materialized
@@ -1048,19 +1094,19 @@ _emit_destructure_binds :: (fn(enum_type : TypeValue, variant_name : String, par
                     if(fi < labels.len(), {
                       ftype := match(types.get(fi), .Some(t) => t, .None => TypeValue.Unit);
                       if(!is_unit_type(ftype), {
-                        decl := body_indent.clone();
-                        decl.push_string(get_type_string(ftype, context.base));
-                        decl.push_str(" ");
-                        decl.push_string(sanitize_for_c_identifier(ast_expr_token(var_expr).value, false));
-                        decl.push_str(" = ");
-                        decl.push_string(matched_value_code.clone());
-                        decl.push_str(access);
-                        decl.push_str("data.");
-                        decl.push_string(cvariant.clone());
-                        decl.push_str(".");
-                        decl.push_string(sanitize_for_c_identifier(label.clone(), false));
-                        decl.push_str(";");
-                        em.emit_string_line(decl);
+                        init := matched_value_code.clone();
+                        init.push_str(access);
+                        init.push_str("data.");
+                        init.push_string(cvariant.clone());
+                        init.push_str(".");
+                        init.push_string(sanitize_for_c_identifier(label.clone(), false));
+                        _emit_pattern_binding_decl(
+                          context,
+                          body_indent.clone(),
+                          sanitize_for_c_identifier(ast_expr_token(var_expr).value, false),
+                          ftype,
+                          init
+                        );
                         _shadow_add(context, sanitize_for_c_identifier(ast_expr_token(var_expr).value, false));
                       });
                     });
@@ -1083,19 +1129,19 @@ _emit_destructure_binds :: (fn(enum_type : TypeValue, variant_name : String, par
                 field_label := match(labels.get(fi), .Some(fl) => fl, .None => String.from(""));
                 ftype := match(types.get(fi), .Some(t) => t, .None => TypeValue.Unit);
                 if(!is_unit_type(ftype), {
-                  decl := body_indent.clone();
-                  decl.push_string(get_type_string(ftype, context.base));
-                  decl.push_str(" ");
-                  decl.push_string(sanitize_for_c_identifier(ast_expr_token(var_expr).value, false));
-                  decl.push_str(" = ");
-                  decl.push_string(matched_value_code.clone());
-                  decl.push_str(access);
-                  decl.push_str("data.");
-                  decl.push_string(cvariant.clone());
-                  decl.push_str(".");
-                  decl.push_string(sanitize_for_c_identifier(field_label, false));
-                  decl.push_str(";");
-                  em.emit_string_line(decl);
+                  init := matched_value_code.clone();
+                  init.push_str(access);
+                  init.push_str("data.");
+                  init.push_string(cvariant.clone());
+                  init.push_str(".");
+                  init.push_string(sanitize_for_c_identifier(field_label, false));
+                  _emit_pattern_binding_decl(
+                    context,
+                    body_indent.clone(),
+                    sanitize_for_c_identifier(ast_expr_token(var_expr).value, false),
+                    ftype,
+                    init
+                  );
                   _shadow_add(context, sanitize_for_c_identifier(ast_expr_token(var_expr).value, false));
                 });
               }),
@@ -1207,14 +1253,13 @@ _gen_tagged_union_match :: (fn(expr : AstExpr, indent : String, context : Functi
                     match(
                       rargs.get(usize(0)),
                       .Some(rename_expr) => {
-                        rdecl := body_indent.clone();
-                        rdecl.push_string(get_type_string(match_value_type, context.base));
-                        rdecl.push_str(" ");
-                        rdecl.push_string(sanitize_for_c_identifier(ast_expr_token(rename_expr).value, false));
-                        rdecl.push_str(" = ");
-                        rdecl.push_string(matched_value_code.clone());
-                        rdecl.push_str(";");
-                        em.emit_string_line(rdecl);
+                        _emit_pattern_binding_decl(
+                          context,
+                          body_indent.clone(),
+                          sanitize_for_c_identifier(ast_expr_token(rename_expr).value, false),
+                          match_value_type,
+                          matched_value_code.clone()
+                        );
                       },
                       .None => ()
                     );
@@ -1290,14 +1335,13 @@ generate_match_expression :: (fn(expr : AstExpr, indent : String, context : Func
         )
       }, false);
       if(!is_inout_atom && !(matched_value_code == subject_var_name), {
-        decl := indent.clone();
-        decl.push_string(get_type_string(match_value_type, context.base));
-        decl.push_str(" ");
-        decl.push_string(subject_var_name.clone());
-        decl.push_str(" = ");
-        decl.push_string(matched_value_code.clone());
-        decl.push_str(";");
-        em.emit_string_line(decl);
+        _emit_pattern_binding_decl(
+          context,
+          indent.clone(),
+          subject_var_name.clone(),
+          match_value_type,
+          matched_value_code.clone()
+        );
         context.base.declared_c_var_names.insert(subject_var_name.clone());
         matched_value_code = subject_var_name;
       });
@@ -1353,4 +1397,4 @@ generate_match_expression :: (fn(expr : AstExpr, indent : String, context : Func
   // Tagged-union destructuring.
   _gen_tagged_union_match(expr, indent.clone(), context, matched_value_code, match_value_type, enum_type, is_ptr || is_ref_sem, temp_var_opt, is_unit)
 });
-export(generate_case_body, generate_primitive_match_expression, generate_match_expression);
+export(generate_case_body, generate_primitive_match_expression, generate_match_expression, _emit_pattern_binding_decl);

--- a/tests/internal/match_binding_shadow.test.yo
+++ b/tests/internal/match_binding_shadow.test.yo
@@ -1,0 +1,60 @@
+//! Tests for the pattern-binding declaration emitter
+//! (`_emit_pattern_binding_decl`, src/codegen/exprs/match.yo).
+//!
+//! A C declaration's initializer is evaluated with the NEW binding already
+//! in scope (C11 6.2.1p4 — the declarator completes before the initializer),
+//! so the naive `T t = t->data.Node.t;` — what a Yo arm `.Node(_, t)`
+//! against scrutinee `t` used to emit — reads the UNINITIALIZED new `t`
+//! instead of the scrutinee: undefined behavior that surfaced as
+//! nondeterministic garbage pointers and rc=139 walks in the V3 verifier
+//! (issues/match-binding-shadows-scrutinee-self-referential-initializer.md).
+//! The emitter must hoist the initializer into a fresh temp whenever the
+//! binding's name appears in it, and leave the plain form alone otherwise.
+open(import("std/string"));
+{ Emitter } :: import("../../src/emitter.yo");
+{ expr_info_table_new } :: import("../../src/expr_info.yo");
+{ host_target } :: import("../../src/target.yo");
+{ TypeValue } :: import("../../src/types/definitions.yo");
+{ CodeGenContext } :: import("../../src/codegen/utils/index.yo");
+{ FunctionGenerationContext } :: import("../../src/codegen/functions/context.yo");
+{ _emit_pattern_binding_decl } :: import("../../src/codegen/exprs/match.yo");
+{ assert } :: import("std/assert");
+
+mk_context :: (fn() -> FunctionGenerationContext)({
+  base := CodeGenContext.new(
+    Emitter.new(),
+    expr_info_table_new(),
+    host_target(),
+    String.from("system"),
+    false,
+    false,
+    false,
+    false
+  );
+  FunctionGenerationContext.new(base)
+});
+
+emit_decl :: (fn(bind : String, init : String) -> String)({
+  ctx := mk_context();
+  _emit_pattern_binding_decl(ctx, String.from("  "), bind, TypeValue.Int(u8(32), true), init);
+  ctx.base.emitter.print()
+});
+
+test("binding shadowing the scrutinee hoists through a fresh temp", {
+  c := emit_decl(String.from("t"), String.from("t->data.Node.t"));
+  assert(c.contains("__yo_pat_t = t->data.Node.t;"), "the temp carries the real initializer");
+  assert(c.contains(" t = __yo_pat_t;"), "the binding copies the temp");
+  assert(!c.contains(" t = t->"), "no self-referential initializer remains");
+});
+
+test("binding with a fresh name emits the plain single declaration", {
+  c := emit_decl(String.from("v"), String.from("t->data.Node.t"));
+  assert(c.contains(" v = t->data.Node.t;"), "plain binding initializes directly");
+  assert(!c.contains("__yo_pat_"), "no hoist temp for a non-shadowing binding");
+});
+
+test("whole-value rename of the scrutinee hoists through a fresh temp", {
+  c := emit_decl(String.from("t"), String.from("t"));
+  assert(c.contains("__yo_pat_"), "T t = t; is self-referential too and must hoist");
+  assert(!c.contains(" t = t;"), "no self-copy declaration remains");
+});


### PR DESCRIPTION
## Summary

A match arm that binds a pattern variable with the same name as the scrutinee (e.g. `.Node(_, t) => walk(t)` against `fn(t : V)`) used to emit

```c
case __YO_T0_NODE: {
  __yo_t0* t = t->data.Node.t;   /* self-referential */
```

In C, a declaration's point of declaration precedes its initializer (C11 6.2.1p4), so the initializer's `t` refers to the **new, uninitialized** binding, not the scrutinee — undefined behavior. Whether it crashes depends entirely on clang's stack-slot assignment for the function, which made it present as nondeterministic corruption: garbage "scrutinee" pointers into ancestor stack frames, tree fields reading valid in one run and NULL in the next at identical addresses, rc=139 with and without ASan. It blocked the V3 verifier's match/datatype walks (`_collect_declared` over `VcTerm`).

## Changes

- `src/codegen/exprs/match.yo`: new `_emit_pattern_binding_decl` routes **all five** pattern-binding declaration sites through a collision check — when the binding's name appears in its initializer, the initializer is hoisted into a `__yo_pat_<bind>` temp first and the binding copies the temp. Sites: positional + labeled tagged-union destructuring, nullable-ptr payload bind, `=> rename` whole-value bind, and (defensively) subject materialization.
- `tests/internal/match_binding_shadow.test.yo`: pins both the hoisted form (no ` t = t->` remains) and the plain form (no temp for non-shadowing bindings), calling the emitter directly with a constructed `FunctionGenerationContext` (same shape as `gc_runtime_atomics.test.yo`).
- `issues/match-binding-shadows-scrutinee-self-referential-initializer.md`: full analysis with the disassembly proof (three arms, same initializer shape, two different base slots — the shadowing ones read uninitialized slots).

## Notes for reviewers

- The Yo-level code was always legal; only the C emission was wrong.
- The temp name is derived from the binding name: two same-named bindings can never share a C scope (arms are separate `case` blocks, nesting goes deeper).
- Local validation: `yo check ./src` green; the new test's assertions pass locally — the run still reports LeakSanitizer findings under the v0.2.29 seed, the same way the existing `gc_runtime_atomics.test.yo` does (CI compiles these with the PR-tree compiler). The stage-2 fixpoint in CI is the real gate for the emitted-C change.