### PR TITLE
ci: gate the Yo programs embedded in scripts and workflows (GATE 8)

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -365,6 +365,36 @@ Review the diff before committing: it should be exactly one changed hash line
 per case per edited skill file. Anything else means the install copied
 something you did not intend.
 
+## Yo source also lives INSIDE scripts and workflows — GATE 8 checks it
+
+Seven Yo programs are embedded in non-`.yo` files, and `yo check ./std`,
+`yo check ./src` and the language suite can see none of them:
+
+- the verification hello world in `scripts/install.sh` and
+  `scripts/install.ps1` (compiled on a user's machine, with the release the
+  script just downloaded);
+- the post-install smoke in `.github/workflows/install-scripts.yml` (POSIX and
+  Windows legs);
+- the three bundle smokes in `.github/workflows/release.yml`.
+
+`install-scripts.yml` is `paths`-filtered to the two installer files, and
+`release.yml` runs at release time only, so **a language change that removes a
+form one of those snippets used to land green and still break the installer
+for real users.** That happened when the `open(...)` builtin was removed
+(`issues/fixed/installer-verification-snippet-is-outside-every-per-pr-gate.md`).
+
+`scripts/check-embedded-yo.sh <path-to-yo>` extracts each snippet from its host
+file, compiles it, runs it and compares stdout against the line that host file
+asserts. It runs as GATE 8 of `gates_fast.sh`, so it is covered on every PR.
+**A tree-wide language sweep must include these files** — grep the scripts and
+workflows, not just `std/`, `src/` and `tests/`.
+
+`scripts/build_site.yo` is the same class of file (Yo source outside the three
+checked directories). `test.yml`'s `docs-site` job compiles it per-PR, but with
+the **SEED** compiler, which by construction still accepts every form it
+shipped with — that job catches std API drift, not language removals. Sweep it
+by hand.
+
 ## A fixpoint run's stage-1 must live OUTSIDE the repo (`/tmp/yo-s1`)
 
 Type keys embed each declaring module's PATH SPELLING, and std resolution is

