### PR TITLE
std: OrderedMap position index (swap_remove, index_of, get_index); async race_first/any_first

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -413,7 +413,7 @@ window as D9–D18):
 | row as written | actual state |
 | --- | --- |
 | `Alignment` exported | done — `std/fmt/writer.yo:22` |
-| `JoinHandle` `Dispose` | done — Yo's `Thread` IS Rust's `JoinHandle` and has `Dispose` (`std/thread.yo:88`, detach-on-drop) |
+| `JoinHandle` `Dispose` | **that row conflated two types, and the ask is answered differently — see the `race_first`/`any_first` note below.** Yo's `Thread` is Rust's *thread* `JoinHandle` and does have `Dispose` (`std/thread.yo:88`, detach-on-drop); Yo's async `JoinHandle(T)` is TOKIO's, and cannot carry `Dispose` at all |
 | HTTP byte bodies (*"`parse_response` string-concats the body — binary responses are broken client-side"*) | **done, and the claim is stale**: the body is copied byte-wise and wrapped with unchecked `String.from_bytes` (`std/http/http.yo:363-374`), byte-transparent end to end, pinned by `tests/http/server.test.yo` |
 | `OrderedMap` `IntoIterator` | done via D14 — `std/collections/ordered_map.yo:319` |
 
@@ -1003,7 +1003,8 @@ or dropping the claim; `Once.call` rewritten over `Mutex.with_lock`;
 `_raw_lock`/`_raw_unlock`/`_raw_handle_ptr` off the public surface;
 `spawn_blocking`. (`interval` and the concurrent `Mutex` tests landed
 2026-09-10 — below; `JoinHandle` `Dispose` was ANSWERED rather than
-implemented, see `race_first`/`any_first`.)
+implemented, see `race_first`/`any_first`; and `async/channel.try_recv` was
+already aligned — both below.)
 
 **`Waker`/`Park` and a timer-free `yield` — LANDED 2026-09-11. This is the
 missing primitive the whole concurrency group was waiting on.**
@@ -1092,6 +1093,40 @@ than the feature — and would flake on a slower runner. That discrepancy is
 filed on its own
 (`issues/yield-now-costs-a-millisecond-per-turn-inside-a-test-batch.md`)
 because it will otherwise mask the next piece of async performance work.
