### PR TITLE
tests/time: drop the interval test's last wall-clock bound

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -802,9 +802,13 @@ periods. A first version compared measured elapsed time against a computed
 "a drifting loop would take ~180 ms" and failed on a macOS CI runner that took
 492 ms: that runner needs 163 ms for a 60 ms sleep, so every 30 ms tick costs
 ~90 ms and BOTH loops blow past any absolute figure. Timer granularity is not
-something a test can assume away. One wall-clock assertion survives, in the
-only direction that is safe anywhere: a tick that is not yet due must WAIT, and
-a slow machine makes that longer, never shorter.
+something a test can assume away. NO wall-clock assertion survives. One did
+briefly — "a not-yet-due tick waits at least 20ms of its 30ms period", on the
+theory that a slow machine makes a wait longer and never shorter. That is wrong
+for a COARSE one: Windows timers have ~15.6ms granularity and windows-11-arm
+measured 19ms for a 30ms wait. Whether `sleep` sleeps long enough is `sleep`'s
+contract, covered by its own cases; re-asserting it inside the interval tests
+only imported that flakiness.
 
 **`Once.call` now runs its slow path under `Mutex.with_lock`** (2026-09-10),
 and the long-standing NOTE claiming the old manual `_raw_lock`/`_raw_unlock`

--- a/tests/time/sleep.test.yo
+++ b/tests/time/sleep.test.yo
@@ -124,16 +124,16 @@ test("interval's first tick is due immediately", {
   // After it, the next is due one period later — never two.
   assert(t._next.duration_since(before).as_millis() >= i64(35), "the second tick is a period out");
 });
-test("interval waits between ticks and bursts to catch up after an overrun", {
-  // The one wall-clock assertion left, and only in the direction that is
-  // safe on ANY machine: a tick that is not yet due must WAIT. A slow runner
-  // makes this take longer, never shorter.
+test("interval bursts to catch up after an overrun", {
+  // NO wall-clock assertion here, deliberately. A first version asserted that
+  // a not-yet-due tick waited at least 20ms of its 30ms period, on the theory
+  // that a slow machine makes a wait LONGER, never shorter. That is wrong for
+  // a COARSE one: Windows timers have ~15.6ms granularity and the
+  // windows-11-arm leg measured 19ms for a 30ms wait. Whether `sleep` sleeps
+  // long enough is `sleep`'s contract, tested by the sleep cases above; it is
+  // not interval's, and re-asserting it here only imports that flakiness.
   t := interval(Duration.from_millis(i64(30)), io);
   io.await(t.tick(io), io);
-  start := Instant.now();
-  io.await(t.tick(io), io);
-  waited := start.elapsed();
-  assert(waited.as_millis() >= i64(20), `a not-yet-due tick waited, ${waited.as_millis()}ms`);
   // Missed ticks BURST: after an overrun the owed ticks are already due, so
   // the schedule catches up one period at a time rather than re-anchoring to
   // now. Checked on the schedule again — how FAST the burst comes back is a


### PR DESCRIPTION
`windows-11-arm` measured **19 ms for a 30 ms wait** and failed
`waited >= i64(20)` — 3821 passed, 1 failed, and the one was mine.

The assertion rested on *"a slow machine makes a wait longer, never shorter."*
That holds for a slow machine and **not for a coarse one**: Windows timers have
~15.6 ms granularity, so a 30 ms sleep can be measured at 19 ms.

Whether `sleep` sleeps long enough is **`sleep`'s** contract, already covered by
the sleep cases in this same file. Re-asserting it inside the interval tests
only imported that flakiness for a property that is not interval's.

What remains is what `interval` actually promises, and all of it is
deterministic arithmetic on the schedule:

- the due time advances by **exactly one period per tick** however long the
  body took — which *is* the no-drift property;
- the first tick is due at construction;
- three ticks owed after an overrun advance the schedule by exactly three
  periods.

This is the second time this file's timing assumptions were wrong. The previous
version compared measured elapsed time against a computed absolute and failed
on a macOS runner that needs 163 ms for a 60 ms sleep. Timer quality is not
something a test can assume in either direction, which is now written down next
to the tests and in the plan.

Found while validating `develop` ahead of the v0.2.30 release, on a re-run of
the full Test workflow at `95bc2493a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)