--- a/issues/fixed/installer-verification-snippet-is-outside-every-per-pr-gate.md
+++ b/issues/fixed/installer-verification-snippet-is-outside-every-per-pr-gate.md
@@ -1,0 +1,118 @@
+# Yo source embedded in scripts/workflows is outside every per-PR gate
+
+**Status:** FIXED — `scripts/check-embedded-yo.sh`, wired as GATE 8 of
+`scripts/bootstrap/gates_fast.sh`.
+
+## Symptom
+
+A user ran `bash scripts/install.sh` and the installer failed its own
+verification step against the release it had just downloaded:
+
+```
+Installing Yo v0.2.30 for macos-arm64
+Verifying (compiling a hello world)..
+Verification FAILED. Compiler output:
+error[E0401]: Variable "open" not found.
+  --> /var/folders/.../hello.yo:1:1
+  |
+1 | open(import("std/fmt"));
+  | ^^^^
+help: did you mean "Send"?
+The install is present but cannot compile. See the output above.
+```
+
+## What was actually wrong in that instance
+
+Nothing in `develop`, in the `v0.2.30` tag, or in the published
+`https://shd101wyy.github.io/Yo/install.sh`. All three already carry
+`{ println } :: import("std/fmt");` — #530 ("remove the `open(...)` builtin")
+converted the snippet with the rest of the tree, and the site copy is
+regenerated from `scripts/install.sh` by `scripts/build_site.yo` on every
+deploy. Verified:
+
+```
+$ git show v0.2.29:scripts/install.sh | grep -c 'open(import'   # 1
+$ git show v0.2.30:scripts/install.sh | grep -c 'open(import'   # 0
+$ curl -fsSL https://shd101wyy.github.io/Yo/install.sh | sed -n 865p
+{ println } :: import("std/fmt");
+```
+
+The failing script was a **local checkout 99 commits behind `develop`**, on a
+branch cut before #530. `install.sh` resolves and installs the *latest* release
+regardless of its own age, so an old copy of the script hands an old hello
+world to a new compiler.
+
+## The real defect
+
+Six Yo programs live INSIDE other files, and nothing checks them per-PR:
+
+| program | host | when it is exercised today |
+| --- | --- | --- |
+| installer verification hello world | `scripts/install.sh` | `install-scripts.yml`, paths-filtered to that file |
+| ditto, Windows | `scripts/install.ps1` | ditto |
+| post-install smoke | `.github/workflows/install-scripts.yml` (POSIX leg) | that workflow only |
+| ditto, Windows leg | same file | that workflow only |
+| bundle smoke ×3 | `.github/workflows/release.yml` | **release time only** |
+
+`yo check ./std` and `yo check ./src` cover the directories that hold `.yo`
+files; the language suite covers `tests/`. None of them can see Yo source
+embedded in a shell script, a PowerShell script or a YAML block scalar. And
+`install-scripts.yml` is `paths`-filtered to the two installer files plus
+itself, with a Monday 07:00 UTC schedule as the only other trigger.
+
+So a language change that removes a form one of those snippets uses **lands
+green on every required check**, and the breakage surfaces to a user at install
+time — up to a week later — with a diagnostic that reads like a broken release.
+#530 happened to edit `install.sh`, which is why it tripped the path filter and
+was fixed there; a removal landed anywhere else would not have been.
+
+`scripts/build_site.yo` is a seventh instance of the same class, and the
+obvious mitigation does not work: `test.yml`'s `docs-site` job does compile it
+on every PR, but **with the SEED compiler** (`env.SEED_VERSION`, with
+`YO_STD=$GITHUB_WORKSPACE/std`). A seed by definition still accepts every form
+it shipped with, so it cannot reject a form the tree just removed. That job
+catches std API drift, not language removals. It is left as-is here: the file
+is at least compiled somewhere, and `yo build`'s own bootstrap does not include
+it.
+
+## Fix
+
+`scripts/check-embedded-yo.sh <path-to-yo> [workdir]`, run as GATE 8 of
+`gates_fast.sh` (so: every PR via the `bootstrap-self-test` job, and locally):
+
+1. **Extracts** each snippet from its host file — the `YOEOF` here-doc, the
+   PowerShell `@' … '@` here-string, the YAML-indented here-docs (dedented),
+   and `release.yml`'s `printf '%s\n' … > hello.yo` one-liners (re-run through
+   the shell rather than re-parsing their quoting). Extraction, never a copy:
+   a copy drifts, and drift is the failure being prevented.
+2. Fails if an extraction yields **nothing**, so moving a marker cannot
+   silently turn the gate vacuous.
+3. **Compiles and runs** each with the tree compiler and asserts stdout equals
+   the line its host file itself asserts (`Yo is installed`, `installed ok`,
+   `hello from the yo seed`).
+4. Asserts the two installers embed **identical** programs, and that
+   `release.yml`'s three sites smoke identical programs.
+
+Verified to catch the original regression — reintroducing
+`open(import("std/fmt"));` in `scripts/install.sh` produces:
+
+```
+FAIL: scripts/install.sh verify snippet: does not compile
+    error[E0401]: Variable "open" not found.
+FAIL: install.sh and install.ps1 verify DIFFERENT programs
+```
+
+and a clean tree reports `EMBEDDED_YO: sites=7 failures=0`.
+
+## Also changed
+
+Both installers now name the stale-copy possibility when verification fails,
+because the compiler output alone reads like a broken release:
+
+```
+If this copy of install.sh is older than v0.2.30, it may be compiling a hello
+world that v0.2.30 no longer accepts. Re-fetch the installer and retry:
+  curl -fsSL https://shd101wyy.github.io/Yo/install.sh | sh
+```
+
+That is the diagnosis that took a full debugging cycle to reach here.

--- a/scripts/bootstrap/gates_fast.sh
+++ b/scripts/bootstrap/gates_fast.sh
@@ -255,5 +255,26 @@ case "$clidiff_tail" in
      dump_log "/tmp/${P}_clidiff.log" ;;
 esac
 
