### PR TITLE
std: Child pipes as Reader/Writer handles; Watcher gets the Dispose it never had

### DIFF
--- a/issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md
+++ b/issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md
@@ -1,0 +1,131 @@
+# A dropped `Watcher` leaves the event loop calling into freed memory
+
+**Status:** FIXED 2026-09-10 — `std/fs/watch.yo` gained a `Dispose` impl.
+
+## Symptom
+
+`std/fs/watch`'s `Watcher` had a `close()` method and **no `Dispose` impl**, so
+a watcher that simply fell out of scope was never unregistered:
+
+```rust
+{ watch, WatchOptions } :: import("std/fs/watch");
+_start_watching :: (fn(p : Path, exn : Exception) -> unit)({
+  w := watch(p, WatchOptions.defaults(), exn);
+  // ... no w.close(); w's last reference dies here
+});
+```
+
+## Why this is a use-after-free, not just a leak
+
+`watch` registers the callback with a **raw, non-owning** pointer to the
+watcher itself (`std/fs/watch.yo`):
+
+```rust
+rc := events.fs_event_start(w._handle, cstr, flags, _on_fs_event, unsafe.cast(w, *u8));
+```
+
+`unsafe.cast(w, *u8)` does not dup the Rc, so the runtime's active-watch list
+holds a pointer that does not keep the watcher alive. When the last Yo-side
+reference dies, the `Watcher` is freed while still registered, and the next
+backend notification runs:
+
+```rust
+_on_fs_event :: (fn(path : *u8, mask : i32, user_data : *u8) -> unit)({
+  w := unsafe.cast(user_data, Watcher);
+  if(w._active, {                      // <-- read of freed memory
+    ...
+    w._queue.push(...);                // <-- write into freed memory
+```
+
+`w._active` is a read of freed memory, and if the freed bytes happen to be
+nonzero it goes on to `push` into a freed `ArrayList` — heap corruption on the
+event loop thread, at an arbitrary later time, with no connection to the code
+that dropped the watcher.
+
+On top of that, `__yo_fs_event_close` is what frees the backend handle and its
+descriptor (`src/codegen/async/runtime_io_common.yo`):
+
+```c
+static void __yo_fs_event_close(void* h) {
+  __yo_fs_event_t* handle = (__yo_fs_event_t*)h;
+  if (!handle) return;
+  if (handle->active) __yo_fs_event_stop(h);
+  __yo_free(handle);
+}
+```
+
+so a dropped watcher also leaks the `__yo_fs_event_t` and its inotify (Linux)
+or kqueue (macOS) descriptor. **Linux caps inotify instances per user** —
+`/proc/sys/fs/inotify/max_user_instances`, default 128 — so this leak is not
+merely untidy: a program that creates and drops watchers in a loop stops being
+able to watch anything at all, and `watch` starts throwing `IoError`.
+
+## Why no other closeable in std had this
+
+Every other closeable resource in `std/` pairs its `close` with a `Dispose`:
+`File`, `TcpListener`, `TcpStream`, `UdpSocket`, `Cond`, `RwLock`, `Mutex`,
+`Channel`, `TempFile`, `TempDir`. `Watcher` was the only one that shipped a
+`close()` and stopped there — and it is the one where a missed teardown is a
+UAF rather than a leak, because it is the only one that hands the runtime a
+non-owning self-pointer.
+
+## Fix
+
+```rust
+impl(
+  Watcher,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)(self.close())
+  )
+);
+```
+
+`close` changed from `inout(self)` to `self : Self` so `dispose` can delegate
+to it — every other closeable in `std/` already spells it that way, and
+`Watcher` is a `ref(struct)`, so the field writes work identically through the
+Rc handle. `close` was already idempotent (`if(self._active, …)`), so an
+explicit `close()` followed by drop stops the watch exactly once.
+
+The `Dispose` impl is also what makes the non-owning `user_data` **sound**
+rather than merely convenient: the callback can no longer outlive the object,
+because the object's own teardown removes it from the loop's list.
+
+## Test
+
+`tests/fs/watch.test.yo` — "a watcher dropped without close() releases its
+backend handle": 200 create-and-drop cycles, with the **descriptor number** as
+the oracle, then a fresh watcher that must still deliver an event.
+
+The oracle matters. My first version asserted that the 200 cycles all succeed,
+reasoning that Linux caps inotify instances at 128 by default so the loop would
+throw. **That test passed with the `Dispose` impl removed** — this machine's
+`RLIMIT_NOFILE` swallows 200 leaked macOS watchers without complaining, so on
+macOS it was vacuous, and I would have shipped a test that proves nothing on
+the platform I develop on.
+
+The replacement opens and closes a probe file before and after the loop and
+compares the descriptor numbers. The kernel hands out the lowest free
+descriptor, so that reads as "how many descriptors are in use" with no
+dependence on any limit — and each live watcher holds one inotify instance on
+Linux, or an `O_EVTONLY` descriptor **plus** a kqueue descriptor on macOS.
+Verified both ways with the impl in and out:
+
+```
+  ✗ a watcher dropped without close() releases its backend handle     (no Dispose)
+  ✓ a watcher dropped without close() releases its backend handle     (with Dispose)
+```
+
+The use-after-free half is not directly observable without a sanitizer (and
+macOS blocks ASan under AMFI — see the GuardMalloc recipe), but it has the same
+single cause and the same single fix.
+
+## The `ChildStdin` half of the same batch
+
+`std/process/command.yo`'s new `ChildStdin` handle has the same hazard in a
+gentler form: a dropped write end that does not close leaves the child waiting
+for an EOF that never arrives. Its test (`tests/process/command.test.yo`,
+"dropping a ChildStdin closes the pipe") therefore **bounds** its read with
+`std/async`'s `timeout` rather than reading straight through — without the
+`Dispose` impl the bare read HANGS, and a hanging test burns a CI job's whole
+timeout instead of reporting a failure. Bounded, the regression reports in
+~2 seconds.

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -559,11 +559,54 @@ non-test caller existed in the whole tree (`src/main.yo`'s
 **I/O.** Verified against the code 2026-09-09 — LANDED:
 `Stdout.write_string`; `Reader.read_exact`; lazy `read_dir`;
 `Metadata.modified`; `SocketAddr`/`IpAddr` `Eq`/`Hash`/`Ord`/`Clone` + `parse`;
-`TcpStream.local_addr`; `TcpListener.incoming`. STILL OPEN: `Child`
-stdin/stdout/stderr as `Reader`/`Writer` handles; `Watcher` `Dispose`; HTTP
-keep-alive. (`Seek`, `OpenOptions`, `SystemTime`, `IpAddr.parse_v6`,
+`TcpStream.local_addr`; `TcpListener.incoming`. STILL OPEN: HTTP keep-alive.
+(`Child` stdin/stdout/stderr as `Reader`/`Writer` handles and `Watcher`
+`Dispose` landed 2026-09-10 — described just below.) (`Seek`, `OpenOptions`, `SystemTime`, `IpAddr.parse_v6`,
 `UdpSocket.recv_from -> (n, from)`, `StatusCode` and `HeaderMap` all landed
 2026-09-09 — described just below.)
+
+**`Child` pipe handles + `Watcher` `Dispose` — LANDED 2026-09-10.**
+
+`Command.spawn`'s `Child` now yields the parent ends of its pipes as typed
+handles: `take_stdin() -> Option(ChildStdin)` (a `Writer`),
+`take_stdout() -> Option(ChildStdout)` and
+`take_stderr() -> Option(ChildStderr)` (both `Reader`s). That is what puts a
+child's streams inside `std/io`'s surface — `write_all`, `read_to_string`,
+`read_exact`, `BufReader.lines` — instead of the three bespoke methods
+(`write_stdin`, `read_stdout_to_end`, `read_stderr_to_end`) that were the only
+way in. Those stay, and now say they throw `BadFileDescriptor` once the fd has
+been taken.
+
+Three shape decisions:
+
+- **Taking MOVES the fd** out of the `Child` (`_stdout_fd = .None`), so `wait()`
+  no longer closes it and there is exactly one owner. A second `take_stdout()`
+  is `.None`, which is also how "this stream was not `Stdio.Piped`" reads —
+  the same answer to the same question ("can I have that stream?").
+- **`ChildStderr` is a distinct type** from `ChildStdout` despite being
+  structurally identical, for Rust's reason: the type says which stream you
+  are holding.
+- **`close` sets its flag INSIDE the async body**, after the close, mirroring
+  `File.close`. A future that is created and never awaited must leave the
+  handle closeable, or `dispose` would skip an fd that is still open.
+
+Each handle has a `Dispose`, so dropping a `ChildStdin` delivers the EOF the
+child is waiting for without an explicit `close`.
+
+`Watcher` gained the `Dispose` it never had, and the missing one was worse than
+a leak. `watch` registers its callback with a **raw, non-owning** pointer to
+the watcher (`unsafe.cast(w, *u8)`), so a watcher dropped while active left the
+event loop calling `_on_fs_event` into freed memory — reading `w._active` and
+then pushing into a freed `ArrayList` — on top of leaking the backend's
+`__yo_fs_event_t` and its inotify/kqueue descriptor. Linux caps inotify
+instances per user at 128 by default, so the leak alone stopped a
+watcher-creating loop from watching anything. `dispose` delegating to the
+already-idempotent `close()` is what makes the non-owning `user_data` sound:
+the callback cannot outlive the object, because the object's teardown removes
+it. `close` moved from `inout(self)` to `self : Self` to allow that delegation
+— every other closeable in `std/` already spelled it that way, and `Watcher`
+is a `ref(struct)`, so the field writes are unchanged.
+(`issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md`)
 
 **`Seek` + `OpenOptions` + `SystemTime` — LANDED 2026-09-09, and the shapes
 each had a reason.**

--- a/std/fs/watch.yo
+++ b/std/fs/watch.yo
@@ -15,6 +15,11 @@
 //! w.close();
 //! ```
 //!
+//! `close()` is idempotent and runs automatically when the last reference to
+//! the watcher goes away, so a watcher that simply falls out of scope stops
+//! its native watch rather than leaving the event loop calling back into
+//! freed memory.
+//!
 //! Event kinds follow the backend's (and libuv's) two-way split: `Rename`
 //! covers create / delete / move, `Change` covers a write or metadata change.
 //! `name` is the entry name relative to a watched directory (the file's own
@@ -173,13 +178,31 @@ impl(
     })
   ),
   /// Stop the native watch. Queued events stay readable through `poll`;