+
+**`JoinHandle` `Dispose` — ANSWERED 2026-09-10, and the answer is `race_first`
+/ `any_first`, not a `Dispose`.**
+
+The row asked for "a `Dispose` on `JoinHandle` that aborts a non-terminal
+task", motivated by the finding that `race`/`any` leave a manual contract
+("every handle must still be awaited exactly once; abort the losers first if
+their results are unwanted") whose losers leak when a caller forgets it.
+
+The prescription is wrong twice over:
+
+- **Structurally.** `JoinHandle(T)` is a bare copyable `struct` over a raw
+  pointer (`struct(__future : *(T))`), not an `Rc`, and `Dispose` is
+  `where(Self <: Rc)`. Making it an `Rc` would change what `io.spawn` returns
+  and how every handle copies.
+- **Semantically.** Dropping Yo's async `JoinHandle` DETACHES the task,
+  exactly as dropping Tokio's does — that is what makes fire-and-forget
+  `io.spawn` work at all. Abort-on-drop is Tokio's opt-in
+  `AbortOnDropHandle`, not its default, and adopting it as the default would
+  silently kill every detached task.
+
+The leak is a combinator-contract problem, so it is fixed in the combinators:
+`race_first(handles, io) -> Option(T)` and
+`any_first(handles, io) -> Option(T)` do the cleanup themselves — they abort
+**and await** every loser (aborting alone marks the task and leaves its await
+outstanding, which is the same leak one step later) and return the winner's
+result. `race`/`any` keep their index-returning shapes for callers who want
+them.
+
+**`async/channel.try_recv` was already aligned.** The concurrency list's row
+("`async/channel.try_recv` still returns `Option(T)` where `sync/channel`'s
+returns `Result(T, TryRecvError)`") is stale: `std/async/channel.yo:145` reads
+`try_recv : (fn(self : Self) -> Result(T, TryRecvError))`, over the SAME
+`TryRecvError` type, and says so in its doc comment.
 
 **`interval` — LANDED 2026-09-10.** `std/time/sleep.yo` gains `Interval` and
 `interval(period, io)`. The reason it exists rather than a `sleep` in a loop is
@@ -1471,6 +1506,33 @@ first.
      `get` then `insert`, which is the same two walks a combined form would
      pay, and `insert`'s signature stays the one every existing call site
      wants.
+
+   Still open in this group: `imm` `remove` shape, private `ctrl/data/size`
+   fields (which needs a visibility feature Yo does not have), the `imm/Vec`
+   RRB-vs-flat-COW doc (§5).
+
+   **`OrderedMap.swap_remove` — LANDED 2026-09-10, and it needed a side
+   table.** `IndexMap::swap_remove` is O(1) because `IndexMap` keeps a
+   key→position map. Yo's `OrderedMap` kept only `HashMap(K, V)` plus an
+   `ArrayList(K)` order list, so finding the slot to swap into meant scanning
+   the order list — which would have made `swap_remove` O(n) and pointless,
+   since avoiding the walk is the entire reason it exists beside `remove`. It
+   therefore gains `_index : HashMap(K, usize)`, maintained at the four sites
+   that write `_order` (`new`, `insert`, `remove`, `clear`).
+
+   The side table pays for itself three more times. `remove` used to rebuild
+   the whole order list into a fresh `ArrayList` to skip one key; now it asks
+   the index where the key is, calls `ArrayList.remove` on that slot, and
+   re-records only the TAIL — same O(n) worst case, but no allocation, one
+   pass instead of two, and O(1) when the removed key is near the end. And
+   `index_of` / `get_index` (Rust's `get_index_of` / `get_index`) fall out of
+   it for free, which is the positional half of `IndexMap`'s surface that
+   `OrderedMap` had no way to offer before.
+
+   Both removals now PANIC if the key is in `_map` but not in `_index`
+   instead of defaulting the position to 0. A default would corrupt the order
+   list silently on the next operation; the invariant is internal, so a
+   violation is a bug in this file and not something a caller can cause.
 
    **Evidence for that §5 decision, found while writing the iterator tests:**
    `imm.Vec.push` takes `own(self)`, so the receiver is MOVED and keeping the

--- a/std/async/index.yo
+++ b/std/async/index.yo
@@ -1,7 +1,8 @@
 //! Async task utilities — cooperative `yield` and `JoinHandle` combinators
 //! (`plans/archive/STD_API_AUDIT.md` §7 P0 item 6).
 //!
-//! The combinators (`join_all`, `race`, `any`, `timeout`) are BLOCKING-POLL
+//! The combinators (`join_all`, `race`, `race_first`, `any`, `any_first`,
+//! `timeout`) are BLOCKING-POLL
 //! functions in the same sense as `JoinHandle.await`: they drive the event
 //! loop while they wait, so every spawned task keeps making progress. They
 //! take spawned handles, not futures — spawn at the call site:
@@ -24,7 +25,8 @@
 //!
 //! ## Stability
 //!
-//! unstable — the NAMES and signatures (`yield`, `join_all`, `race`, `any`,
+//! unstable — the NAMES and signatures (`yield`, `join_all`, `race`,
+//! `race_first`, `any`, `any_first`,
 //! `timeout`, `TimeoutError`) are intended to keep their meanings, but the
 //! MECHANISM under them is expected to change: every combinator drives the
 //! loop by polling, re-checking on a 1 ms timer tick, so a handle that
@@ -131,6 +133,63 @@ any :: (fn(generic(T : Type), handles : ArrayList(JoinHandle(T)), io : Io) -> Op
   });
   result
 });
