### PR TITLE
std/imm: extract — the remove that reports what it removed

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -1040,9 +1040,47 @@ cooperative-scheduling contract.
    optimization. `SortedMap` gained the `entries()` it was missing beside
    `imm.Map`'s.
 
-   Still open in this group: `imm` `remove` shape,
-   `OrderedMap.swap_remove`, private `ctrl/data/size` fields, the `imm/Vec`
-   RRB-vs-flat-COW doc (§5).
+   Still open in this group: `OrderedMap.swap_remove`, private
+   `ctrl/data/size` fields, the `imm/Vec` RRB-vs-flat-COW doc (§5).
+
+   **The `imm` `remove` shape — ANSWERED 2026-09-10 by adding `extract`, not
+   by changing `remove`.** The finding was that `Map`/`SortedMap`/`Set`/
+   `SortedSet` `remove -> Self` throws away what it removed, so a caller
+   cannot tell "removed a value" from "the key was never there" — both answer
+   with a map of the same size — and cannot get the value without a separate
+   `get`.
+
+   The prescription in the raw findings was `remove -> (Self, Option(V))`.
+   That is not what `im` does, and `im` is right: the persistent remove is
+   `without(&self, k) -> Self`, and the value-reporting form is a SECOND
+   method, `extract(&self, k) -> Option<(V, Self)>`. Keeping them apart is
+   what lets the common case stay allocation-free on a miss — `remove` of an
+   absent key returns `self` ITSELF — while `extract`'s `.None` arm carries no
+   map at all, because on a miss the caller's own value already is the answer.
+   Changing `remove`'s return would also have made every call site destructure
+   a pair it does not want.
+
+   So `extract` is added to all four types, `im`'s shape and `im`'s name, and
+   `remove`'s doc now says it is `im`'s `without` and points at `extract`. On
+   the two SETS it is `extract(elem) -> Option(Self)`: a set has no value to
+   hand back, so the `Option` carries the entire answer.
+
+   Two decisions inside it:
+
+   - **`extract` walks the structure twice** (`get` then `remove`), and says
+     so. `im` manages one walk because Rust moves the value out of the node it
+     visits; threading the value out of `_node_remove` here would put an
+     `Option(V)` in `RemoveResult` and make every `remove` — the common path —
+     carry and then drop a value it never wanted. A HAMT walk is ⌈log₃₂ n⌉
+     levels (2 for a million entries), which is cheaper than the refcount
+     traffic that would buy. `SortedMap.remove` already walks twice (it asks
+     `_node_contains` before rebuilding), so there it costs nothing new.
+   - **`insert` is deliberately left alone.** The same finding asked for the
+     displaced value, and `im` does not offer that persistently either — its
+     `insert -> Option<V>` is the MUTATING form. A caller who needs it writes
+     `get` then `insert`, which is the same two walks a combined form would
+     pay, and `insert`'s signature stays the one every existing call site
+     wants.
 
    **Evidence for that §5 decision, found while writing the iterator tests:**
    `imm.Vec.push` takes `own(self)`, so the receiver is MOVED and keeping the

--- a/std/imm/map.yo
+++ b/std/imm/map.yo
@@ -894,7 +894,11 @@ impl(
       )
     )
   ),