-  /// `next` no longer waits.
-  close : (fn(inout(self) : Self) -> unit)({
+  /// `next` no longer waits. Idempotent, and called for you when the last
+  /// reference to the watcher goes away (`Dispose` below).
+  close : (fn(self : Self) -> unit)({
     if(self._active, {
       self._active = false;
       events.fs_event_stop(self._handle);
       events.fs_event_close(self._handle);
     });
   })
+);
+impl(
+  Watcher,
+  /// Releasing the last reference stops the native watch.
+  ///
+  /// This is not merely tidy. `watch` registers `_on_fs_event` with a RAW,
+  /// NON-OWNING pointer to the watcher (`unsafe.cast(w, *u8)`), so a watcher
+  /// that is dropped while active leaves the event loop holding a dangling
+  /// pointer and calling back into freed memory — a use-after-free, on top of
+  /// leaking the backend's `__yo_fs_event_t` and its inotify/kqueue
+  /// descriptor. `dispose` unregistering the watch is exactly what makes the
+  /// non-owning `user_data` sound: the callback cannot outlive the object,
+  /// because the object's own teardown removes it.
+  /// (issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md)
+  Dispose(
+    dispose : (fn(self : Self) -> unit)(self.close())
+  )
 );
 export(FsEventKind, FsEvent, WatchOptions, Watcher, watch);

--- a/std/process/command.yo
+++ b/std/process/command.yo
@@ -17,6 +17,38 @@
 //!   assert(out.status.success(), "echo should succeed");
 //! });
 //! ```
+//!
+//! ## Streaming a child's pipes
+//!
+//! `Command.spawn` returns a `Child`; `take_stdin`/`take_stdout`/`take_stderr`
+//! hand you the parent ends as `Writer`/`Reader` handles, so all of
+//! `std/io`'s surface — `write_all`, `read_to_string`, `read_exact`,
+//! `BufReader.lines` — applies to a child's streams:
+//!
+//! ```rust
+//! { Command, Stdio } :: import("std/process/command");
+//! { BufReader } :: import("std/io/buffered");
+//!
+//! cmd := Command.new(`sort`);
+//! cmd.stdin(Stdio.Piped);
+//! cmd.stdout(Stdio.Piped);
+//! child := io.await(cmd.spawn(io), ie);
+//! match(child.take_stdin(), .Some(w) => {
+//!   io.await(w.write_string(`b\na\n`, io), ie);
+//!   io.await(w.close(io), ie);            // EOF — or just drop `w`
+//! }, .None => ());
+//! text := match(
+//!   child.take_stdout(),
+//!   .Some(r) => io.await(r.read_to_string(io), ie),
+//!   .None => String.new()
+//! );
+//! io.await(child.wait(io), ie);
+//! ```
+//!
+//! Taking a stream MOVES its fd out of the `Child`, so `wait()` will not close
+//! it and the handle's own `close` (or its drop) does. Read a piped stdout
+//! before `wait()` when the child may produce more than a pipe buffer holds,
+//! or the child blocks writing while you block waiting.
 pragma(Pragma.AllowUnsafe);
 { ArrayList } :: import("../collections/array_list");
 { String } :: import("../string");
@@ -33,6 +65,8 @@ IO_pipe :: import("../sys/pipe");
 { O_NONBLOCK, FD_CLOEXEC } :: import("../libc/fcntl");
 { malloc, free } :: GlobalAllocator;
 { stdout, fflush } :: import("../libc/stdio");
+{ close_sync } :: import("../sys/file");
+IoTraits :: import("../io");
 // ============================================================================
 // ExitStatus
 // ============================================================================
@@ -563,13 +597,280 @@ Child :: ref(
     _reaped : bool
   )
 );
