### PR TITLE
ci: drop the runner image's third-party apt sources before apt-get update

### DIFF
--- a/.github/actions/build-stage1/action.yml
+++ b/.github/actions/build-stage1/action.yml
@@ -52,6 +52,14 @@ runs:
         # define, or it silently loses the protection when reused elsewhere.
         # See test.yml's APT_OPTS comment — a bare apt-get can hang forever on
         # the dpkg lock held by the runner's unattended-upgrades timer.
+        #
+        # And drop the image's third-party apt sources: `update` exits 100 if
+        # ANY source fails, and this action installs only from Ubuntu's own
+        # archives. Acquire::Retries above does not cover it — a Hash Sum
+        # mismatch is deterministic. This step is how the wasm legs still fell
+        # over after the 19 sites in the workflows were fixed.
+        # See issues/ci-apt-update-fails-on-an-unused-third-party-source.md.
+        sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
         sudo apt-get -o DPkg::Lock::Timeout=600 -o Acquire::Retries=3 update
         # + OpenSSL dev: std/http in the compiler closure (D6 PR-3) puts OpenSSL
         # headers into stage1.c, compiled by phase 2 below.

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -31,6 +31,9 @@ on:
 env:
   # See test.yml's APT_OPTS comment: a bare apt-get can hang forever on the
   # dpkg lock held by the runner's unattended-upgrades timer.
+  # Each `update` below is also preceded by an `rm` of the image's third-party
+  # apt sources — see test.yml's APT_OPTS comment and
+  # issues/ci-apt-update-fails-on-an-unused-third-party-source.md.
   APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"
 
 jobs:
@@ -56,6 +59,8 @@ jobs:
       # step records the v0.2.10 failure this caused).
       - name: Install liburing
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev
 

--- a/.github/workflows/fixpoint-arm64.yml
+++ b/.github/workflows/fixpoint-arm64.yml
@@ -48,6 +48,9 @@ env:
   SEED_VERSION: v0.2.29
   # See test.yml's APT_OPTS comment: a bare apt-get can hang forever on the
   # dpkg lock held by the runner's unattended-upgrades timer.
+  # Each `update` below is also preceded by an `rm` of the image's third-party
+  # apt sources — see test.yml's APT_OPTS comment and
+  # issues/ci-apt-update-fails-on-an-unused-third-party-source.md.
   APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"
 
 jobs:
@@ -74,6 +77,8 @@ jobs:
 
       - name: Install liburing and GNU time
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config time
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,17 @@ env:
   #
   # EVERY apt-get call in this file must use these — a bare one reintroduces
   # the hang. See issues/ci-apt-hangs-on-dpkg-lock.md.
+  #
+  # Every `update` is ALSO preceded by an `rm` of the runner image's
+  # third-party apt sources, which is a separate failure with the same blast
+  # radius: `apt-get update` exits 100 if ANY configured source fails, and on
+  # 2026-09-09 a Hash Sum mismatch on the image's Google Chrome list took out
+  # every Linux job across three PRs — 18 red checks from one root cause, most
+  # of them reported as "Artifact not found" on legs that never even ran apt.
+  # This repo installs only from Ubuntu's own archives, so those lists are pure
+  # liability. Acquire::Retries above cannot help: a hash mismatch is
+  # DETERMINISTIC, so each retry re-fetches the same bad file.
+  # See issues/ci-apt-update-fails-on-an-unused-third-party-source.md.
   APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"
 
 jobs:
@@ -371,6 +382,8 @@ jobs:
       # and the extension published.
       - name: Install liburing
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev
 
@@ -538,6 +551,8 @@ jobs:
       # src/main.yo, with the Homebrew-keg fallbacks for local runs).
       - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 
@@ -954,6 +969,8 @@ jobs:
       # exact seed-driven pipeline in PR CI).
       - name: Install liburing (needed to run the seed)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev
 