+echo "=== T1 GATE 8: embedded Yo programs compile ==="
+# Yo source that lives INSIDE another file is covered by nothing else here:
+# GATE 3/4 check ./std and ./src, GATE 1 runs tests/, and none of them can see
+# the hello worlds embedded in the two install scripts, in
+# install-scripts.yml, or in release.yml's three bundle smokes. Those decide
+# whether a user's install succeeds and whether a release publishes, and the
+# workflows carrying them are paths-filtered or release-time only — so a
+# language change that removes a form one of them uses lands green and breaks
+# the installer for real users (it did, when the `open(...)` builtin was
+# removed: issues/fixed/installer-verification-snippet-is-outside-every-per-pr-gate.md).
+#
+# The checker EXTRACTS each snippet from its host file, compiles it, runs it,
+# and compares stdout against the line that host file itself asserts.
+scripts/check-embedded-yo.sh "$S1" "/tmp/${P}_embyo" &> "/tmp/${P}_embyo.log"
+embyo_rc=$?
+echo "EMBYO_RC=$embyo_rc  $(tail -1 "/tmp/${P}_embyo.log")"
+if [ "$embyo_rc" != "0" ]; then
+  fail "embedded Yo programs failed (rc=$embyo_rc)"
+  dump_log "/tmp/${P}_embyo.log"
+fi
+
 echo "=== T1_DONE (${P}) failures=${fails} ==="
 [ "$fails" = "0" ] || exit 1