+// ============================================================================
+// Child pipe handles (Reader / Writer over the parent end of a pipe)
+// ============================================================================
+// A pipe is read and written at offset 0 — pipes have no seek position — and
+// an fd of -1 makes the syscall return EBADF, which `IoError.check` turns into
+// `IoError.BadFileDescriptor`. That is how a handle closed (or disposed)
+// before use reports itself, with no branch inside the `io.async` body.
+_pipe_write :: (fn(fd : i32, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => {
+    n := e.io.await(IO_file.write(fd, buf, u32(size), u64(0)), e.io);
+    usize(IoError.check(n, e.exn))
+  })
+);
+_pipe_read :: (fn(fd : i32, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => {
+    n := e.io.await(IO_file.read(fd, buf, u32(size), u64(0)), e.io);
+    usize(IoError.check(n, e.exn))
+  })
+);
+/// The parent's write end of a child's stdin pipe — a `Writer`, so
+/// `write_all`, `write_string` and the rest of `std/io`'s writer surface work
+/// on it. Take it off a `Child` with `take_stdin()`; closing it (explicitly,
+/// or by dropping it) is the EOF the child is usually waiting for.
+ChildStdin :: ref(struct(_fd : i32, _closed : bool));
+/// The parent's read end of a child's stdout pipe — a `Reader`, so
+/// `read_to_end`, `read_to_string`, `read_exact` and `BufReader` work on it.
+/// Take it off a `Child` with `take_stdout()`.
+ChildStdout :: ref(struct(_fd : i32, _closed : bool));
+/// The parent's read end of a child's stderr pipe. Structurally identical to
+/// `ChildStdout` and distinct for the same reason Rust keeps them apart: the
+/// type says which stream you are holding.
+ChildStderr :: ref(struct(_fd : i32, _closed : bool));
+impl(
+  ChildStdin,
+  /// The underlying file descriptor.
+  fd : (fn(self : Self) -> i32)(self._fd),
+  /// Whether the handle has been closed.
+  is_closed : (fn(self : Self) -> bool)(self._closed),
+  /// Write up to `size` bytes. Returns the number written.
+  write : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
+    raw := cond(self._closed => i32(-1), true => self._fd);
+    _pipe_write(raw, buf, size, io)
+  }),
+  /// Close the write end — the child sees EOF. Safe to call multiple times.
+  ///
+  /// The flag is set INSIDE the async body, after the close, exactly as
+  /// `File.close` does: a future that is created and never awaited must leave
+  /// the handle closeable, or `dispose` would skip an fd that is still open.
+  close : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))({
+    raw := self._fd;
+    io.async(
+      e =>
+        cond(
+          self._closed => (),
+          true => {
+            result := e.io.await(IO_file.close(raw), e.io);
+            self._closed = true;
+            cond(
+              (result < i32(0)) => e.exn.throw(dyn(IoError.from_errno(i32(0) - result))),
+              true => ()
+            )
+          }
+        )
+    )
+  })
+);
+impl(
+  ChildStdin,
+  IoTraits.Writer(
+    write : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.write(buf, size, io)
+    ),
+    // A pipe write goes straight to the kernel — nothing is buffered here.
+    flush : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))(
+      io.async(e => ())
+    )
+  )
+);
+// Registered AFTER the `Writer` impl above: `write_string` calls the
+// `write_all` DEFAULT on a `ChildStdin`, and a module evaluates top to bottom,
+// so an impl that came later would leave this `io.async` body hollow at
+// definition time — the same ordering constraint std/fs/file.yo records.
+impl(
+  ChildStdin,
+  /// Write a `String`, in full. `File.write_string` spells the same
+  /// convenience.
+  write_string : (fn(self : Self, data : String, io : Io) -> Impl(Future(usize, IoExn)))(
+    io.async(e => {
+      bytes := data.as_bytes();
+      cond(
+        (bytes.len() == usize(0)) => usize(0),
+        true => {
+          e.io.await(self.write_all(bytes.ptr().unwrap(), bytes.len(), e.io), e);
+          bytes.len()
+        }
+      )
+    })
+  )
+);
+impl(
+  ChildStdin,
+  /// Dropping the handle closes the pipe, so a child waiting on EOF is not
+  /// left hanging by a forgotten `close`.
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      cond(
+        !self._closed => {
+          close_sync(self._fd);
+          self._closed = true;
+        },
+        true => ()
+      );
+    })
+  )
+);
+impl(
+  ChildStdout,
+  /// The underlying file descriptor.
+  fd : (fn(self : Self) -> i32)(self._fd),
+  /// Whether the handle has been closed.
+  is_closed : (fn(self : Self) -> bool)(self._closed),
+  /// Read up to `size` bytes. Returns the number read; 0 means EOF.
+  read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
+    raw := cond(self._closed => i32(-1), true => self._fd);
+    _pipe_read(raw, buf, size, io)
+  }),
+  /// Close the read end. Safe to call multiple times. Sets the flag after the
+  /// close, for the reason `ChildStdin.close` records.
+  close : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))({
+    raw := self._fd;
+    io.async(
+      e =>
+        cond(
+          self._closed => (),
+          true => {
+            result := e.io.await(IO_file.close(raw), e.io);
+            self._closed = true;
+            cond(
+              (result < i32(0)) => e.exn.throw(dyn(IoError.from_errno(i32(0) - result))),
+              true => ()
+            )
+          }
+        )
+    )
+  })
+);
+impl(
+  ChildStdout,
+  IoTraits.Reader(
+    read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.read(buf, size, io)
+    )
+  )
+);
+impl(
+  ChildStdout,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      cond(
+        !self._closed => {
+          close_sync(self._fd);
+          self._closed = true;
+        },
+        true => ()
+      );
+    })
+  )
+);
+impl(
+  ChildStderr,
+  /// The underlying file descriptor.
+  fd : (fn(self : Self) -> i32)(self._fd),
+  /// Whether the handle has been closed.
+  is_closed : (fn(self : Self) -> bool)(self._closed),
+  /// Read up to `size` bytes. Returns the number read; 0 means EOF.
+  read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))({
+    raw := cond(self._closed => i32(-1), true => self._fd);
+    _pipe_read(raw, buf, size, io)
+  }),
+  /// Close the read end. Safe to call multiple times. Sets the flag after the
+  /// close, for the reason `ChildStdin.close` records.
+  close : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))({
+    raw := self._fd;
+    io.async(
+      e =>
+        cond(
+          self._closed => (),
+          true => {
+            result := e.io.await(IO_file.close(raw), e.io);
+            self._closed = true;
+            cond(
+              (result < i32(0)) => e.exn.throw(dyn(IoError.from_errno(i32(0) - result))),
+              true => ()
+            )
+          }
+        )
+    )
+  })
+);
+impl(
+  ChildStderr,
+  IoTraits.Reader(
+    read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.read(buf, size, io)
+    )
+  )
+);
+impl(
+  ChildStderr,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      cond(
+        !self._closed => {
+          close_sync(self._fd);
+          self._closed = true;
+        },
+        true => ()
+      );
+    })
+  )
+);
 impl(
   Child,
   /// The child's process id.
   pid : (fn(self : Self) -> i32)(
     self._pid
   ),
+  /// Take the parent's write end of the child's stdin pipe as a `Writer`.
+  /// `.None` if stdin was not `Stdio.Piped`, or if it has already been taken
+  /// or closed.
+  ///
+  /// Taking MOVES the fd out of the `Child`: `wait()` no longer closes it, the
+  /// returned handle owns it, and `write_stdin`/`close_stdin` on this `Child`
+  /// throw `BadFileDescriptor` from then on. Dropping the handle closes the
+  /// pipe, which is the EOF the child is usually waiting for.
+  take_stdin : (fn(self : Self) -> Option(ChildStdin))(
+    match(
+      self._stdin_fd,
+      .Some(f) => {
+        self._stdin_fd = Option(i32).None;
+        Option(ChildStdin).Some(ChildStdin(_fd : f, _closed : false))
+      },
+      .None => Option(ChildStdin).None
+    )
+  ),
+  /// Take the parent's read end of the child's stdout pipe as a `Reader`, so
+  /// `read_to_string`, `read_exact` and `BufReader` apply. `.None` if stdout
+  /// was not `Stdio.Piped`, or if it has already been taken.
+  ///
+  /// Taking MOVES the fd out of the `Child`, exactly as `take_stdin` does.
+  take_stdout : (fn(self : Self) -> Option(ChildStdout))(
+    match(
+      self._stdout_fd,
+      .Some(f) => {
+        self._stdout_fd = Option(i32).None;
+        Option(ChildStdout).Some(ChildStdout(_fd : f, _closed : false))
+      },
+      .None => Option(ChildStdout).None
+    )
+  ),
+  /// Take the parent's read end of the child's stderr pipe as a `Reader`.
+  /// `.None` if stderr was not `Stdio.Piped`, or if it has already been taken.
+  take_stderr : (fn(self : Self) -> Option(ChildStderr))(
+    match(
+      self._stderr_fd,
+      .Some(f) => {
+        self._stderr_fd = Option(i32).None;
+        Option(ChildStderr).Some(ChildStderr(_fd : f, _closed : false))
+      },
+      .None => Option(ChildStderr).None
+    )
+  ),
   /// Write bytes into the child's piped stdin. Requires `stdin(Stdio.Piped)`.
+  /// Throws `BadFileDescriptor` once `take_stdin()` has moved the fd out.
   write_stdin : (fn(self : Self, data : ArrayList(u8), io : Io) -> Impl(Future(usize, IoExn)))({
     fd_opt := self._stdin_fd;
     io.async(e => {
@@ -756,4 +1057,4 @@ impl(
     })
   )
 );
-export(Command, ExitStatus, Output, Child);
+export(Command, ExitStatus, Output, Child, ChildStdin, ChildStdout, ChildStderr);

--- a/tests/fs/watch.test.yo
+++ b/tests/fs/watch.test.yo
@@ -113,3 +113,75 @@ test("FsEventKind renders", {
   assert(FsEventKind.Rename.to_string() == "rename", "rename");
   assert(FsEventKind.Change.to_string() == "change", "change");
 });
+// A watcher created inside this function drops at the function's end without
+// `close()`. Returns false if `watch` itself threw.
+_watch_and_drop :: (fn(p : String) -> bool)({
+  exn := Exception(
+    throw : (
+      err -> {
+        unwind(false);
+      }
+    )
+  );
+  w := watch(Path.new(p), WatchOptions.defaults(), exn);
+  assert(w.is_active(), "a fresh watcher is active");
+  true
+});
+// Open-and-close a file and report the descriptor number it got. The kernel
+// hands out the LOWEST free descriptor, so this reads as "how many fds are
+// currently in use" without depending on any resource limit.
+_probe_fd :: (fn(path : String, io : Io) -> i32)({
+  c := path.to_cstr();
+  p := c.ptr().unwrap();
+  fd := io.await(file.openat(AT_FDCWD, p, O_CREAT | O_WRONLY, i32(0o644)), io);
+  assert(fd >= i32(0), "the probe file opened");
+  io.await(file.close(fd), io);
+  fd
+});
+// Regression: `Watcher` shipped a `close()` and no `Dispose`, so a dropped
+// watcher never unregistered — leaking the backend's `__yo_fs_event_t` and its
+// descriptors, AND leaving the event loop holding a raw non-owning pointer to
+// freed memory
+// (issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md).
+//
+// The oracle is the descriptor NUMBER, not a resource limit: each live watcher
+// holds an inotify instance on Linux and an O_EVTONLY fd plus a kqueue fd on
+// macOS, so 200 leaked watchers push the next free descriptor hundreds higher.
+// A limit-based oracle would have been vacuous here — this machine's
+// RLIMIT_NOFILE swallows 200 leaks without complaining.
+test("a watcher dropped without close() releases its backend handle", {
+  d := temp_dir();
+  probe := path_join(d, `yo_watch_fd_probe.txt`);
+  base := _probe_fd(probe, io);
+  (i : usize) = usize(0);
+  while(i < usize(200), {
+    assert(
+      _watch_and_drop(d),
+      `watch failed at iteration ${i} — dropped watchers are not releasing their backend handles`
+    );
+    i = (i + usize(1));
+  });
+  after := _probe_fd(probe, io);
+  assert(
+    after <= (base + i32(8)),
+    `200 dropped watchers moved the next free descriptor from ${base} to ${after} — their backend handles leaked`
+  );
+  // And the backend still works afterwards: a fresh watcher still delivers.
+  t_exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  target := path_join(d, `yo_watch_drop.txt`);
+  _unlink(target, io);
+  w := watch(Path.new(d), WatchOptions.defaults(), t_exn);
+  _touch(target, String.from("x"), io);
+  ev := io.await(w.next(io), io);
+  assert(ev.is_some(), "a watcher created after 200 dropped ones still delivers");
+  w.close();
+  _unlink(target, io);
+  _unlink(probe, io);
+});

--- a/tests/process/command.test.yo
+++ b/tests/process/command.test.yo
@@ -3,11 +3,13 @@ pragma(Pragma.SkipWasm32Emscripten); // no process model in WASM
 pragma(Pragma.SkipWasm32Wasi); // no process model in WASM
 { assert } :: import("std/assert");
 { stdin, stdout, stderr, printf, EOF } :: import("std/libc/stdio");
-{ Command, ExitStatus, Output, Child, Stdio } :: import("std/process/command");
+{ Command, ExitStatus, Output, Child, ChildStdin, ChildStdout, ChildStderr, Stdio } :: import("std/process/command");
 { Exception, AnyError, IoExn } :: import("std/error");
 { String } :: import("std/string");
 { ArrayList } :: import("std/collections/array_list");
 { platform, Platform } :: import("std/process");
+{ timeout } :: import("std/async");
+{ Duration } :: import("std/time/duration");
 test("Command.new + status (echo exits 0)", {
   exn := Exception(
     throw : (
@@ -430,4 +432,140 @@ test("Command.output drains stdout and stderr concurrently (large stderr does no
   assert(out.stdout.len() >= usize(2), "stdout captured after the stderr flood");
   assert(out.stdout(usize(0)) == u8(111), "o");
   assert(out.stdout(usize(1)) == u8(107), "k");
+});
+// === Child pipe handles as Reader/Writer (plans/STD_API_STABILIZATION.md, I/O row) ===
+test("take_stdin/take_stdout give Writer/Reader handles over the child's pipes", {
+  if(platform == Platform.Windows, {
+    unsafe(printf("  skipped on windows\n"));
+    return(());
+  });
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  cmd := Command.new(`/bin/cat`.to_string());
+  cmd.stdin(Stdio.Piped).stdout(Stdio.Piped);
+  child := io.await(cmd.spawn(io), e);
+  w := child.take_stdin().unwrap();
+  r := child.take_stdout().unwrap();
+  assert(w.fd() >= i32(0), "the write handle owns a real fd");
+  assert(r.fd() >= i32(0), "the read handle owns a real fd");
+  // The Writer default `write_string` reaches a child pipe.
+  n := io.await(w.write_string(`handles héllo`, io), e);
+  assert(n == usize(14), "wrote 14 UTF-8 bytes through the Writer");
+  io.await(w.close(io), e);
+  assert(w.is_closed(), "closing is recorded");
+  // The Reader default `read_to_string` drains a child pipe to EOF.
+  text := io.await(r.read_to_string(io), e);
+  assert(text == `handles héllo`, `cat echoed it back: ${text}`);
+  st := io.await(child.wait(io), e);
+  assert(st.success(), "cat exits 0");
+});
+test("taking a stream moves the fd out of the Child", {
+  if(platform == Platform.Windows, {
+    unsafe(printf("  skipped on windows\n"));
+    return(());
+  });
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  cmd := Command.new(`/bin/cat`.to_string());
+  cmd.stdin(Stdio.Piped).stdout(Stdio.Piped);
+  child := io.await(cmd.spawn(io), e);
+  first := child.take_stdout();
+  assert(first.is_some(), "the first take yields the handle");
+  assert(child.take_stdout().is_none(), "a second take yields .None — the fd moved out");
+  // stderr was never piped, so there is nothing to take.
+  assert(child.take_stderr().is_none(), "an unpiped stream has no handle");
+  match(child.take_stdin(), .Some(w) => io.await(w.close(io), e), .None => assert(false, "stdin was piped"));
+  r := first.unwrap();
+  out := io.await(r.read_to_end(io), e);
+  assert(out.len() == usize(0), "cat saw EOF immediately and wrote nothing");
+  io.await(child.wait(io), e);
+});
+// Dropping a taken stdin handle closes the pipe, so the child sees EOF without
+// an explicit close — `Dispose` on ChildStdin. Without it, `cat` would never
+// exit and `wait` below would hang.
+_feed_and_drop :: (fn(child : Child, payload : String, io : Io, e : IoExn) -> bool)(
+  match(
+    child.take_stdin(),
+    .Some(w) => {
+      io.await(w.write_string(payload, io), e);
+      // no close: `w`'s last reference dies with this frame
+      true
+    },
+    .None => false
+  )
+);
+test("dropping a ChildStdin closes the pipe (the child sees EOF)", {
+  if(platform == Platform.Windows, {
+    unsafe(printf("  skipped on windows\n"));
+    return(());
+  });
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  cmd := Command.new(`/bin/cat`.to_string());
+  cmd.stdin(Stdio.Piped).stdout(Stdio.Piped);
+  child := io.await(cmd.spawn(io), e);
+  r := child.take_stdout().unwrap();
+  assert(_feed_and_drop(child, `dropped`, io, e), "stdin was piped");
+  // BOUNDED on purpose. Without `Dispose` on `ChildStdin` the pipe stays open,
+  // `cat` waits for an EOF that never comes, and a bare `read_to_string` here
+  // HANGS — which in CI burns a job's whole timeout instead of reporting a
+  // failure. Verified: with the impl removed this reports Elapsed in ~2s;
+  // with it, the read finishes immediately.
+  rh := io.spawn(r.read_to_string(io), e);
+  text := match(
+    timeout(rh, Duration.from_millis(i64(2000)), io),
+    .Ok(t) => t,
+    .Err(te) => {
+      assert(false, `dropping the ChildStdin did not deliver EOF — ${te}`);
+      String.new()
+    }
+  );
+  assert(text == `dropped`, `cat echoed it and exited: ${text}`);
+  st := io.await(child.wait(io), e);
+  assert(st.success(), "cat exits 0 after the dropped handle's EOF");
+});
+test("take_stderr reads a child's stderr as a Reader", {
+  if(platform == Platform.Windows, {
+    unsafe(printf("  skipped on windows\n"));
+    return(());
+  });
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  cmd := Command.new(`/bin/sh`.to_string());
+  cmd.arg(`-c`.to_string());
+  cmd.arg(`printf 'to stderr' 1>&2`.to_string());
+  cmd.stderr(Stdio.Piped);
+  child := io.await(cmd.spawn(io), e);
+  r := child.take_stderr().unwrap();
+  text := io.await(r.read_to_string(io), e);
+  assert(text == `to stderr`, `stderr came through: ${text}`);
+  io.await(child.wait(io), e);
 });


### PR DESCRIPTION
Two I/O rows from `plans/STD_API_STABILIZATION.md`, one of which was hiding a use-after-free.

## `Child` stdin/stdout/stderr as `Reader`/`Writer` handles

`take_stdin() -> Option(ChildStdin)` (a `Writer`), `take_stdout()` and `take_stderr()` (`Reader`s) — so a child's streams are inside `std/io`'s surface (`write_all`, `read_to_string`, `read_exact`, `BufReader.lines`) instead of only reachable through the three bespoke methods. Those stay, and now document that they throw `BadFileDescriptor` once the fd has been taken.

```rust
cmd := Command.new(`sort`);
cmd.stdin(Stdio.Piped);
cmd.stdout(Stdio.Piped);
child := io.await(cmd.spawn(io), ie);
match(child.take_stdin(), .Some(w) => {
  io.await(w.write_string(`b\na\n`, io), ie);
  io.await(w.close(io), ie);            // EOF — or just drop `w`
}, .None => ());
text := match(child.take_stdout(), .Some(r) => io.await(r.read_to_string(io), ie), .None => String.new());
io.await(child.wait(io), ie);
```

Four shape decisions worth naming:

- **Taking MOVES the fd** out of the `Child` (`_stdout_fd = .None`), so `wait()` no longer closes it and there is exactly one owner. A second `take_stdout()` is `.None` — which is also how "this stream was not `Stdio.Piped`" reads, the same answer to the same question.
- **`ChildStderr` is a distinct type** from `ChildStdout` despite being structurally identical, for Rust's reason: the type says which stream you are holding.
- **`close` sets its flag inside the async body**, after the close, mirroring `File.close`. A future created and never awaited must leave the handle closeable, or `dispose` would skip an fd that is still open.
- **`write_string` is registered in a later `impl` block** than the `Writer` impl whose `write_all` default it calls — a module evaluates top to bottom, so an impl registered afterwards would leave that `io.async` body hollow at definition time. `std/fs/file.yo` already records this constraint.

## `Watcher` `Dispose` — the missing one was a use-after-free, not a leak

`watch` registers its callback with a **raw, non-owning** pointer to the watcher:

```rust
rc := events.fs_event_start(w._handle, cstr, flags, _on_fs_event, unsafe.cast(w, *u8));
```

`unsafe.cast` does not dup the Rc, so the runtime's active-watch list held a pointer that did not keep the watcher alive. A watcher dropped while active left the event loop calling `_on_fs_event` into freed memory — `w._active` is a read of freed memory, and if those bytes are nonzero it goes on to `push` into a freed `ArrayList`: heap corruption on the loop thread, at an arbitrary later time, disconnected from the code that dropped it.

It also leaked the backend's `__yo_fs_event_t` and its descriptors — an inotify instance on Linux (**capped at 128 per user by default**, so a watcher-creating loop stopped being able to watch anything at all) or an `O_EVTONLY` fd plus a kqueue fd on macOS.

`dispose` delegating to the already-idempotent `close()` is what makes the non-owning `user_data` **sound** rather than merely convenient: the callback cannot outlive the object, because the object's own teardown removes it from the loop's list. `close` moved from `inout(self)` to `self : Self` to allow the delegation — every other closeable in `std/` (`File`, `TcpListener`, `TcpStream`, `UdpSocket`, `Cond`, `RwLock`, `Mutex`, `Channel`, `TempFile`, `TempDir`) already spelled it that way, and `Watcher` is a `ref(struct)` so the field writes are unchanged.

`issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md`

## Both tests were rebuilt around better oracles

**The watch test was vacuous on the platform it was written on.** My first version asserted that 200 create-and-drop cycles all succeed, reasoning that Linux's 128-instance inotify cap would trip. It **passed with the `Dispose` impl removed** — this machine's `RLIMIT_NOFILE` swallows 200 leaked macOS watchers without complaining. The oracle is now the **descriptor number**: the kernel hands out the lowest free descriptor, so an open/close probe before and after the loop reads as "how many descriptors are in use", with no dependence on any resource limit.

**The `ChildStdin` drop test bounds its read** with `std/async`'s `timeout`. Without the `Dispose` impl the bare read HANGS — the child waits for an EOF that never comes — and a hanging test burns a CI job's whole timeout instead of reporting a failure. Bounded, the regression reports in ~2s (8s wall including compile).

Both verified in **both** directions, with each `dispose` body emptied and restored:

```
  ✗ a watcher dropped without close() releases its backend handle    (no Dispose)
  ✓ a watcher dropped without close() releases its backend handle    (with Dispose)
  ✗ dropping a ChildStdin closes the pipe (the child sees EOF)       (no Dispose, 8s)
  ✓ dropping a ChildStdin closes the pipe (the child sees EOF)       (with Dispose)
```

## Local coverage

- Full suite (tree-built compiler, `YO_STD=` the worktree): **3977 passed, 0 failed** — includes `tests/dyn.test.yo`.
- `tests/process/command.test.yo` 16/16, `tests/fs/watch.test.yo` 5/5.
- `gates_fast.sh` (S1 built from this tree, staged outside the repo): **failures=0** — battery hollow=0, corpus `PASS 156 GOLDEN-DIFF 0 NO-GOLDEN 0`, `check ./std` 173/173, `check ./src` 269/269, fmt idempotent, cli-cases `PASS 92 GOLDEN-DIFF 0 NO-GOLDEN 0`.
- `fixpoint_only.sh`: **FIXPOINT_HOLDS** (stage2 hollow=0, STAGE3_RC=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)