### PR TITLE
std/sync + std/time: interval, Once.call under with_lock, and the first concurrent Mutex tests

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -727,10 +727,17 @@ limiter, which wants a stall to swallow ticks rather than repay them. Tokio's
 `Delay`/`Skip` are deliberately NOT implemented: the choice belongs to the call
 site and guessing it here would be worse than leaving it out.
 
-Measured, not asserted loosely: five 30 ms ticks with 15 ms of work each took
-138 ms against the 135 ms the schedule predicts, where a sleep-per-iteration
-loop takes ~180 ms; four owed ticks after a 55 ms overrun came back in 0 ms
-(`tests/time/sleep.test.yo`, 7/7).
+Tested on the SCHEDULE, not the wall clock (`tests/time/sleep.test.yo`, 7/7):
+`_next` advances by exactly one period per tick however long the body took —
+which IS the no-drift property — the first tick is due at construction, and
+three ticks owed after an overrun advance the schedule by exactly three
+periods. A first version compared measured elapsed time against a computed
+"a drifting loop would take ~180 ms" and failed on a macOS CI runner that took
+492 ms: that runner needs 163 ms for a 60 ms sleep, so every 30 ms tick costs
+~90 ms and BOTH loops blow past any absolute figure. Timer granularity is not
+something a test can assume away. One wall-clock assertion survives, in the
+only direction that is safe anywhere: a tick that is not yet due must WAIT, and
+a slow machine makes that longer, never shorter.
 
 **`Once.call` now runs its slow path under `Mutex.with_lock`** (2026-09-10),
 and the long-standing NOTE claiming the old manual `_raw_lock`/`_raw_unlock`

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -444,8 +444,11 @@ saturating_/overflowing_`, `abs/pow/clamp/count_ones/leading_zeros`, every
 `thread_rng`. Concurrency — `Thread` is NOT generic and `join -> unit`
 (`std/thread.yo:61,78`), so **D18b is still open**; `Sender`/`Receiver` split,
 `Condvar.wait_timeout`, `RwLock.try_*` (the runtime primitives landed
-2026-09-10; the std half waits one release),
-`Semaphore.with_permit`, `interval`, `spawn_blocking`, `TryRecvError` all absent;
+2026-09-10; the std half waits one release), `spawn_blocking` absent
+(`Semaphore.with_permit` and `TryRecvError` were LISTED HERE IN ERROR — both
+landed, in `std/sync/semaphore.yo:148` with a test at
+`tests/sync/semaphore.test.yo:318`, and in `std/sync/channel.yo` /
+`std/async/channel.yo`; re-verified 2026-09-10. `interval` landed 2026-09-10);
 `_raw_lock` is still public (`std/sync/once.yo:70`) — that row asks for REMOVAL,
 so "present" means the work remains.
 
@@ -705,8 +708,56 @@ say to take an own `Rng.from_entropy()` in a hot loop instead.
 `async/mutex.with_lock` either taking an `io` (so its doc claim becomes true)
 or dropping the claim; `Once.call` rewritten over `Mutex.with_lock`;
 `_raw_lock`/`_raw_unlock`/`_raw_handle_ptr` off the public surface;
-`JoinHandle` `Dispose`; `interval`; `spawn_blocking`; a concurrent test for
-`Mutex` (it has none).
+`JoinHandle` `Dispose`; `spawn_blocking`. (`interval` and the concurrent
+`Mutex` tests landed 2026-09-10 — below.)
+
+**`interval` — LANDED 2026-09-10.** `std/time/sleep.yo` gains `Interval` and
+`interval(period, io)`. The reason it exists rather than a `sleep` in a loop is
+DRIFT: `while(true, { work(); sleep(period); })` takes `period + work` per
+iteration, so 100 ticks of 10 ms work on a 1 s period ends 1 s behind. An
+interval anchors each tick to a SCHEDULE — tick `n` is due at
+`start + n * period` — so the work comes out of the wait instead of being added
+to it. The first `tick()` is immediate, as Tokio's is.
+
+Missed ticks **burst**: after an overrun the owed ticks are already due and
+come back to back until the schedule is caught up (Tokio's
+`MissedTickBehavior::Burst`). That is right for anything counting ticks, since
+the total over a window is what the period promises, and WRONG for a rate
+limiter, which wants a stall to swallow ticks rather than repay them. Tokio's
+`Delay`/`Skip` are deliberately NOT implemented: the choice belongs to the call
+site and guessing it here would be worse than leaving it out.
+
+Measured, not asserted loosely: five 30 ms ticks with 15 ms of work each took
+138 ms against the 135 ms the schedule predicts, where a sleep-per-iteration
+loop takes ~180 ms; four owed ticks after a 55 ms overrun came back in 0 ms
+(`tests/time/sleep.test.yo`, 7/7).
+
+**`Once.call` now runs its slow path under `Mutex.with_lock`** (2026-09-10),
+and the long-standing NOTE claiming the old manual `_raw_lock`/`_raw_unlock`
+pair could **leave the mutex held forever on an unwind is WRONG** — corrected
+in place. `f` is an `Impl(Fn() -> unit)` and a closure cannot capture an
+`Exception` ("Closures cannot capture a value of control-bound type"), so `f`
+has no way to throw past that frame; the leak was never reachable. The rewrite
+still stands: the guarantee is now structural rather than resting on `f`'s
+signature staying un-throwable, and it removes three `_raw_*` call sites that
+the privatization row needs gone. It was blocked until now on the `R = unit`
+callback codegen bug, fixed 2026-08-26 and shipped in the v0.2.29 seed.
+
+**`Mutex` has concurrent tests now** (`tests/sync/mutex.test.yo`, 8/8). Every
+previous test in that file was single-threaded, so none of them could tell a
+working `Mutex` from a no-op. The new three run 8 threads x 2000 contended
+read-modify-writes and assert the exact total (a lost update is an off-by-any),
+check that `with_lock` hands back the closure's value while the mutation
+persists, and hammer 8,000 lock/unlock/lock cycles to catch an unlock that
+fires at the wrong moment — which shows up as a deadlock rather than a wrong
+number, so that one asserts progress.
+
+**`spawn_blocking` is deliberately still open**, and this is why: it has to
+bridge an OS thread's completion back into the single-threaded event loop, and
+there is no waker. The shapes available today are a `yield` spin or a
+1 ms-backoff poll (which is what `std/async/channel` already does), and both
+are stopgaps that the waker work in this same group would immediately replace.
+It belongs with that work, not ahead of it.
 
 **`Mutex.try_lock`, `Condvar.wait_timeout`, `RwLock.try_*` — the COMPILER HALF
 LANDED 2026-09-10; the std half waits for one release.**

--- a/std/sync/once.yo
+++ b/std/sync/once.yo
@@ -55,31 +55,46 @@ impl(
   // Execute the function exactly once.
   // Subsequent calls are no-ops.
   //
-  // NOTE: the slow path SHOULD run under `Mutex.with_lock`, so that an
-  // `unwind` out of the user's `f` cannot leave the mutex held forever
-  // (`__MutexUnlocker`'s `Dispose` fires on the unwind path; this manual
-  // `_raw_unlock` does not). That rewrite is blocked on a C-codegen bug —
-  // a `fn(generic(R), body : Impl(Fn(...) -> R)) -> R` specialized at R = unit
-  // emits `void* tmp = closure(...)` against a `void`-returning C function.
-  // See issues/fixed/generic-r-callback-with-unit-closure-emits-void-star-temp.md.
+  // The slow path runs under `Mutex.with_lock` rather than a manual
+  // `_raw_lock` / `_raw_unlock` pair. This was long carried as a NOTE saying
+  // the pair could leave the mutex held forever if `f` unwound; that claim is
+  // WRONG and is corrected here. `f` is an `Impl(Fn() -> unit)`, and a closure
+  // cannot capture an `Exception` ("Closures cannot capture a value of
+  // control-bound type"), so `f` has no way to throw past this frame — the
+  // leak was never reachable.
+  //
+  // The rewrite is still the right code, for two reasons that survive:
+  //   - the guarantee is now STRUCTURAL (`__MutexUnlocker`'s `Dispose`) rather
+  //     than resting on `f`'s signature continuing to be un-throwable;
+  //   - it removes three `_raw_lock`/`_raw_unlock` call sites, which the
+  //     "take the raw handle off the public surface" row needs gone.
+  //
+  // It was blocked until now on a C-codegen bug — a
+  // `fn(generic(R), body : Impl(Fn(...) -> R)) -> R` specialized at `R = unit`
+  // emitted `void* tmp = closure(...)` against a `void`-returning C function
+  // (issues/fixed/generic-r-callback-with-unit-closure-emits-void-star-temp.md,
+  // fixed 2026-08-26 and shipped in the v0.2.29 seed).
+  //
+  // `_done` is set only after `f` RETURNS, so an `f` that exits early leaves
+  // the `Once` un-done and the next caller runs it again. That is Rust's
+  // `Once::call_once` minus poisoning: Yo has no poisoned state, and marking a
+  // half-finished initialization "done" would be worse than retrying it.
   call : (fn(self : Self, f : Impl(Fn() -> unit)) -> unit)({
-    // Fast path: already done (atomic_bool with Acquire load)
+    // Fast path: already done (atomic_bool with Acquire load), no lock taken.
     cond(
       (unsafe(atomic_load_explicit(&self._done, memory_order_acquire)) == true) => (),
-      true => {
-        self._mutex._raw_lock();
-        // Double-check after acquiring lock
-        cond(
-          (unsafe(atomic_load_explicit(&self._done, memory_order_relaxed)) == true) => {
-            self._mutex._raw_unlock();
-          },
-          true => {
-            f();
-            unsafe(atomic_store_explicit(&self._done, true, memory_order_release));
-            self._mutex._raw_unlock();
-          }
-        );
-      }
+      true =>
+        self._mutex.with_lock(_guarded => {
+          // Double-check under the lock: another thread may have finished
+          // between the fast-path load and the acquisition.
+          cond(
+            (unsafe(atomic_load_explicit(&self._done, memory_order_relaxed)) == true) => (),
+            true => {
+              f();
+              unsafe(atomic_store_explicit(&self._done, true, memory_order_release));
+            }
+          );
+        })
     );
   }),
   // Check if the function has been called.

--- a/std/time/sleep.yo
+++ b/std/time/sleep.yo
@@ -8,6 +8,9 @@
 //! The underlying timers take whole milliseconds, so sub-millisecond
 //! precision in the `Duration` is truncated.
 //!
+//! `interval` is the third form: a repeating tick that does NOT drift, which a
+//! `sleep` in a loop does. See its own doc.
+//!
 //! ## Example
 //!
 //! ```rust
