### PR TITLE
build: dev profile — --emit-chunks auto and the DEBUG yo-build default (Phase 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -873,6 +873,57 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # Phase 1 (plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md §4.6): `yo build`
+  # now compiles DEBUG executables with `--emit-chunks auto`, so chunking is
+  # a DEFAULT for something and the behavioural fixpoint gate runs on every
+  # code PR — a chunked-built and a single-file-built compiler must emit
+  # byte-identical C.
+  chunked-gate:
+    name: Chunked-emission behavioural fixpoint (chunked vs single)
+    needs: [changes, suite-candidate]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # Same memory treatment as every self-emitting job (see release.yml's
+      # seed-cross-emit for the 16 min vs 159 min zswap measurement).
+      - name: Add swap space
+        run: |
+          sudo fallocate -l 32G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+
+      - name: Tune the kernel for a swap-heavy self-emit
+        run: |
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/enabled || true
+          echo never | sudo tee /sys/kernel/mm/transparent_hugepage/defrag || true
+          echo Y | sudo tee /sys/module/zswap/parameters/enabled || true
+
+      - name: Install liburing (+ OpenSSL dev for std/http in the compiler closure)
+        run: |
+          # Drop the runner image's third-party apt sources first — see APT_OPTS.
+          sudo rm -f /etc/apt/sources.list.d/*google*.list /etc/apt/sources.list.d/*google*.sources
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y liburing-dev libssl-dev pkg-config
+
+      - name: Download the candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: suite-candidate
+
+      - name: Run the chunked behavioural fixpoint gate
+        env:
+          YO_MAIN_STACK_MB: "4096"
+        run: |
+          chmod +x yo-candidate
+          S1="$PWD/yo-candidate" N=4 bash scripts/bootstrap/chunked_gate.sh
+
   suite-cross-emit:
     name: Cross-emit suite compiler (${{ matrix.target }})
     needs: [changes, suite-candidate]

--- a/plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md
+++ b/plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md
@@ -2,8 +2,9 @@
 
 _Status: ACTIVE (2026-09-09) — Phase 0 (instrumentation) LANDED 2026-09-10
 (`--profile` / `--profile-json` real, `tests/cli-cases/compile-profile` gate,
-answers recorded in §3.1); Phases 1–5 not started. Every later phase is gated
-on the numbers Phase 0 produced.
+answers recorded in §3.1); Phase 1 (dev profile) LANDED 2026-09-10
+(`--emit-chunks auto` + the DEBUG `yo build` default + the `chunked-gate`
+CI job, numbers in §4); Phases 2–5 not started.
 
 This is the successor to two landed designs and should be read after them:
 
@@ -280,6 +281,41 @@ batch; if it is 10 s, Phase 3 matters more than Phase 4. The order of the
 later phases may change on these numbers; the phases themselves do not.
 
 ## 4. Phase 1 — a dev profile that skips the optimizer (Zig lesson 1a)
+
+**LANDED 2026-09-10.** `--emit-chunks auto` resolves
+`N = clamp(1, cap, emitted_bytes / MIN_CHUNK_BYTES)` from the REAL emitted
+size at chunk-assembly time (`compile_module`, `src/codegen/codegen_c.yo`);
+`cap` is `YO_JOBS` when usable, else `std/thread.get_hardware_threads()`
+(the cross-platform runtime shim that already existed — the plan's
+"missing primitive" was `available_parallelism`; the existing API serves).
+`MIN_CHUNK_BYTES = 4 MiB`, measured: a 410-line program emits 168 KB whose
+shared header is ~20%, so N=4 there costs ~155% of the single-file C work —
+every such program stays N=1. `--jobs` now defaults to the auto cap when
+`--emit-chunks auto` is given (0-sentinel until parsed), else 8 as before.
+`yo build` compiles DEBUG executables (no `optimize` field) with
+`--emit-chunks auto` (`compile_artifact`, `src/build_runner.yo`), gated off
+for optimized builds, libraries, `emit_c_to` and wasm; `YO_JOBS=1` is the
+opt-out. `Executable.emit_chunks` already threaded to the child argv —
+CHUNKED_C_EMISSION step 5 had landed it.
+
+Measured on the dev machine (Ryzen AI MAX+ 395, 32c, clang 21):
+
+| self-build C leg, `-O0` | wall |
+| --- | --- |
+| single file (`--profile`'s `cc compile+link` phase) | 23.9 s |
+| `--emit-chunks auto` (N=32, jobs=32, header 12.1 MB; chunk-write→linked) | **7 s** |
+
+Cheap `-O0` flags, measured individually on a 168 KB emission and NOT
+adopted: `-fno-asynchronous-unwind-tables` and `-fno-color-diagnostics`
+were both inside the ±10% run-to-run noise (309–338 ms baselines), the
+latter because cc never colorizes a piped child anyway, and dropping unwind
+tables risks the runtime's `backtrace()` diagnostics; `-g` was already
+conditional on `--debug-symbols`.
+
+Gates: `chunked-gate` CI job (test.yml) runs
+`scripts/bootstrap/chunked_gate.sh` against the shared suite-candidate —
+chunking is now a default for something; `tests/cli-cases/compile-emit-chunks`
+grew an `auto` line pinning `chunks: 1 unit(s), … (jobs=4)`.
 
 Zig's biggest single win was refusing to run an optimizer on debug builds.
 Yo's equivalent is already measured: at `-O0`, chunked parallel compile is

--- a/plans/reference/CHUNKED_C_EMISSION.md
+++ b/plans/reference/CHUNKED_C_EMISSION.md
@@ -37,15 +37,21 @@ emits **byte-identical** C to a single-file-built one
 
 ## What is intentionally not done
 
-- **Chunking stays opt-in.** The four conditions for flipping the default are
-  under "Chunk count" below; three now hold, and the fourth (auto-N) is blocked
-  on a std CPU-count API.
-- **Auto-N** — blocked: `std` has no `available_parallelism`, and there is no
-  `YO_JOBS` override yet. The N sweep below says the target is ~8, not
-  "2x cores".
-- **The behavioural fixpoint gate is a script, not a CI job** — two self-builds
-  plus two self-emits (~12 min, heavy RAM) to guard an opt-in flag no default
-  path uses.
+- **Chunking stays opt-in for `yo compile`.** All four default-on conditions
+  hold since Phase 1 (`plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md` §4):
+  `--emit-chunks auto` exists, and the ONE default flip it enabled is
+  `yo build`'s DEBUG executables. Plain `yo compile` still emits one file
+  unless the flag is passed — the single-file emission remains what the
+  bootstrap gates and the portable-C distribution compare.
+- **Auto-N — LANDED**: `N = clamp(1, cap, emitted_bytes / MIN_CHUNK_BYTES)`
+  resolved at chunk-assembly time from the REAL emitted bytes; cap is
+  `YO_JOBS` when usable, else `std/thread.get_hardware_threads()`.
+  `MIN_CHUNK_BYTES = 4 MiB`, measured (a 410-line program emits 168 KB with
+  a ~20% shared header — N=4 there is ~155% of the single-file C work, so
+  the floor keeps it N=1).
+- **The behavioural fixpoint gate is now a CI job** (`chunked-gate` in
+  test.yml, since the DEBUG-build default made chunking a default path) —
+  two self-builds plus two self-emits against the shared suite-candidate.
 - **The parallel driver still generates a `sh` script.** It did that because
   `io.spawn` in a loop hung — which is now FIXED
   (`issues/fixed/io-spawn-in-loop-or-recursion-hangs.md`: a surviving

--- a/scripts/bootstrap/chunked_gate.sh
+++ b/scripts/bootstrap/chunked_gate.sh
@@ -17,9 +17,10 @@
 # compilers would disagree on some emitted byte. They do not.
 #
 # Cost: two full self-builds plus two self-emits (~12 min on an M4, and a lot
-# of RAM). That is why this is a script you run deliberately rather than a CI
-# job on every PR — `--emit-chunks` is opt-in and no default path uses it. Wire
-# it in if chunking ever becomes a default (see the plan's four conditions).
+# of RAM). Since Phase 1 (plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md §4)
+# made `--emit-chunks auto` the default for DEBUG `yo build` executables,
+# chunking IS a default path, so test.yml runs this as the `chunked-gate` job
+# on every code PR (against the shared suite-candidate binary).
 set -u
 cd "$(dirname "$0")/../.." || exit 2
 S1=${S1:?set S1 to a working yo binary}

--- a/src/build_runner.yo
+++ b/src/build_runner.yo
@@ -785,6 +785,19 @@ compile_artifact :: (
     if(artifact.emit_chunks > usize(0), {
       cmd.arg(String.from("--emit-chunks"));
       cmd.arg(artifact.emit_chunks.to_string());
+    }, {
+      // Phase 1 dev-profile default (plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md
+      // §4.4): a DEBUG (−O0) executable build chunks automatically — the
+      // measured 3.3× C-leg win with identical runtime, no ThinLTO needed.
+      // Gated OFF for optimized builds (the ThinLTO link is the floor there),
+      // libraries (run_compile rejects the combination), `emit_c_to` (one C
+      // file is the contract), and wasm (chunked wasm is out of scope).
+      // YO_JOBS=1 is the opt-out: it caps auto at one chunk.
+      if(((!(is_lib) && (optimize_num.len() == usize(0))) && (artifact.emit_c_to.len() == usize(0)))
+      && !(effective_target.starts_with(String.from("wasm"))), {
+        cmd.arg(String.from("--emit-chunks"));
+        cmd.arg(String.from("auto"));
+      });
     });
     if(artifact.sanitize != "none", {
       cmd.arg(String.from("--sanitize"));

--- a/src/codegen/codegen_c.yo
+++ b/src/codegen/codegen_c.yo
@@ -296,7 +296,16 @@ static void __yo_dispose_dispatch(void* ptr) {
 /// preRegisterAsyncBlockTypes / preRegisterEffectfulFunctions /
 /// generateDeferredAsyncBlocks (Phase 5), generateClosureDisposeFunctions
 /// (Phase 5), generateSpecialized* (Gap 2), generateLibraryInitFunction.
-compile_module :: (fn(module_value : EvalValue, info : ExprInfoTable, target : TargetInfo, allocator : String, debug_gc : bool, debug_parallelism : bool, debug_async_await : bool, is_library : bool, eval_ctx : EvalContext, module_env : Environment, exn : Exception, (chunk_parts_out : ArrayList(String)) ?= ArrayList(String).new(), (emit_chunks : usize) ?= usize(0)) -> String)({
+/// The smallest emission for which splitting into chunks pays — the floor of
+/// `--emit-chunks auto`'s `N = clamp(1, cap, emitted_bytes / MIN_CHUNK_BYTES)`
+/// (Phase 1, plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md §4). Measured
+/// 2026-09-10 (clang 21 -O0): a 410-line program emits 168 KB with a 33 KB
+/// (~20%) shared header, so N=4 there costs ~155% of the single-file C work
+/// for a build that is subsecond either way; the self-build emits 163 MB.
+/// 4 MB keeps every such small program at N=1 while large programs still
+/// saturate the core count.
+MIN_CHUNK_BYTES :: usize(4194304);
+compile_module :: (fn(module_value : EvalValue, info : ExprInfoTable, target : TargetInfo, allocator : String, debug_gc : bool, debug_parallelism : bool, debug_async_await : bool, is_library : bool, eval_ctx : EvalContext, module_env : Environment, exn : Exception, (chunk_parts_out : ArrayList(String)) ?= ArrayList(String).new(), (emit_chunks : usize) ?= usize(0), (chunk_auto_cap : usize) ?= usize(0)) -> String)({
   // Route fatal emitter errors (codegen_fatal) through this compile's exn so
   // they exit rc=1 like a TS compile error instead of __yo_panic's SIGABRT.
   set_codegen_fatal_exn(exn);
@@ -318,8 +327,11 @@ compile_module :: (fn(module_value : EvalValue, info : ExprInfoTable, target : T
   base := CodeGenContext.new(emitter, info, target, allocator, debug_gc, debug_parallelism, debug_async_await, is_library);
   // Chunked emission (plans/reference/CHUNKED_C_EMISSION.md): record function byte
   // ranges and split cross-chunk statics. MUST stay false by default — the
-  // single-file emission is gated byte-identical.
-  base.chunk_mode = (emit_chunks >= usize(1));
+  // single-file emission is gated byte-identical. `chunk_auto_cap >= 1` is the
+  // Phase 1 `--emit-chunks auto` mode: the actual N is resolved from the REAL
+  // emitted size at assembly time (below), so the range recording runs during
+  // emission and the split decision happens with exact bytes.
+  base.chunk_mode = ((emit_chunks >= usize(1)) || (chunk_auto_cap >= usize(1)));
   // Seed the always-needed standard C headers (mirrors the cIncludes set the TS
   // CodeGeneratorC.compileModule constructs). <unistd.h>/<sys/stat.h> are
   // platform-specific and added by emit_c_includes.
@@ -460,6 +472,19 @@ static Slice_uint8_t_u42_ __yo_args;
   // hand them to the driver as parts[0] = header, parts[1..] = chunk bodies
   // (without the #include line — the driver knows the header's file name).
   if(base.chunk_mode, {
+    (n_chunks : usize) = emit_chunks;
+    if(chunk_auto_cap >= usize(1), {
+      emitted_bytes := (
+        base.emitter.headers.len() + base.emitter.declarations.len()
+        + base.emitter.code.len()
+      );
+      by_size := (emitted_bytes / MIN_CHUNK_BYTES);
+      n_chunks = cond(
+        (by_size < usize(1)) => usize(1),
+        (by_size > chunk_auto_cap) => chunk_auto_cap,
+        true => by_size
+      );
+    });
     asm2 := assemble_chunks(
       base.emitter.headers,
       base.emitter.declarations,
@@ -467,7 +492,7 @@ static Slice_uint8_t_u42_ __yo_args;
       base.chunk_fn_ranges,
       base.chunk_header_ranges,
       base.chunk_globals,
-      emit_chunks
+      n_chunks
     );
     chunk_parts_out.push(asm2.header_text);
     (ci2 : usize) = usize(0);

--- a/src/main.yo
+++ b/src/main.yo
@@ -36,6 +36,7 @@ _(env : proc_env) :: import("std/env");
 { sleep_blocking } :: import("std/time/sleep");
 { Duration } :: import("std/time/duration");
 { Instant } :: import("std/time/instant");
+{ get_hardware_threads } :: import("std/thread");
 {
   profile_set_enabled,
   profile_reset,
@@ -2137,9 +2138,17 @@ run_compile :: (
   (sysroot : String) = String.from("");
   (allocator : String) = String.from("system");
   (emit_chunks : usize) = usize(0);
+  // `--emit-chunks auto` (Phase 1, plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md
+  // §4): N is resolved AFTER emission, from the actual emitted bytes —
+  // clamp(1, cap, emitted / MIN_CHUNK_BYTES) — with cap = YO_JOBS or the
+  // hardware thread count.
+  (emit_chunks_auto : bool) = false;
   (chunk_no_lto : bool) = false;
   // --jobs J: parallel per-chunk `cc -c` jobs (chunked emission only).
-  (jobs : usize) = usize(8);
+  // 0 = not given: defaults to 8, or to the auto cap when --emit-chunks auto
+  // resolves N from the core count (no point minting more chunks than the
+  // driver will compile at once).
+  (jobs : usize) = usize(0);
   (optimize : String) = String.from(""); // "" = unset; "0".."3"
   (sanitize : String) = String.from(""); // "" / "address" / "leak" / "thread"
   (cflags : String) = String.from("");
@@ -2367,7 +2376,14 @@ run_compile :: (
       },
       (a == "--emit-chunks") => {
         ecv := _arg_val_req(argv, ai, String.from("--emit-chunks"), exn);
-        emit_chunks = match(ecv.parse_u64(), .Some(n) => usize(n), .None => usize(0));
+        cond(
+          (ecv == "auto") => {
+            emit_chunks_auto = true;
+          },
+          true => {
+            emit_chunks = match(ecv.parse_u64(), .Some(n) => usize(n), .None => usize(0));
+          }
+        );
         ai = (ai + usize(2));
       },
       (a == "--debug-parallelism") => {
@@ -2430,15 +2446,44 @@ run_compile :: (
   });
   // Chunked emission drives multiple TU inputs through the executable link
   // line; the static-library path compiles ONE input to ONE `.o`.
-  if((emit_chunks >= usize(1)) && static_library, {
+  if(((emit_chunks >= usize(1)) || emit_chunks_auto) && static_library, {
     exn.throw(dyn(String.from("compile: --emit-chunks is not supported with --static-library")));
   });
   // Both flags decide what C files get WRITTEN, so the combination is
   // ambiguous rather than merely redundant: `--emit-c-to` names ONE file, and
   // the chunked path writes a header plus N chunks. (`--emit-c`, which only
   // PRINTS the single-file equivalent, stays allowed.)
-  if((emit_chunks >= usize(1)) && (emit_c_to.len() > usize(0)), {
+  if(((emit_chunks >= usize(1)) || emit_chunks_auto) && (emit_c_to.len() > usize(0)), {
     exn.throw(dyn(String.from("compile: --emit-c-to writes one C file and --emit-chunks writes a header plus N chunks — pass only one")));
+  });
+  // `--emit-chunks auto` cap (Phase 1): YO_JOBS wins when set to a usable
+  // value, else the hardware thread count. A malformed YO_JOBS warns and
+  // falls back — it is a tuning knob, not a correctness setting.
+  (chunk_auto_cap : usize) = usize(0);
+  if(emit_chunks_auto, {
+    match(
+      proc_env.get(String.from("YO_JOBS")),
+      .Some(v) => match(
+        v.parse_u64(),
+        .Some(n) => if(n > u64(0), {
+          chunk_auto_cap = usize(n);
+        }, {
+          eprintln(String.from("compile: YO_JOBS must be a positive integer; ignoring it"));
+        }),
+        .None => {
+          eprintln(String.from("compile: YO_JOBS must be a positive integer; ignoring it"));
+        }
+      ),
+      .None => ()
+    );
+    if(chunk_auto_cap == usize(0), {
+      chunk_auto_cap = get_hardware_threads();
+    });
+  });
+  // --jobs default: 8, or the auto cap (no point minting more chunks than
+  // the driver will compile at once).
+  if(jobs == usize(0), {
+    jobs = cond((chunk_auto_cap >= usize(1)) => chunk_auto_cap, true => usize(8));
   });
   // ----- C compiler resolution (src/yo-cli.ts:468-486) ---------------------
   // Auto-select emcc for wasm targets when --cc was not given; otherwise probe
@@ -2676,7 +2721,16 @@ run_compile :: (
     // wrapper (is_library = true). Allocator + debug-logging flags are threaded
     // through to the code generator (mirrors CodeGeneratorC.compileModule).
     chunk_parts := ArrayList(String).new();
-    c_src := compile_module(module_value, ctx.expr_info_table, target, allocator.clone(), debug_gc, debug_parallelism, debug_async_await, static_library, ctx, env, exn, chunk_parts, emit_chunks);
+    c_src := compile_module(module_value, ctx.expr_info_table, target, allocator.clone(), debug_gc, debug_parallelism, debug_async_await, static_library, ctx, env, exn, chunk_parts, emit_chunks, chunk_auto_cap);
+    // `--emit-chunks auto` resolved its N inside compile_module (from the
+    // actual emitted bytes); read it back so every later decision — the
+    // chunk writer, the ThinLTO gate, the driver report — sees the real N.
+    if(emit_chunks_auto, {
+      emit_chunks = cond(
+        (chunk_parts.len() > usize(1)) => (chunk_parts.len() - usize(1)),
+        true => usize(0)
+      );
+    });
     // --emit-c prints the generated C to stdout (module-manager.ts:473-475) —
     // and compilation continues; only --skip-c-compiler stops before the link.
     if(emit_c, {
@@ -5076,7 +5130,8 @@ Options:
   --emit-c-to <path>        Write the generated C to a file and stop
   --skip-c-compiler         Generate C but skip the C compile
   --skip-codegen            Evaluate only (no C generation)
-  --emit-chunks <n>         Split emitted C into n translation units (implies -flto=thin)
+  --emit-chunks <n|auto>    Split emitted C into n translation units (implies -flto=thin);
+                            auto picks n from emitted size and core count (YO_JOBS overrides)
   --no-chunk-lto            Opt out of ThinLTO for chunked builds
   --jobs <n>                Parallel C compiles for chunked builds
   --compile-timeout-ms <ms> C compiler timeout
@@ -5119,7 +5174,8 @@ Examples:
   --emit-c-to <path>        把生成的 C 写入文件然后停止
   --skip-c-compiler         只生成 C，跳过 C 编译
   --skip-codegen            只做求值（不生成 C）
-  --emit-chunks <n>         把生成的 C 拆成 n 个翻译单元（隐含 -flto=thin）
+  --emit-chunks <n|auto>    把生成的 C 拆成 n 个翻译单元（隐含 -flto=thin）；
+                            auto 按产物大小与核数选 n（可用 YO_JOBS 覆盖）
   --no-chunk-lto            分块构建时退出 ThinLTO
   --jobs <n>                分块构建的并行 C 编译数
   --compile-timeout-ms <ms> C 编译器超时

--- a/tests/cli-cases/compile-emit-chunks/cmd
+++ b/tests/cli-cases/compile-emit-chunks/cmd
@@ -1,2 +1,3 @@
 compile main.yo --optimize 2 --emit-chunks 3 -o app
 compile main.yo --optimize 2 --emit-chunks 3 -o app
+compile main.yo --emit-chunks auto --jobs 4 -o app2

--- a/tests/cli-cases/compile-emit-chunks/expected_stdout
+++ b/tests/cli-cases/compile-emit-chunks/expected_stdout
@@ -2,3 +2,5 @@ Using system allocator
 chunks: 3 unit(s), 0 cached, 3 to compile (jobs=8)
 Using system allocator
 chunks: 3 unit(s), 3 cached, 0 to compile (jobs=8)
+Using system allocator
+chunks: 1 unit(s), 0 cached, 1 to compile (jobs=4)

--- a/tests/cli-cases/compile-emit-chunks/ignore
+++ b/tests/cli-cases/compile-emit-chunks/ignore
@@ -5,3 +5,9 @@
 ./app_chunk*.o
 ./app_chunk*.o.inputs-sha256
 ./app_chunks_compile.sh
+./app2
+./app2_shared.h
+./app2_chunk*.c
+./app2_chunk*.o
+./app2_chunk*.o.inputs-sha256
+./app2_chunks_compile.sh

--- a/tests/cli-cases/help-compile/expected_stdout
+++ b/tests/cli-cases/help-compile/expected_stdout
@@ -28,7 +28,8 @@ Options:
   --emit-c-to <path>        Write the generated C to a file and stop
   --skip-c-compiler         Generate C but skip the C compile
   --skip-codegen            Evaluate only (no C generation)
-  --emit-chunks <n>         Split emitted C into n translation units (implies -flto=thin)
+  --emit-chunks <n|auto>    Split emitted C into n translation units (implies -flto=thin);
+                            auto picks n from emitted size and core count (YO_JOBS overrides)
   --no-chunk-lto            Opt out of ThinLTO for chunked builds
   --jobs <n>                Parallel C compiles for chunked builds
   --compile-timeout-ms <ms> C compiler timeout


### PR DESCRIPTION
Stacked on #540 (Phase 0). Phase 1 of `plans/INCREMENTAL_COMPILATION_ZIG_LESSONS.md`: Zig's single biggest win was refusing to run an optimizer on debug builds — this lands Yo's equivalent end-to-end.

## What changed

- **`--emit-chunks auto`**: `N = clamp(1, cap, emitted_bytes / MIN_CHUNK_BYTES)` resolved at chunk-**assembly** time in `compile_module`, from the real emitted size (chunk assignment happens post-emission, so no size estimate is needed). `cap` = `YO_JOBS` when usable, else the already-existing `std/thread.get_hardware_threads()` cross-platform shim. `MIN_CHUNK_BYTES = 4 MiB`, measured: a 410-line program emits 168 KB with a ~20 % shared header, so N=4 there costs ~155 % of the single-file C work — such programs stay N=1.
- **`--jobs`** defaults to the auto cap under `auto`, else 8 as before.
- **`yo build` compiles DEBUG executables with `--emit-chunks auto`** — gated off for optimized builds (ThinLTO link is the floor there), libraries, `emit_c_to`, and wasm. `YO_JOBS=1` is the opt-out. Plain `yo compile` still emits one file unless asked, so the bootstrap fixpoint and portable-C comparisons are untouched — default emitted C verified byte-identical.
- **Cheap `-O0` flags** (`-fno-asynchronous-unwind-tables`, `-fno-color-diagnostics`): measured individually, both inside run-to-run noise, and dropping unwind tables would risk the runtime's `backtrace()` diagnostics — not adopted (per the plan's "adopt only what measures").

## Measured (self-build dev profile, Ryzen AI MAX+ 395, clang 21)

| C leg at `-O0` | wall |
| --- | --- |
| single file | 23.9 s |
| `--emit-chunks auto` (N=32, jobs=32, 12.1 MB header) | **7 s** |

3.4×, matching the M4's 3.3× from `CHUNKED_C_EMISSION.md`.

## Gates

- **`chunked-gate` CI job** (test.yml) runs `scripts/bootstrap/chunked_gate.sh` against the shared suite-candidate — chunking is now a default path, so the behavioural fixpoint runs on every code PR. Verified locally: `BEHAVIORAL_FIXPOINT_HOLDS`, hollow=0.
- `compile-emit-chunks` grew an `auto` line pinning `chunks: 1 unit(s), … (jobs=4)`; `help-compile` re-recorded for the new help text.
- `check ./src` 269/269, string suite 289/289, CLI corpus 88/92 (the 3 doc-* diffs are local git-message noise, identical with the unmodified binary).