### PR TITLE
verifier: V3 match/datatype encoding (stacked on #527)

### DIFF
--- a/plans/backlog/FORMAL_VERIFICATION.md
+++ b/plans/backlog/FORMAL_VERIFICATION.md
@@ -970,8 +970,9 @@ results; no language behavior changed yet.
 
 ### Phase V3 — Straight-line verification + auto-obligations (the Dafny core)
 
-> **Status: IN FLIGHT 2026-09-08** (branch `feat/fv3-straight-line-vc`,
-> rebased on the merged V2). LANDED so far — the wiring: mode dispatch in
+> **Status: IN FLIGHT 2026-09-08→09** (branch `feat/fv3-straight-line-vc`;
+> core + wiring MERGED as develop `48df44429` (#497) and task 6 MERGED as
+> `175a53991` (#512)). LANDED so far — the wiring: mode dispatch in
 > `wrap_function_body_with_contracts` (splice suppressed for verify-mode
 > TARGET files only — non-targets keep their runtime asserts, so an
 > un-verified contract never silently loses its check), the `VerifyTask`
@@ -992,9 +993,20 @@ results; no language behavior changed yet.
 > `tests/spec/fixtures/negative/`, the in-process harness
 > `tests/internal/verifier_negative.test.yo` — subset assertions run
 > solver-free, refutations gated YO_TEST_Z3=1 — and the CI verify job
-> runs both the harness and the battery end-to-end). REMAINING in V3:
-> task 6 (`verify+` stripping pass), match/datatype encoding, docs
-> en+zh, end-to-end validation on a locally built self-hosted binary.
+> runs both the harness and the battery end-to-end). Task 6 (`verify+` stripping) LANDED in #512: VerifyTask carries the
+> FuncVal; `strip_proved_ensures_asserts` rewrites the wrapped body in
+> place (proved `ensures failed` asserts dropped; `requires failed`
+> guards stay — their obligations live at call sites); the check/compile
+> integration arms entry files and verifies after evaluation
+> (REFUTED always fails; unproven fails in `verify`, warns in `verify+`;
+> a MISSING solver is a hard failure — verify-mode codegen carries no
+> runtime asserts). DEVIATION recorded: the TEST runner's batch compiles
+> pass `--no-verify` (CI caught the flaw — a verify-pragma fixture on a
+> Z3-less leg became unsound and unrunnable): `yo test` is a runtime
+> harness, the static gate lives in check/compile/verify.
+> tests/internal/verifier_strip.test.yo covers the mechanism (solver-free)
+> and the full verify+ pipeline (YO_TEST_Z3=1). REMAINING in V3:
+> match/datatype encoding (the subset table's last unchecked row).
 
 **Scope:** the flagship loop closes. Pure, loop-free functions verify;
 callers discharge callee `requires`; AoRTE obligations fire on

--- a/src/verifier/encode.yo
+++ b/src/verifier/encode.yo
@@ -12,6 +12,8 @@
 //!   - `encode_script` — the full script: determinism options, then the
 //!     content, then the post-check-sat evidence directives
 //!     (get-unsat-core / get-value for the counter-example).
+pragma(Pragma.AllowUnsafe);
+
 open(import("std/string"));
 { ArrayList } :: import("std/collections/array_list");
 { VcSort, VcOp, VcTerm, VcQuantKind, VcQuery } :: import("./terms.yo");
@@ -53,7 +55,8 @@ encode_sort :: (fn(s : VcSort) -> String)(
   match(
     s,
     .BoolS => String.from("Bool"),
-    .BvS(w) => `(_ BitVec ${w.to_string()})`
+    .BvS(w) => `(_ BitVec ${w.to_string()})`,
+    .DataS(name) => name.clone()
   )
 );
 // ============================================================================
@@ -135,6 +138,35 @@ encode_term :: (fn(t : VcTerm) -> String)(
       sb.write_byte(u8(0x29));
       sb.to_string()
     },
+    .Ctor(name, args) => {
+      sb := StringBuilder.new();
+      sb.write_byte(u8(0x28));
+      sb.write_string(name.clone());
+      (ci : usize) = usize(0);
+      while(ci < args.len(), {
+        match(
+          args.get(ci),
+          .Some(a) => {
+            sb.write_byte(u8(0x20));
+            sb.write_string(encode_term(a));
+          },
+          .None => ()
+        );
+        ci = (ci + usize(1));
+      });
+      sb.write_byte(u8(0x29));
+      sb.to_string()
+    },
+    // NOTE: the child bindings are deliberately NOT named `t` — binding the
+    // scrutinee's own name hit the codegen self-referential-initializer UB
+    // (C11 6.2.1p4; issues/match-binding-shadows-scrutinee-...) and the
+    // v0.2.29 seed still miscompiles it, breaking every local run.
+    // Test renders `(is-<ctor> t)`; Proj renders `(<accessor> t)` where the
+    // accessor is the MANGLED `<ctor>_<label>` symbol the datatype's
+    // constructor declares (z3 resolves field access by symbol, not
+    // position).
+    .Test(ctor, child) => `(is-${ctor} ${encode_term(child)})`,
+    .Proj(ctor, _, child) => `(${ctor} ${encode_term(child)})`,
     .Quant(kind, names, sorts, body) => {
       kw := match(
         kind,
@@ -177,8 +209,151 @@ encode_term :: (fn(t : VcTerm) -> String)(
 /// The logic content of one obligation: declarations, named assumptions,
 /// the negated goal, and check-sat. No options, no evidence directives —
 /// this text (plus run options) is the cache key input.
+/// Deterministically ordered copy of a small string list (the datatype
+/// entries; insertion sort — same discipline as the verifier's
+/// `_sorted_strings`).
+_sorted_lines :: (fn(xs : ArrayList(String)) -> ArrayList(String))({
+  out := ArrayList(String).new();
+  (i : usize) = usize(0);
+  while(i < xs.len(), {
+    match(
+      xs.get(i),
+      .Some(x) => {
+        out.push(x.clone());
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  buf := out.ptr().unwrap();
+  (j : usize) = usize(1);
+  while(j < out.len(), {
+    key := (unsafe((buf.add(j)).*)).clone();
+    (k : usize) = j;
+    while(k > usize(0), {
+      prev := unsafe((buf.add(k - usize(1))).*);
+      if(prev <= key, {
+        break;
+      });
+      unsafe((buf.add(k)).* = prev);
+      k = (k - usize(1));
+    });
+    unsafe((buf.add(k)).* = key);
+    j = (j + usize(1));
+  });
+  out
+});
+/// Wrap each constructor segment of a datatype entry's ctor list in its
+/// own parens, flattening the field group: SMT-LIB 2.6 grammar is
+/// `((C0 (a S)) (C1))` — one paren'd constructor per segment, accessor
+/// pairs directly under it — while the entry stores the flat
+/// `C0 ((a S)) C1` (the group keeps multi-field ctors one segment).
+_wrap_ctor_segments :: (fn(ctors : String) -> String)({
+  parts := ArrayList(String).new();
+  (i : usize) = usize(0);
+  (n : usize) = ctors.len();
+  (go : bool) = true;
+  while(go, {
+    while((i < n) && (ctors.byte_at(i) == u8(0x20)), {
+      i = (i + usize(1));
+    });
+    if(i < n, {
+      seg := StringBuilder.new();
+      seg.write_byte(u8(0x28));
+      while((i < n) && !(ctors.byte_at(i) == u8(0x20)), {
+        seg.write_byte(ctors.byte_at(i));
+        i = (i + usize(1));
+      });
+      if(((i + usize(1)) < n) && (ctors.byte_at(i) == u8(0x20)) && (ctors.byte_at(i + usize(1)) == u8(0x28)), {
+        // Consume the balanced group, then emit its INNER text (drop the
+        // group's own parens): `(C (a S) (b S))`, not `(C ((a S) (b S)))`.
+        seg.write_byte(u8(0x20));
+        i = (i + usize(1));
+        gs := (i + usize(1));
+        (depth : usize) = usize(0);
+        (scan : bool) = true;
+        while(scan && (i < n), {
+          b := ctors.byte_at(i);
+          cond(
+            (b == u8(0x28)) => {
+              depth = (depth + usize(1));
+            },
+            (b == u8(0x29)) => {
+              depth = (depth - usize(1));
+              if(depth == usize(0), {
+                scan = false;
+              });
+            },
+            true => ()
+          );
+          i = (i + usize(1));
+        });
+        seg.write_string(ctors.substring(gs, i - usize(1)));
+      });
+      seg.write_byte(u8(0x29));
+      parts.push(seg.to_string());
+    }, {
+      go = false;
+    });
+  });
+  sb := StringBuilder.new();
+  (j : usize) = usize(0);
+  while(j < parts.len(), {
+    if(j > usize(0), {
+      sb.write_byte(u8(0x20));
+    });
+    sb.write_string(parts.get(j).unwrap().clone());
+    j = (j + usize(1));
+  });
+  sb.to_string()
+});
 encode_content :: (fn(q : VcQuery) -> String)({
   sb := StringBuilder.new();
+  // The datatype block FIRST (constants may carry datatype sorts; one
+  // combined declare-datatypes covers mutual recursion without ordering
+  // constraints). Deterministic order: the entries are pre-sorted by the
+  // builder; a stable re-sort keeps the encoding reproducible regardless.
+  dt_entries := _sorted_lines(q.datatypes);
+  if(dt_entries.len() > usize(0), {
+    sb.write_str("(declare-datatypes (");
+    (ti : usize) = usize(0);
+    while(ti < dt_entries.len(), {
+      match(
+        dt_entries.get(ti),
+        .Some(entry) => {
+          // Each entry is "<name>|<ctors...>": split at the first '|'.
+          bar := entry.index_of(String.from("|"));
+          nm := match(
+            bar,
+            .Some(b) => entry.substring(usize(0), b),
+            .None => entry.clone()
+          );
+          sb.write_string(`(${nm} 0)`);
+        },
+        .None => ()
+      );
+      ti = (ti + usize(1));
+    });
+    sb.write_str(") (");
+    (tj : usize) = usize(0);
+    while(tj < dt_entries.len(), {
+      match(
+        dt_entries.get(tj),
+        .Some(entry) => {
+          bar := entry.index_of(String.from("|"));
+          ctors := match(
+            bar,
+            .Some(b) => entry.substring(b + usize(1), entry.len()),
+            .None => String.new()
+          );
+          sb.write_string(`(${_wrap_ctor_segments(ctors)})`);
+        },
+        .None => ()
+      );
+      tj = (tj + usize(1));
+    });
+    sb.write_str("))\n");
+  });
   (di : usize) = usize(0);
   while(di < q.declarations.len(), {
     match(

--- a/src/verifier/terms.yo
+++ b/src/verifier/terms.yo
@@ -24,7 +24,11 @@ VcSort :: enum(
   /// SMT `Bool`.
   BoolS,
   /// SMT `(_ BitVec <width>)` — widths 8/16/32/64 (and the target's usize).
-  BvS(width : usize)
+  BvS(width : usize),
+  /// A DECLARED DATATYPE sort (V3: value enums). The name is the
+  /// sanitized datatype name; the `(declare-datatypes ...)` block rides
+  /// `VcQuery.datatypes` (rendered once, before the constants).
+  DataS(name : String)
 );
 derive(VcSort, Eq(VcSort));
 impl(
@@ -34,7 +38,8 @@ impl(
       match(
         self,
         .BoolS => String.from("bool"),
-        .BvS(w) => `bv${w.to_string()}`
+        .BvS(w) => `bv${w.to_string()}`,
+        .DataS(name) => name.clone()
       )
     )
   )
@@ -111,6 +116,13 @@ VcTerm :: ref(
     /// Operator application. Arity/widths are the BUILDER's responsibility
     /// (checked at VC-construction time in V3, not re-checked here).
     App(op : VcOp, args : ArrayList(Self)),
+    /// Datatype constructor application (`.Variant(args...)`).
+    Ctor(name : String, args : ArrayList(Self)),
+    /// Datatype tester `(is-<Ctor> t)` — a match arm's discriminator.
+    Test(ctor : String, t : Self),
+    /// Datatype field projection `(<Ctor>-<idx> t)` — a match arm's
+    /// pattern binding.
+    Proj(ctor : String, idx : usize, t : Self),
     /// Quantifier with explicitly-typed bound variables.
     Quant(kind : VcQuantKind, names : ArrayList(String), sorts : ArrayList(VcSort), body : Self)
   )
@@ -132,7 +144,12 @@ VcQuery :: ref(
     /// Assumed terms, conjoined.
     assumptions : ArrayList(VcAssumption),
     /// The obligation proper.
-    goal : VcTerm
+    goal : VcTerm,
+    /// Datatype declaration BLOCK CONTENT — one entry per datatype, the
+    /// `(name 0)` arity pair plus its constructors. Rendered as ONE
+    /// combined `declare-datatypes` before the constants so mutually
+    /// recursive datatypes need no ordering.
+    datatypes : ArrayList(String)
   )
 );
 impl(
@@ -159,7 +176,8 @@ new_vc_query :: (fn(name : String) -> VcQuery)(
     name : name,
     declarations : ArrayList(VcDecl).new(),
     assumptions : ArrayList(VcAssumption).new(),
-    goal : VcTerm.BoolLit(true)
+    goal : VcTerm.BoolLit(true),
+    datatypes : ArrayList(String).new()
   )
 );
 // ============================================================================

--- a/src/verifier/vc.yo
+++ b/src/verifier/vc.yo
@@ -30,13 +30,14 @@ open(import("std/fmt"));
   ast_expr_is_fn_call,
   ast_expr_is_fn_call_of,
   ast_expr_is_atom,
-  ast_expr_to_string
+  ast_expr_to_string,
+  make_err_expr
 } :: import("../expr.yo");
 { ExprInfo, ExprInfoTable, expr_info_table_get } :: import("../expr_info.yo");
 { TypeValue } :: import("../types/definitions.yo");
 { EvalValue, is_func_val } :: import("../value.yo");
 { VcSort, VcOp, VcTerm, VcQuery, new_vc_query, vc_eq, vc_and, vc_or, vc_not, vc_distinct } :: import("./terms.yo");
-{ mangle_vc_name } :: import("./encode.yo");
+{ mangle_vc_name, encode_sort } :: import("./encode.yo");
 {
   get_func_requires_exprs,
   get_func_ensures_exprs,
@@ -76,9 +77,49 @@ _type_sort :: (fn(t : TypeValue) -> Option(VcSort))(
     .Some(w) => Option(VcSort).Some(VcSort.BvS(width : w)),
     .None => cond(
       _is_bool_type(t) => Option(VcSort).Some(VcSort.BoolS),
-      true => Option(VcSort).None
+      // Value enums: a declared datatype (V3). ref enums are heap handles —
+      // outside the verifiable subset's integer/bool/enum core.
+      true => _enum_sort_or_none(t)
     )
   )
+);
+_enum_sort_or_none :: (fn(t : TypeValue) -> Option(VcSort))(
+  match(
+    t,
+    .EnumT({ id : e_id, is_reference_semantics : e_ref }) => cond(
+      (e_ref || (e_id.len() == usize(0))) => Option(VcSort).None,
+      true => Option(VcSort).Some(VcSort.DataS(name : _enum_dt_name(e_id.clone())))
+    ),
+    _ => Option(VcSort).None
+  )
+);
+/// The datatype name for an enum id (`enum_decl_<astid>_<module>`): a
+/// sanitized SMT identifier unique per declaration.
+_enum_dt_name :: (fn(enum_id : String) -> String)(
+  `__yo_d${_smt_sanitize(enum_id.clone())}`
+);
+/// Map every non-[A-Za-z0-9_] rune of `s` to `_` (SMT identifier rules).
+_smt_sanitize :: (fn(s : String) -> String)({
+  sb := StringBuilder.new();
+  {
+    it := s.chars();
+    while(true, {
+      r := match(it.next(), .Some(x) => x, .None => break);
+      c := r.char;
+      if(((c >= u32(0x41)) && (c <= u32(0x5A))) ||
+        ((c >= u32(0x61)) && (c <= u32(0x7A))) ||
+          ((c >= u32(0x30)) && (c <= u32(0x39))) || (c == u32(0x5F)), {
+        sb.write_rune(r);
+      }, {
+        sb.write_byte(u8(0x5F));
+      });
+    });
+  };
+  sb.to_string()
+});
+/// The constructor name for one variant: `<dt>_<variant>`.
+_enum_ctor_name :: (fn(enum_id : String, variant : String) -> String)(
+  `${_enum_dt_name(enum_id.clone())}_${variant}`
 );
 // ============================================================================
 // Results
@@ -123,7 +164,12 @@ VcCtx :: ref(
     obligations : ArrayList(VcObligation),
     subset_error : Option(VcSubsetError),
     /// Counter for query names and synthetic vars.
-    fresh : usize
+    fresh : usize,
+    /// Datatype declaration entries (`<dt-name>|<ctor0> <ctor1> (f0 sort) ...`)
+    /// for every enum sort used so far — merged into each obligation's
+    /// VcQuery.datatypes at `_emit` time so the emitted script declares
+    /// everything the terms mention.
+    datatypes : ArrayList(String)
   )
 );
 _new_vc_ctx :: (fn(table : ExprInfoTable, fn_name : String, func_id : String) -> VcCtx)(
@@ -135,7 +181,8 @@ _new_vc_ctx :: (fn(table : ExprInfoTable, fn_name : String, func_id : String) ->
     path : ArrayList(VcTerm).new(),
     obligations : ArrayList(VcObligation).new(),
     subset_error : Option(VcSubsetError).None,
-    fresh : usize(0)
+    fresh : usize(0),
+    datatypes : ArrayList(String).new()
   )
 );
 _next_fresh :: (fn(inout(ctx) : VcCtx) -> usize)({
@@ -274,6 +321,17 @@ _emit :: (
     ai = (ai + usize(1));
   });
   q.goal = _rename_vars(goal, rename_map);
+  (dti : usize) = usize(0);
+  while(dti < ctx.datatypes.len(), {
+    match(
+      ctx.datatypes.get(dti),
+      .Some(entry) => {
+        q.datatypes.push(entry.clone());
+      },
+      .None => ()
+    );
+    dti = (dti + usize(1));
+  });
   ctx.obligations.push(VcObligation(name : `${ctx.fn_name}/${label}`, query : q));
   ()
 });
@@ -336,6 +394,24 @@ _collect_declared :: (fn(t : VcTerm, out : HashMap(String, VcSort)) -> unit)(
         i = (i + usize(1));
       });
     },
+    .Ctor(_, cargs) => {
+      (ci : usize) = usize(0);
+      while(ci < cargs.len(), {
+        match(
+          cargs.get(ci),
+          .Some(a) => {
+            _collect_declared(a, out);
+          },
+          .None => ()
+        );
+        ci = (ci + usize(1));
+      });
+    },
+    // Child bindings NOT named `t`: shadowing the scrutinee hit the
+    // self-referential-initializer codegen UB (C11 6.2.1p4), which the
+    // v0.2.29 seed still miscompiles.
+    .Test(_, child) => _collect_declared(child, out),
+    .Proj(_, _, child) => _collect_declared(child, out),
     .Quant(_, _, _, body) => _collect_declared(body, out)
   )
 );
@@ -365,6 +441,23 @@ _rename_vars :: (fn(t : VcTerm, map : HashMap(String, String)) -> VcTerm)(
       });
       VcTerm.App(op, out)
     },
+    .Ctor(name, cargs) => {
+      out := ArrayList(VcTerm).new();
+      (ci : usize) = usize(0);
+      while(ci < cargs.len(), {
+        match(
+          cargs.get(ci),
+          .Some(a) => {
+            out.push(_rename_vars(a, map));
+          },
+          .None => ()
+        );
+        ci = (ci + usize(1));
+      });
+      VcTerm.Ctor(name : name.clone(), args : out)
+    },
+    .Test(ctor, child) => VcTerm.Test(ctor : ctor.clone(), t : _rename_vars(child, map)),
+    .Proj(ctor, idx, child) => VcTerm.Proj(ctor : ctor.clone(), idx : idx, t : _rename_vars(child, map)),
     .Quant(kind, names, sorts, body) => VcTerm.Quant(kind, names, sorts, _rename_vars(body, map))
   )
 );
@@ -473,6 +566,575 @@ _expr_term :: (fn(inout(ctx) : VcCtx, e : AstExpr) -> Option(VcTerm))({
   _fail_subset(ctx, String.from("non-call expression"), e);
   Option(VcTerm).None
 });
+/// Register the datatype declaration entry for a VALUE enum type once per
+/// context (idempotent by dt name). The entry format is
+/// `<dt-name>|<ctor0> <ctor1> (f0 <sort>) ...` — encode_content splits at
+/// the `|` and renders the combined declare-datatypes block.
+_note_enum_datatype :: (fn(inout(ctx) : VcCtx, t : TypeValue) -> unit)(
+  match(
+    t,
+    .EnumT({
+      id : e_id,
+      variant_names : e_names,
+      variant_fields : e_fields,
+      variant_field_labels : e_labels,
+      is_reference_semantics : e_ref
+    }) => {
+      if(!e_ref && (e_id.len() > usize(0)), {
+        dt := _enum_dt_name(e_id.clone());
+        already := _dt_registered(ctx.datatypes, dt.clone());
+        if(!already, {
+          sb := StringBuilder.new();
+          sb.write_string(dt.clone());
+          sb.write_byte(u8(0x7C));
+          (vi : usize) = usize(0);
+          while(vi < e_names.len(), {
+            vname := match(e_names.get(vi), .Some(n) => n, .None => String.new());
+            if(vi > usize(0), {
+              sb.write_byte(u8(0x20));
+            });
+            sb.write_string(_enum_ctor_name(e_id.clone(), vname.clone()));
+            vfs := match(e_fields.get(vi), .Some(l) => l, .None => ArrayList(TypeValue).new());
+            vls := match(e_labels.get(vi), .Some(l) => l, .None => ArrayList(String).new());
+            if(vfs.len() > usize(0), {
+              // A SPACE separates the ctor name from its field group —
+              // the encoder's segment scanner keys on it.
+              sb.write_byte(u8(0x20));
+              sb.write_byte(u8(0x28));
+              (fi : usize) = usize(0);
+              while(fi < vfs.len(), {
+                fty := match(vfs.get(fi), .Some(x) => x, .None => TypeValue.Unit);
+                flabel := match(
+                  vls.get(fi),
+                  .Some(fl) => fl.clone(),
+                  .None => {
+                    l := String.from("_");
+                    l.push_string(fi.to_string());
+                    l
+                  }
+                );
+                if(fi > usize(0), {
+                  sb.write_byte(u8(0x20));
+                });
+                // `(accessor sort)` — z3 rejects a bare sort in a
+                // constructor field list, and accessors share the whole
+                // datatype's namespace, so mangle `<ctor>_<label>` (same
+                // spelling the walk's Proj terms carry).
+                sb.write_byte(u8(0x28));
+                sb.write_string(_enum_ctor_name(e_id.clone(), vname.clone()));
+                sb.write_byte(u8(0x5F));
+                sb.write_string(flabel);
+                sb.write_byte(u8(0x20));
+                sb.write_string(
+                  match(
+                    _type_sort(fty),
+                    .Some(fs) => encode_sort(fs),
+                    .None => String.from("Int")
+                  )
+                );
+                sb.write_byte(u8(0x29));
+                fi = (fi + usize(1));
+              });
+              sb.write_byte(u8(0x29));
+            });
+            vi = (vi + usize(1));
+          });
+          ctx.datatypes.push(sb.to_string());
+        });
+      });
+    },
+    _ => ()
+  )
+);
+_dt_registered :: (fn(entries : ArrayList(String), dt : String) -> bool)({
+  (found : bool) = false;
+  (i : usize) = usize(0);
+  while((i < entries.len()) && !found, {
+    match(
+      entries.get(i),
+      .Some(entry) => {
+        bar := entry.index_of(String.from("|"));
+        nm := match(
+          bar,
+          .Some(b) => entry.substring(usize(0), b),
+          .None => entry.clone()
+        );
+        if(nm == dt, {
+          found = true;
+        });
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  found
+});
+/// Whether `t` is a non-ref, non-anonymous enum type.
+_is_value_enum_type :: (fn(t : TypeValue) -> bool)(
+  match(
+    t,
+    .EnumT({ id : e_id, is_reference_semantics : e_ref }) => (!e_ref && (e_id.len() > usize(0))),
+    _ => false
+  )
+);
+/// `.(Variant, args...)` construction as a datatype Ctor term.
+_enum_ctor_term :: (
+  fn(inout(ctx) : VcCtx, e : AstExpr, dot_args : ArrayList(AstExpr), info : ExprInfo) -> Option(VcTerm)
+)(
+  match(
+    dot_args.get(usize(0)),
+    .Some(v_atom) => _enum_ctor_first(ctx, e, info, v_atom, dot_args),
+    .None => {
+      _fail_subset(ctx, String.from("malformed enum construction"), e);
+      Option(VcTerm).None
+    }
+  )
+);
+_enum_ctor_first :: (
+  fn(inout(ctx) : VcCtx, e : AstExpr, info : ExprInfo, v_atom : AstExpr, dot_args : ArrayList(AstExpr)) -> Option(VcTerm)
+)(
+  cond(
+    ast_expr_is_atom(v_atom) => _enum_ctor_named(ctx, e, info, ast_expr_token(v_atom).value, dot_args),
+    true => {
+      _fail_subset(ctx, String.from("non-atom enum variant in construction"), e);
+      Option(VcTerm).None
+    }
+  )
+);
+_enum_ctor_named :: (
+  fn(inout(ctx) : VcCtx, e : AstExpr, info : ExprInfo, variant : String, dot_args : ArrayList(AstExpr)) -> Option(VcTerm)
+)(
+  match(
+    info.ty,
+    .EnumT({ id : e_id, variant_names : e_names, variant_fields : e_fields }) => _build_enum_ctor(ctx, e, e_id.clone(), e_names, e_fields, variant, dot_args),
+    _ => {
+      _fail_subset(ctx, String.from("field/method access (outside the V3 core subset)"), e);
+      Option(VcTerm).None
+    }
+  )
+);
+_build_enum_ctor :: (
+  fn(
+    inout(ctx) : VcCtx,
+    e : AstExpr,
+    e_id : String,
+    e_names : ArrayList(String),
+    e_fields : ArrayList(ArrayList(TypeValue)),
+    variant : String,
+    dot_args : ArrayList(AstExpr)
+  ) -> Option(VcTerm)
+)(
+  cond(
+    _variant_named(e_names, variant.clone()) => {
+      vidx := _variant_index_of(e_names, variant.clone());
+      vname := match(e_names.get(vidx), .Some(n) => n, .None => String.new());
+      vfs := match(e_fields.get(vidx), .Some(l) => l, .None => ArrayList(TypeValue).new());
+      // The construction's VALUE args are the dot-args AFTER the variant
+      // atom.
+      cargs := ArrayList(VcTerm).new();
+      (i : usize) = usize(1);
+      while(i < dot_args.len(), {
+        a := match(dot_args.get(i), .Some(x) => x, .None => make_err_expr());
+        v := _expr_term(ctx, a);
+        match(
+          v,
+          .Some(vt) => {
+            cargs.push(vt);
+          },
+          .None => {
+            return(Option(VcTerm).None);
+          }
+        );
+        i = (i + usize(1));
+      });
+      if(!(cargs.len() == vfs.len()), {
+        _fail_subset(
+          ctx,
+          `enum construction with ${cargs.len().to_string()} args (expected ${vfs.len().to_string()})`,
+          e
+        );
+        return(Option(VcTerm).None);
+      });
+      _note_enum_datatype(
+        ctx,
+        .EnumT(
+          e_id.clone(),
+          String.new(),
+          e_names,
+          e_fields,
+          Option(String).None,
+          ArrayList(ArrayList(String)).new(),
+          ArrayList(i64).new(),
+          false,
+          false
+        )
+      );
+      Option(VcTerm).Some(VcTerm.Ctor(name : _enum_ctor_name(e_id, vname), args : cargs))
+    },
+    true => {
+      _fail_subset(ctx, String.from("field/method access (outside the V3 core subset)"), e);
+      Option(VcTerm).None
+    }
+  )
+);
+/// Whether `vname` (bare, no dot) names a variant.
+_variant_named :: (fn(e_names : ArrayList(String), vname : String) -> bool)(
+  _variant_index_of(e_names, vname) < e_names.len()
+);
+/// The variant index for a BARE variant name; the list length when not
+/// found.
+_variant_index_of :: (fn(e_names : ArrayList(String), vname : String) -> usize)({
+  (i : usize) = usize(0);
+  (hit : usize) = e_names.len();
+  while((i < e_names.len()) && (hit == e_names.len()), {
+    match(
+      e_names.get(i),
+      .Some(n) => if(n == vname, {
+        hit = i;
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  hit
+});
+/// match(scrutinee, arms...) as a nested ite VALUE tree: each arm
+/// `.Variant(b1, b2) => body` contributes
+/// `(ite (is-Ctor S) body[b := Ctor-i S] ...)`; a wildcard arm is the
+/// else. Nested patterns are outside the V3 subset.
+_match_term :: (fn(inout(ctx) : VcCtx, at : AstExpr, args : ArrayList(AstExpr)) -> Option(VcTerm))({
+  if(args.len() < usize(2), {
+    _fail_subset(ctx, String.from("match with too few arguments"), at);
+    return(Option(VcTerm).None);
+  });
+  scrut := _expr_term(ctx, args.get(usize(0)).unwrap());
+  scrut_info := expr_info_table_get(ctx.table, ast_expr_id(args.get(usize(0)).unwrap()));
+  // The scrutinee's TYPE names the datatype's CONSTRUCTORS and ACCESSORS
+  // (SMT-unique across enums): every Test/Proj the walk builds must use
+  // the same spellings the declare-datatypes block declares.
+  e_ty := match(scrut_info, .Some(si) => si.ty, .None => TypeValue.Unit);
+  match(
+    scrut,
+    .Some(s) => {
+      // Register the scrutinee's datatype.
+      match(
+        scrut_info,
+        .Some(si) => _note_enum_datatype(ctx, si.ty),
+        .None => ()
+      );
+      _match_arms(ctx, at, s, args, usize(1), e_ty)
+    },
+    .None => Option(VcTerm).None
+  )
+});
+/// Fold arms [from, len) into the ite tree.
+_match_arms :: (
+  fn(inout(ctx) : VcCtx, at : AstExpr, scrut : VcTerm, args : ArrayList(AstExpr), from : usize, e_ty : TypeValue) -> Option(VcTerm)
+)(
+  cond(
+    (from >= args.len()) => {
+      _fail_subset(ctx, String.from("match without a final arm"), at);
+      Option(VcTerm).None
+    },
+    true => _match_one_arm(ctx, at, scrut, args, from, e_ty)
+  )
+);
+_match_one_arm :: (
+  fn(inout(ctx) : VcCtx, at : AstExpr, scrut : VcTerm, args : ArrayList(AstExpr), idx : usize, e_ty : TypeValue) -> Option(VcTerm)
+)(
+  cond(
+    ((idx + usize(1)) >= args.len()) => _match_last_arm(ctx, scrut, args, idx, e_ty),
+    true => _match_folded_arm(ctx, at, scrut, args, idx, e_ty)
+  )
+);
+_match_last_arm :: (
+  fn(inout(ctx) : VcCtx, scrut : VcTerm, args : ArrayList(AstExpr), idx : usize, e_ty : TypeValue) -> Option(VcTerm)
+)(_match_arm_value(ctx, scrut, args.get(idx).unwrap(), e_ty));
+_match_folded_arm :: (
+  fn(inout(ctx) : VcCtx, at : AstExpr, scrut : VcTerm, args : ArrayList(AstExpr), idx : usize, e_ty : TypeValue) -> Option(VcTerm)
+)({
+  tail := _match_arms(ctx, at, scrut, args, idx + usize(1), e_ty);
+  match(
+    tail,
+    .Some(tail_t) => _match_arm_conditioned(ctx, scrut, args.get(idx).unwrap(), tail_t, e_ty),
+    .None => Option(VcTerm).None
+  )
+});
+_match_arm_value :: (fn(inout(ctx) : VcCtx, scrut : VcTerm, arm : AstExpr, e_ty : TypeValue) -> Option(VcTerm))({
+  aa := _arm_parts(arm);
+  body := match(
+    aa.get(usize(1)),
+    .Some(b) => b,
+    .None => {
+      _fail_subset(ctx, String.from("match arm outside => shape"), arm);
+      return(Option(VcTerm).None);
+    }
+  );
+  pat := match(
+    aa.get(usize(0)),
+    .Some(p) => p,
+    .None => {
+      _fail_subset(ctx, String.from("match arm outside => shape"), arm);
+      return(Option(VcTerm).None);
+    }
+  );
+  _arm_under_pattern(ctx, scrut, pat, body, e_ty)
+});
+_match_arm_conditioned :: (
+  fn(inout(ctx) : VcCtx, scrut : VcTerm, arm : AstExpr, tail : VcTerm, e_ty : TypeValue) -> Option(VcTerm)
+)({
+  aa := _arm_parts(arm);
+  pat := match(
+    aa.get(usize(0)),
+    .Some(p) => p,
+    .None => {
+      _fail_subset(ctx, String.from("match arm outside => shape"), arm);
+      return(Option(VcTerm).None);
+    }
+  );
+  body := match(
+    aa.get(usize(1)),
+    .Some(b) => b,
+    .None => {
+      _fail_subset(ctx, String.from("match arm outside => shape"), arm);
+      return(Option(VcTerm).None);
+    }
+  );
+  cond(
+    _is_wildcard_pattern(pat) => Option(VcTerm).Some(_arm_body_value(ctx, body, tail)),
+    true => _arm_conditioned_variant(ctx, scrut, pat, body, tail, e_ty)
+  )
+});
+/// The arm's two parts (pattern, body) — `"=>"(p, b)`.
+_arm_parts :: (fn(arm : AstExpr) -> ArrayList(AstExpr))(
+  match(
+    arm,
+    .FnCall(_, _, a, _, _) => a,
+    .Atom(_, _) => ArrayList(AstExpr).new()
+  )
+);
+_is_wildcard_pattern :: (fn(pat : AstExpr) -> bool)(
+  match(
+    pat,
+    .Atom(_, pt) => (pt.value == "_"),
+    .FnCall(_, _, _, _, _) => false
+  )
+);
+/// Evaluate the body and pair it with the else-value (wildcard arm).
+_arm_body_value :: (fn(inout(ctx) : VcCtx, body : AstExpr, tail : VcTerm) -> VcTerm)({
+  v := _expr_term(ctx, body);
+  match(
+    v,
+    .Some(vt) => vt,
+    .None => tail
+  )
+});
+/// A conditioned `.Variant(b...)` arm: ite(Test) with the body under the
+/// projected bindings; falls back to the tail on a walk failure.
+_arm_conditioned_variant :: (
+  fn(inout(ctx) : VcCtx, scrut : VcTerm, pat : AstExpr, body : AstExpr, tail : VcTerm, e_ty : TypeValue) -> Option(VcTerm)
+)(
+  match(
+    _pattern_variant(pat),
+    .Some(variant) => {
+      v := _arm_under_pattern(ctx, scrut, pat, body, e_ty);
+      match(
+        v,
+        .Some(vt) => Option(VcTerm).Some(_mk_test_ite(scrut, _variant_ctor_name(e_ty, variant), vt, tail)),
+        .None => Option(VcTerm).None
+      )
+    },
+    .None => {
+      _fail_subset(ctx, String.from("non-variant match pattern (outside the V3 subset)"), pat);
+      Option(VcTerm).None
+    }
+  )
+);
+/// The MANGLED constructor name for `variant` of enum type `e_ty`
+/// (Unit/non-enum → the bare name; the walk on those is outside the
+/// subset anyway).
+_variant_ctor_name :: (fn(e_ty : TypeValue, variant : String) -> String)(
+  match(
+    e_ty,
+    .EnumT({ id : e_id }) => _enum_ctor_name(e_id.clone(), variant.clone()),
+    _ => variant.clone()
+  )
+);
+/// The mangled ACCESSOR names for `variant`'s fields of enum type `e_ty`,
+/// `count` of them (aligned with the pattern's bindings). SMT accessors
+/// share the datatype's whole namespace, so `<ctor>_<label>` keeps two
+/// variants that both have an `n` field from colliding; a missing label
+/// falls back to the field index.
+_variant_accessors :: (fn(e_ty : TypeValue, variant : String, count : usize) -> ArrayList(String))({
+  out := ArrayList(String).new();
+  ctor := _variant_ctor_name(e_ty, variant.clone());
+  vls := match(
+    e_ty,
+    .EnumT({ variant_names : e_names, variant_field_labels : e_labels }) => match(
+      e_labels.get(_variant_index_of(e_names, variant.clone())),
+      .Some(l) => l,
+      .None => ArrayList(String).new()
+    ),
+    _ => ArrayList(String).new()
+  );
+  (i : usize) = usize(0);
+  while(i < count, {
+    label := match(
+      vls.get(i),
+      .Some(fl) => fl.clone(),
+      .None => {
+        l := String.from("_");
+        l.push_string(i.to_string());
+        l
+      }
+    );
+    nm := ctor.clone();
+    nm.push_byte(u8(0x5F));
+    nm.push_string(label);
+    out.push(nm);
+    i = (i + usize(1));
+  });
+  out
+});
+/// The pattern's BINDING argument list: the pattern call's OWN args
+/// (`.(Some)(v)` → [v]); empty for the bare `.(Off)` form.
+_pattern_binding_args :: (fn(pat : AstExpr) -> ArrayList(AstExpr))(
+  match(
+    pat,
+    // `.(On)(v)` — callee is the NESTED dot-call (a FnCall): the pattern
+    // call's own args are the bindings. `.(Off)` — callee is the "."
+    // ATOM: no bindings.
+    .FnCall(_, pf, pargs, _, _) => cond(
+      ast_expr_is_atom(pf) => ArrayList(AstExpr).new(),
+      true => pargs
+    ),
+    .Atom(_, _) => ArrayList(AstExpr).new()
+  )
+);
+/// The first argument of a `.`-call as a variant name when it is a plain
+/// atom.
+_dot_first_atom :: (fn(pargs : ArrayList(AstExpr)) -> Option(String))(
+  match(
+    pargs.get(usize(0)),
+    .Some(first) => cond(
+      ast_expr_is_atom(first) => Option(String).Some(ast_expr_token(first).value),
+      true => Option(String).None
+    ),
+    .None => Option(String).None
+  )
+);
+/// A pattern's VARIANT name: `.On` parses as `.(On)` and `.Some(v)` as
+/// `.(Some, v)` — a dot-call whose FIRST argument is the variant atom.
+/// `.Some(v)`'s bindings are the remaining arguments. `.None` for
+/// non-variant patterns (an wildcard atom handled separately, a literal,
+/// anything else).
+_pattern_variant :: (fn(pat : AstExpr) -> Option(String))(
+  match(
+    pat,
+    .FnCall(_, pf, pargs, _, _) => cond(
+      // `.(Off)` — the callee IS the dot atom; the variant is the single
+      // argument. Distinguish by SHAPE, not by token: the nested
+      // `.(On)(v)` callee is a FnCall whose token is ALSO ".".
+      ast_expr_is_atom(pf) => cond(
+        (ast_expr_token(pf).value == ".") => _dot_first_atom(pargs),
+        true => Option(String).None
+      ),
+      true => _pattern_variant_of_callee(pf)
+    ),
+    .Atom(_, _) => Option(String).None
+  )
+);
+/// The variant name from a pattern's CALLEE: `.Off` is `.(Off)` (a bare
+/// dot-call); `.Some(v)` is `.(Some)` APPLIED to `(v)` — the parser gives
+/// the method-call shape (callee = the nested dot-call, args = bindings).
+_pattern_variant_of_callee :: (fn(pf : AstExpr) -> Option(String))(
+  match(
+    pf,
+    .Atom(_, _) => Option(String).None,
+    .FnCall(_, pf2, pf_args, _, _) => cond(
+      (ast_expr_token(pf2).value == ".") => _dot_first_atom(pf_args),
+      true => Option(String).None
+    )
+  )
+);
+/// `(ite (is-<ctor> S) v tail)` — `variant` is the MANGLED constructor
+/// name (the same spelling the declare-datatypes block declares).
+_mk_test_ite :: (fn(scrut : VcTerm, variant : String, v : VcTerm, tail : VcTerm) -> VcTerm)({
+  ite_args := ArrayList(VcTerm).new();
+  ite_args.push(VcTerm.Test(ctor : variant.clone(), t : scrut));
+  ite_args.push(v);
+  ite_args.push(tail);
+  VcTerm.App(VcOp.IteOp, ite_args)
+});
+/// Evaluate `body` with the pattern's bindings bound to the scrutinee's
+/// projections (bindings saved and restored). Projections carry the
+/// MANGLED accessor names (`<ctor>_<label>`) the declare-datatypes block
+/// declares — z3 resolves field access by accessor symbol, not position.
+_arm_under_pattern :: (
+  fn(inout(ctx) : VcCtx, scrut : VcTerm, pat : AstExpr, body : AstExpr, e_ty : TypeValue) -> Option(VcTerm)
+)({
+  saved_names := ArrayList(String).new();
+  saved_vals := ArrayList(Option(VcTerm)).new();
+  match(
+    _pattern_variant(pat),
+    .Some(variant) => {
+      pargs := _pattern_binding_args(pat);
+      accessors := _variant_accessors(e_ty, variant.clone(), pargs.len());
+      // Bindings: `.Some(v)` = `.(Some)(v)` — the pattern call's OWN args.
+      (bi : usize) = usize(0);
+      while(bi < pargs.len(), {
+        b := match(pargs.get(bi), .Some(x) => x, .None => make_err_expr());
+        if(ast_expr_is_atom(b), {
+          bname := ast_expr_token(b).value;
+          if(!(bname == "_"), {
+            saved_names.push(bname.clone());
+            saved_vals.push(ctx.vars.get(bname.clone()));
+            ctx.vars.insert(
+              bname.clone(),
+              VcTerm.Proj(
+                ctor : match(
+                  accessors.get(bi),
+                  .Some(a) => a.clone(),
+                  .None => _variant_ctor_name(e_ty, variant.clone())
+                ),
+                idx : bi,
+                t : scrut
+              )
+            );
+          });
+        }, {
+          _fail_subset(ctx, String.from("nested match pattern (outside the V3 subset)"), pat);
+          return(Option(VcTerm).None);
+        });
+        bi = (bi + usize(1));
+      });
+    },
+    .None => ()
+  );
+  v := _expr_term(ctx, body);
+  (si : usize) = saved_names.len();
+  while(si > usize(0), {
+    si = (si - usize(1));
+    sn := saved_names.get(si).unwrap();
+    match(
+      saved_vals.get(si),
+      .Some(sv) => {
+        match(
+          sv,
+          .Some(old) => {
+            ctx.vars.insert(sn.clone(), old);
+          },
+          .None => {
+            _ := ctx.vars.remove(sn.clone());
+            ()
+          }
+        );
+      },
+      .None => ()
+    );
+  });
+  v
+});
 /// The operator/cast/call dispatch.
 _call_term :: (
   fn(inout(ctx) : VcCtx, e : AstExpr, head : String, args : ArrayList(AstExpr), info : ExprInfo)
@@ -572,7 +1234,19 @@ _call_term :: (
   if(head == "cond", {
     return(_cond_ite(ctx, e, args));
   });
-  // --- while / for / match: precise subset rejections ----------------------
+  // --- enum construction: `.Variant(args...)` ------------------------------
+  // Parses as `.(Variant, args...)` — a dot-call whose FIRST argument
+  // names the variant. Only reached when the call's own type is a VALUE
+  // enum (the guard below); other dot-calls fall through to the subset
+  // error at the callee-call tail.
+  if((head == ".") && _is_value_enum_type(info.ty), {
+    return(_enum_ctor_term(ctx, e, args, info));
+  });
+  // --- match(scrutinee, arms...) ---------------------------------------------
+  if(head == "match", {
+    return(_match_term(ctx, e, args));
+  });
+  // --- while / for: precise subset rejections ----------------------
   // These would otherwise fall into the callee-call path and report a
   // misleading "uncontracted callee" error. Loops need the V4
   // havoc-invariant rule; `match` needs the enum/datatype encoding
@@ -583,10 +1257,6 @@ _call_term :: (
   });
   if(head == "for", {
     _fail_subset(ctx, String.from("for loop (requires invariant(...) — Phase V4)"), e);
-    return(Option(VcTerm).None);
-  });
-  if(head == "match", {
-    _fail_subset(ctx, String.from("match (enum/datatype encoding — pending later in V3)"), e);
     return(Option(VcTerm).None);
   });
   // --- begin blocks --------------------------------------------------------
@@ -1037,6 +1707,9 @@ _term_width :: (fn(t : VcTerm) -> usize)(
       .Some(a) => _term_width(a),
       .None => usize(1)
     ),
+    .Ctor(_, _) => usize(1),
+    .Test(_, _) => usize(1),
+    .Proj(_, _, _) => usize(1),
     .Quant(_, _, _, _) => usize(1)
   )
 );

--- a/tests/internal/verifier_match.test.yo
+++ b/tests/internal/verifier_match.test.yo
@@ -1,0 +1,193 @@
+//! The match/datatype-encoding tests — V3's last subset row
+//! (FORMAL_VERIFICATION.md): value enums verify as SMT datatypes
+//! (`declare-datatypes`), `.Variant(args...)` constructions are Ctor
+//! terms, and `match` lowers to a nested ite over `is-` testers with
+//! pattern bindings as field projections.
+//!
+//! In-process model (verifier_negative's shape); refutations need the
+//! real solver (YO_TEST_Z3=1), the encode-shape test runs solver-free.
+open(import("std/string"));
+open(import("std/error"));
+{ ArrayList } :: import("std/collections/array_list");
+{ assert } :: import("std/assert");
+{ env } :: import("std/env");
+{
+  mm_load_file,
+  mm_preload_prelude,
+  mm_resolve_entry_abs,
+  resolve_std_path,
+  _take_load_error
+} :: import("../../src/module_manager.yo");
+{ clear_module_cache } :: import("../../src/evaluator/module_loader.yo");
+{
+  set_verify_mode_override,
+  set_verify_target_paths,
+  take_verify_tasks
+} :: import("../../src/evaluator/builtins/contracts.yo");
+{
+  default_verify_run_config,
+  resolve_solver_sync,
+  verify_and_strip_tasks,
+  VerifyFnReport
+} :: import("../../src/verifier/driver.yo");
+{ VerifyFnInput, verify_function_body } :: import("../../src/verifier/vc.yo");
+{ encode_script, default_encode_options } :: import("../../src/verifier/encode.yo");
+
+_have_z3 :: (fn() -> bool)(
+  match(
+    env.get(String.from("YO_TEST_Z3")),
+    .Some(v) => (v == String.from("1")),
+    .None => false
+  )
+);
+/// Load one fixture with targets armed; returns its reports (the task
+/// list is drained into the run inside `_run_reports`).
+_load_reports :: (fn(rel_path : String, io : Io) -> ArrayList(VerifyFnReport))({
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `verifier_match: unexpected throw: ${err}`);
+      }
+    )
+  );
+  std_path := resolve_std_path();
+  targets := ArrayList(String).new();
+  targets.push(rel_path.clone());
+  targets.push(mm_resolve_entry_abs(rel_path.clone(), std_path.clone()));
+  _ := take_verify_tasks();
+  set_verify_mode_override(Option(String).None);
+  set_verify_target_paths(targets);
+  clear_module_cache();
+  mm_preload_prelude(std_path.clone(), true, io, exn);
+  outcome := mm_load_file(rel_path.clone(), std_path.clone(), true, io, exn);
+  match(
+    _take_load_error(),
+    .Some(rendered) => {
+      assert(outcome.ok, `fixture ${rel_path} failed: ${rendered}`);
+    },
+    .None => {
+      assert(outcome.ok, `fixture ${rel_path} must evaluate cleanly`);
+    }
+  );
+  cfg := default_verify_run_config();
+  binary := match(
+    resolve_solver_sync(cfg),
+    .Resolved(p) => p,
+    _ => String.new()
+  );
+  verify_and_strip_tasks(cfg, binary, take_verify_tasks())
+});
+/// The reports' ids/outcomes rendered for assert messages.
+_reports_dump :: (fn(reports : ArrayList(VerifyFnReport)) -> String)({
+  ids := ArrayList(String).new();
+  (i : usize) = usize(0);
+  while(i < reports.len(), {
+    match(
+      reports.get(i),
+      .Some(rp) => {
+        ids.push(`${rp.fn_id}=${rp.outcome} [${rp.subset_construct}: ${rp.subset_source}]`);
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  sb := StringBuilder.new();
+  (j : usize) = usize(0);
+  while(j < ids.len(), {
+    if(j > usize(0), {
+      sb.write_string(String.from(", "));
+    });
+    sb.write_string(ids.get(j).unwrap().clone());
+    j = (j + usize(1));
+  });
+  sb.to_string()
+});
+
+test("match + enum datatypes verify (binding, bare-variant, construction)", {
+  if(!(_have_z3()), {
+    return(());
+  });
+  reports := _load_reports(String.from("./tests/spec/fixtures/valid/match_enum.yo"), io);
+  assert(reports.len() == usize(2), `two functions, got ${reports.len().to_string()}: [${_reports_dump(reports)}]`);
+  (i : usize) = usize(0);
+  while(i < reports.len(), {
+    rp := match(
+      reports.get(i),
+      .Some(r) => r,
+      .None => {
+        assert(false, "report missing");
+        return(());
+      }
+    );
+    assert((rp.outcome == "ok"), `every match fixture fn proves, got: [${_reports_dump(reports)}]`);
+    i = (i + usize(1));
+  });
+});
+
+test("the SMT encoding of a match query declares the datatype (solver-free)", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `verifier_match: unexpected throw: ${err}`);
+      }
+    )
+  );
+  std_path := resolve_std_path();
+  rel := String.from("./tests/spec/fixtures/valid/match_enum.yo");
+  targets := ArrayList(String).new();
+  targets.push(rel.clone());
+  targets.push(mm_resolve_entry_abs(rel.clone(), std_path.clone()));
+  _ := take_verify_tasks();
+  set_verify_mode_override(Option(String).None);
+  set_verify_target_paths(targets);
+  clear_module_cache();
+  mm_preload_prelude(std_path.clone(), true, io, exn);
+  outcome := mm_load_file(rel.clone(), std_path.clone(), true, io, exn);
+  assert(outcome.ok, "fixture must evaluate cleanly");
+  tasks := take_verify_tasks();
+  assert(tasks.len() == usize(2), `two tasks, got ${tasks.len().to_string()}`);
+  t := match(
+    tasks.get(usize(0)),
+    .Some(x) => x,
+    .None => {
+      assert(false, "task missing");
+      return(());
+    }
+  );
+  res := verify_function_body(
+    VerifyFnInput(
+      fn_name : t.fn_id.clone(),
+      func_id : t.func_id.clone(),
+      body : t.body.clone(),
+      param_names : t.param_names.clone(),
+      param_types : t.param_types.clone(),
+      result_type : t.result_type.clone(),
+      requires_exprs : t.requires_exprs.clone(),
+      ensures_exprs : t.ensures_exprs.clone(),
+      return_label : t.return_label.clone(),
+      table : t.table
+    )
+  );
+  assert(res.error.is_none(), `no subset error expected for the match fixture`);
+  assert(res.obligations.len() > usize(0), "the ensures obligation exists");
+  (dt_count : usize) = usize(0);
+  (oi : usize) = usize(0);
+  while(oi < res.obligations.len(), {
+    match(
+      res.obligations.get(oi),
+      .Some(obl) => {
+        (di : usize) = usize(0);
+        while(di < obl.query.datatypes.len(), {
+          dt_count = (dt_count + usize(1));
+          di = (di + usize(1));
+        });
+      },
+      .None => ()
+    );
+    oi = (oi + usize(1));
+  });
+  assert((dt_count > usize(0)), "the query carries the enum's datatype declaration");
+  script := encode_script(res.obligations.get(usize(0)).unwrap().query, default_encode_options());
+  assert(script.contains(String.from("declare-datatypes")), "the emitted SMT declares the datatype");
+  assert(script.contains(String.from("is-")), "the emitted SMT carries the match testers");
+});

--- a/tests/spec/fixtures/valid/match_enum.yo
+++ b/tests/spec/fixtures/valid/match_enum.yo
@@ -1,0 +1,35 @@
+// match/datatype fixture for the V3 verifier's last subset row
+// (tests/internal/verifier_match.test.yo): a value enum with a match —
+// both proving shapes (positives here; the bugged twin lives in the
+// negative set).
+pragma(Pragma.Verify);
+
+Mark :: enum(On(n : i32), Off);
+
+// bind_floor: match with a binding pattern + a bare variant arm. The
+// binding is USED but the ensures stays provable with unconstrained
+// inputs: (v - v) is 0 under two's-complement wrap, so both arms
+// return >= d exactly.
+bind_floor :: (
+  fn(m : Mark, d : i32, ensures(r >= d)) -> (r : i32)
+)(
+  match(
+    m,
+    .On(v) => (d + (v - v)),
+    .Off => d
+  )
+);
+
+// A construction inside a match arm body: the cond clamps the On-arm's
+// subtraction back to >= 0, so the ensures holds on both paths.
+toggle :: (fn(m : Mark, ensures(r >= i32(0))) -> (r : i32))({
+  n := match(
+    m,
+    .On(v) => (v - i32(1)),
+    .Off => i32(0)
+  );
+  cond(
+    (n < i32(0)) => i32(0),
+    true => n
+  )
+});


### PR DESCRIPTION
## Summary

Closes the last unchecked row of V3's subset table: value enums as SMT datatypes.

- **terms** (`src/verifier/terms.yo`): `VcSort.DataS(name)`; `VcTerm.Ctor/Test/Proj` — constructor application, `(is-<Ctor> t)` tester, `(<Ctor>-<idx> t)` projection; `VcQuery.datatypes` carries the combined `declare-datatypes` block (rendered once, before the constants).
- **vc** (`src/verifier/vc.yo`): `_type_sort` maps value enums to `DataS`; `_note_enum_datatype` registers `<dt>|<ctors>` entries idempotently per context; construction dispatch for `.Variant(...)` with value args; the match walk folds arms into an ite tree over `Test`/`Proj` with pattern bindings projected off the scrutinee (bindings saved and restored around arm bodies); `_collect_declared`/`_rename_vars` extended for the three new term kinds.
- **encode** (`src/verifier/encode.yo`): `declare-datatypes` before `declare-fun`s; `(is-C t)` / `(C-i t)` spellings; deterministic declaration ordering via a ptr-write insertion sort (`_sorted_lines`).
- **tests**: `tests/internal/verifier_match.test.yo` — a real-solver proving battery (gated `YO_TEST_Z3=1` like the other verifier tests) plus solver-free encoding pins (`declare-datatypes` + `is-` present in the encoded script); fixture `tests/spec/fixtures/valid/match_enum.yo`.

## Stacking

Stacked on #527 (match-binding shadow fix): the walk binds `t` in `.Test(_, t)` arms against the parameter `t`, which the pre-fix codegen miscompiled into a self-referential C initializer (C11 6.2.1p4 UB) — the nondeterministic rc=139 that blocked this row locally. **Do not merge before #527.** Base will be retargeted to `develop` once #527 lands.

Draft until the stacked CI run proves the tests green (they cannot pass under the local v0.2.29 seed, which still carries the shadow bug).