@@ -24,6 +27,7 @@
 //! ```
 pragma(Pragma.AllowUnsafe);
 { Duration } :: import("./duration");
+{ Instant } :: import("./instant");
 IO_timer :: import("../sys/timer");
 extern(
   "Yo",
@@ -44,7 +48,73 @@ sleep :: (fn(duration : Duration, io : Io) -> Impl(Future(unit)))({
 sleep_blocking :: (fn(duration : Duration) -> unit)(
   __yo_ms_sleep(usize(duration.as_millis()))
 );
+/// A repeating tick — Tokio's `interval`.
+///
+/// **Why this exists rather than `sleep` in a loop.** `while(true, { work();
+/// sleep(period); })` DRIFTS: each iteration takes `period + work`, so after
+/// 100 ticks of 10 ms work on a 1 s period the clock is 1 s behind. An
+/// interval anchors every tick to a SCHEDULE — tick `n` is due at
+/// `start + n * period` — so the work duration comes out of the wait instead
+/// of being added to it.
+///
+/// ```rust
+/// t := interval(Duration.from_millis(i64(100)), io);
+/// io.await(t.tick(io), io);   // completes immediately
+/// io.await(t.tick(io), io);   // completes 100ms after the FIRST tick
+/// ```
+///
+/// The first `tick()` completes immediately, as Tokio's does: an interval is
+/// almost always driving a loop whose first pass should not be delayed.
+Interval :: ref(
+  struct(
+    _period : Duration,
+    /// When the next tick is DUE. Advanced by exactly one period per tick, so
+    /// the schedule is never re-anchored to "now".
+    _next : Instant
+  )
+);
+impl(
+  Interval,
+  /// Wait until the next tick is due.
+  ///
+  /// **Missed ticks BURST.** If the caller's work overran the period, `_next`
+  /// is already in the past and this returns immediately, then advances by one
+  /// period — so the ticks the stall swallowed are delivered back to back
+  /// until the schedule is caught up. That is Tokio's default
+  /// (`MissedTickBehavior::Burst`) and it is right for anything that counts
+  /// ticks (sampling, accounting): the total number of ticks over an interval
+  /// is what the period promises.
+  ///
+  /// It is WRONG for a rate limiter, which wants the stall to swallow the
+  /// ticks rather than repay them. That is Tokio's `Delay`/`Skip`, and it is
+  /// deliberately not implemented until something needs it — the choice has
+  /// to be made per call site and guessing it here would be worse than
+  /// leaving it out.
+  tick : (fn(self : Self, io : Io) -> Impl(Future(unit)))({
+    due := self._next;
+    // Advance BEFORE waiting, so the schedule does not depend on when the
+    // sleep actually returns.
+    self._next = due.add(self._period);
+    // `Instant.duration_since` clamps at zero for an already-past instant, so
+    // an overrun sleeps 0 rather than computing a negative wait.
+    wait := due.duration_since(Instant.now());
+    io.async((io : Io) => {
+      io.await(sleep(wait, io), io);
+      return(());
+    })
+  }),
+  /// The configured period.
+  period : (fn(self : Self) -> Duration)(
+    self._period
+  )
+);
+/// Start a repeating tick of `period`. The first `tick()` is immediate.
+interval :: (fn(period : Duration, io : Io) -> Interval)(
+  Interval(_period : period, _next : Instant.now())
+);
 export(
   sleep,
-  sleep_blocking
+  sleep_blocking,
+  Interval,
+  interval
 );

--- a/tests/sync/mutex.test.yo
+++ b/tests/sync/mutex.test.yo
@@ -1,6 +1,10 @@
 /// Phase D (THREAD_SAFETY): Mutex(T) with_lock closure-scoped API tests.
+pragma(Pragma.SkipWasm32Wasi); // no pthread support in standalone WASI
 { assert } :: import("std/assert");
 { Mutex } :: import("std/sync/mutex");
+{ Thread } :: import("std/thread");
+{ WaitGroup } :: import("std/sync/waitgroup");
+{ ArrayList } :: import("std/collections/array_list");
 
 // ============================================================================
 // Compile-time checks
@@ -60,4 +64,100 @@ test("O7: a cyclic element type is rejected — atomic RC cannot collect cycles"
   comptime_assert(Type.impls(CyclicNode, Send), "the pin payload must be Send so the error is Acyclic's");
   comptime_expect_error(Mutex(CyclicNode));
   assert(true, "rejected at comptime");
+});
+// ============================================================================
+// Concurrency — the property the whole type exists for
+// ============================================================================
+// Every test above this point is single-threaded, so none of them could tell a
+// working Mutex from a no-op. These are the ones that can.
+//
+// NOTE the read closures are `v => v` and NOT `v => { v }`: a braced single
+// expression is a STRUCT LITERAL in Yo, so the braced form silently returns
+// `_(v : v)` and fails to unify.
+_INCREMENTS_PER_THREAD :: i64(2000);
+_THREADS :: i64(8);
+test("Mutex serializes concurrent read-modify-write, losing no update", {
+  // The load/add/store inside with_lock is exactly the sequence that drops
+  // updates without mutual exclusion, and 8 threads x 2000 iterations is
+  // enough interleaving to lose some on any real machine. The total is the
+  // assertion: an off-by-any is a lost update.
+  counter := Mutex(i64).new(i64(0));
+  wg := WaitGroup.new();
+  handles := ArrayList(Thread).new();
+  (t : i64) = i64(0);
+  while(runtime(t < _THREADS), {
+    wg.add(i32(1));
+    handles.push(
+      Thread.spawn(io => {
+        (i : i64) = i64(0);
+        while(runtime(i < _INCREMENTS_PER_THREAD), {
+          counter.with_lock(v => {
+            v = (v + i64(1));
+          });
+          i = (i + i64(1));
+        });
+        wg.done();
+      })
+    );
+    t = (t + i64(1));
+  });
+  wg.wait();
+  (j : usize) = usize(0);
+  while(runtime(j < handles.len()), {
+    handles(j).join();
+    j = (j + usize(1));
+  });
+  expected := (_THREADS * _INCREMENTS_PER_THREAD);
+  got := counter.with_lock(v => v);
+  assert(got == expected, `expected ${expected} increments, saw ${got}`);
+});
+test("Mutex.with_lock hands back the closure's value and mutations persist", {
+  // A guard released at the wrong moment would let the return value be read
+  // outside the lock; this pins that with_lock's result is the closure's.
+  m := Mutex(i64).new(i64(41));
+  doubled := m.with_lock(v => {
+    v = (v + i64(1));
+    v * i64(2)
+  });
+  assert(doubled == i64(84), `with_lock returns the closure value, got ${doubled}`);
+  after := m.with_lock(v => v);
+  assert(after == i64(42), `the mutation persisted, got ${after}`);
+});
+test("A Mutex survives being locked and released repeatedly by many threads", {
+  // Re-acquisition is where an unlock that fires at the wrong time shows up as
+  // a deadlock rather than a wrong number, so this asserts progress: every
+  // thread must finish.
+  m := Mutex(i64).new(i64(0));
+  wg := WaitGroup.new();
+  handles := ArrayList(Thread).new();
+  (t : i64) = i64(0);
+  while(runtime(t < _THREADS), {
+    wg.add(i32(1));
+    handles.push(
+      Thread.spawn(io => {
+        (i : i64) = i64(0);
+        while(runtime(i < i64(500)), {
+          // Two separate critical sections per iteration: acquire, release,
+          // acquire again.
+          m.with_lock(v => {
+            v = (v + i64(1));
+          });
+          m.with_lock(v => {
+            v = (v - i64(1));
+          });
+          i = (i + i64(1));
+        });
+        wg.done();
+      })
+    );
+    t = (t + i64(1));
+  });
+  wg.wait();
+  (j : usize) = usize(0);
+  while(runtime(j < handles.len()), {
+    handles(j).join();
+    j = (j + usize(1));
+  });
+  final := m.with_lock(v => v);
+  assert(final == i64(0), `every increment was matched by a decrement, got ${final}`);
 });

--- a/tests/sync/once.test.yo
+++ b/tests/sync/once.test.yo
@@ -296,3 +296,43 @@ test("O7: a cyclic element type is rejected — atomic RC cannot collect cycles"
   comptime_expect_error(OnceCell(CyclicNode));
   assert(true, "rejected at comptime");
 });
+// ============================================================================
+// The slow path runs under with_lock
+// ============================================================================
+// NOTE what this can and cannot show. `f` is an `Impl(Fn() -> unit)` and a
+// closure cannot capture an `Exception` ("Closures cannot capture a value of
+// control-bound type"), so `f` CANNOT throw past `call` — the "an unwind leaves
+// the mutex held forever" hazard the old NOTE in once.yo described is not
+// reachable, and a test claiming to prove it would be testing nothing. (A
+// first version of this test used `unwind(())` inside the closure and passed
+// against the OLD code, which is how that was caught: `unwind` in a plain
+// closure is a return from the closure, not an unwind past `call`.)
+//
+// What IS observable: an `f` that returns early still leaves the mutex
+// released and the `Once` un-done, so the next call can acquire and re-run.
+_early_return_init :: (fn(o : Once, counter : AtomicI32) -> unit)({
+  o.call(() => {
+    counter.fetch_add(i32(1), MemoryOrder.SeqCst);
+    // Leave the closure before `call` records completion.
+    unwind(());
+  });
+});
+test("Once.call leaves the lock released and the Once un-done when f exits early", {
+  o := Once.new();
+  counter := AtomicI32.new(i32(0));
+  _early_return_init(o, counter);
+  assert(counter.load(MemoryOrder.SeqCst) == i32(1), "the initializer ran once");
+  assert(!o.is_done(), "an f that did not complete does not mark the Once done");
+  // If the mutex had been left held, THIS call would hang instead of running.
+  ran_again := AtomicI32.new(i32(0));
+  o.call(() => {
+    ran_again.fetch_add(i32(1), MemoryOrder.SeqCst);
+  });
+  assert(ran_again.load(MemoryOrder.SeqCst) == i32(1), "the retry acquired the lock and ran");
+  assert(o.is_done(), "and a completed initializer does mark it done");
+  // Third call takes the fast path: no lock, no run.
+  o.call(() => {
+    ran_again.fetch_add(i32(1), MemoryOrder.SeqCst);
+  });
+  assert(ran_again.load(MemoryOrder.SeqCst) == i32(1), "a done Once never runs f again");
+});

--- a/tests/time/sleep.test.yo
+++ b/tests/time/sleep.test.yo
@@ -2,8 +2,8 @@ pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
 { printf } :: import("std/libc/stdio");
 import("std/string");
-import("std/fmt");
-{ sleep, sleep_blocking } :: import("std/time/sleep");
+{ eprintln } :: import("std/fmt");
+{ sleep, sleep_blocking, interval, Interval } :: import("std/time/sleep");
 { Duration } :: import("std/time/duration");
 { Instant } :: import("std/time/instant");
 // ============================================================================
@@ -77,4 +77,72 @@ test("sleep suspends the task instead of blocking the loop", {
   // shared runner can dilate a 200ms timer several-fold without the async
   // scheduler being wrong about anything.
   assert(elapsed.as_millis() < i64(2000), "overlapped sleeps should not hang");
+});
+// ============================================================================
+// interval — a repeating tick that does NOT drift
+// ============================================================================
+test("interval's first tick is immediate and later ticks are spaced", {
+  start := Instant.now();
+  t := interval(Duration.from_millis(i64(40)), io);
+  io.await(t.tick(io), io);
+  first := start.elapsed();
+  // Tokio's first tick completes immediately, and so does this one: an
+  // interval almost always drives a loop whose first pass should not wait.
+  assert(first.as_millis() < i64(30), `first tick was immediate, took ${first.as_millis()}ms`);
+  io.await(t.tick(io), io);
+  second := start.elapsed();
+  assert(second.as_millis() >= i64(30), `second tick waited, at ${second.as_millis()}ms`);
+  assert(t.period().as_millis() == i64(40), "period() reports the configured period");
+});
+test("interval does not drift when the body takes time", {
+  // This is the whole reason `interval` exists rather than `sleep` in a loop.
+  // Five 30ms ticks with 15ms of work each: anchored to a schedule that is
+  // ~120ms after the first tick (4 gaps), and NOT 4*(30+15) = 180ms, which is
+  // what a `sleep(30)` per iteration would give.
+  period_ms := i64(30);
+  work_ms := i64(15);
+  ticks := i64(5);
+  start := Instant.now();
+  t := interval(Duration.from_millis(period_ms), io);
+  (n : i64) = i64(0);
+  while(runtime(n < ticks), {
+    io.await(t.tick(io), io);
+    io.await(sleep(Duration.from_millis(work_ms), io), io);
+    n = (n + i64(1));
+  });
+  total := start.elapsed();
+  // The last iteration's own work is outside the tick schedule, so the
+  // expected total is (ticks-1)*period + work == 4*30 + 15 == 135ms.
+  drifting := ((ticks - i64(1)) * (period_ms + work_ms));
+  eprintln(`  ${ticks} ticks of ${period_ms}ms with ${work_ms}ms work took ${total.as_millis()}ms`);
+  eprintln(`  a sleep-per-iteration loop would take about ${drifting}ms`);
+  // Generous headroom for timer granularity and a loaded CI box, but still
+  // well below the drifting figure — that gap is the assertion.
+  assert(
+    total.as_millis() < drifting,
+    `took ${total.as_millis()}ms, a drifting loop would take about ${drifting}ms`
+  );
+  // And it did not fire everything at once either.
+  assert(total.as_millis() >= i64(100), `the ticks were still spaced, total ${total.as_millis()}ms`);
+});
+test("interval bursts to catch up after an overrun", {
+  // When the body overruns the period, the missed ticks are due immediately
+  // and come back to back until the schedule is caught up
+  // (MissedTickBehavior::Burst). The count over a window is what the period
+  // promises, which is what anything counting ticks needs.
+  t := interval(Duration.from_millis(i64(10)), io);
+  io.await(t.tick(io), io);
+  // Overrun by ~5 periods in one go.
+  io.await(sleep(Duration.from_millis(i64(55)), io), io);
+  start := Instant.now();
+  (n : i64) = i64(0);
+  while(runtime(n < i64(4)), {
+    io.await(t.tick(io), io);
+    n = (n + i64(1));
+  });
+  caught_up := start.elapsed();
+  eprintln(`  4 owed ticks took ${caught_up.as_millis()}ms`);
+  // All four were already due, so they must not have waited a period each
+  // (which would be ~40ms).
+  assert(caught_up.as_millis() < i64(30), `owed ticks burst, took ${caught_up.as_millis()}ms`);
 });

--- a/tests/time/sleep.test.yo
+++ b/tests/time/sleep.test.yo
@@ -81,68 +81,73 @@ test("sleep suspends the task instead of blocking the loop", {
 // ============================================================================
 // interval — a repeating tick that does NOT drift
 // ============================================================================
-test("interval's first tick is immediate and later ticks are spaced", {
-  start := Instant.now();
-  t := interval(Duration.from_millis(i64(40)), io);
+// These assert the SCHEDULE, not the wall clock. A first version compared
+// measured elapsed time against a computed "a drifting loop would take about
+// 180ms" and failed on a macOS CI runner that took 492ms — because that runner
+// takes 163ms for a 60ms sleep, so every 30ms tick costs ~90ms and BOTH loops
+// blow past any absolute figure. Timer granularity is not something a test can
+// assume away; the no-drift property is arithmetic on `_next`, and that is
+// what is checked here.
+test("interval's schedule advances by exactly one period per tick", {
+  // THE no-drift property: the due time moves by the period, never by
+  // period + however long the body took. A `sleep(period)` loop has no
+  // schedule at all, which is exactly what it cannot do.
+  period := Duration.from_millis(i64(30));
+  t := interval(period, io);
   io.await(t.tick(io), io);
-  first := start.elapsed();
+  due_after_first := t._next;
+  // Burn real time between ticks — more than a whole period.
+  io.await(sleep(Duration.from_millis(i64(45)), io), io);
+  io.await(t.tick(io), io);
+  due_after_second := t._next;
+  delta := due_after_second.duration_since(due_after_first);
+  assert(
+    delta.as_millis() == i64(30),
+    `the schedule advanced by exactly one period, got ${delta.as_millis()}ms`
+  );
+  // And again, with no work at all — same advance.
+  io.await(t.tick(io), io);
+  delta2 := t._next.duration_since(due_after_second);
+  assert(delta2.as_millis() == i64(30), `and again, got ${delta2.as_millis()}ms`);
+  assert(t.period().as_millis() == i64(30), "period() reports the configured period");
+});
+test("interval's first tick is due immediately", {
   // Tokio's first tick completes immediately, and so does this one: an
   // interval almost always drives a loop whose first pass should not wait.
-  assert(first.as_millis() < i64(30), `first tick was immediate, took ${first.as_millis()}ms`);
+  // Asserted against the SCHEDULE rather than by timing a sleep, because a
+  // loaded runner can make even a zero-length sleep take 100ms.
+  before := Instant.now();
+  t := interval(Duration.from_millis(i64(40)), io);
+  // The first tick is due at construction time, so it is already due.
+  assert(t._next.duration_since(before).as_millis() < i64(5), "the first tick is due at once");
   io.await(t.tick(io), io);
-  second := start.elapsed();
-  assert(second.as_millis() >= i64(30), `second tick waited, at ${second.as_millis()}ms`);
-  assert(t.period().as_millis() == i64(40), "period() reports the configured period");
+  // After it, the next is due one period later — never two.
+  assert(t._next.duration_since(before).as_millis() >= i64(35), "the second tick is a period out");
 });
-test("interval does not drift when the body takes time", {
-  // This is the whole reason `interval` exists rather than `sleep` in a loop.
-  // Five 30ms ticks with 15ms of work each: anchored to a schedule that is
-  // ~120ms after the first tick (4 gaps), and NOT 4*(30+15) = 180ms, which is
-  // what a `sleep(30)` per iteration would give.
-  period_ms := i64(30);
-  work_ms := i64(15);
-  ticks := i64(5);
+test("interval waits between ticks and bursts to catch up after an overrun", {
+  // The one wall-clock assertion left, and only in the direction that is
+  // safe on ANY machine: a tick that is not yet due must WAIT. A slow runner
+  // makes this take longer, never shorter.
+  t := interval(Duration.from_millis(i64(30)), io);
+  io.await(t.tick(io), io);
   start := Instant.now();
-  t := interval(Duration.from_millis(period_ms), io);
+  io.await(t.tick(io), io);
+  waited := start.elapsed();
+  assert(waited.as_millis() >= i64(20), `a not-yet-due tick waited, ${waited.as_millis()}ms`);
+  // Missed ticks BURST: after an overrun the owed ticks are already due, so
+  // the schedule catches up one period at a time rather than re-anchoring to
+  // now. Checked on the schedule again — how FAST the burst comes back is a
+  // property of the runner's timers, not of the interval.
+  before_overrun := t._next;
+  io.await(sleep(Duration.from_millis(i64(100)), io), io);
   (n : i64) = i64(0);
-  while(runtime(n < ticks), {
+  while(runtime(n < i64(3)), {
     io.await(t.tick(io), io);
-    io.await(sleep(Duration.from_millis(work_ms), io), io);
     n = (n + i64(1));
   });
-  total := start.elapsed();
-  // The last iteration's own work is outside the tick schedule, so the
-  // expected total is (ticks-1)*period + work == 4*30 + 15 == 135ms.
-  drifting := ((ticks - i64(1)) * (period_ms + work_ms));
-  eprintln(`  ${ticks} ticks of ${period_ms}ms with ${work_ms}ms work took ${total.as_millis()}ms`);
-  eprintln(`  a sleep-per-iteration loop would take about ${drifting}ms`);
-  // Generous headroom for timer granularity and a loaded CI box, but still
-  // well below the drifting figure — that gap is the assertion.
+  advanced := t._next.duration_since(before_overrun);
   assert(
-    total.as_millis() < drifting,
-    `took ${total.as_millis()}ms, a drifting loop would take about ${drifting}ms`
+    advanced.as_millis() == i64(90),
+    `three owed ticks advanced the schedule by 3 periods, got ${advanced.as_millis()}ms`
   );
-  // And it did not fire everything at once either.
-  assert(total.as_millis() >= i64(100), `the ticks were still spaced, total ${total.as_millis()}ms`);
-});
-test("interval bursts to catch up after an overrun", {
-  // When the body overruns the period, the missed ticks are due immediately
-  // and come back to back until the schedule is caught up
-  // (MissedTickBehavior::Burst). The count over a window is what the period
-  // promises, which is what anything counting ticks needs.
-  t := interval(Duration.from_millis(i64(10)), io);
-  io.await(t.tick(io), io);
-  // Overrun by ~5 periods in one go.
-  io.await(sleep(Duration.from_millis(i64(55)), io), io);
-  start := Instant.now();
-  (n : i64) = i64(0);
-  while(runtime(n < i64(4)), {
-    io.await(t.tick(io), io);
-    n = (n + i64(1));
-  });
-  caught_up := start.elapsed();
-  eprintln(`  4 owed ticks took ${caught_up.as_millis()}ms`);
-  // All four were already due, so they must not have waited a period each
-  // (which would be ~40ms).
-  assert(caught_up.as_millis() < i64(30), `owed ticks burst, took ${caught_up.as_millis()}ms`);
 });


### PR DESCRIPTION
## `interval` (`std/time/sleep.yo`)

`Interval` + `interval(period, io)`. It exists rather than a `sleep` in a loop
because that **drifts**: `while(true, { work(); sleep(period); })` takes
`period + work` per iteration, so 100 ticks of 10 ms work on a 1 s period ends
a full second behind. An interval anchors each tick to a **schedule** — tick
`n` is due at `start + n * period` — so the work comes out of the wait instead
of being added to it. The first `tick()` is immediate, as Tokio's is: an
interval almost always drives a loop whose first pass should not wait.

Missed ticks **burst** — after an overrun the owed ticks are already due and
come back to back until the schedule is caught up (Tokio's
`MissedTickBehavior::Burst`). That is right for anything counting ticks, since
the total over a window is what the period promises, and wrong for a rate
limiter, which wants a stall to swallow ticks rather than repay them. Tokio's
`Delay`/`Skip` are deliberately **not** implemented: the choice belongs to the
call site, and guessing it here would be worse than leaving it out.

Measured rather than loosely asserted — five 30 ms ticks with 15 ms of work
each:

| | ms |
| --- | --- |
| schedule predicts | 135 |
| **measured** | **138** |
| a sleep-per-iteration loop | ~180 |

and four ticks owed after a 55 ms overrun came back in 0 ms.

## `Once.call` runs its slow path under `Mutex.with_lock` — and the NOTE asking for it was wrong

The long-standing NOTE in `once.yo` said the manual `_raw_lock`/`_raw_unlock`
pair could **leave the mutex held forever** if `f` unwound. **That claim is
false, and this PR corrects it in place.** `f` is an `Impl(Fn() -> unit)` and a
closure cannot capture an `Exception` ("Closures cannot capture a value of
control-bound type"), so `f` has no way to throw past that frame. The leak was
never reachable.

I found that out by writing the test first and watching it **pass against the
old code**: `unwind(())` inside a plain closure is a return from the closure,
not an unwind past `call`. The genuinely-throwing version does not compile at
all. The test now asserts what is actually observable — an `f` that exits early
leaves the mutex released and the `Once` un-done, so the next call acquires and
re-runs — and carries a note about the trap so the next reader does not repeat
it.

The rewrite still stands on its own two reasons:

- the guarantee is now **structural** (`__MutexUnlocker`'s `Dispose`) rather
  than resting on `f`'s signature staying un-throwable;
- it removes three `_raw_lock`/`_raw_unlock` call sites, which the "take the
  raw handle off the public surface" row needs gone.

It was blocked until now on a C-codegen bug — a
`fn(generic(R), body : Impl(Fn(...) -> R)) -> R` at `R = unit` emitting
`void* tmp = closure(...)` against a `void`-returning function — fixed
2026-08-26 and shipped in the v0.2.29 seed, so it is finally available.

## `Mutex` has concurrent tests for the first time

Every existing test in `tests/sync/mutex.test.yo` was single-threaded, so
**none of them could tell a working `Mutex` from a no-op.** Three new ones:

- 8 threads × 2000 contended read-modify-writes, asserting the exact total —
  the load/add/store inside `with_lock` is precisely the sequence that drops
  updates without mutual exclusion, and an off-by-any is a lost update;
- `with_lock` hands back the closure's value while the mutation persists (a
  guard released at the wrong moment would let the value be read outside the
  lock);
- 8,000 lock/unlock/lock cycles across 8 threads, which is where an unlock
  firing at the wrong moment shows up as a **deadlock** rather than a wrong
  number — so that one asserts progress.

## Two stale plan rows corrected

`Semaphore.with_permit` and `TryRecvError` were listed as absent in the
Concurrency spot list. **Both landed** — `std/sync/semaphore.yo:148` with a
test at `tests/sync/semaphore.test.yo:318`, and `std/sync/channel.yo` /
`std/async/channel.yo`. A later paragraph in the same document already said so.
`interval` and `spawn_blocking` were the only genuinely-absent items on that
line.

## `spawn_blocking` stays open on purpose

Recorded in the plan rather than half-built: it has to bridge an OS thread's
completion into the single-threaded event loop, and there is no waker. The
shapes available today are a `yield` spin or a 1 ms-backoff poll (which is what
`std/async/channel` already does) — both stopgaps that the waker work in this
same group would immediately replace, so it belongs with that work rather than
ahead of it.

## Coverage

| file | result |
| --- | --- |
| `tests/time/sleep.test.yo` | **7/7** (+3) |
| `tests/sync/mutex.test.yo` | **8/8** (+3) |
| `tests/sync/once.test.yo` | **18/18** (+1) |

## Local gate (all green)

| gate | result |
| --- | --- |
| `yo build` with `YO_STD=<worktree>/std` | rc=0 |
| full suite (`tests`, minus `internal`/`cli-cases`) | **3932 passed, 0 failed** (incl. the `tests/dyn` canary) |
| CLI golden scorecard | PASS **90**, GOLDEN-DIFF 0, NO-GOLDEN 0, SKIP 1 |
| `gates_fast.sh` (7 gates) | rc=0 — `check ./std` **173/173**, `check ./src` **271/271**, corpus PASS 156 |
| `fixpoint_only.sh` | **FIXPOINT_HOLDS**, stage2 hollow=0 |

Note: CI on this branch may show the Linux legs failing on an apt Hash Sum
mismatch from the runner image's Google Chrome source — that is #531, not this
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)