@@ -1255,6 +1272,8 @@ jobs:
       # anything.
       - name: Install OpenSSL headers (portable-C parse gate)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y libssl-dev pkg-config
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,17 @@ env:
   #
   # EVERY apt-get call in this file must use these — a bare one reintroduces
   # the hang. See issues/ci-apt-hangs-on-dpkg-lock.md.
+  #
+  # Every `update` is ALSO preceded by an `rm` of the runner image's
+  # third-party apt sources, which is a separate failure with the same blast
+  # radius: `apt-get update` exits 100 if ANY configured source fails, and on
+  # 2026-09-09 a Hash Sum mismatch on the image's Google Chrome list took out
+  # every Linux job across three PRs — 18 red checks from one root cause, most
+  # of them reported as "Artifact not found" on legs that never even ran apt.
+  # This repo installs only from Ubuntu's own archives, so those lists are pure
+  # liability. Acquire::Retries above cannot help: a hash mismatch is
+  # DETERMINISTIC, so each retry re-fetches the same bad file.
+  # See issues/ci-apt-update-fails-on-an-unused-third-party-source.md.
   APT_OPTS: "-o DPkg::Lock::Timeout=600 -o Acquire::Retries=3"
 
 jobs:
@@ -285,6 +296,8 @@ jobs:
       # The seed links liburing dynamically and cannot start without it.
       - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 
@@ -374,6 +387,8 @@ jobs:
       - name: Install the pinned Z3
         run: |
           set -euo pipefail
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y unzip
           curl -fsSL -o /tmp/z3.zip \
@@ -385,6 +400,8 @@ jobs:
       # The seed links liburing dynamically and cannot start without it.
       - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 
@@ -488,6 +505,8 @@ jobs:
 
       - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 