--- a/scripts/check-embedded-yo.sh
+++ b/scripts/check-embedded-yo.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Compile-and-run every Yo program EMBEDDED in a shell script, PowerShell
+# script or workflow file in this repository.
+#
+# Why this exists
+# ---------------
+# `yo check ./std`, `yo check ./src` and the language suite cover the three
+# directories that hold `.yo` files. They do not cover Yo source that lives
+# INSIDE another file — and six such programs gate the release and the install
+# experience:
+#
+#   * the hello world `scripts/install.sh` / `scripts/install.ps1` compile with
+#     the release they just downloaded (their verification step);
+#   * the hello world `.github/workflows/install-scripts.yml` compiles after a
+#     real install, on POSIX and on Windows;
+#   * the hello world `.github/workflows/release.yml` compiles against each
+#     freshly built bundle (three sites: bundle smoke, musl container smoke,
+#     portable-C smoke).
+#
+# A language change that removes a form one of those uses lands green on every
+# required check. `install-scripts.yml` is paths-filtered to the two installer
+# files plus itself, and `release.yml` only runs at release time — so the
+# breakage surfaces to a USER, at install time, with a diagnostic that reads
+# like a broken release. That is exactly what happened when the `open(...)`
+# builtin was removed: see
+# issues/fixed/installer-verification-snippet-is-outside-every-per-pr-gate.md.
+#
+# Every snippet is EXTRACTED from its host file, never copied here. A copy
+# drifts, and drift is the failure being prevented. Extraction that yields
+# nothing is itself a failure, so moving a here-doc marker cannot silently turn
+# this check vacuous.
+#
+# Usage:
+#   scripts/check-embedded-yo.sh <path-to-yo> [workdir]
+#
+# Run from the repository root. Exits nonzero if any snippet fails to extract,
+# fails to compile, or prints something other than what its host file asserts.
+
+set -uo pipefail
+
+YO=${1:?usage: check-embedded-yo.sh <path-to-yo> [workdir]}
+WORK=${2:-$(mktemp -d)}
+mkdir -p "$WORK"
+
+# The snippets are compiled from a scratch directory, and <path-to-yo> is
+# routinely a stage-1 staged OUTSIDE this checkout (CI's /tmp/yo-stage1), where
+# the exe-relative walk-up finds no std/. Pin std to the checkout being
+# checked — these are the snippets THIS tree ships, so they must be checked
+# against THIS tree's std.
+if [ -z "${YO_STD:-}" ] && [ -d "$PWD/std" ]; then
+  export YO_STD="$PWD/std"
+fi
+
+fails=0
+fail() { echo "FAIL: $*"; fails=$((fails + 1)); }
+
+# Strip the common leading indentation of a here-doc that was embedded in a
+# YAML block scalar (`run: |`), where the indent belongs to the YAML and not to
+# the program.
+dedent() {
+  awk '
+    NR == 1 { match($0, /^[ \t]*/); n = RLENGTH }
+    { print substr($0, n + 1) }
+  ' "$1"
+}
+
+# check <label> <expected-stdout> <source-file>
+check() {
+  label=$1 expect=$2 src=$3
+  if [ ! -s "$src" ]; then
+    fail "$label: extraction produced nothing — the surrounding markers moved; update this script"
+    return
+  fi
+  if ! "$YO" compile "$src" -o "$src.bin" > "$src.log" 2>&1; then
+    fail "$label: does not compile"
+    sed 's/^/    /' "$src.log"
+    return
+  fi
+  got=$("$src.bin" 2>&1)
+  if [ "$got" != "$expect" ]; then
+    fail "$label: printed '$got', host file asserts '$expect'"
+    return
+  fi
+  echo "ok: $label"
+}
+
+#---------------------------------------------------------
+# 1+2. scripts/install.sh and scripts/install.ps1
+#
+# Both installers verify by compiling AND running a hello world, and both
+# assert the same line — so they must embed the same program.
+#---------------------------------------------------------
+awk '/cat > "\$YO_TEMP_DIR\/hello.yo" <<.YOEOF.$/{f=1;next} f&&/^YOEOF$/{exit} f' \
+  scripts/install.sh > "$WORK/install_sh.yo"
+awk '/^  \$hello = @.$/{f=1;next} f&&/^.@$/{exit} f' \
+  scripts/install.ps1 > "$WORK/install_ps1.yo"
+
+check "scripts/install.sh verify snippet"  "Yo is installed" "$WORK/install_sh.yo"
+check "scripts/install.ps1 verify snippet" "Yo is installed" "$WORK/install_ps1.yo"
+if [ -s "$WORK/install_sh.yo" ] && [ -s "$WORK/install_ps1.yo" ]; then
+  if ! diff -u "$WORK/install_sh.yo" "$WORK/install_ps1.yo" > "$WORK/installers.diff" 2>&1; then
+    fail "install.sh and install.ps1 verify DIFFERENT programs"
+    sed 's/^/    /' "$WORK/installers.diff"
+  fi
+fi
+
+#---------------------------------------------------------
+# 3+4. .github/workflows/install-scripts.yml (POSIX + Windows legs)
+#
+# Indented inside a YAML block scalar, so dedent before compiling.
+#---------------------------------------------------------
+awk '/cat > hello.yo <<.EOF.$/{f=1;next} f&&/^ *EOF$/{exit} f' \
+  .github/workflows/install-scripts.yml > "$WORK/iw_posix.raw"
+awk '/^ *@.$/{f=1;next} f&&/^ *.@ \| Set-Content/{exit} f' \
+  .github/workflows/install-scripts.yml > "$WORK/iw_win.raw"
+dedent "$WORK/iw_posix.raw" > "$WORK/iw_posix.yo"
+dedent "$WORK/iw_win.raw"   > "$WORK/iw_win.yo"
+
+check "install-scripts.yml POSIX smoke"   "installed ok" "$WORK/iw_posix.yo"
+check "install-scripts.yml Windows smoke" "installed ok" "$WORK/iw_win.yo"
+
+#---------------------------------------------------------
+# 5. .github/workflows/release.yml — three `printf` one-liners
+#
+# Shape: printf '%s\n' 'line' 'line' 'line' > <path>/hello.yo
+# Re-run the printf itself rather than re-parsing its quoting, then require all
+# three sites to agree: they smoke the same bundle three different ways.
+#---------------------------------------------------------
+grep -n "printf '%s\\\\n' .* > .*hello\.yo" .github/workflows/release.yml \
+  > "$WORK/release_sites.txt"
+site_count=$(wc -l < "$WORK/release_sites.txt" | tr -d ' ')
+if [ "$site_count" = "0" ]; then
+  fail "release.yml: found no hello-world printf sites — the shape changed; update this script"
+fi
+n=0
+while IFS= read -r line; do
+  n=$((n + 1))
+  lineno=${line%%:*}
+  body=${line#*:}
+  args=${body#*printf }
+  args=${args%% > *}
+  # `eval` of a printf whose arguments come from this repository's own
+  # workflow file — the alternative is re-implementing shell quoting.
+  eval "printf $args" > "$WORK/release_$n.yo" 2>"$WORK/release_$n.evalerr" || {
+    fail "release.yml:$lineno: could not re-run its printf"
+    sed 's/^/    /' "$WORK/release_$n.evalerr"
+    continue
+  }
+  check "release.yml:$lineno bundle smoke" "hello from the yo seed" "$WORK/release_$n.yo"
+  if [ "$n" -gt 1 ] && ! diff -q "$WORK/release_1.yo" "$WORK/release_$n.yo" > /dev/null 2>&1; then
+    fail "release.yml:$lineno smokes a DIFFERENT program than the first site"
+  fi
+done < "$WORK/release_sites.txt"
+
+echo "EMBEDDED_YO: sites=$((2 + 2 + site_count)) failures=$fails"
+[ "$fails" = "0" ] || exit 1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -425,6 +425,12 @@ export(main);
   $ErrorActionPreference = 'Stop'
   if ($LASTEXITCODE -ne 0) {
     Warn ($log | Out-String)
+    # This script installs the LATEST release, not the one it shipped with, so
+    # an old local copy can hand a hello world to a newer compiler that no
+    # longer accepts it. Say so: the compiler output alone reads like a broken
+    # release.
+    Warn "If this copy of install.ps1 is older than $Version, it may be compiling a hello world that $Version no longer accepts. Re-fetch the installer and retry:"
+    Warn '  irm https://shd101wyy.github.io/Yo/install.ps1 | iex'
     Fail 'The install is present but cannot compile. See the output above.'
   }
   $ErrorActionPreference = 'Continue'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -872,6 +872,12 @@ YOEOF
   if ! "$PREFIX/lib/yo/$VERSION/bin/yo" compile "$YO_TEMP_DIR/hello.yo" -o "$YO_TEMP_DIR/hello" > "$YO_TEMP_DIR/verify.log" 2>&1 ; then
     warn "Verification FAILED. Compiler output:"
     warn "$(cat "$YO_TEMP_DIR/verify.log")"
+    # This script installs the LATEST release, not the one it shipped with, so
+    # an old local copy can hand a hello world to a newer compiler that no
+    # longer accepts it. Say so: the compiler output alone reads like a broken
+    # release.
+    warn "If this copy of install.sh is older than $VERSION, it may be compiling a hello world that $VERSION no longer accepts. Re-fetch the installer and retry:"
+    warn "  curl -fsSL https://shd101wyy.github.io/Yo/install.sh | sh"
     stop "The install is present but cannot compile. See the output above."
   fi
   out="$("$YO_TEMP_DIR/hello" 2>&1 || true)"


### PR DESCRIPTION
## The report

A user's `bash scripts/install.sh` failed its **own verification step** against the just-published v0.2.30:

```
Verifying (compiling a hello world)..
Verification FAILED. Compiler output:
error[E0401]: Variable "open" not found.
  --> /var/folders/.../hello.yo:1:1
1 | open(import("std/fmt"));
```

## What was actually wrong in that instance: nothing shipped

`develop`, the `v0.2.30` tag and the published site installer all already carry `{ println } :: import("std/fmt");`:

```
$ git show v0.2.29:scripts/install.sh | grep -c 'open(import'   # 1
$ git show v0.2.30:scripts/install.sh | grep -c 'open(import'   # 0
$ curl -fsSL https://shd101wyy.github.io/Yo/install.sh | sed -n 865p
{ println } :: import("std/fmt");
```

The failing script was a **local checkout 99 commits behind `develop`**, on a branch cut before #530 removed the `open(...)` builtin. `install.sh` installs the *latest* release regardless of its own age, so an old copy hands an old hello world to a new compiler.

## The class, though, was real and ungated

Seven Yo programs live **inside** non-`.yo` files, so `yo check ./std`, `yo check ./src` and the language suite can see none of them:

| program | host | exercised today |
| --- | --- | --- |
| verification hello world | `scripts/install.sh` | `install-scripts.yml`, paths-filtered to that file |
| ditto, Windows | `scripts/install.ps1` | ditto |
| post-install smoke ×2 | `.github/workflows/install-scripts.yml` | that workflow only |
| bundle smoke ×3 | `.github/workflows/release.yml` | **release time only** |

So a language change that removes a form one of those uses **lands green on every required check** and surfaces to a user at install time — with a diagnostic that reads like a broken release. #530 was fixed only because it happened to edit `install.sh` and trip the path filter.

## Fix

`scripts/check-embedded-yo.sh <path-to-yo>`, wired as **GATE 8** of `gates_fast.sh` (every PR via `bootstrap-self-test`, and locally):

1. **Extracts** each snippet from its host file — the `YOEOF` here-doc, the PowerShell `@' … '@` here-string, the YAML-indented here-docs (dedented), and `release.yml`'s `printf '%s\n' … > hello.yo` one-liners (re-run through the shell rather than re-parsing their quoting). Extraction, never a copy: a copy drifts, and drift is the failure being prevented.
2. Fails if an extraction yields **nothing** — moving a marker cannot make the gate vacuous.
3. **Compiles and runs** each with the tree compiler, asserting stdout equals the line its host file itself asserts.
4. Asserts the two installers embed **identical** programs, and that `release.yml`'s three sites smoke identical programs.

## Verification

Clean tree:

```
ok: scripts/install.sh verify snippet
ok: scripts/install.ps1 verify snippet
ok: install-scripts.yml POSIX smoke
ok: install-scripts.yml Windows smoke
ok: release.yml:852 bundle smoke
ok: release.yml:1150 bundle smoke
ok: release.yml:1188 bundle smoke
EMBEDDED_YO: sites=7 failures=0
```

Reintroducing `open(import("std/fmt"));` in `scripts/install.sh` — i.e. the exact reported regression:

```
FAIL: scripts/install.sh verify snippet: does not compile
    error[E0401]: Variable "open" not found.
FAIL: install.sh and install.ps1 verify DIFFERENT programs
```

GATE 8's integration in `gates_fast.sh` was run in isolation with a real compiler: `EMBYO_RC=0  EMBEDDED_YO: sites=7 failures=0`.

## Also

- Both installers now name the stale-copy possibility on a verification failure — that diagnosis cost a full debugging cycle here. (`$VERSION`/`$Version` already carry the `v` prefix; the message does not double it.)
- `.github/instructions/testing.instructions.md` documents the class so a future tree-wide language sweep includes scripts and workflows, not just `std/`, `src/`, `tests/`.
- `issues/fixed/installer-verification-snippet-is-outside-every-per-pr-gate.md` records it.
- Noted rather than fixed: `scripts/build_site.yo` is the same class of file. `test.yml`'s `docs-site` job compiles it per-PR, but with the **SEED** compiler, which by construction still accepts every form it shipped with — so it catches std API drift, not language removals. It needs a manual sweep.

## Local coverage

No `.yo` source changes, no `std/`/`src/` changes — the language gates cannot regress. Shell/PowerShell syntax checked (`bash -n`); the new gate verified positively and negatively as above. `install-scripts.yml` runs for real on this PR, since `scripts/install.sh` is in its path filter. `.github/instructions/` is not bundled by `yo init`/`yo skills install`, so no cli-case goldens move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)