### PR TITLE
codegen: one capture predicate; std/http: leftover-carrying message framing

### DIFF
--- a/.github/instructions/c-codegen.instructions.md
+++ b/.github/instructions/c-codegen.instructions.md
@@ -87,6 +87,34 @@ no-ops; `windows-11-arm` gets the latest from choco). An "arm64-only" C failure
 may be a clang VERSION difference, not an architecture one — check the
 versions in the job logs first.
 
+## `ExprInfo.variable_name` is UNTRUSTWORTHY in cond/match arm-value position
+
+`attach_temp_variable_to_expr` can stamp a SPURIOUS temp `variable_name` onto a
+bare variable reference used as a `cond`/`match` arm's value (`(n == 0) => min`).
+`src/codegen/exprs/atom.yo` already resolved the NAME by the source token for
+that reason — but it still asked "is this variable captured by the current
+closure?" about `variable_name`, which is not in the capture set, so the answer
+was "no", the plain-identifier early return fired, and a closure body emitted a
+bare identifier that does not exist in it:
+
+```c
+if (((((__yo_t14*)closure_context)->cap) < (10ULL))) { /* rewritten */ }
+else { _file____priv_temp_17218 = cap; }               /* NOT rewritten */
+```
+
+**Any question about a variable in this position must be asked about the SOURCE
+TOKEN, not `variable_name`.** And do not write the same predicate twice: the
+guard that decides whether to take an early return and the site that actually
+emits must call ONE function, or they will eventually disagree — that
+disagreement *was* the bug
+(`issues/fixed/captured-variable-as-a-cond-arm-value-emits-a-bare-identifier.md`,
+`_is_captured_here`).
+
+Why it survived so long: wrapping the capture in ANY expression
+(`cap + usize(1)`) routes it through the call-argument path, which rewrites
+correctly. Every use of a capture in `std/` and `src/` happened to sit inside
+some expression, so the bare-atom arm position had never been exercised.
+
 ## Compilation commands
 
 - Emit C only: `yo compile tmp/fixme.yo --emit-c --skip-c-compiler --optimize 2`

--- a/issues/fixed/captured-variable-as-a-cond-arm-value-emits-a-bare-identifier.md
+++ b/issues/fixed/captured-variable-as-a-cond-arm-value-emits-a-bare-identifier.md
@@ -1,0 +1,170 @@
+# A captured variable used as a `cond` arm's VALUE emits a bare identifier
+
+**Status:** FIXED 2026-09-10 — `src/codegen/exprs/atom.yo`.
+
+## Symptom
+
+Inside an `io.async` closure, reading a captured parameter as a `cond` arm's
+value emits the bare name instead of the `closure_context` access, and the C
+compiler rejects the file:
+
+```
+./tests/http/.yo_selftest_batch_1_0.bin.c:20486:32: error: use of undeclared identifier 'size'
+```
+
+## Minimal reproducer
+
+`issues/repros/captured-variable-as-a-cond-arm-value.yo`:
+
+```rust
+{ println } :: import("std/fmt");
+{ IoExn, Exception } :: import("std/error");
+
+pick :: (fn(cap : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => {
+    r := cond((cap < usize(10)) => usize(0), true => cap);
+    r
+  })
+);
+
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  e := IoExn(io : io, exn : exn);
+  println(`${io.await(pick(usize(42), io), e)}`);
+});
+export(main);
+```
+
+```
+$ yo compile tmp/fixme.yo --optimize 2 -o /tmp/fixme_bin
+/tmp/fixme_bin.c:2153:32: error: use of undeclared identifier 'cap'
+```
+
+The emitted C shows the asymmetry exactly — the condition's `cap` is rewritten,
+the arm's is not:
+
+```c
+static inline size_t closure_yo_id_11460(void* closure_context, __yo_t0 e) {
+  size_t _file____priv_temp_17218;
+  if (((((__yo_t14*)closure_context)->cap) < (10ULL))) {   /* rewritten */
+    _file____priv_temp_17218 = 0ULL;
+  }
+  else {
+    _file____priv_temp_17218 = cap;                        /* NOT rewritten */
+  }
+  ...
+```
+
+Shapes measured, same closure and same variable:
+
+| arm value | result |
+| --- | --- |
+| `cond((cap < usize(10)) => usize(0), true => cap)` | **broken** |
+| `cond((cap < usize(10)) => cap, true => usize(0))` | **broken** |
+| `cond(true => cap)` | **broken** |
+| `cond((cap < usize(10)) => usize(0), true => (cap + usize(1)))` | fine |
+| `cond((usize(1) < usize(10)) => usize(0), true => cap)` | fine (the cond folds away) |
+
+So the trigger is a **bare** capture atom in an arm-value position. Wrapping it
+in any expression routes it through the function-call argument path, which
+rewrites correctly — which is why this survived: almost every real use of a
+capture is inside some expression.
+
+## Root cause
+
+`src/codegen/exprs/atom.yo` asked "is this variable captured?" **twice**, and
+the two copies keyed on **different names**.
+
+The emitting path keys on the source token:
+
+```rust
+cap_name := tv.clone();
+is_captured := ... caps.contains(cap_name.clone()) && check_variable_is_closure_captured(cap_name, e, level) ...
+```
+
+The guard that decides whether to take the plain-identifier early return keyed
+on `ExprInfo.variable_name`:
+
+```rust
+captured := ... caps.contains(var_name.clone()) && check_variable_is_closure_captured(var_name, e, level) ...
+if(!captured, {
+  return(_var_read_code(tv.clone(), env_opt));   // <-- bare identifier
+});
+```
+
+And `variable_name` is exactly the field that is untrustworthy in this
+position. The comment immediately below the guard already said so:
+
+> yo-self's `attach_temp_variable_to_expr` can stamp a SPURIOUS temp
+> `variable_name` onto a bare reference used as a cond/match arm value (e.g.
+> `(cap == 0) => min_cap`); emitting that temp yields an undeclared identifier.
+
+For a cond-arm value, `variable_name` is that spurious temp
+(`_file____priv_temp_17218`). The capture set holds the real name (`cap`), so
+`caps.contains(var_name)` was false, the guard concluded "not captured", took
+the early return, and emitted the bare token — never reaching the path that
+would have rewritten it. The fix for the *spurious temp* was already in place
+(resolve by token, not by `variable_name`); what was missing is that the
+**capture question must be asked about the token too**.
+
+## Fix
+
+One predicate, `_is_captured_here(name, env_opt, context)`, used by both sites
+with the source token. Two copies of one question, keyed differently, is the
+defect; deleting the duplicate is the fix rather than patching the guard's key.
+
+```rust
+_is_captured_here :: (fn(name : String, env_opt : Option(Environment), context : FunctionGenerationContext) -> bool)(
+  match(
+    context.current_closure_captures,
+    .Some(caps) => match(
+      context.current_closure_capture_frame_level,
+      .Some(level) => (
+        caps.contains(name.clone()) &&
+          match(env_opt, .Some(e) => check_variable_is_closure_captured(name.clone(), e, level), .None => true)
+      ),
+      .None => false
+    ),
+    .None => false
+  )
+);
+```
+
+## Why byte-identity still holds
+
+The change only affects atoms the old guard classified as "not captured" while
+the emitter would have classified them as captured — and every such program
+**failed to compile**. Nothing that compiled before can change, which the
+stage-2/stage-3 fixpoint confirms.
+
+## Test
+
+`tests/closure_capture_cond_arm.test.yo` — the capture read as a bare arm value
+in every broken shape (final arm, first arm, single-arm `cond`, `match` arm),
+plus the expression-wrapped shape as a control.
+
+Verified in both directions with the same test file:
+
+```
+$ <compiler built BEFORE the fix> test ./tests/closure_capture_cond_arm.test.yo
+./tests/.yo_selftest_batch_1_0.bin.c:5922:32: error: use of undeclared identifier 'cap'
+./tests/.yo_selftest_batch_1_0.bin.c:5949:32: error: use of undeclared identifier 'cap'
+./tests/.yo_selftest_batch_1_0.bin.c:5977:37: error: use of undeclared identifier 'cap'
+./tests/.yo_selftest_batch_1_0.bin.c:6011:32: error: use of undeclared identifier 'cap'
+
+$ <compiler built AFTER the fix> test ./tests/closure_capture_cond_arm.test.yo
+5 passed
+```
+
+Four of the five shapes were broken; the fifth is the control.
+
+## How it was found
+
+Writing a test-local `Reader` for `std/http/wire`'s keep-alive framing:
+
+```rust
+limit := cond((self.chunk < size) => self.chunk, true => size);
+```
+
+`size` is the `read` parameter, captured by the `io.async` closure. Every
+`std/` and `src/` use of a capture happens to sit inside some larger
+expression, so nothing in the tree had ever hit the bare-atom arm position.