@@ -804,6 +823,8 @@ jobs:
 
       - name: Install liburing (needed to run the seed's compiled children; + OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 
@@ -909,6 +930,8 @@ jobs:
 
       - name: Install liburing (needed to run the candidate)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev
 
@@ -1104,6 +1127,8 @@ jobs:
 
       - name: Install liburing and GNU time
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           # + OpenSSL dev: this job compiles stage-2 itself (std/http in the
           # compiler closure puts OpenSSL headers into the emitted C).
@@ -1236,6 +1261,8 @@ jobs:
 
       - name: Install liburing and GNU time
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev time
 
@@ -1333,6 +1360,8 @@ jobs:
 
       - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 
@@ -1470,6 +1499,8 @@ jobs:
 
       - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 
@@ -1587,6 +1618,8 @@ jobs:
       # the Alpine stage links into the artifact below.
       - name: Install liburing (needed to run the seed)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev
 
@@ -1728,6 +1761,8 @@ jobs:
 
       - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 
@@ -1978,6 +2013,8 @@ jobs:
 
       - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
         run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
           sudo apt-get $APT_OPTS update
           sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
 

--- a/issues/ci-apt-update-fails-on-an-unused-third-party-source.md
+++ b/issues/ci-apt-update-fails-on-an-unused-third-party-source.md
@@ -1,0 +1,104 @@
+# One broken third-party apt source takes out every Linux CI job
+
+**Status:** FIXED 2026-09-10 (observed 2026-09-09/10; hit #522, #526 and #529 simultaneously).
+
+## Symptom
+
+Every Linux-based job fails in its dependency step, before any Yo code runs:
+
+```
+Get:29 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages [1405 B]
+Err:29 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
+  Hash Sum mismatch
+  Hashes of expected file:
+   - Filesize:1405 [weak]
+   - SHA256:233e56de019b57db89238fa7bcc3647718dbbea3a40c2dc1c633a8c8952aa9e9
+...
+E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
+E: Some index files failed to download. They have been ignored, or old ones used instead.
+##[error]Process completed with exit code 100.
+```
+
+The blast radius is the whole run, not one job. "Build the suite candidate
+(Linux, shared by the cross-emits)" dies on this, and then every leg that
+consumes its artifact fails with a DIFFERENT and misleading error:
+
+```
+##[error]Unable to download artifact(s): Artifact not found for name: suite-c-macos-arm64
+```
+
+so `test (macos-latest)` looks like a macOS regression when the cause is an apt
+mirror. On #529 that produced 18 red checks from one root cause.
+
+## Why the existing mitigation does not help
+
+`APT_OPTS` already carries `-o Acquire::Retries=3` (test.yml:108 and the same
+line in `fixpoint-arm64.yml`, `deploy-site.yml`). **A Hash Sum mismatch is
+DETERMINISTIC** — the mirror is serving a `Packages.gz` whose bytes do not
+match the hash in its own release index — so all three attempts re-download the
+same bad file. Retries only help a flaky connection.
+
+`apt-get update` exits **100 if ANY configured source fails**, even when every
+source the build actually installs from succeeded.
+
+## Root cause
+
+The GitHub Ubuntu runner image ships third-party apt sources (Google Chrome,
+and others depending on the image) under `/etc/apt/sources.list.d/`. This
+repository installs only `liburing-dev`, `libssl-dev`, `pkg-config` and `time`
+— all from Ubuntu's own archives. So a source that is never used can, and did,
+fail the build.
+
+## The fix
+
+Drop the third-party lists this repo does not install from, before `update`:
+
+```yaml
+- name: Install Linux dependencies
+  run: |
+    # The runner image ships third-party apt sources (Google Chrome, ...) that
+    # nothing here installs from, and `apt-get update` exits 100 if ANY source
+    # fails. A Hash Sum mismatch on dl.google.com took out every Linux job on
+    # 2026-09-09, and Acquire::Retries cannot help — a hash mismatch is
+    # deterministic, so every retry re-fetches the same bad file.
+    sudo rm -f /etc/apt/sources.list.d/*google*.list \
+               /etc/apt/sources.list.d/*google*.sources
+    sudo apt-get $APT_OPTS update
+    sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config time
+```
+
+Both `.list` and `.sources` (deb822) forms, because newer images use the
+latter.
+
+Applied at all **19** `sudo apt-get $APT_OPTS update` sites:
+
+| workflow | sites |
+| --- | --- |
+| `.github/workflows/test.yml` | 13 |
+| `.github/workflows/release.yml` | 4 |
+| `.github/workflows/fixpoint-arm64.yml` | 1 |
+| `.github/workflows/deploy-site.yml` | 1 |
+
+The rationale lives with the existing `APT_OPTS` comment block (which already
+documents the dpkg-lock hang, `issues/ci-apt-hangs-on-dpkg-lock.md`), so the
+per-site line is one comment pointing back at it. Not factored into a composite
+action: `APT_OPTS` is already duplicated per workflow the same way, and matching
+that beats introducing a second mechanism for one `rm`.
+
+## Rejected alternatives
+
+- `apt-get update || true` — hides a genuine failure of a source the build
+  DOES need, turning a clear error into a confusing "package not found" later.
+- Pinning/refreshing the Google list — the repo has no reason to carry it at
+  all.
+
+## Verification
+
+The fix is self-testing: a `pull_request` event runs the workflow from the PR's
+own head, so this PR's own Linux legs exercise the pruned source list.
+
+## Note for whoever touches this again
+
+Workflow-touching PRs need care: `gh pr merge --admin` refuses a PR that
+touches workflows while it is BEHIND the base, so bring the branch up to date
+immediately before merging.

--- a/issues/ci-apt-update-fails-on-an-unused-third-party-source.md
+++ b/issues/ci-apt-update-fails-on-an-unused-third-party-source.md
@@ -70,14 +70,23 @@ Drop the third-party lists this repo does not install from, before `update`:
 Both `.list` and `.sources` (deb822) forms, because newer images use the
 latter.
 
-Applied at all **19** `sudo apt-get $APT_OPTS update` sites:
+Applied at all **20** `apt-get ... update` call sites:
 
-| workflow | sites |
+| file | sites |
 | --- | --- |
 | `.github/workflows/test.yml` | 13 |
 | `.github/workflows/release.yml` | 4 |
 | `.github/workflows/fixpoint-arm64.yml` | 1 |
 | `.github/workflows/deploy-site.yml` | 1 |
+| `.github/actions/build-stage1/action.yml` | 1 |
+
+**The composite action was the one that mattered and the one nearly missed.**
+A first pass patched only the 19 `sudo apt-get $APT_OPTS update` lines in the
+workflows, and the wasm legs still fell over — `.github/actions/build-stage1`
+spells its flags out inline rather than reading the caller's `$APT_OPTS` (on
+purpose: a composite action must not depend on an env var the caller happens to
+define), so a grep for `$APT_OPTS` does not find it. Audit by matching
+`apt-get` + `update` across `.github/**`, not by matching the env var.
 
 The rationale lives with the existing `APT_OPTS` comment block (which already
 documents the dpkg-lock hang, `issues/ci-apt-hangs-on-dpkg-lock.md`), so the


### PR DESCRIPTION
## What broke

`apt-get update` exits **100 if any configured source fails**. On 2026-09-09 a
Hash Sum mismatch on the runner image's Google Chrome list took out **every
Linux job across #522, #526 and #529** — 18 red checks on #529 alone:

```
Err:29 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
E: Failed to fetch .../chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
##[error]Process completed with exit code 100.
```

Most of those 18 were reported as something else entirely:

```
##[error]Unable to download artifact(s): Artifact not found for name: suite-c-macos-arm64
```

on legs that never ran apt at all — because the Linux "Build the suite
candidate" job that produces that artifact died first. A **macOS** leg looked
like a macOS regression.

## Why `Acquire::Retries` didn't save it

`APT_OPTS` already carries `-o Acquire::Retries=3`. It cannot help here: a Hash
Sum mismatch is **deterministic** — the mirror serves a `Packages.gz` whose
bytes do not match the hash in its own release index — so all three attempts
re-fetch the same bad file. Retries only cover a flaky connection.

## The fix

This repo installs only `liburing-dev`, `libssl-dev`, `pkg-config` and `time`,
all from Ubuntu's own archives. The image's third-party lists are pure
liability, so they go before each `update`:

```yaml
# Drop the runner image's third-party apt sources first — see APT_OPTS.
sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
sudo apt-get $APT_OPTS update
```

Both forms, because newer images use deb822 `.sources`.

Applied at **all 19** `sudo apt-get $APT_OPTS update` sites:

| workflow | sites |
| --- | --- |
| `test.yml` | 13 |
| `release.yml` | 4 |
| `fixpoint-arm64.yml` | 1 |
| `deploy-site.yml` | 1 |

The rationale sits with the existing `APT_OPTS` comment block — which already
documents the dpkg-lock hang (`issues/ci-apt-hangs-on-dpkg-lock.md`) — so each
site carries one comment pointing back at it.

Deliberately **not** factored into a composite action: `APT_OPTS` is already
duplicated per workflow the same way, and matching the existing shape beats
introducing a second mechanism for one `rm`.

Rejected `apt-get update || true`: it would hide a genuine failure of a source
the build *does* need, turning a clear error into a confusing "package not
found" later.

## Verification

**Self-testing.** A `pull_request` event runs the workflow from the PR's own
head, so this PR's Linux legs exercise the pruned source list. Indentation of
all 19 insertions was checked programmatically against the `apt-get` line each
one precedes.

Write-up: `issues/ci-apt-update-fails-on-an-unused-third-party-source.md`.

Note for later: `gh pr merge --admin` refuses a workflow-touching PR that is
BEHIND its base, so this one needs to be up to date at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)