-  /// Return a new map without `key`.
+  /// Return a new map without `key` — `im`'s `without`. A key that is not
+  /// present gives back `self` itself, not a copy.
+  ///
+  /// This deliberately does NOT report what it removed; `extract` is the form
+  /// that does.
   remove : (fn(self : Self, key : K) -> Self)(
     match(
       self._root,
@@ -909,6 +913,29 @@ impl(
       .None => self
     )
   ),
+  /// The value at `key` together with the map WITHOUT it, or `.None` when
+  /// the key is absent — `im`'s `extract`.
+  ///
+  /// This exists because `remove` answers only "the map afterwards", so a
+  /// caller who wants the removed value had to look it up first and could not
+  /// tell "absent" from "removed a value that happens to equal the default".
+  /// The `.None` arm carries no map, which is the point: on a miss the
+  /// caller's own `self` already IS the answer, so nothing is rebuilt.
+  ///
+  /// TWO walks of the trie, not one. `im`'s `extract` is one walk because
+  /// Rust can move the value out of the node it visits; threading the value
+  /// out of `_node_remove` here would make every `remove` — the common case —
+  /// carry and then drop a value it does not want. A HAMT walk is
+  /// ⌈log₃₂ n⌉ levels (2 for a million entries), so the second walk is a
+  /// smaller cost than the refcount traffic on the first.
+  extract : (fn(self : Self, key : K) -> Option(Tuple(V, Self)))({
+    hit := self.get(key);
+    match(
+      hit,
+      .Some(v) => Option(Tuple(V, Self)).Some((v, self.remove(key))),
+      .None => Option(Tuple(V, Self)).None
+    )
+  }),
   /// Merge another map into this one. Keys from `other` overwrite `self`.
   merge : (fn(self : Self, other : Self) -> Self)(
     match(

--- a/std/imm/set.yo
+++ b/std/imm/set.yo
@@ -49,9 +49,25 @@ impl(
   insert : (fn(self : Self, elem : T) -> Self)(
     Self(_inner : self._inner.insert(elem, true))
   ),
-  /// Return a new set with `elem` removed.
+  /// Return a new set with `elem` removed — `im`'s `without`. An element that
+  /// is not present gives back an equal set, and says nothing about whether
+  /// anything was there; `extract` is the form that does.
   remove : (fn(self : Self, elem : T) -> Self)(
     Self(_inner : self._inner.remove(elem))
+  ),
+  /// The set WITHOUT `elem`, or `.None` when `elem` was not a member — `im`'s
+  /// `extract`.
+  ///
+  /// A set has no value to hand back, so the `Option` carries the whole
+  /// answer: `.Some` means "it was there, and here is the set without it",
+  /// `.None` means "nothing to remove, and your own set is already correct".
+  /// That is what `remove` alone cannot say — its result is
+  /// indistinguishable from a no-op.
+  extract : (fn(self : Self, elem : T) -> Option(Self))(
+    cond(
+      self.contains(elem) => Option(Self).Some(self.remove(elem)),
+      true => Option(Self).None
+    )
   ),
   /// Return the union of two sets (`self ∪ other`).
   union : (fn(self : Self, other : Self) -> Self)(

--- a/std/imm/sorted_map.yo
+++ b/std/imm/sorted_map.yo
@@ -582,7 +582,11 @@ impl(
     );
     Self(_root : .Some(black_root), _len : new_len)
   }),
-  /// Return a new map with the key removed.
+  /// Return a new map with the key removed — `im`'s `without`. A key that is
+  /// not present gives back `self` itself, not a copy.
+  ///
+  /// This deliberately does NOT report what it removed; `extract` is the form
+  /// that does.
   remove : (fn(self : Self, key : K) -> Self)(
     match(
       self._root,
@@ -602,6 +606,21 @@ impl(
       }
     )
   ),
+  /// The value at `key` together with the map WITHOUT it, or `.None` when
+  /// the key is absent — `im`'s `extract`, and the form `remove` is not:
+  /// `remove` answers only "the map afterwards".
+  ///
+  /// Two walks of the tree, as `remove` itself already does (it asks
+  /// `_node_contains` before rebuilding), so this costs one lookup more than
+  /// `remove` and nothing more than `get` + `remove` written by hand.
+  extract : (fn(self : Self, key : K) -> Option(Tuple(V, Self)))({
+    hit := self.get(key);
+    match(
+      hit,
+      .Some(v) => Option(Tuple(V, Self)).Some((v, self.remove(key))),
+      .None => Option(Tuple(V, Self)).None
+    )
+  }),
   /// Get the minimum key in the map.
   min_key : (fn(self : Self) -> Option(K))(
     match(

--- a/std/imm/sorted_set.yo
+++ b/std/imm/sorted_set.yo
@@ -47,9 +47,25 @@ impl(
   insert : (fn(self : Self, elem : T) -> Self)(
     Self(_inner : self._inner.insert(elem, true))
   ),
-  /// Return a new set with `elem` removed.
+  /// Return a new set with `elem` removed — `im`'s `without`. An element that
+  /// is not present gives back an equal set, and says nothing about whether
+  /// anything was there; `extract` is the form that does.
   remove : (fn(self : Self, elem : T) -> Self)(
     Self(_inner : self._inner.remove(elem))
+  ),
+  /// The set WITHOUT `elem`, or `.None` when `elem` was not a member — `im`'s
+  /// `extract`.
+  ///
+  /// A set has no value to hand back, so the `Option` carries the whole
+  /// answer: `.Some` means "it was there, and here is the set without it",
+  /// `.None` means "nothing to remove, and your own set is already correct".
+  /// That is what `remove` alone cannot say — its result is
+  /// indistinguishable from a no-op.
+  extract : (fn(self : Self, elem : T) -> Option(Self))(
+    cond(
+      self.contains(elem) => Option(Self).Some(self.remove(elem)),
+      true => Option(Self).None
+    )
   ),
   /// Get the minimum element.
   min : (fn(self : Self) -> Option(T))(

--- a/tests/imm_map.test.yo
+++ b/tests/imm_map.test.yo
@@ -196,3 +196,47 @@ test("Map Default is the empty map", {
   assert(m.is_empty(), "default map is empty");
   assert(m.insert(i32(1), i32(2)).len() == usize(1), "the default map is a usable map");
 });
+// `extract` is the form `remove` is not: it reports what came out. `remove`
+// alone cannot distinguish "removed a value" from "the key was never there",
+// because both answer with a map of the same size.
+test("Map extract returns the removed value with the map without it", {
+  m := Map(i32, i32).new().insert(i32(1), i32(10)).insert(i32(2), i32(20));
+  got := m.extract(i32(1));
+  assert(got.is_some(), "1 was present, so extract says .Some");
+  pair := got.unwrap();
+  assert(pair.0 == i32(10), "and hands back 1's value");
+  assert(pair.1.len() == usize(1), "with a one-entry map");
+  assert(pair.1.get(i32(1)).is_none(), "1 is gone from it");
+  assert(pair.1.get(i32(2)).unwrap() == i32(20), "and 2 survives");
+  // The receiver is untouched — these are persistent maps.
+  assert(m.len() == usize(2), "the original map still has both entries");
+  assert(m.get(i32(1)).unwrap() == i32(10), "and still holds 1");
+});
+test("Map extract of an absent key is None and carries no map", {
+  m := Map(i32, i32).new().insert(i32(1), i32(10));
+  assert(m.extract(i32(999)).is_none(), "a missing key extracts nothing");
+  // The distinction `remove` cannot make: removing a value that equals the
+  // zero value looks exactly like removing nothing.
+  z := Map(i32, i32).new().insert(i32(5), i32(0));
+  assert(z.extract(i32(5)).is_some(), "extracting a zero value still says .Some");
+  assert(z.extract(i32(5)).unwrap().0 == i32(0), "and the value is that zero");
+  assert(z.extract(i32(6)).is_none(), "while a genuinely absent key is .None");
+});
+test("Map extract drains a map one key at a time", {
+  (m : Map(i32, i32)) = Map(i32, i32).new();
+  (i : i32) = i32(0);
+  while(i < i32(40), i = (i + i32(1)), {
+    m = m.insert(i, i * i32(10));
+  });
+  (sum : i32) = i32(0);
+  (k : i32) = i32(0);
+  while(k < i32(40), k = (k + i32(1)), {
+    e := m.extract(k);
+    assert(e.is_some(), "every inserted key extracts");
+    p := e.unwrap();
+    sum = (sum + p.0);
+    m = p.1;
+  });
+  assert(m.is_empty(), "the map is drained");
+  assert(sum == i32(7800), "and every value came out exactly once");
+});

--- a/tests/imm_set.test.yo
+++ b/tests/imm_set.test.yo
@@ -189,3 +189,20 @@ test("Set Default is the empty set", {
   assert(s.is_empty(), "default set is empty");
   assert(s.insert(i32(1)).len() == usize(1), "the default set is a usable set");
 });
+// A set has no value to report, so `extract`'s Option carries the whole
+// answer: `.Some` means "it was a member, here is the set without it".
+// `remove` cannot say that — its result is indistinguishable from a no-op.
+test("Set extract reports membership as well as removing", {
+  s := Set(i32).new().insert(i32(1)).insert(i32(2));
+  got := s.extract(i32(1));
+  assert(got.is_some(), "1 was a member");
+  t := got.unwrap();
+  assert(t.len() == usize(1), "the returned set is one smaller");
+  assert(!t.contains(i32(1)), "1 is gone from it");
+  assert(t.contains(i32(2)), "and 2 survives");
+  assert(s.len() == usize(2), "the original set is untouched");
+  assert(s.extract(i32(99)).is_none(), "a non-member extracts nothing");
+  // The contrast that motivates it: `remove` of a non-member looks identical
+  // to `remove` of a member, from the result alone.
+  assert(s.remove(i32(99)).len() == s.len(), "remove of a non-member changes no size");
+});

--- a/tests/imm_sorted_map.test.yo
+++ b/tests/imm_sorted_map.test.yo
@@ -211,3 +211,37 @@ test("SortedMap Default is the empty map", {
   assert(m.is_empty(), "default sorted map is empty");
   assert(m.insert(i32(1), i32(2)).len() == usize(1), "the default sorted map is usable");
 });
+// `extract` reports what came out; `remove` answers only "the map afterwards".
+test("SortedMap extract returns the removed value with the map without it", {
+  m := SortedMap(i32, i32).new().insert(i32(1), i32(10)).insert(i32(2), i32(20));
+  got := m.extract(i32(1));
+  assert(got.is_some(), "1 was present");
+  p := got.unwrap();
+  assert(p.0 == i32(10), "and its value comes back");
+  assert(p.1.len() == usize(1), "with a one-entry map");
+  assert(p.1.get(i32(1)).is_none(), "1 is gone from it");
+  assert(p.1.get(i32(2)).unwrap() == i32(20), "and 2 survives");
+  assert(m.len() == usize(2), "the original is untouched");
+});
+test("SortedMap extract of an absent key is None", {
+  m := SortedMap(i32, i32).new().insert(i32(1), i32(10));
+  assert(m.extract(i32(99)).is_none(), "a missing key extracts nothing");
+  assert(m.extract(i32(1)).is_some(), "a present one does");
+});
+test("SortedMap extract keeps the tree ordered while draining", {
+  (m : SortedMap(i32, i32)) = SortedMap(i32, i32).new();
+  (i : i32) = i32(0);
+  while(i < i32(30), i = (i + i32(1)), {
+    m = m.insert(i, i);
+  });
+  // Drain from the MIDDLE outwards, which is the case that rebalances most.
+  (k : i32) = i32(15);
+  while(k < i32(30), k = (k + i32(1)), {
+    p := m.extract(k).unwrap();
+    assert(p.0 == k, "the extracted value is the key's own");
+    m = p.1;
+  });
+  assert(m.len() == usize(15), "half the keys remain");
+  assert(m.min_key().unwrap() == i32(0), "the minimum is still 0");
+  assert(m.max_key().unwrap() == i32(14), "and the maximum is now 14");
+});

--- a/tests/imm_sorted_set.test.yo
+++ b/tests/imm_sorted_set.test.yo
@@ -214,3 +214,16 @@ test("SortedSet Default is the empty set", {
   assert(s.is_empty(), "default sorted set is empty");
   assert(s.insert(i32(1)).len() == usize(1), "the default sorted set is usable");
 });
+// See `imm_set.test.yo` for why the Option carries the whole answer here.
+test("SortedSet extract reports membership as well as removing", {
+  s := SortedSet(i32).new().insert(i32(3)).insert(i32(1)).insert(i32(2));
+  got := s.extract(i32(2));
+  assert(got.is_some(), "2 was a member");
+  t := got.unwrap();
+  assert(t.len() == usize(2), "the returned set is one smaller");
+  assert(!t.contains(i32(2)), "2 is gone from it");
+  assert(t.min().unwrap() == i32(1), "the minimum is still 1");
+  assert(t.max().unwrap() == i32(3), "and the maximum is still 3");
+  assert(s.len() == usize(3), "the original set is untouched");
+  assert(s.extract(i32(99)).is_none(), "a non-member extracts nothing");
+});


### PR DESCRIPTION
Closes the `imm` `remove` shape row in `plans/STD_API_STABILIZATION.md` §4
(collections group).

## The finding

`Map`/`SortedMap`/`Set`/`SortedSet` `remove -> Self` throws away what it
removed, so a caller cannot tell "removed a value" from "the key was never
there" — both answer with a collection of the same size — and cannot get the
value out without a separate `get`.

## Why not `remove -> (Self, Option(V))`

That was the raw finding's prescription, and it is not what `im` does. `im`
splits them: `without(&self, k) -> Self` is the persistent remove, and
`extract(&self, k) -> Option<(V, Self)>` is the value-reporting one. The split
is load-bearing:

- `remove` of an absent key returns `self` ITSELF, allocating nothing. A pair
  return would have to fabricate something for the miss.
- `extract`'s `.None` arm carries no collection, because on a miss the caller's
  own value already is the answer.
- Every existing `remove` call site would have had to destructure a pair it
  does not want.

So `extract` is added with `im`'s shape and `im`'s name; `remove`'s doc now
says it is `im`'s `without` and points at `extract`. On the two SETS it is
`extract(elem) -> Option(Self)` — a set has no value to hand back, so the
`Option` carries the whole answer, which is exactly what `remove` alone cannot
say.

## Two decisions recorded at the definitions

- **`extract` walks the structure twice** (`get` then `remove`). `im` manages
  one walk because Rust moves the value out of the node it visits; threading
  the value out of `_node_remove` here would put an `Option(V)` in
  `RemoveResult` and make every `remove` — the common path — carry and then
  drop a value it never wanted. A HAMT walk is ⌈log₃₂ n⌉ levels (2 for a
  million entries), cheaper than the refcount traffic that would buy.
  `SortedMap.remove` already walks twice, so there it costs nothing new.
- **`insert` is deliberately left alone.** The same finding asked for the
  displaced value; `im` does not offer that persistently either (its
  `insert -> Option<V>` is the MUTATING form), and `get` + `insert` is the same
  two walks a combined form would pay.

## Coverage

- `yo check ./std --std-path ./std` → 173/173
- `tests/imm_map.test.yo` 25/25, `tests/imm_sorted_map.test.yo` 21/21,
  `tests/imm_set.test.yo` 21/21, `tests/imm_sorted_set.test.yo` 20/20
- New cases cover: the value + the smaller collection, the receiver staying
  untouched, an absent key, extracting a value that EQUALS the zero value (the
  case `remove` cannot distinguish), draining a whole map key by key, and
  draining a `SortedMap` from the middle outwards so the tree rebalances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)