+/// Await the FIRST handle to finish and abort the rest — `race` with the
+/// cleanup done for you. Returns the winner's result (`.None` if the winner
+/// was aborted rather than completed). Panics on an empty list.
+///
+/// This exists because `race`/`any` hand back an index and leave a manual
+/// contract behind ("every handle must still be awaited exactly once; abort
+/// the losers first if their results are unwanted"), and a caller who forgets
+/// it leaks every loser's state machine. The plan's original prescription for
+/// that leak was a `Dispose` on `JoinHandle` that aborts a non-terminal task,
+/// and that is the wrong fix twice over: `JoinHandle(T)` is a bare copyable
+/// `struct` over a raw pointer, not an `Rc`, so it cannot carry `Dispose` at
+/// all; and abort-on-drop is not the semantics Yo's async `JoinHandle`
+/// follows — dropping it DETACHES, exactly as Tokio's does, which is what
+/// makes fire-and-forget `io.spawn` work. The leak is a combinator contract
+/// problem, so it is fixed in the combinator.
+///
+/// Every loser is aborted AND awaited: aborting alone marks the task and
+/// leaves its await outstanding, which is the same leak one step later.
+race_first :: (fn(generic(T : Type), handles : ArrayList(JoinHandle(T)), io : Io) -> Option(T))({
+  assert(handles.len() > usize(0), "race_first: empty handle list");
+  w := race(handles, io);
+  (i : usize) = usize(0);
+  while(i < handles.len(), i = (i + usize(1)), {
+    cond(
+      (i == w) => (),
+      true => {
+        l := handles(i);
+        l.abort();
+        l.await(io);
+      }
+    );
+  });
+  win := handles(w);
+  win.await(io)
+});
+/// Await the first handle to COMPLETE and abort the rest — `any` with the
+/// cleanup done for you. `.None` when every handle ended without completing.
+/// Panics on an empty list. See `race_first` for why this exists.
+any_first :: (fn(generic(T : Type), handles : ArrayList(JoinHandle(T)), io : Io) -> Option(T))({
+  assert(handles.len() > usize(0), "any_first: empty handle list");
+  decided := any(handles, io);
+  (out : Option(T)) = Option(T).None;
+  (i : usize) = usize(0);
+  while(i < handles.len(), i = (i + usize(1)), {
+    h := handles(i);
+    cond(
+      match(decided, .Some(w) => (i == w), .None => false) => {
+        out = h.await(io);
+      },
+      true => {
+        h.abort();
+        h.await(io);
+      }
+    );
+  });
+  out
+});
 /// Why `timeout(...)` produced no value (D18).
 ///
 /// The old `Option(T)` return collapsed these two outcomes into each other —
@@ -207,4 +266,4 @@ timeout :: (
     )
   )
 });
-export(yield, join_all, race, any, timeout, TimeoutError);
+export(yield, join_all, race, race_first, any, any_first, timeout, TimeoutError);

--- a/std/collections/ordered_map.yo
+++ b/std/collections/ordered_map.yo
@@ -10,7 +10,10 @@
 //! - `set` (new key): O(1) amortized
 //! - `set` (existing key): O(1) — value updated in place, order unchanged
 //! - `get` / `contains_key`: O(1) average
-//! - `remove`: O(n) — must rebuild the key order list to skip the removed key
+//! - `remove`: O(n) — the keys after the removed one shift down a slot
+//! - `swap_remove`: O(1) — moves the last key into the removed slot, so the
+//!   iteration order changes (Rust's `IndexMap::swap_remove`)
+//! - `index_of` / `get_index`: O(1) — positional lookup, both directions
 //! - `iter` / `keys` / `values`: O(n), in insertion order
 //!
 //! ## Example