--- a/issues/repros/captured-variable-as-a-cond-arm-value.yo
+++ b/issues/repros/captured-variable-as-a-cond-arm-value.yo
@@ -1,0 +1,15 @@
+{ println } :: import("std/fmt");
+{ IoExn, Exception } :: import("std/error");
+
+pick :: (fn(cap : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => {
+    r := cond((cap < usize(10)) => usize(0), true => cap);
+    r
+  })
+);
+
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  e := IoExn(io : io, exn : exn);
+  println(`${io.await(pick(usize(42), io), e)}`);
+});
+export(main);

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -560,9 +560,11 @@ non-test caller existed in the whole tree (`src/main.yo`'s
 **I/O.** Verified against the code 2026-09-09 — LANDED:
 `Stdout.write_string`; `Reader.read_exact`; lazy `read_dir`;
 `Metadata.modified`; `SocketAddr`/`IpAddr` `Eq`/`Hash`/`Ord`/`Clone` + `parse`;
-`TcpStream.local_addr`; `TcpListener.incoming`. STILL OPEN: HTTP keep-alive.
-(`Child` stdin/stdout/stderr as `Reader`/`Writer` handles and `Watcher`
-`Dispose` landed 2026-09-10 — described just below.) (`Seek`, `OpenOptions`, `SystemTime`, `IpAddr.parse_v6`,
+`TcpStream.local_addr`; `TcpListener.incoming`. STILL OPEN: HTTP keep-alive —
+its FRAMING half landed 2026-09-10 (described just below), the pooling client
+is the remaining piece. (`Child` stdin/stdout/stderr as `Reader`/`Writer`
+handles and `Watcher` `Dispose` also landed 2026-09-10, described below.)
+(`Seek`, `OpenOptions`, `SystemTime`, `IpAddr.parse_v6`,
 `UdpSocket.recv_from -> (n, from)`, `StatusCode` and `HeaderMap` all landed
 2026-09-09 — described just below.)
 
@@ -608,6 +610,53 @@ it. `close` moved from `inout(self)` to `self : Self` to allow that delegation
 — every other closeable in `std/` already spelled it that way, and `Watcher`
 is a `ref(struct)`, so the field writes are unchanged.
 (`issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md`)
+
+**HTTP keep-alive, the framing half — LANDED 2026-09-10.**
+
+Connection reuse is blocked on one thing before any pool exists: a single
+`read` can return bytes belonging to TWO messages, and framing the second by
+"whatever arrives next" is request/response smuggling (RFC 9112 §11.2) — and a
+heisenbug, because it only shows up when the peer's writes coalesce.
+`read_http_message` already truncated at the message boundary (that was
+`_message_upto`, added for exactly this reason) but **discarded** the excess,
+which is correct only because its connection was about to be closed.
+
+`read_http_message_buffered(stream, max_bytes, is_request, carry, io)` is the
+reusable form: `carry` comes in holding whatever the previous message left
+behind and goes out holding whatever this one left behind. One list per
+connection. `read_http_message` stays as a wrapper that passes a fresh list, so
+no existing caller changes.
+
+Three supporting pieces, each needed by the above:
+
+- **`Dechunk.Done` carries an `end`.** A chunked body's boundary is the index
+  just past its terminating CRLF, and nothing recorded it — the decoder only
+  handed back the decoded data.
+- **The stopping decision moved into `_frame_status`.** It was inline in the
+  read loop, which meant a keep-alive read could not ask it BEFORE its first
+  read — and asking first is not an optimization: a message already complete in
+  the carried bytes must not cost a read, because that read would block until
+  the peer sent something it has no reason to send.
+- **`HttpResponse.version`.** The status line's version was parsed and thrown
+  away, and reuse turns on it: an `HTTP/1.0` response without
+  `Connection: keep-alive` ends its connection (RFC 9112 §9.3). It is kept for
+  the same reason `status_text` is — a proxy passes it through — and
+  `to_string` now emits it, so a parsed response round-trips.
+
+Tests drive a SCRIPTED reader rather than a socket (`tests/http/wire.test.yo`):
+the whole point is what happens when one read spans two messages, and a socket
+cannot be made to do that on demand. The reader counts its calls, so "did this
+cost a read?" is an assertion rather than an assumption.
+
+Still open for the client: the pool itself. The intended shape is an
+`HttpClient` object that OWNS its idle connections (Rust's `reqwest::Client`
+model) rather than a module-global — explicit lifetime, `Dispose` closes the
+idle set, and no global mutable state in `std/`. The free `fetch`/`fetch_with`
+keep their current one-shot behaviour. Server-side keep-alive needs a
+prerequisite of its own that the client does not: an IDLE TIMEOUT. `serve` is
+one-connection-at-a-time, so a client that holds a keep-alive connection open
+and sends nothing would wedge the server — which is why the server half is not
+simply "loop until the client closes".
 
 **`Seek` + `OpenOptions` + `SystemTime` — LANDED 2026-09-09, and the shapes
 each had a reason.**

--- a/src/codegen/exprs/atom.yo
+++ b/src/codegen/exprs/atom.yo
@@ -405,6 +405,29 @@ _emit_loop_body_drops_before_exit :: (fn(context : FunctionGenerationContext, in
     .None => ()
   )
 );
+// Whether `name` is captured by the closure currently being generated, and so
+// must be read through `closure_context` rather than as a plain identifier.
+//
+// ONE predicate, deliberately. It used to be written out twice — once as the
+// guard that decides whether to take the plain-identifier early return, once
+// where the `closure_context` access is actually emitted — and the two copies
+// keyed on different names, so a variable could be "not captured" for the
+// guard and "captured" for the emitter. The guard won, and the closure body
+// referenced a variable that does not exist in it.
+_is_captured_here :: (fn(name : String, env_opt : Option(Environment), context : FunctionGenerationContext) -> bool)(
+  match(
+    context.current_closure_captures,
+    .Some(caps) => match(
+      context.current_closure_capture_frame_level,
+      .Some(level) => (
+        caps.contains(name.clone()) &&
+          match(env_opt, .Some(e) => check_variable_is_closure_captured(name.clone(), e, level), .None => true)
+      ),
+      .None => false
+    ),
+    .None => false
+  )
+);
 /// Resolve a plain identifier read to its C code: the variable's C name, wrapped
 /// in `(*name)` when the binding is a by-`ref` borrow (`inout(name) : T` param — at
 /// the C level `name` is `T*`, so a read dereferences). Mirrors TS generateAtom
@@ -666,20 +689,18 @@ generate_atom :: (fn(expr : AstExpr, context : FunctionGenerationContext, indent
             return(match(ei.value, .Some(v) => generate_comptime_value(v, match(expr_info_converted_runtime_type(ei), .Some(crt) => crt, .None => ei.ty), context.base), .None => String.from("")));
           });
           // Closure-captured variable → access through closure_context.
-          captured := match(
-            env_opt,
-            .Some(e) => match(
-              context.current_closure_captures,
-              .Some(caps) => match(
-                context.current_closure_capture_frame_level,
-                .Some(level) => (caps.contains(var_name.clone()) && check_variable_is_closure_captured(var_name.clone(), e, level)),
-                .None => false
-              ),
-              .None => false
-            ),
-            .None => false
-          );
-          if(!captured, {
+          //
+          // Keyed on the SOURCE TOKEN, through the same predicate the
+          // emitting path below uses. This guard used to test
+          // `variable_name`, and the two disagreed exactly where the comment
+          // below says `variable_name` is untrustworthy: a bare reference used
+          // as a cond/match arm value can carry a SPURIOUS temp
+          // `variable_name`, which is not in the capture set, so this answered
+          // "not captured", took the `_var_read_code` early return, and
+          // emitted the BARE identifier inside a closure body — undeclared in
+          // the generated C
+          // (issues/fixed/captured-variable-as-a-cond-arm-value-emits-a-bare-identifier.md).
+          if(!_is_captured_here(tv.clone(), env_opt, context), {
             // Resolve a plain identifier by its SOURCE TOKEN, not the recorded
             // `variable_name`. Mirrors TS generateAtom (atom.ts:262 uses
             // `expr.token.value`). yo-self's attach_temp_variable_to_expr can
@@ -697,15 +718,7 @@ generate_atom :: (fn(expr : AstExpr, context : FunctionGenerationContext, indent
       // Closure-captured access (the general path); otherwise a literal with a
       // comptime value is inlined, else the bare variable name.
       cap_name := tv.clone();
-      is_captured := match(
-        context.current_closure_captures,
-        .Some(caps) => match(
-          context.current_closure_capture_frame_level,
-          .Some(level) => (caps.contains(cap_name.clone()) && match(env_opt, .Some(e) => check_variable_is_closure_captured(cap_name.clone(), e, level), .None => true)),
-          .None => false
-        ),
-        .None => false
-      );
+      is_captured := _is_captured_here(cap_name.clone(), env_opt, context);
       cond(
         is_captured => match(
           context.current_closure_capture_type_c_name,

--- a/std/http/http.yo
+++ b/std/http/http.yo
@@ -413,6 +413,12 @@ HttpResponse :: ref(
     /// SS15 makes it advisory). `status.reason()` gives the registered phrase
     /// instead; keeping both means a proxy can pass the original through.
     status_text : String,
+    /// The version on the status line, as received — `HTTP/1.1` or
+    /// `HTTP/1.0`. Kept for the same reason `status_text` is: a proxy passes
+    /// it through, and connection reuse turns on it (an `HTTP/1.0` response
+    /// without `Connection: keep-alive` ends its connection, RFC 9112 §9.3).
+    /// `HttpResponse.new` defaults it to `HTTP/1.1`.
+    version : String,
     headers : HeaderMap,
     body : String
   )
@@ -421,7 +427,7 @@ impl(
   HttpResponse,
   /// Create a response with the given status and reason phrase.
   new : (fn(status : StatusCode, status_text : String) -> Self)(
-    Self(status : status, status_text : status_text, headers : HeaderMap.new(), body : ``)
+    Self(status : status, status_text : status_text, version : `HTTP/1.1`, headers : HeaderMap.new(), body : ``)
   ),
   /// Look up a header value by name (case-insensitive). The first value, when
   /// the field repeats — `self.headers.get_all(name)` for all of them, which
@@ -464,11 +470,12 @@ impl(
 impl(
   HttpResponse,
   ToString(
-    /// Serialize to HTTP/1.1 wire format. A `Content-Length` header is added
+    /// Serialize to wire format, on the status line's own `version` (so a
+    /// parsed response round-trips). A `Content-Length` header is added
     /// when none is present (the byte length of `body`), so the peer can
     /// delimit the message without waiting for close.
     to_string : (fn(self : Self) -> String)({
-      result := `HTTP/1.1 ${self.status.to_string()} ${self.status_text}\r\n${self.headers.to_string()}`;
+      result := `${self.version} ${self.status.to_string()} ${self.status_text}\r\n${self.headers.to_string()}`;
       cond(
         self.get_header(`Content-Length`).is_none() => {
           result = `${result}Content-Length: ${self.body.len().to_string()}\r\n`;
@@ -559,6 +566,7 @@ parse_response :: (fn(raw : String) -> Result(HttpResponse, HttpParseError))({
     true => ()
   );
   sp1 := sp1_opt.unwrap();
+  version := status_line.substring(usize(0), sp1);
   rest := status_line.substring(sp1 + usize(1), status_line.len());
   // The reason phrase is OPTIONAL (RFC 9112 SS4): `HTTP/1.1 204` with no
   // trailing space is well-formed, and rejecting it made this parser stricter
@@ -588,6 +596,7 @@ parse_response :: (fn(raw : String) -> Result(HttpResponse, HttpParseError))({
     }
   );
   resp := HttpResponse.new(status, status_text);
+  resp.version = version;
   j := usize(1);
   while(j < lines.len(), j = (j + usize(1)), {
     hline := lines(j);

--- a/std/http/wire.yo
+++ b/std/http/wire.yo
@@ -236,8 +236,10 @@ is_chunked :: (fn(data : ArrayList(u8), header_end : usize) -> bool)({
 // Outcome of decoding a chunked body prefix.
 Dechunk :: enum(
   // Every chunk up to and including the terminating zero chunk was present;
-  // `data` is the concatenated chunk data (trailers dropped).
-  Done(data : ArrayList(u8)),
+  // `data` is the concatenated chunk data (trailers dropped) and `end` is the
+  // index just past the body's final CRLF — where the NEXT message on a
+  // keep-alive connection begins.
+  Done(data : ArrayList(u8), end : usize),
   // Well-formed so far, but the terminating zero chunk has not arrived.
   Incomplete,
   // The framing is broken; `msg` names the defect.
@@ -307,7 +309,7 @@ dechunk :: (fn(body : ArrayList(u8), body_start : usize) -> Dechunk)({
               return(Dechunk.Incomplete);
             },
             ((body(i) == u8(13)) && (body(i + usize(1)) == u8(10))) => {
-              return(Dechunk.Done(out));
+              return(Dechunk.Done(out, i + usize(2)));
             },
             true => ()
           );
@@ -352,7 +354,12 @@ dechunk :: (fn(body : ArrayList(u8), body_start : usize) -> Dechunk)({
 // ours. Handing those bytes on as body is response smuggling (RFC 9112 §11.2)
 // — and it is a heisenbug, because the same server and the same client agree
 // on every platform where the writes happen not to coalesce.
-_message_upto :: (fn(data : ArrayList(u8), limit : usize) -> String)(
+// The bytes past `limit` are not garbage: on a keep-alive connection they are
+// the beginning of the NEXT message, so they are moved into `carry` rather
+// than dropped. `carry` is emptied first — a caller reuses one list across a
+// connection's whole lifetime.
+_split_message :: (fn(data : ArrayList(u8), limit : usize, carry : ArrayList(u8)) -> String)({
+  carry.clear();
   cond(
     (limit >= data.len()) => String.from_bytes(data),
     true => {
@@ -362,7 +369,65 @@ _message_upto :: (fn(data : ArrayList(u8), limit : usize) -> String)(
         out.push(data(i));
         i = (i + usize(1));
       });
+      i = limit;
+      while(runtime(i < data.len()), {
+        carry.push(data(i));
+        i = (i + usize(1));
+      });
       String.from_bytes(out)
+    }
+  )
+});
+// Whether the bytes in hand already frame a whole message — the read loop's
+// stopping decision, and the same decision a keep-alive read makes BEFORE its
+// first read.
+_FrameStatus :: enum(
+  // Stop reading. Either the message is complete, or its chunk framing is
+  // broken — the assembly below re-runs `dechunk` and turns that into the
+  // `MalformedChunkedBody` error, so both cases stop the same way.
+  Complete,
+  // Keep reading: the header section or the body is still short.
+  NeedMore,
+  // RFC 9112 §6.3: a `Content-Length` that is present but unreadable is an
+  // unrecoverable framing error, NOT a body-less message — reading on would
+  // frame the body by whatever the peer does next.
+  BadContentLength(msg : String)
+);
+_frame_status :: (fn(data : ArrayList(u8), is_request : bool) -> _FrameStatus)(
+  cond(
+    (data.len() <= usize(4)) => _FrameStatus.NeedMore,
+    true => {
+      header_end := find_header_end(data);
+      cond(
+        (header_end == usize(0)) => _FrameStatus.NeedMore,
+        true => {
+          body_start := (header_end + usize(4));
+          cond(
+            // Chunked: complete once the terminating zero chunk and its final
+            // CRLF are in.
+            is_chunked(data, header_end) => match(
+              dechunk(data, body_start),
+              .Done(_, _) => _FrameStatus.Complete,
+              .Malformed(_) => _FrameStatus.Complete,
+              .Incomplete => _FrameStatus.NeedMore
+            ),
+            true => match(
+              find_content_length(data, header_end),
+              .Length(cl) => cond(
+                ((data.len() - body_start) >= cl) => _FrameStatus.Complete,
+                true => _FrameStatus.NeedMore
+              ),
+              .Invalid(msg) => _FrameStatus.BadContentLength(msg),
+              // A request with no body framing ends with its headers; a
+              // response with none is delimited by close.
+              .Absent => cond(
+                is_request => _FrameStatus.Complete,
+                true => _FrameStatus.NeedMore
+              )
+            )
+          )
+        }
+      )
     }
   )
 );
@@ -394,22 +459,62 @@ _message_upto :: (fn(data : ArrayList(u8), limit : usize) -> String)(
 /// decoder returns `Result`; the client throws the `.Err` at its call site —
 /// issues/fixed/one-malformed-request-killed-http-server-serve.md). I/O
 /// failures on the stream itself still throw through `io`'s exception.
-read_http_message :: (
-  fn(generic(R : Type), stream : R, max_bytes : usize, is_request : bool, io : Io, where(R <: Reader)) ->
-    Impl(Future(Result(String, HttpError), IoExn))
+/// The keep-alive form: `carry` holds whatever a previous call read PAST the
+/// previous message on this connection, and on return holds whatever this call
+/// read past THIS message. One list per connection, reused across its
+/// messages; pass a fresh empty one for a connection that is used once.
+///
+/// This is what makes connection reuse safe. A single `read` can return bytes
+/// belonging to two pipelined messages, and framing the second one by
+/// "whatever arrived next" is request/response smuggling (RFC 9112 §11.2) —
+/// and a heisenbug, because it only shows up when the peer's writes coalesce.
+read_http_message_buffered :: (
+  fn(
+    generic(R : Type),
+    stream : R,
+    max_bytes : usize,
+    is_request : bool,
+    carry : ArrayList(u8),
+    io : Io,
+    where(R <: Reader)
+  ) -> Impl(Future(Result(String, HttpError), IoExn))
 )(
   io.async(e => {
     buf_size := usize(8192);
     buf := (*u8)(malloc(buf_size).unwrap());
+    // Seed from what the previous message left behind — those bytes are
+    // already this message's, and there may be enough of them that no read is
+    // needed at all.
     result := ArrayList(u8).new();
+    ci := usize(0);
+    while(runtime(ci < carry.len()), {
+      result.push(carry(ci));
+      ci = (ci + usize(1));
+    });
+    carry.clear();
     // A framing defect ends the read loop and comes back as the `.Err`. The
     // body is deliberately free of mid-loop `return`s: an async body's state
     // machine does not lower them, and the closure then fails codegen as
     // "never fully evaluated".
     failed := i32(0);
     failed_msg := String.new();
-    // Read until connection closes or we've read the full response
+    // Read until the connection closes or a whole message is in hand. The
+    // FIRST decision is made before any read: the carried-over bytes may
+    // already contain a complete message, and reading in that case would
+    // block until the peer sent something it has no reason to send.
     done := false;
+    match(
+      _frame_status(result, is_request),
+      .Complete => {
+        done = true;
+      },
+      .BadContentLength(msg) => {
+        failed = i32(2);
+        failed_msg = msg;
+        done = true;
+      },
+      .NeedMore => ()
+    );
     while(runtime(!done), {
       n := e.io.await(stream.read(buf, buf_size, e.io), e);
       cond(
@@ -434,66 +539,21 @@ read_http_message :: (
             result.push((buf.add(i)).*);
             i = (i + usize(1));
           });
-          // Check if we've received the full response by looking for
-          // Content-Length or end of chunked transfer
-          // For simplicity, check if the header section is complete
-          // and if Content-Length is satisfied
-          cond(
-            (!done && (result.len() > usize(4))) => {
-              // Check if we have a complete header section (\r\n\r\n)
-              header_end := find_header_end(result);
-              cond(
-                (header_end > usize(0)) => {
-                  body_start := (header_end + usize(4));
-                  cond(
-                    // Chunked: complete once the terminating zero chunk and
-                    // its final CRLF are in; malformed framing surfaces below.
-                    is_chunked(result, header_end) => match(
-                      dechunk(result, body_start),
-                      .Done(_) => {
-                        done = true;
-                      },
-                      .Malformed(_) => {
-                        done = true;
-                      },
-                      .Incomplete => ()
-                    ),
-                    true => match(
-                      find_content_length(result, header_end),
-                      .Length(cl) => {
-                        body_len := (result.len() - body_start);
-                        cond(
-                          (body_len >= cl) => {
-                            done = true;
-                          },
-                          true => ()
-                        );
-                      },
-                      // RFC 9112 §6.3: a Content-Length that is present but
-                      // unreadable is an unrecoverable framing error, NOT a
-                      // body-less message — reading on would frame the body
-                      // by whatever the peer does next.
-                      .Invalid(msg) => {
-                        failed = i32(2);
-                        failed_msg = msg;
-                        done = true;
-                      },
-                      // A request with no body framing ends with its headers.
-                      .Absent => {
-                        cond(
-                          is_request => {
-                            done = true;
-                          },
-                          true => ()
-                        );
-                      }
-                    )
-                  );
-                },
-                true => ()
-              );
+          // Stop as soon as the bytes in hand frame a whole message. Extracted
+          // to `_frame_status` because a keep-alive read must ask the SAME
+          // question before its first read: a message already complete in the
+          // carried-over bytes must not cost a read that would block.
+          match(
+            _frame_status(result, is_request),
+            .Complete => {
+              done = true;
             },
-            true => ()
+            .BadContentLength(msg) => {
+              failed = i32(2);
+              failed_msg = msg;
+              done = true;
+            },
+            .NeedMore => ()
           );
         }
       );
@@ -510,7 +570,16 @@ read_http_message :: (
         body_start := (header_end + usize(4));
         match(
           dechunk(result, body_start),
-          .Done(data) => {
+          .Done(data, end) => {
+            // Bytes after the terminating chunk belong to the next message.
+            // `_split_message` is not usable here: the value handed on is the
+            // DECODED rewrite, not a prefix of `result`.
+            carry.clear();
+            k := end;
+            while(runtime(k < result.len()), {
+              carry.push(result(k));
+              k = (k + usize(1));
+            });
             decoded := ArrayList(u8).with_capacity(body_start + data.len());
             j := usize(0);
             while(runtime(j < body_start), {
@@ -537,13 +606,13 @@ read_http_message :: (
             // `cl < avail`, not `(body_start + cl) < result.len()`: the sum can
             // overflow usize on a hostile Content-Length.
             .Length(cl) => cond(
-              (cl < avail) => _message_upto(result, body_start + cl),
+              (cl < avail) => _split_message(result, body_start + cl, carry),
               true => String.from_bytes(result)
             ),
             // A REQUEST with no framing header ends with its headers; a RESPONSE
             // with none is delimited by close, so every byte read is body.
             .Absent => cond(
-              is_request => _message_upto(result, body_start),
+              is_request => _split_message(result, body_start, carry),
               true => String.from_bytes(result)
             ),
             // Unreachable: the read loop records `.Invalid` as soon as the header
@@ -556,4 +625,23 @@ read_http_message :: (
     )
   })
 );
-export(find_header_end, ContentLength, find_content_length, is_chunked, Dechunk, dechunk, read_http_message);
+/// Read exactly one HTTP message off `stream`. For a connection used once:
+/// anything the peer sent past this message is DISCARDED, which is the right
+/// answer when the connection is about to be closed and the wrong one when it
+/// is about to be reused — use `read_http_message_buffered` there.
+read_http_message :: (
+  fn(generic(R : Type), stream : R, max_bytes : usize, is_request : bool, io : Io, where(R <: Reader)) ->
+    Impl(Future(Result(String, HttpError), IoExn))
+)(
+  read_http_message_buffered(stream, max_bytes, is_request, ArrayList(u8).new(), io)
+);
+export(
+  find_header_end,
+  ContentLength,
+  find_content_length,
+  is_chunked,
+  Dechunk,
+  dechunk,
+  read_http_message,
+  read_http_message_buffered
+);

--- a/tests/closure_capture_cond_arm.test.yo
+++ b/tests/closure_capture_cond_arm.test.yo
@@ -1,0 +1,58 @@
+//! Regression: a captured variable read as a `cond`/`match` arm's VALUE was
+//! emitted as a bare identifier instead of a `closure_context` access, so the
+//! generated C did not compile
+//! (issues/fixed/captured-variable-as-a-cond-arm-value-emits-a-bare-identifier.md).
+//!
+//! The trigger is a BARE capture atom in arm-value position. Wrapping it in any
+//! expression routes it through the call-argument path, which always rewrote
+//! correctly — which is why this survived: nearly every real use of a capture
+//! sits inside some expression. Each shape below is therefore its own test.
+{ assert } :: import("std/assert");
+{ IoExn, Exception } :: import("std/error");
+// Bare capture as the `true` (final else) arm's value.
+_last_arm :: (fn(cap : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => cond((cap < usize(10)) => usize(0), true => cap))
+);
+// Bare capture as the FIRST arm's value.
+_first_arm :: (fn(cap : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => cond((cap < usize(10)) => cap, true => usize(0)))
+);
+// Bare capture as a single-arm cond's value.
+_single_arm :: (fn(cap : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => cond(true => cap))
+);
+// Bare capture as a `match` arm's value — the same position, other construct.
+_match_arm :: (fn(cap : usize, flag : bool, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => match(Option(usize).Some(cap), .Some(v) => v, .None => cap))
+);
+// Control: the same capture INSIDE an expression, which always worked.
+_wrapped :: (fn(cap : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async(e => cond((cap < usize(10)) => usize(0), true => (cap + usize(1))))
+);
+test("a captured variable is readable as a cond arm's value (final arm)", {
+  exn := Exception(throw : (_err -> unwind(())));
+  e := IoExn(io : io, exn : exn);
+  assert(io.await(_last_arm(usize(42), io), e) == usize(42), "the taken arm reads the capture");
+  assert(io.await(_last_arm(usize(3), io), e) == usize(0), "and the other arm still works");
+});
+test("a captured variable is readable as a cond arm's value (first arm)", {
+  exn := Exception(throw : (_err -> unwind(())));
+  e := IoExn(io : io, exn : exn);
+  assert(io.await(_first_arm(usize(3), io), e) == usize(3), "the first arm reads the capture");
+  assert(io.await(_first_arm(usize(42), io), e) == usize(0), "and the other arm still works");
+});
+test("a captured variable is readable as a single-arm cond's value", {
+  exn := Exception(throw : (_err -> unwind(())));
+  e := IoExn(io : io, exn : exn);
+  assert(io.await(_single_arm(usize(7), io), e) == usize(7), "a one-arm cond reads the capture");
+});
+test("a captured variable is readable as a match arm's value", {
+  exn := Exception(throw : (_err -> unwind(())));
+  e := IoExn(io : io, exn : exn);
+  assert(io.await(_match_arm(usize(9), true, io), e) == usize(9), "a match arm reads the capture");
+});
+test("a captured variable inside an arm EXPRESSION still works", {
+  exn := Exception(throw : (_err -> unwind(())));
+  e := IoExn(io : io, exn : exn);
+  assert(io.await(_wrapped(usize(42), io), e) == usize(43), "the wrapped shape is unchanged");
+});

--- a/tests/http/wire.test.yo
+++ b/tests/http/wire.test.yo
@@ -1,0 +1,239 @@
+//! `std/http/wire` — HTTP/1.1 message framing, and specifically the
+//! leftover-carrying read that connection reuse needs.
+//!
+//! These tests drive `read_http_message_buffered` through a SCRIPTED reader
+//! rather than a socket: the point is what happens when one `read` returns
+//! bytes belonging to two messages, and a socket cannot be made to do that on
+//! demand. The scripted reader hands out at most `chunk` bytes per call and
+//! counts its calls, so "did this cost a read?" is directly observable.
+pragma(Pragma.AllowUnsafe); // pointer writes into the reader's buffer
+{ assert } :: import("std/assert");
+{ String } :: import("std/string");
+{ ArrayList } :: import("std/collections/array_list");
+{ Exception, IoExn } :: import("std/error");
+{ Reader } :: import("std/io");
+{ println } :: import("std/fmt");
+wire :: import("std/http/wire.yo");
+{ parse_response } :: import("std/http/http.yo");
+// A `Reader` over a fixed byte script, handing out at most `chunk` bytes per
+// call. `reads` counts the calls, which is how a test asserts that a message
+// already sitting in the carry buffer cost NO read — on a real connection that
+// read would block until the peer sent something it has no reason to send.
+_ScriptedReader :: ref(
+  struct(
+    data : ArrayList(u8),
+    pos : usize,
+    chunk : usize,
+    reads : usize
+  )
+);
+_scripted :: (fn(text : String, chunk : usize) -> _ScriptedReader)(
+  _ScriptedReader(data : text.as_bytes(), pos : usize(0), chunk : chunk, reads : usize(0))
+);
+impl(
+  _ScriptedReader,
+  read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+    io.async(e => {
+      self.reads = (self.reads + usize(1));
+      limit := cond((self.chunk < size) => self.chunk, true => size);
+      n := usize(0);
+      while(runtime((n < limit) && (self.pos < self.data.len())), {
+        consume((buf.add(n)).* = self.data(self.pos));
+        self.pos = (self.pos + usize(1));
+        n = (n + usize(1));
+      });
+      n
+    })
+  )
+);
+impl(
+  _ScriptedReader,
+  Reader(
+    read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.read(buf, size, io)
+    )
+  )
+);
+_R1 :: "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nfirst";
+_R2 :: "HTTP/1.1 201 Created\r\nContent-Length: 6\r\n\r\nsecond";
+// Two responses arriving in ONE read is the case that makes reuse unsafe: the
+// second response's bytes must be CARRIED, not appended to the first body.
+// Framing the second by "whatever arrives next" is response smuggling
+// (RFC 9112 §11.2) and is a heisenbug — it only shows when writes coalesce.
+test("two pipelined responses in one read: the first is framed exactly, the second is carried", {
+  // A `ctl` handler unwinds the frame it is installed in, so it cannot be
+  // returned from a helper — each test installs its own.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  // A chunk larger than both responses together, so ONE read delivers both.
+  r := _scripted(`${_R1}${_R2}`, usize(4096));
+  carry := ArrayList(u8).new();
+  first := io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e);
+  raw1 := match(
+    first,
+    .Ok(x) => x,
+    .Err(err) => {
+      assert(false, `first message: ${err}`);
+      String.new()
+    }
+  );
+  assert(raw1 == String.from(_R1), `the first message is framed at its Content-Length, got ${raw1.len()} bytes`);
+  assert(carry.len() == String.from(_R2).len(), `the second response's bytes are carried, not swallowed (carry=${carry.len()})`);
+  // The second message is already in hand: reading it must cost no read at all.
+  reads_before := r.reads;
+  second := io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e);
+  raw2 := match(
+    second,
+    .Ok(x) => x,
+    .Err(err) => {
+      assert(false, `second message: ${err}`);
+      String.new()
+    }
+  );
+  assert(raw2 == String.from(_R2), `the second message is framed from the carried bytes, got ${raw2.len()} bytes`);
+  assert(r.reads == reads_before, "a message already carried costs no read");
+  assert(carry.len() == usize(0), "nothing is left after the second message");
+  // Both parse, and both keep their own status and version.
+  p1 := parse_response(raw1).unwrap();
+  p2 := parse_response(raw2).unwrap();
+  assert(p1.status.as_u16() == u16(200), "first is 200");
+  assert(p1.body == `first`, `first body: ${p1.body}`);
+  assert(p2.status.as_u16() == u16(201), "second is 201");
+  assert(p2.body == `second`, `second body: ${p2.body}`);
+});
+// The same, byte-at-a-time: the framing decision must not depend on how the
+// peer's writes happen to split.
+test("one-byte reads frame the same two messages", {
+  // A `ctl` handler unwinds the frame it is installed in, so it cannot be
+  // returned from a helper — each test installs its own.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  r := _scripted(`${_R1}${_R2}`, usize(1));
+  carry := ArrayList(u8).new();
+  raw1 := match(
+    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    .Ok(x) => x,
+    .Err(_) => {
+      assert(false, "first message");
+      String.new()
+    }
+  );
+  assert(raw1 == String.from(_R1), "byte-at-a-time framing matches");
+  raw2 := match(
+    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    .Ok(x) => x,
+    .Err(_) => {
+      assert(false, "second message");
+      String.new()
+    }
+  );
+  assert(raw2 == String.from(_R2), "and so does the second");
+});
+// A chunked body's terminating zero chunk is the boundary; `Dechunk.Done` now
+// reports where it ended, which is what lets the next message be carried.
+test("a chunked response followed by another response carries the tail", {
+  // A `ctl` handler unwinds the frame it is installed in, so it cannot be
+  // returned from a helper — each test installs its own.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  chunked := "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+  r := _scripted(`${chunked}${_R2}`, usize(4096));
+  carry := ArrayList(u8).new();
+  raw1 := match(
+    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    .Ok(x) => x,
+    .Err(err) => {
+      assert(false, `chunked message: ${err}`);
+      String.new()
+    }
+  );
+  p1 := parse_response(raw1).unwrap();
+  assert(p1.body == `hello`, `the chunked body is decoded: ${p1.body}`);
+  assert(carry.len() == String.from(_R2).len(), `the following response is carried (carry=${carry.len()})`);
+  raw2 := match(
+    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    .Ok(x) => x,
+    .Err(_) => {
+      assert(false, "second message after chunked");
+      String.new()
+    }
+  );
+  assert(raw2 == String.from(_R2), "the message after a chunked body is framed from the carry");
+});
+// The one-shot wrapper keeps its old behaviour: it frames the first message
+// and DISCARDS the rest, which is correct only because its connection is
+// about to be closed.
+test("read_http_message frames the first message and discards the rest", {
+  // A `ctl` handler unwinds the frame it is installed in, so it cannot be
+  // returned from a helper — each test installs its own.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  r := _scripted(`${_R1}${_R2}`, usize(4096));
+  raw := match(
+    io.await(wire.read_http_message(r, usize(0), false, io), e),
+    .Ok(x) => x,
+    .Err(_) => {
+      assert(false, "message");
+      String.new()
+    }
+  );
+  assert(raw == String.from(_R1), "the one-shot read still frames exactly one message");
+});
+// A response with no framing header at all is delimited by the close, so every
+// byte read is body and nothing can be carried.
+test("a close-delimited response consumes everything", {
+  // A `ctl` handler unwinds the frame it is installed in, so it cannot be
+  // returned from a helper — each test installs its own.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  body := "HTTP/1.0 200 OK\r\nServer: x\r\n\r\nno length here";
+  r := _scripted(String.from(body), usize(4096));
+  carry := ArrayList(u8).new();
+  raw := match(
+    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    .Ok(x) => x,
+    .Err(_) => {
+      assert(false, "message");
+      String.new()
+    }
+  );
+  assert(raw == String.from(body), "a close-delimited response is every byte read");
+  assert(carry.len() == usize(0), "and leaves nothing to carry");
+  p := parse_response(raw).unwrap();
+  assert(p.version == `HTTP/1.0`, `the version is kept as received: ${p.version}`);
+});


### PR DESCRIPTION
Two things, causally linked: writing the second surfaced the first.

## codegen — a captured variable as a `cond` arm's VALUE emitted a bare name

`src/codegen/exprs/atom.yo` asked *"is this variable captured by the current closure?"* **twice**, and the two copies keyed on **different names** — the emitting path on the source token, the guard that decides whether to take the plain-identifier early return on `ExprInfo.variable_name`.

For a bare variable reference in a cond/match arm-value position, `variable_name` is a **spurious temp** — the comment immediately below the guard already said so:

> yo-self's `attach_temp_variable_to_expr` can stamp a SPURIOUS temp `variable_name` onto a bare reference used as a cond/match arm value (e.g. `(cap == 0) => min_cap`)

That temp is not in the capture set, so the guard concluded "not captured", took the early return, and emitted a bare identifier inside a closure body:

```c
static inline size_t closure_yo_id_11460(void* closure_context, __yo_t0 e) {
  size_t _file____priv_temp_17218;
  if (((((__yo_t14*)closure_context)->cap) < (10ULL))) {   /* rewritten */
    _file____priv_temp_17218 = 0ULL;
  }
  else {
    _file____priv_temp_17218 = cap;                        /* NOT rewritten */
  }
```

→ `error: use of undeclared identifier 'cap'`.

Fixed by **deleting the duplicate**: one `_is_captured_here(name, env, context)`, used by both sites with the source token. Two copies of one question, keyed differently, *is* the defect — patching the guard's key would leave the next divergence available.

Shapes measured, same closure and same variable:

| arm value | before |
| --- | --- |
| `cond((cap < usize(10)) => usize(0), true => cap)` | **broken** |
| `cond((cap < usize(10)) => cap, true => usize(0))` | **broken** |
| `cond(true => cap)` | **broken** |
| `match(o, .Some(v) => v, .None => cap)` | **broken** |
| `cond(… => (cap + usize(1)))` | fine (control) |

**Why it survived:** wrapping the capture in any expression routes it through the call-argument path, which always rewrote correctly. Every use of a capture in `std/` and `src/` happens to sit inside some expression, so the bare-atom arm position had never been exercised.

**Byte-identity holds.** The change only affects atoms the old guard classified as "not captured" while the emitter would have classified them as captured — and every such program *failed to compile*. Nothing that compiled before can change, which the stage-2/stage-3 fixpoint confirms.

`issues/fixed/captured-variable-as-a-cond-arm-value-emits-a-bare-identifier.md` + `issues/repros/`.

## std/http/wire — framing a reused connection can trust

Connection reuse is blocked on one thing before any pool exists: a single `read` can return bytes belonging to **two** messages, and framing the second by "whatever arrives next" is request/response smuggling (RFC 9112 §11.2) — and a heisenbug, because it only appears when the peer's writes coalesce. `read_http_message` already truncated at the boundary (that is what `_message_upto` was added for) but **discarded** the excess, which is correct only because its connection was about to be closed.

`read_http_message_buffered(stream, max_bytes, is_request, carry, io)` carries it instead: `carry` comes in holding what the previous message left behind and goes out holding what this one left behind. One list per connection. `read_http_message` stays as a wrapper passing a fresh list, so **no existing caller changes**.

Three supporting pieces, each needed by the above:

- **`Dechunk.Done` carries an `end`** — a chunked body's boundary is the index just past its terminating CRLF, and nothing recorded it; the decoder only handed back the decoded data.
- **The stopping decision moved into `_frame_status`.** It was inline in the read loop, so a keep-alive read could not ask it *before* its first read — and asking first is not an optimization: a message already complete in the carried bytes must not cost a read, because that read would block until the peer sent something it has no reason to send.
- **`HttpResponse.version`.** The status line's version was parsed and thrown away, and reuse turns on it: an `HTTP/1.0` response without `Connection: keep-alive` ends its connection (RFC 9112 §9.3). Kept for the same reason `status_text` is — a proxy passes it through — and `to_string` now emits it, so a parsed response round-trips.

**Tests drive a scripted reader, not a socket** (`tests/http/wire.test.yo`): the whole point is one read spanning two messages, and a socket cannot be made to do that on demand. The reader hands out at most `chunk` bytes per call and counts its calls, so *"did this cost a read?"* is an assertion rather than an assumption:

```
  ✓ two pipelined responses in one read: the first is framed exactly, the second is carried
  ✓ one-byte reads frame the same two messages
  ✓ a chunked response followed by another response carries the tail
  ✓ read_http_message frames the first message and discards the rest
  ✓ a close-delimited response consumes everything
```

## Still open, and why it is a separate change

- **The pool itself.** Intended shape is an `HttpClient` that OWNS its idle connections (`reqwest::Client`'s model) rather than a module-global: explicit lifetime, `Dispose` closes the idle set, no global mutable state in `std/`. The free `fetch`/`fetch_with` keep their one-shot behaviour.
- **Server-side keep-alive needs a prerequisite the client does not: an idle timeout.** `serve` is one-connection-at-a-time, so a client that holds a keep-alive connection open and sends nothing would wedge the server — which is why the server half is not simply "loop until the client closes".

## Local coverage

- Full suite: **3982 passed, 0 failed**.
- The four broken capture shapes verified **failing** on a compiler built before the fix (`use of undeclared identifier 'cap'` ×4) and **passing** after.
- `tests/http/`: wire 5/5, server 13/13, http 35/35, http_limits 6/6.
- `gates_fast.sh`: **failures=0** — corpus `PASS 156 GOLDEN-DIFF 0`, `check ./std` 173/173, `check ./src` 269/269, fmt idempotent, cli-cases `PASS 92 GOLDEN-DIFF 0`.
- `fixpoint_only.sh`: **FIXPOINT_HOLDS** (stage2 hollow=0, STAGE3_RC=0) — the byte-identity acceptance test for the codegen change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)