### PR TITLE
codegen: __yo_mutex_trylock and __yo_cond_timedwait in the emitted runtime

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -443,7 +443,8 @@ saturating_/overflowing_`, `abs/pow/clamp/count_ones/leading_zeros`, every
 `ErrorChain`, `Context`, `derive_rule(Error)`, `black_box`, log `Sink`/`YO_LOG`,
 `thread_rng`. Concurrency — `Thread` is NOT generic and `join -> unit`
 (`std/thread.yo:61,78`), so **D18b is still open**; `Sender`/`Receiver` split,
-`Mutex.try_lock`, `Condvar.wait_timeout`, `RwLock.try_*`,
+`Condvar.wait_timeout`, `RwLock.try_*` (the runtime primitives landed
+2026-09-10; the std half waits one release),
 `Semaphore.with_permit`, `interval`, `spawn_blocking`, `TryRecvError` all absent;
 `_raw_lock` is still public (`std/sync/once.yo:70`) — that row asks for REMOVAL,
 so "present" means the work remains.
@@ -658,13 +659,55 @@ or dropping the claim; `Once.call` rewritten over `Mutex.with_lock`;
 `JoinHandle` `Dispose`; `interval`; `spawn_blocking`; a concurrent test for
 `Mutex` (it has none).
 
-**BLOCKED on the seed, not on design:** `Mutex.try_lock`,
-`Condvar.wait_timeout` and `RwLock.try_*` all need `__yo_mutex_trylock` /
-`__yo_cond_timedwait` in the runtime, and `std/` cannot use a new `__yo_*`
-macro until the SEED ships it. The compiler half also has to give Linux's
-condvar a monotonic-clock init, which changes `__yo_cond_init` — shared with
-the GC's stop-the-world condvar — so it is a compiler PR first, then a std PR
-one release later.
+**`Mutex.try_lock`, `Condvar.wait_timeout`, `RwLock.try_*` — the COMPILER HALF
+LANDED 2026-09-10; the std half waits for one release.**
+
+`__yo_mutex_trylock` and `__yo_cond_timedwait` are now in the emitted runtime
+(`src/codegen/types/generation.yo`). `std/` still cannot call them until the
+SEED ships them, so the sequence is: this compiler PR → release → SEED_VERSION
+bump → the std PR.
+
+Three platform shapes, and the reason for each:
+
+- **Windows** rounds the timeout UP to the next millisecond.
+  `SleepConditionVariableCS` takes milliseconds, so truncating a
+  sub-millisecond timeout to 0 makes it return IMMEDIATELY — a "wait 100 us"
+  would never wait at all. Only `ERROR_TIMEOUT` counts as a timeout; any other
+  failure is reported as a wake so the caller re-checks its predicate rather
+  than concluding the wait expired.
+- **macOS** uses `pthread_cond_timedwait_relative_np`. It has no
+  `pthread_condattr_setclock`, and the relative form needs no deadline
+  arithmetic and no clock agreement at all.
+- **Linux** binds the condvar to `CLOCK_MONOTONIC` at init and reads the
+  deadline from the same clock. The clock is a property of the CONDVAR, not of
+  the wait — `pthread_cond_timedwait` interprets its absolute deadline with
+  whatever clock the condvar was created with — so the two MUST agree, and one
+  macro names it for both. Everything else POSIX (wasm) falls back to the wall
+  clock for both halves.
+
+`__yo_cond_init` therefore changed from a macro to a `static inline` on POSIX,
+which is shared with the GC's stop-the-world condvar and the parallelism
+workers. **The blast radius is nil in practice:** an UNTIMED
+`pthread_cond_wait` never consults a clock, so binding the condvar to
+`CLOCK_MONOTONIC` changes nothing for any existing waiter — only a timed wait
+can observe it, and until the std half lands the only timed wait in the tree is
+the test below.
+
+Coverage: `tests/sync/timedwait.test.yo` (6 tests) declares both primitives
+`extern` and exercises them — `tests/` is not seed-gated, so this is what
+proves they WORK a release before `std/` can call them, which a `static inline`
+with no caller would otherwise never demonstrate. It covers an uncontended
+trylock, a trylock contended from ANOTHER thread (a same-thread re-lock is not
+portable: a Windows `CRITICAL_SECTION` is recursive and answers true where a
+POSIX `NORMAL` mutex answers false), a timeout WITH an elapsed-time assertion,
+an early return on signal, a sub-millisecond timeout, and zero/negative
+timeouts. The elapsed assertion is the load-bearing one: a deadline whose
+`tv_nsec` escapes `[0, 1e9)` makes `pthread_cond_timedwait` return `EINVAL`
+immediately, which is indistinguishable from a timeout by return value alone.
+Verified locally on macOS (60 ms measured for a 50 ms request) and under
+`--c-compiler emcc`, which takes the same absolute-deadline path Linux does;
+the `CLOCK_MONOTONIC` init itself is Linux-only and is covered by CI's Linux
+legs.
 
 **A live runtime bug sits under this group:**
 `issues/yield-resumption-order-diverges-on-macos-ci.md` — two tasks that

--- a/src/codegen/types/generation.yo
+++ b/src/codegen/types/generation.yo
@@ -552,11 +552,33 @@ typedef HANDLE __YO_THREAD_TYPE;
 #define __yo_mutex_destroy(m) DeleteCriticalSection(m)
 #define __yo_mutex_lock(m) EnterCriticalSection(m)
 #define __yo_mutex_unlock(m) LeaveCriticalSection(m)
+// NOTE a CRITICAL_SECTION is RECURSIVE: a thread that already owns it acquires
+// it again, so this answers true where POSIX's default mutex answers false.
+// The divergence is pre-existing (__yo_mutex_lock is EnterCriticalSection,
+// which re-enters, while pthread_mutex_lock on a NORMAL mutex deadlocks) and
+// std/sync never re-locks from the owning thread.
+#define __yo_mutex_trylock(m) (TryEnterCriticalSection(m) != 0)
 #define __yo_cond_init(c) InitializeConditionVariable(c)
 #define __yo_cond_destroy(c) ((void)0)
 #define __yo_cond_wait(c, m) SleepConditionVariableCS(c, m, INFINITE)
 #define __yo_cond_signal(c) WakeConditionVariable(c)
 #define __yo_cond_broadcast(c) WakeAllConditionVariable(c)
+// Wait until signalled or until timeout_ns elapse. True means the wait ended
+// in a wake (possibly SPURIOUS - the caller re-checks its predicate either
+// way, which is the condvar contract); false means it genuinely timed out.
+static inline bool __yo_cond_timedwait(__YO_COND_TYPE* c, __YO_THREAD_SYNC_TYPE* m, int64_t timeout_ns) {
+  int64_t ms;
+  if (timeout_ns < 0) timeout_ns = 0;
+  // Round UP to the next millisecond. SleepConditionVariableCS takes ms, and
+  // truncating a sub-millisecond timeout to 0 makes it return IMMEDIATELY, so
+  // a "wait 100 us" would never wait at all.
+  ms = (timeout_ns + 999999LL) / 1000000LL;
+  if (ms > (int64_t)(INFINITE - 1)) ms = (int64_t)(INFINITE - 1);
+  if (SleepConditionVariableCS(c, m, (DWORD)ms)) return true;
+  // Only ERROR_TIMEOUT is a timeout. Any other failure is reported as a wake
+  // so the caller re-checks its predicate instead of concluding "timed out".
+  return GetLastError() != ERROR_TIMEOUT;
+}
 #define __yo_raw_thread_create(t, func, arg) (*(t) = (HANDLE)_beginthreadex(NULL, 0, func, arg, 0, NULL), *(t) != NULL ? 0 : -1)
 #define __yo_raw_thread_join(t) (WaitForSingleObject(t, INFINITE), CloseHandle(t), 0)
 #define __yo_raw_thread_detach(t) (CloseHandle(t), 0)
@@ -573,6 +595,8 @@ typedef HANDLE __YO_THREAD_TYPE;
 #include <pthread.h>
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <errno.h>
+#include <time.h>
 ${macos_includes}
 typedef pthread_mutex_t __YO_THREAD_SYNC_TYPE;
 typedef pthread_cond_t __YO_COND_TYPE;
@@ -585,11 +609,80 @@ typedef pthread_t __YO_THREAD_TYPE;
 #define __yo_mutex_destroy(m) pthread_mutex_destroy(m)
 #define __yo_mutex_lock(m) pthread_mutex_lock(m)
 #define __yo_mutex_unlock(m) pthread_mutex_unlock(m)
-#define __yo_cond_init(c) pthread_cond_init(c, NULL)
+// EBUSY (not 0) is the "someone else holds it" answer, and every other
+// non-zero return is also a failure to acquire, so success is exactly == 0.
+#define __yo_mutex_trylock(m) (pthread_mutex_trylock(m) == 0)
 #define __yo_cond_destroy(c) pthread_cond_destroy(c)
 #define __yo_cond_wait(c, m) pthread_cond_wait(c, m)
 #define __yo_cond_signal(c) pthread_cond_signal(c)
 #define __yo_cond_broadcast(c) pthread_cond_broadcast(c)
+// A timed condvar wait must not be lengthened or cut short by a wall-clock
+// step, so it runs off a MONOTONIC clock wherever the platform allows it. The
+// clock is a property of the CONDVAR, not of the wait: pthread_cond_timedwait
+// interprets its absolute deadline with the clock the condvar was created
+// with, so __yo_cond_init below and the deadline read in __yo_cond_timedwait
+// MUST agree - hence one macro naming the clock for both.
+#if defined(__APPLE__)
+  // macOS has no pthread_condattr_setclock. It does have the RELATIVE wait,
+  // which needs no deadline arithmetic and no clock agreement at all.
+  #define __YO_COND_RELATIVE_WAIT 1
+  #define __YO_COND_CLOCKID CLOCK_REALTIME
+#elif defined(__linux__) && defined(CLOCK_MONOTONIC)
+  #define __YO_COND_RELATIVE_WAIT 0
+  #define __YO_COND_MONOTONIC 1
+  #define __YO_COND_CLOCKID CLOCK_MONOTONIC
+#else
+  // wasm and anything else without condattr clock selection: the wall clock
+  // for BOTH halves, which is still correct absent a clock step.
+  #define __YO_COND_RELATIVE_WAIT 0
+  #define __YO_COND_CLOCKID CLOCK_REALTIME
+#endif
+static inline void __yo_cond_init(__YO_COND_TYPE* c) {
+#if defined(__YO_COND_MONOTONIC)
+  pthread_condattr_t attr;
+  if (pthread_condattr_init(&attr) == 0) {
+    if (pthread_condattr_setclock(&attr, __YO_COND_CLOCKID) == 0) {
+      int rc = pthread_cond_init(c, &attr);
+      pthread_condattr_destroy(&attr);
+      if (rc == 0) return;
+    } else {
+      pthread_condattr_destroy(&attr);
+    }
+  }
+  // Fall through to the default clock: a condvar that exists on the wall clock
+  // beats one that failed to initialize.
+#endif
+  pthread_cond_init(c, NULL);
+}
+// Wait until signalled or until timeout_ns elapse. True means the wait ended
+// in a wake (possibly SPURIOUS - the caller re-checks its predicate either
+// way, which is the condvar contract); false means it genuinely timed out.
+static inline bool __yo_cond_timedwait(__YO_COND_TYPE* c, __YO_THREAD_SYNC_TYPE* m, int64_t timeout_ns) {
+  int rc;
+  if (timeout_ns < 0) timeout_ns = 0;
+#if __YO_COND_RELATIVE_WAIT
+  {
+    struct timespec rel;
+    rel.tv_sec = (time_t)(timeout_ns / 1000000000LL);
+    rel.tv_nsec = (long)(timeout_ns % 1000000000LL);
+    rc = pthread_cond_timedwait_relative_np(c, m, &rel);
+  }
+#else
+  {
+    struct timespec deadline;
+    int64_t nsec;
+    clock_gettime(__YO_COND_CLOCKID, &deadline);
+    // Carry the nanosecond sum into seconds. tv_nsec must stay in [0, 1e9) or
+    // pthread_cond_timedwait returns EINVAL and the wait never happens at all
+    // - which looks exactly like an instant timeout.
+    nsec = (int64_t)deadline.tv_nsec + (timeout_ns % 1000000000LL);
+    deadline.tv_sec += (time_t)((timeout_ns / 1000000000LL) + (nsec / 1000000000LL));
+    deadline.tv_nsec = (long)(nsec % 1000000000LL);
+    rc = pthread_cond_timedwait(c, m, &deadline);
+  }
+#endif
+  return rc != ETIMEDOUT;
+}
 #define __yo_raw_thread_create(t, func, arg) pthread_create(t, NULL, func, arg)
 #define __yo_raw_thread_join(t) pthread_join(t, NULL)
 #define __yo_raw_thread_detach(t) pthread_detach(t)

--- a/tests/sync/timedwait.test.yo
+++ b/tests/sync/timedwait.test.yo
@@ -1,0 +1,122 @@
+pragma(Pragma.SkipWasm32Wasi); // no pthread support in standalone WASI
+/// Behavioural coverage for the two runtime primitives the compiler emits for
+/// `Mutex.try_lock` / `Condvar.wait_timeout` / `RwLock.try_*`:
+/// `__yo_mutex_trylock` and `__yo_cond_timedwait`.
+///
+/// std/ cannot use them until the SEED ships them, so this file is what proves
+/// they WORK before that release — `tests/` is not seed-gated and is compiled
+/// by the tree's own compiler on every CI platform, which is exactly the
+/// coverage a `static inline` with no caller would otherwise lack.
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+{ Mutex } :: import("std/sync/mutex");
+{ Cond } :: import("std/sync/cond");
+{ Channel } :: import("std/sync/channel");
+{ Thread } :: import("std/thread");
+{ Instant } :: import("std/time/instant");
+{ eprintln } :: import("std/fmt");
+extern(
+  "Yo",
+  __YO_THREAD_SYNC_TYPE : Type,
+  __YO_COND_TYPE : Type,
+  __yo_mutex_trylock : (fn(mutex : *__YO_THREAD_SYNC_TYPE) -> bool),
+  __yo_cond_timedwait : (fn(cv : *__YO_COND_TYPE, mutex : *__YO_THREAD_SYNC_TYPE, timeout_ns : i64) -> bool)
+);
+test("__yo_mutex_trylock acquires an uncontended mutex", {
+  m := Mutex(i64).new(i64(0));
+  assert(__yo_mutex_trylock(m._raw_handle_ptr()), "trylock succeeds on a free mutex");
+  m._raw_unlock();
+  // And again, so a successful trylock is a real acquisition that unlock
+  // released — not a no-op that always answers true.
+  assert(__yo_mutex_trylock(m._raw_handle_ptr()), "trylock succeeds again after unlock");
+  m._raw_unlock();
+});
+test("__yo_mutex_trylock fails while ANOTHER thread holds the mutex", {
+  // Cross-thread on purpose: a same-thread re-lock diverges by platform
+  // (a Windows CRITICAL_SECTION is recursive and would answer true, a POSIX
+  // NORMAL mutex answers false), so it would not be a portable assertion.
+  m := Mutex(i64).new(i64(0));
+  held := Channel(i32).new(usize(1));
+  release := Channel(i32).new(usize(1));
+  holder := Thread.spawn(io => {
+    m._raw_lock();
+    held.send(i32(1));
+    release.recv();
+    m._raw_unlock();
+  });
+  // Block until the other thread is definitely holding it.
+  held.recv();
+  assert(!__yo_mutex_trylock(m._raw_handle_ptr()), "trylock fails on a held mutex");
+  release.send(i32(1));
+  holder.join();
+  // Once released, it is acquirable again.
+  assert(__yo_mutex_trylock(m._raw_handle_ptr()), "trylock succeeds after the holder released");
+  m._raw_unlock();
+});
+test("__yo_cond_timedwait times out, and actually waits that long", {
+  // The elapsed check is the load-bearing half. A deadline whose tv_nsec is
+  // left outside [0, 1e9) makes pthread_cond_timedwait return EINVAL
+  // IMMEDIATELY, which looks like a timeout — so "returned false" alone would
+  // pass over a broken carry. Only the elapsed time distinguishes them.
+  m := Mutex(i64).new(i64(0));
+  cv := Cond.new();
+  m._raw_lock();
+  start := Instant.now();
+  signalled := __yo_cond_timedwait(&cv.cv, m._raw_handle_ptr(), i64(50000000));
+  waited := start.elapsed();
+  m._raw_unlock();
+  assert(!signalled, "nobody signalled, so it must report a timeout");
+  eprintln(`  waited ${waited.as_millis()}ms for a 50ms timeout`);
+  // 40ms rather than 50ms: a platform may round the deadline down to its timer
+  // granularity. What matters is that it did NOT return immediately.
+  assert(waited.as_millis() >= i64(40), `waited ${waited.as_millis()}ms, expected at least 40`);
+});
+test("__yo_cond_timedwait returns early when signalled", {
+  m := Mutex(i64).new(i64(0));
+  cv := Cond.new();
+  ready := Channel(i32).new(usize(1));
+  signaller := Thread.spawn(io => {
+    // Wait until the main thread is inside the wait, then signal. Taking the
+    // mutex is what guarantees that: the waiter releases it atomically on
+    // entering the wait, so acquiring it here means the wait has begun.
+    ready.recv();
+    m._raw_lock();
+    cv.signal();
+    m._raw_unlock();
+  });
+  m._raw_lock();
+  ready.send(i32(1));
+  start := Instant.now();
+  // A 10s budget that must not be consumed.
+  signalled := __yo_cond_timedwait(&cv.cv, m._raw_handle_ptr(), i64(10000000000));
+  waited := start.elapsed();
+  m._raw_unlock();
+  signaller.join();
+  assert(signalled, "a signalled wait does not report a timeout");
+  assert(waited.as_secs() < i64(5), `returned in ${waited.as_millis()}ms, well under the 10s budget`);
+});
+test("__yo_cond_timedwait honours a SUB-millisecond timeout", {
+  // Windows' SleepConditionVariableCS takes milliseconds, so a 100us timeout
+  // truncates to 0 — "return immediately" — unless the conversion rounds UP.
+  // Rounding up is the only reason this returns a timeout rather than an
+  // instant false that happens to look the same.
+  m := Mutex(i64).new(i64(0));
+  cv := Cond.new();
+  m._raw_lock();
+  signalled := __yo_cond_timedwait(&cv.cv, m._raw_handle_ptr(), i64(100000));
+  m._raw_unlock();
+  assert(!signalled, "an unsignalled sub-millisecond wait still times out");
+});
+test("__yo_cond_timedwait treats a zero and a negative timeout as 'do not block'", {
+  m := Mutex(i64).new(i64(0));
+  cv := Cond.new();
+  m._raw_lock();
+  start := Instant.now();
+  assert(!__yo_cond_timedwait(&cv.cv, m._raw_handle_ptr(), i64(0)), "zero times out");
+  // A negative timeout is clamped to zero rather than becoming a very long
+  // wait through an unsigned conversion.
+  assert(!__yo_cond_timedwait(&cv.cv, m._raw_handle_ptr(), i64(-1)), "negative times out");
+  waited := start.elapsed();
+  m._raw_unlock();
+  assert(waited.as_secs() < i64(2), `both returned promptly, in ${waited.as_millis()}ms`);
+});


### PR DESCRIPTION
The **compiler half** of `Mutex.try_lock` / `Condvar.wait_timeout` /
`RwLock.try_*`. `std/` cannot call a new `__yo_*` primitive until the SEED
ships it, so the sequence is: this PR → release → `SEED_VERSION` bump → the std
PR. **Nothing in `std/` changes here.**

This unblocks the last "BLOCKED on the seed, not on design" row in
`plans/STD_API_STABILIZATION.md`.

## Three platform shapes, each for a reason

**Windows** rounds the timeout **up** to the next millisecond.
`SleepConditionVariableCS` takes milliseconds, so truncating a sub-millisecond
timeout to 0 makes it return *immediately* — a "wait 100 us" would never wait
at all. Only `ERROR_TIMEOUT` counts as a timeout; any other failure is reported
as a wake, so the caller re-checks its predicate rather than concluding the
wait expired.

**macOS** uses `pthread_cond_timedwait_relative_np`: it has no
`pthread_condattr_setclock`, and the relative form needs no deadline arithmetic
and no clock agreement at all.

**Linux** binds the condvar to `CLOCK_MONOTONIC` at init and reads the deadline
from the same clock, so a wall-clock step cannot lengthen or cut short a wait.
The clock is a property of the **condvar**, not of the wait —
`pthread_cond_timedwait` interprets its absolute deadline with whatever clock
the condvar was created with — so the two must agree, and one macro
(`__YO_COND_CLOCKID`) names it for both. Everything else POSIX (wasm) falls
back to the wall clock for both halves, which is still correct absent a step.

`__yo_mutex_trylock` is a macro on both platforms, but note the pre-existing
divergence it inherits: a Windows `CRITICAL_SECTION` is **recursive**, so a
thread that already owns the mutex acquires it again and gets `true`, where a
POSIX `NORMAL` mutex answers `false`. `__yo_mutex_lock` already had that
asymmetry (`EnterCriticalSection` re-enters; `pthread_mutex_lock` deadlocks)
and `std/sync` never re-locks from the owning thread. Documented at the
definition.

## `__yo_cond_init` became a `static inline` on POSIX — and the blast radius is nil

It is shared with the GC's stop-the-world condvar and the parallelism workers,
so that deserves a straight answer: **an untimed `pthread_cond_wait` never
consults a clock**, so binding the condvar to `CLOCK_MONOTONIC` changes nothing
for any existing waiter. Only a timed wait can observe it, and until the std
half lands the only timed wait in the tree is the test below. The init also
falls back to the default clock if `condattr_init`/`setclock` fail — a condvar
that exists on the wall clock beats one that failed to initialize.

## Coverage: `tests/sync/timedwait.test.yo`, 6 tests

`tests/` is not seed-gated, so it declares both primitives `extern` and
exercises them a release **before** `std/` can. That is the only way a
`static inline` with no caller gets more than a syntax check — an exported
mechanism with zero callers passing every gate is a mistake this repo has made
before (`yo-port-gap-exported-but-uncalled-helpers`).

- an uncontended trylock, twice, so a success is a real acquisition that
  `unlock` released rather than a no-op that always answers true;
- a trylock contended from **another thread**. Cross-thread on purpose: a
  same-thread re-lock is the one case where Windows and POSIX legitimately
  disagree, so it would not be a portable assertion. A `Channel` handshake
  makes it deterministic rather than sleep-based;
- a **timeout with an elapsed-time assertion** — the load-bearing one. A
  deadline whose `tv_nsec` escapes `[0, 1e9)` makes `pthread_cond_timedwait`
  return `EINVAL` *immediately*, which is indistinguishable from a timeout by
  return value alone. Measured 60 ms locally for a 50 ms request;
- an early return when signalled, against a 10 s budget that must not be
  consumed;
- a sub-millisecond timeout (the Windows round-up case);
- zero and negative timeouts, so a negative does not become a very long wait
  through an unsigned conversion.

Verified on macOS (the `relative_np` path) and under `--c-compiler emcc` (the
absolute-deadline path Linux also takes) — **6/6 both ways**. The
`CLOCK_MONOTONIC` init itself is Linux-only and is covered by CI's Linux legs,
including the ThreadSanitizer one.

## Local gate (all green)

| gate | result |
| --- | --- |
| `yo build` with `YO_STD=<worktree>/std` | rc=0 |
| full suite (`tests`, minus `internal`/`cli-cases`) | **3905 passed, 0 failed** (incl. the `tests/dyn` canary) |
| CLI golden scorecard | PASS **90**, GOLDEN-DIFF 0, NO-GOLDEN 0, SKIP 1 |
| `gates_fast.sh` (7 gates) | rc=0 — `check ./std` **173/173**, `check ./src` **271/271**, corpus PASS 156 |
| `fixpoint_only.sh` | **FIXPOINT_HOLDS**, stage2 hollow=0 |

Byte identity against `develop` is deliberately **not** the gate here: turning
`__yo_cond_init` from a macro into a function changes the emitted C for every
program that has a condvar. The fixpoint (stage2 == stage3, both from the new
compiler) plus the corpus compiling is what makes the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)