@@ -51,7 +54,15 @@ OrderedMap :: (
   ref(
     struct(
       _map : HashMap(K, V),
-      _order : ArrayList(K)
+      _order : ArrayList(K),
+      /// Each live key's position in `_order`. This is what makes
+      /// `swap_remove` O(1) — without it, finding the slot to swap into means
+      /// scanning `_order`, and the whole point of `swap_remove` over `remove`
+      /// is that it does not walk the map. `IndexMap` keeps the same side
+      /// table for the same reason. Every write to `_order` must keep it in
+      /// step; the four sites are `new`, `insert`, `remove` and `clear`.
+      /// It also answers `index_of` and, with `_order`, `get_index`.
+      _index : HashMap(K, usize)
     )
   )
 );
@@ -63,7 +74,8 @@ impl(
   new : (fn() -> Self)(
     Self(
       _map : HashMap(K, V).new(),
-      _order : ArrayList(K).new()
+      _order : ArrayList(K).new(),
+      _index : HashMap(K, usize).new()
     )
   ),
   /// Number of entries.
@@ -90,6 +102,7 @@ impl(
       is_new => match(
         result,
         .Ok(_) => {
+          self._index.insert(key, self._order.len());
           self._order.push(key);
         },
         .Err(_) => ()
@@ -110,40 +123,92 @@ impl(
       .Err(_) => __yo_panic("OrderedMap.insert: allocation failed")
     )
   ),
-  /// Remove `key`. Returns the removed value or `.None`.
-  /// O(n) — rebuilds the key order list to drop the removed key.
+  /// Remove `key`, keeping the insertion order of everything else — Rust's
+  /// `IndexMap::shift_remove`. Returns the removed value or `.None`.
+  ///
+  /// O(n) in the number of keys AFTER the removed one: they each shift down a
+  /// slot, and the position index has to learn where they went. Use
+  /// `swap_remove` when the order does not matter.
   remove : (fn(self : Self, key : K) -> Option(V))({
     removed := self._map.remove(key);
     match(
       removed,
       .Some(_) => {
-        new_order := ArrayList(K).new();
-        i := usize(0);
+        idx := match(
+          self._index.remove(key),
+          .Some(i) => i,
+          .None => __yo_panic("OrderedMap.remove: key in the map but not in the position index")
+        );
+        _dropped := self._order.remove(idx);
+        // Only the keys AFTER the hole moved; the ones before it kept their
+        // positions, so the index is patched over the tail rather than rebuilt.
+        j := idx;
         n := self._order.len();
-        while(i < n, i = (i + usize(1)), {
-          match(
-            self._order.get(i),
-            .Some(k) => {
-              cond(
-                (k == key) => (),
-                true => {
-                  new_order.push(k);
-                }
-              );
-            },
-            .None => ()
-          );
+        while(j < n, j = (j + usize(1)), {
+          match(self._order.get(j), .Some(k) => self._index.insert(k, j), .None => Option(usize).None);
         });
-        self._order = new_order;
       },
       .None => ()
     );
     return(removed);
   }),
+  /// Remove `key` in O(1), moving the LAST key into its position — Rust's
+  /// `IndexMap::swap_remove`. Returns the removed value or `.None`.
+  ///
+  /// This CHANGES the iteration order, which is the whole trade: `remove`
+  /// preserves insertion order and pays O(n) to rebuild the key list, while
+  /// this touches three slots and is done. Reach for it when you are draining
+  /// a map, or when order stops mattering once a key is gone.
+  swap_remove : (fn(self : Self, key : K) -> Option(V))({
+    removed := self._map.remove(key);
+    match(
+      removed,
+      .Some(_) => {
+        idx := match(
+          self._index.remove(key),
+          .Some(i) => i,
+          .None => __yo_panic("OrderedMap.swap_remove: key in the map but not in the position index")
+        );
+        last := (self._order.len() - usize(1));
+        cond(
+          (idx == last) => {
+            self._order.pop();
+          },
+          true => {
+            // Read the key that is about to move BEFORE the swap, so its
+            // new position can be recorded.
+            moved := match(self._order.get(last), .Some(k) => Option(K).Some(k), .None => Option(K).None);
+            self._order.swap_remove(idx);
+            match(moved, .Some(mk) => self._index.insert(mk, idx), .None => Option(usize).None);
+          }
+        );
+      },
+      .None => ()
+    );
+    return(removed);
+  }),
+  /// The position of `key` in the iteration order, or `.None` if it is
+  /// absent — Rust's `IndexMap::get_index_of`. O(1): the position index that
+  /// `swap_remove` needs already answers this.
+  index_of : (fn(self : Self, key : K) -> Option(usize))(self._index.get(key)),
+  /// The `(key, value)` pair at position `i` in the iteration order, or
+  /// `.None` when `i` is out of range — Rust's `IndexMap::get_index`.
+  get_index : (fn(self : Self, i : usize) -> Option(MapEntry(K, V)))(
+    match(
+      self._order.get(i),
+      .Some(k) => match(
+        self._map.get(k),
+        .Some(v) => Option(MapEntry(K, V)).Some(MapEntry(K, V)(key : k, value : v)),
+        .None => Option(MapEntry(K, V)).None
+      ),
+      .None => Option(MapEntry(K, V)).None
+    )
+  ),
   /// Remove all entries.
   clear : (fn(self : Self) -> unit)({
     self._map.clear();
     self._order = ArrayList(K).new();
+    self._index = HashMap(K, usize).new();
   })
 );
 /// Iterator over the keys of an `OrderedMap` in insertion order.

--- a/tests/async/combinators.test.yo
+++ b/tests/async/combinators.test.yo
@@ -1,9 +1,10 @@
-//! JoinHandle combinators — `join_all`, `race`, `any`, `timeout`
+//! JoinHandle combinators — `join_all`, `race`, `race_first`, `any`,
+//! `any_first`, `timeout`
 //! (`plans/archive/STD_API_AUDIT.md` §7 P0 item 6).
 pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
 { ArrayList } :: import("std/collections/array_list");
-{ join_all, race, any, timeout, TimeoutError } :: import("std/async");
+{ join_all, race, race_first, any, any_first, timeout, TimeoutError } :: import("std/async");
 { Duration } :: import("std/time/duration");
 { sleep } :: import("std/sys/timer");
 
@@ -138,4 +139,55 @@ test("Test timeout aborts on deadline", {
   // Outlive the aborted task's timer so its completion fires the entry guard.
   io.await(sleep(u64(120)), io);
   assert(!(ran.*), "the timed-out body must not resume past its suspension point");
+});
+// ---------------------------------------------------------------------------
+// race_first / any_first — the cleanup done for you
+//
+// `race`/`any` hand back an INDEX and leave a manual contract behind: every
+// handle must still be awaited exactly once, and the losers aborted first if
+// their results are unwanted. A caller who forgets it leaks every loser's
+// state machine. These two do it themselves — abort AND await each loser
+// (aborting alone leaves the await outstanding, which is the same leak one
+// step later) and return the winner's result.
+//
+// This is the answer to the plan's "JoinHandle Dispose" row: dropping Yo's
+// async `JoinHandle` DETACHES, exactly as dropping Tokio's does, so the fix
+// belongs in the combinator rather than in a drop.
+// ---------------------------------------------------------------------------
+test("Test race_first returns the fastest task's value", {
+  handles := ArrayList(JoinHandle(i32)).new();
+  handles.push(io.spawn(sleepy(i32(10), u64(60), io), io));
+  handles.push(io.spawn(sleepy(i32(20), u64(1), io), io));
+  handles.push(io.spawn(sleepy(i32(30), u64(60), io), io));
+  r := race_first(handles, io);
+  assert(match(r, .Some(v) => (v == i32(20)), .None => false), "the 1 ms task wins");
+  // Both losers are terminal now, and neither is awaiting: race_first
+  // aborted and awaited them.
+  assert(handles(usize(0)).is_finished(), "loser 0 is terminal");
+  assert(handles(usize(2)).is_finished(), "loser 2 is terminal");
+  assert(handles(usize(0)).state() == FutureState.Aborted, "loser 0 was aborted, not left running");
+  assert(handles(usize(2)).state() == FutureState.Aborted, "loser 2 was aborted, not left running");
+});
+test("Test race_first with a single handle", {
+  handles := ArrayList(JoinHandle(i32)).new();
+  handles.push(io.spawn(sleepy(i32(7), u64(1), io), io));
+  r := race_first(handles, io);
+  assert(match(r, .Some(v) => (v == i32(7)), .None => false), "one handle wins by default");
+});
+test("Test any_first returns the first COMPLETED value and aborts the rest", {
+  handles := ArrayList(JoinHandle(i32)).new();
+  handles.push(io.spawn(sleepy(i32(1), u64(60), io), io));
+  handles.push(io.spawn(sleepy(i32(2), u64(1), io), io));
+  r := any_first(handles, io);
+  assert(match(r, .Some(v) => (v == i32(2)), .None => false), "the fast task's value comes back");
+  assert(handles(usize(0)).state() == FutureState.Aborted, "the loser was aborted");
+});
+test("Test any_first is None when every handle was aborted", {
+  handles := ArrayList(JoinHandle(i32)).new();
+  handles.push(io.spawn(sleepy(i32(1), u64(60), io), io));
+  handles.push(io.spawn(sleepy(i32(2), u64(60), io), io));
+  handles(usize(0)).abort();
+  handles(usize(1)).abort();
+  r := any_first(handles, io);
+  assert(match(r, .Some(_) => false, .None => true), "no completion means .None");
 });

--- a/tests/collections/ordered_map.test.yo
+++ b/tests/collections/ordered_map.test.yo
@@ -203,3 +203,139 @@ test("OrderedMap Default is the empty map", {
   m.insert(`k`, i32(7));
   assert(m.len() == usize(1), "the default map is a usable map");
 });
+// `swap_remove` moves the LAST key into the removed slot — Rust's
+// `IndexMap::swap_remove`. O(1), and the iteration order changes: that trade
+// is the reason it exists beside the order-preserving O(n) `remove`.
+_keys :: (fn(m : OrderedMap(String, i32)) -> ArrayList(String))({
+  out := ArrayList(String).new();
+  it := m.keys();
+  while(true, {
+    match(
+      it.next(),
+      .Some(k) => {
+        out.push(k);
+      },
+      .None => break
+    );
+  });
+  out
+});
+test("OrderedMap swap_remove returns the value and moves the last key in", {
+  m := OrderedMap(String, i32).new();
+  m.insert(`a`, i32(1));
+  m.insert(`b`, i32(2));
+  m.insert(`c`, i32(3));
+  m.insert(`d`, i32(4));
+  got := m.swap_remove(`b`);
+  assert(got.is_some(), "swap_remove returns the removed value");
+  assert(got.unwrap() == i32(2), "and it is b's value");
+  assert(m.len() == usize(3), "the map shrank");
+  assert(!m.contains_key(`b`), "b is gone");
+  // `d` moved into b's slot, so the order is a, d, c — NOT a, c, d.
+  ks := _keys(m);
+  assert(ks.len() == usize(3), "three keys remain");
+  assert(ks(usize(0)) == `a`, "a is still first");
+  assert(ks(usize(1)) == `d`, "the LAST key moved into the removed slot");
+  assert(ks(usize(2)) == `c`, "and c did not move");
+  // Every surviving key is still reachable by value.
+  assert(m.get(`a`).unwrap() == i32(1), "a");
+  assert(m.get(`c`).unwrap() == i32(3), "c");
+  assert(m.get(`d`).unwrap() == i32(4), "d");
+});
+test("OrderedMap swap_remove of the last key does not disturb the order", {
+  m := OrderedMap(String, i32).new();
+  m.insert(`a`, i32(1));
+  m.insert(`b`, i32(2));
+  m.insert(`c`, i32(3));
+  assert(m.swap_remove(`c`).unwrap() == i32(3), "removed the last key");
+  ks := _keys(m);
+  assert((ks(usize(0)) == `a`) && (ks(usize(1)) == `b`), "a, b in order");
+  assert(ks.len() == usize(2), "two keys");
+});
+test("OrderedMap swap_remove of a missing key is None and changes nothing", {
+  m := OrderedMap(String, i32).new();
+  m.insert(`a`, i32(1));
+  assert(m.swap_remove(`zzz`).is_none(), "a missing key is .None");
+  assert(m.len() == usize(1), "nothing was removed");
+  assert(m.get(`a`).unwrap() == i32(1), "and a survives");
+});
+// The side index must stay in step with `_order` across EVERY mutator, which
+// is the part a naive swap_remove gets wrong: after a swap the moved key's
+// recorded position is stale, and the next swap_remove then removes the wrong
+// slot. Interleave the operations and re-read the order after each one.
+test("OrderedMap swap_remove keeps its position index in step", {
+  m := OrderedMap(String, i32).new();
+  (i : i32) = i32(0);
+  while(i < i32(6), i = (i + i32(1)), {
+    m.insert(`k${i.to_string()}`, i);
+  });
+  // Remove from the front repeatedly: each one pulls a different key forward.
+  assert(m.swap_remove(`k0`).unwrap() == i32(0), "k0");
+  assert(m.swap_remove(`k1`).unwrap() == i32(1), "k1");
+  assert(m.swap_remove(`k2`).unwrap() == i32(2), "k2");
+  assert(m.len() == usize(3), "three left");
+  ks := _keys(m);
+  assert(ks.len() == usize(3), "the order list agrees with len");
+  // Whatever the order is, every remaining key must still map to its own
+  // value — a stale index would have removed the wrong slot above.
+  (j : usize) = usize(0);
+  while(j < ks.len(), j = (j + usize(1)), {
+    k := ks(j);
+    v := m.get(k);
+    assert(v.is_some(), `${k} is still present`);
+  });
+  // And a fresh insert lands at the end with a correct position.
+  m.insert(`tail`, i32(99));
+  ks2 := _keys(m);
+  assert(ks2(ks2.len() - usize(1)) == `tail`, "a new key goes to the end");
+  assert(m.swap_remove(`tail`).unwrap() == i32(99), "and is removable");
+});
+test("OrderedMap remove still preserves order after a swap_remove", {
+  m := OrderedMap(String, i32).new();
+  m.insert(`a`, i32(1));
+  m.insert(`b`, i32(2));
+  m.insert(`c`, i32(3));
+  m.insert(`d`, i32(4));
+  m.swap_remove(`a`);
+  // order is now d, b, c
+  m.remove(`b`);
+  ks := _keys(m);
+  assert(ks.len() == usize(2), "two keys");
+  assert((ks(usize(0)) == `d`) && (ks(usize(1)) == `c`), "remove keeps the remaining order");
+  assert(m.get(`d`).unwrap() == i32(4), "d");
+  assert(m.get(`c`).unwrap() == i32(3), "c");
+});
+test("OrderedMap clear resets the position index too", {
+  m := OrderedMap(String, i32).new();
+  m.insert(`a`, i32(1));
+  m.insert(`b`, i32(2));
+  m.clear();
+  assert(m.len() == usize(0), "cleared");
+  m.insert(`b`, i32(9));
+  assert(m.swap_remove(`b`).unwrap() == i32(9), "a re-inserted key is removable");
+  assert(m.len() == usize(0), "and the map is empty again");
+});
+// `index_of` / `get_index` — the positional half of `IndexMap`'s surface,
+// which the position index answers in O(1).
+test("OrderedMap index_of and get_index address entries by position", {
+  m := OrderedMap(String, i32).new();
+  m.insert(`a`, i32(1));
+  m.insert(`b`, i32(2));
+  m.insert(`c`, i32(3));
+  assert(m.index_of(`a`).unwrap() == usize(0), "a is at 0");
+  assert(m.index_of(`b`).unwrap() == usize(1), "b is at 1");
+  assert(m.index_of(`c`).unwrap() == usize(2), "c is at 2");
+  assert(m.index_of(`zzz`).is_none(), "a missing key has no position");
+  e := m.get_index(usize(1));
+  assert(e.is_some(), "position 1 holds an entry");
+  assert(e.unwrap().key == `b`, "and it is b");
+  assert(e.unwrap().value == i32(2), "with b's value");
+  assert(m.get_index(usize(3)).is_none(), "past the end is .None");
+  // The positions follow the mutators.
+  m.swap_remove(`a`);
+  assert(m.index_of(`c`).unwrap() == usize(0), "c moved into a's slot");
+  assert(m.index_of(`b`).unwrap() == usize(1), "b did not move");
+  m.remove(`c`);
+  assert(m.index_of(`b`).unwrap() == usize(0), "shift-remove pulled b forward");
+  assert(m.get_index(usize(0)).unwrap().key == `b`, "and get_index agrees");
+});


### PR DESCRIPTION
Two small P1 items from `plans/STD_API_STABILIZATION.md`, plus the plan
corrections that writing them forced.

## `OrderedMap` gains a position index

`IndexMap::swap_remove` is O(1) because `IndexMap` keeps a key→position map.
`OrderedMap` kept only `HashMap(K, V)` plus an `ArrayList(K)` order list, so
finding the slot to swap into meant scanning the order list — which would have
made `swap_remove` O(n) and pointless, since avoiding the walk is the whole
reason it exists beside `remove`.

`_index : HashMap(K, usize)` is maintained at the four sites that write
`_order` (`new`, `insert`, `remove`, `clear`), and it pays for itself three
more times:

- `remove` (Rust's `shift_remove`) used to rebuild the entire order list into a
  fresh `ArrayList` to skip one key. It now asks the index where the key is,
  calls `ArrayList.remove` on that slot, and re-records only the TAIL — same
  O(n) worst case, no allocation, one pass instead of two, and O(1) when the
  removed key is near the end.
- `index_of` / `get_index` (Rust's `get_index_of` / `get_index`) fall out of it
  — the positional half of `IndexMap`'s surface `OrderedMap` could not offer
  before.

Both removals PANIC when a key is in `_map` but missing from `_index` rather
than defaulting the position to 0: a default corrupts the order list silently
on the next operation, and the invariant is internal, so a violation is a bug
in this file rather than something a caller can cause.

## `race_first` / `any_first`

`race` and `any` hand back an INDEX and leave a manual contract behind: every
handle must still be awaited exactly once, and the losers aborted first if
their results are unwanted. A caller who forgets it leaks every loser's state
machine — the finding the plan's "`JoinHandle` `Dispose`" row was really about.

That prescription is wrong twice over. `JoinHandle(T)` is a bare copyable
`struct(__future : *(T))`, not an `Rc`, and `Dispose` is `where(Self <: Rc)`.
And abort-on-drop is not the semantics Yo's async `JoinHandle` has: dropping it
DETACHES, exactly as dropping Tokio's does, which is what makes
fire-and-forget `io.spawn` work at all. Tokio spells the other behaviour
`AbortOnDropHandle` and makes it opt-in for the same reason.

So the leak is fixed in the combinators: `race_first`/`any_first` abort AND
await every loser (aborting alone marks the task and leaves its await
outstanding — the same leak one step later) and return the winner's value.
`race`/`any` keep their index shapes.

## Plan corrections measured against the code

- the two contradictory `JoinHandle Dispose` rows
- `async/channel.try_recv` already returns `Result(T, TryRecvError)` over the
  same error type (since #506), not `Option(T)`

## Coverage

- `yo check ./std --std-path ./std` → 173/173
- `tests/collections/ordered_map.test.yo` → 20/20
- `tests/async/combinators.test.yo` → 12/12
- CI carries the rest of the battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)