### PR TITLE
std/sync,std/async: Sender/Receiver split with auto-close on the last sender

### DIFF
--- a/docs/en-US/PARALLELISM.md
+++ b/docs/en-US/PARALLELISM.md
@@ -220,6 +220,59 @@ threads. No extra `arc()` wrapper is needed.
 
 Channel uses a `Mutex` + `CondVar` internally for synchronization. Send blocks when the channel is full; recv blocks when the channel is empty.
 
+### Sender / Receiver - end of stream without a manual `close()`
+
+A `Channel` is one fused handle that both ends share, and it stays open until somebody
+calls `close()`. When a consumer needs to know that the producers are *finished*, use the
+`Sender`/`Receiver` split instead: the queue counts its live senders, and dropping the last
+one closes the channel by itself.
+
+```rust
+{ Channel } :: import "std/sync/channel";
+
+rx := Channel(i32).receiver(usize(4)); // the queue and its one consumer
+{
+  tx := rx.sender();                   // a counted producer
+  tx.send(i32(1));
+  tx.send(i32(2));
+};                                     // last sender dropped -> channel closed
+
+rx.recv().unwrap();                    // 1  - buffered values come out first
+rx.recv().unwrap();                    // 2
+rx.recv();                             // .Err(TryRecvError.Disconnected)
+```
+
+- `Sender` is cloneable (`tx.clone()`); every clone is another counted producer, and only
+  the LAST one to be dropped closes the queue.
+- Dropping the `Receiver` makes every further `send` fail with the unsent value, instead of
+  blocking on a queue nobody will drain.
+- `Receiver.recv()` returns `Result(T, TryRecvError)`; the error is always `Disconnected`,
+  and it is reported only once the buffer is drained, so no accepted value is lost.
+- `Channel(T).pair(capacity)` returns both halves as a tuple for a Rust-like one-liner, but
+  the tuple keeps both handles alive for its whole scope - so dropping the sender early does
+  *not* close the channel. Prefer `receiver()` + `sender()` whenever the end of the stream
+  matters.
+
+For producers on other threads, mint each thread's `Sender` inside the thread and keep one
+in the parent until the workers are running:
+
+```rust
+rx := Channel(i32).receiver(usize(16));
+{
+  keeper := rx.sender();               // holds the count above zero
+  w := Thread.spawn((io) => {
+    tx := rx.sender();                 // this thread's producer
+    tx.send(i32(7));
+  });                                  // tx drops when the body ends
+  w.join();
+};                                     // keeper drops -> channel closed
+```
+
+A `Sender` *moved into* a `Thread.spawn` closure does not close the channel today: a spawn
+closure's captures are never released, so that sender's drop never runs. Values still flow;
+only the auto-close is lost. Async tasks (`std/async/channel`, which has the same
+`receiver()`/`sender()`/`pair()` API for one event loop) release their captures correctly.
+
 ## Sendable Types
 
 Only types that implement `Send` can cross thread boundaries:

--- a/docs/zh-CN/PARALLELISM.md
+++ b/docs/zh-CN/PARALLELISM.md
@@ -210,6 +210,57 @@ Thread.spawn((io) => {
 
 Channel 内部使用 `Mutex` + `CondVar` 进行同步。当 Channel 满时 send 阻塞；当 Channel 空时 recv 阻塞。
 
+### Sender / Receiver - 无需手动 `close()` 的流结束信号
+
+`Channel` 是两端共享的同一个句柄，只有有人调用 `close()` 它才会关闭。当消费者需要知道生产者
+**已经结束**时，请改用 `Sender`/`Receiver` 拆分：队列会统计存活的 sender，最后一个被丢弃时
+自动关闭 Channel。
+
+```rust
+{ Channel } :: import "std/sync/channel";
+
+rx := Channel(i32).receiver(usize(4)); // 队列及其唯一的消费者
+{
+  tx := rx.sender();                   // 一个被计数的生产者
+  tx.send(i32(1));
+  tx.send(i32(2));
+};                                     // 最后一个 sender 被丢弃 -> Channel 关闭
+
+rx.recv().unwrap();                    // 1  - 已缓冲的值先被取出
+rx.recv().unwrap();                    // 2
+rx.recv();                             // .Err(TryRecvError.Disconnected)
+```
+
+- `Sender` 可克隆（`tx.clone()`）；每个克隆都是又一个被计数的生产者，只有**最后**一个被丢弃时
+  才关闭队列。
+- 丢弃 `Receiver` 后，之后的每次 `send` 都会失败并把未发送的值交还给调用者，而不是阻塞在一个
+  没人消费的队列上。
+- `Receiver.recv()` 返回 `Result(T, TryRecvError)`；错误恒为 `Disconnected`，并且只有在缓冲区
+  被取空之后才会报告，因此已经被接受的值不会丢失。
+- `Channel(T).pair(capacity)` 以元组形式一次返回两端，写法更接近 Rust，但元组会在其整个作用域内
+  持有两个句柄——所以提前丢弃 sender **并不会**关闭 Channel。只要流的结束时机重要，就优先使用
+  `receiver()` + `sender()`。
+
+对于位于其他线程的生产者，请在线程内部创建该线程自己的 `Sender`，并在父线程中保留一个，
+直到工作线程都已启动：
+
+```rust
+rx := Channel(i32).receiver(usize(16));
+{
+  keeper := rx.sender();               // 保证计数不会归零
+  w := Thread.spawn((io) => {
+    tx := rx.sender();                 // 本线程的生产者
+    tx.send(i32(7));
+  });                                  // 线程体结束时 tx 被丢弃
+  w.join();
+};                                     // keeper 被丢弃 -> Channel 关闭
+```
+
+目前把 `Sender` **移入** `Thread.spawn` 闭包并不会关闭 Channel：spawn 闭包捕获的引用从不释放，
+因此该 sender 的丢弃逻辑永远不会执行。值依然可以正常传递，只是失去了自动关闭。异步任务
+（`std/async/channel`，在单个事件循环上提供同样的 `receiver()`/`sender()`/`pair()` API）会正确
+释放捕获。
+
 ## 可发送类型
 
 只有实现了 `Send` 的类型才能跨越线程边界：

--- a/issues/repros/thread-spawn-capture-blocks-channel-autoclose.yo
+++ b/issues/repros/thread-spawn-capture-blocks-channel-autoclose.yo
@@ -1,0 +1,48 @@
+// Reproducer: a `Sender` MOVED INTO a `Thread.spawn` closure never runs its
+// `dispose`, so the channel's sender count never reaches zero and the
+// auto-close never fires. The same handle dropped from a plain scope DOES
+// dispose, which localizes the fault to the spawn closure's captures
+// (issues/spawn-closure-captures-never-dropped-leak.md).
+//
+//   yo compile issues/repros/thread-spawn-capture-blocks-channel-autoclose.yo \
+//     --std-path ./std --optimize 2 -o /tmp/repro && /tmp/repro
+//
+// Expected (correct behaviour):
+//   plain scope: closed after the sender's scope ended = true
+//   spawn capture: closed after join                   = true
+// Measured 2026-09-10 (macOS arm64, --optimize 2): the second line is FALSE.
+{ Channel } :: import("std/sync/channel");
+{ Thread } :: import("std/thread");
+{ printf } :: import("std/libc/stdio");
+pragma(Pragma.AllowUnsafe);
+
+show :: (fn(tag : str, flag : bool) -> unit)(
+  cond(
+    flag => {
+      _a := unsafe(printf("%-50s = true\n", tag));
+    },
+    true => {
+      _b := unsafe(printf("%-50s = false\n", tag));
+    }
+  )
+);
+main :: (fn() -> unit)({
+  // Control: a sender dropped at the end of a plain scope closes the channel.
+  rx1 := Channel(i32).receiver(usize(2));
+  {
+    tx := rx1.sender();
+    _s := tx.send(i32(1));
+  };
+  show("plain scope: closed after the sender's scope ended", rx1.is_closed());
+  // The bug: the same sender moved into a spawned thread's closure.
+  rx2 := Channel(i32).receiver(usize(2));
+  {
+    tx := rx2.sender();
+    t := Thread.spawn(io => {
+      _s := tx.send(i32(2));
+    });
+    t.join();
+  };
+  show("spawn capture: closed after join", rx2.is_closed());
+});
+export(main);

--- a/issues/spawn-closure-captures-never-dropped-leak.md
+++ b/issues/spawn-closure-captures-never-dropped-leak.md
@@ -9,6 +9,20 @@ matters now because `ThreadPool.join_all` allocates a `Channel(bool)`
 internally on **every call**, so a program that drains a pool in a loop leaks
 steadily even if its own task closures capture nothing.
 
+**It also blocks a feature (2026-09-11).** The never-released capture means a
+captured handle's `Dispose` never runs, so any std API whose contract is "the
+last handle to go does X" is silently inert across a `Thread.spawn` boundary.
+The first case is `std/sync/channel`'s `Sender`/`Receiver` split: a `Sender`
+moved into a spawn closure never decrements the sender count, so the channel
+never auto-closes. Measured side by side —
+`issues/repros/thread-spawn-capture-blocks-channel-autoclose.yo` prints `true`
+for a sender dropped in a plain scope and `false` for the same sender captured
+by `Thread.spawn`. So this is no longer only about memory: it is the reason
+that feature ships with a documented "mint the sender inside the thread"
+pattern instead of the Rust one
+(`plans/backlog/SPAWN_CAPTURE_AUTOCLOSE.md`). An `io.async` capture releases
+correctly; this is specific to `__yo_thread_spawn` / `__yo_worker_spawn`.
+
 ## Symptom
 
 Every closure handed to a spawn primitive leaks **one reference per RC'd

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -442,7 +442,8 @@ saturating_/overflowing_`, `abs/pow/clamp/count_ones/leading_zeros`, every
 `f64`/`f32` method and const (only raw `libc/math` today), `Error.is`,
 `ErrorChain`, `Context`, `derive_rule(Error)`, `black_box`, log `Sink`/`YO_LOG`,
 `thread_rng`. Concurrency — `Thread` is NOT generic and `join -> unit`
-(`std/thread.yo:61,78`), so **D18b is still open**; `Sender`/`Receiver` split,
+(`std/thread.yo:61,78`), so **D18b is still open**; `Sender`/`Receiver` split
+absent then, LANDED 2026-09-11 (the Concurrency record below);
 `spawn_blocking` absent (`Mutex.try_with_lock`,
 `Cond.wait_timeout` and `RwLock.try_with_read`/`try_with_write` all LANDED
 2026-09-10, once v0.2.30 shipped the runtime primitives as the seed)
@@ -813,8 +814,9 @@ say to take an own `Rng.from_entropy()` in a hot loop instead.
 
 **Concurrency.** Verified against the code 2026-09-09 — LANDED:
 `Thread(T).spawn` + `join() -> T` (D18); `Semaphore.with_permit`;
-`try_recv -> TryRecvError{Empty, Disconnected}` (#506). STILL OPEN:
-`Sender`/`Receiver` split with auto-close on last sender; waker-based
+`try_recv -> TryRecvError{Empty, Disconnected}` (#506);
+`Sender`/`Receiver` with auto-close on the last sender (2026-09-11, below).
+STILL OPEN: waker-based
 `yield`/`async channel`/`async mutex` instead of 1 ms timer polls;
 `async/mutex.with_lock` either taking an `io` (so its doc claim becomes true)
 or dropping the claim; `Once.call` rewritten over `Mutex.with_lock`;
@@ -988,6 +990,93 @@ candidates are the `io.spawn` codegen path, how an await of an
 already-completed future suspends, and corruption via the LIFO continuation
 free list. Do not weaken the assertion — it encodes the documented
 cooperative-scheduling contract.
+
+**`Sender`/`Receiver` with auto-close on the last sender — LANDED
+2026-09-11**, in `std/sync/channel.yo` (blocking, cross-thread) and
+`std/async/channel.yo` (one event loop). The row was accurate: nothing of it
+existed, though `TryRecvError` and `SendError`-style value-returning `send`
+already did and are REUSED rather than re-invented.
+
+The shape, and why each part is shaped that way:
+
+- **`Channel(T)` survives, and the split layers on top of it.** `Channel` is
+  genuinely multi-CONSUMER and 40-odd call sites use it that way —
+  `std/thread`'s pool internals, `tests/imm_threading`, the `RwLock` and
+  `Cond` handshakes — so replacing it was never on the table. What the split
+  adds is a LIFETIME the fused handle cannot express: the queue counts its
+  live senders, and the `1 -> 0` transition closes it. Both APIs share one
+  buffer, mutex and pair of condvars; `Sender`/`Receiver` hold a `Channel(T)`
+  and forward.
+- **Exactly one `Receiver` per queue, minted by `Channel(T).receiver(cap)`;
+  `Receiver` is not cloneable.** That single-owner lifetime is the whole point:
+  it makes "the receiver is gone" a fact a sender can act on
+  (`send` then fails with the value rather than blocking on a queue nobody
+  will drain), and a cloneable receiver would take it away. Multi-consumer
+  work keeps using `Channel` directly.
+- **`Receiver.recv() -> Result(T, TryRecvError)`**, `Err` always
+  `Disconnected`. Rust's `RecvError` is a separate unit type; a second error
+  type here would buy nothing, and `Empty` is unreachable for a blocking
+  receive by construction. Buffered values are still handed out one per call
+  BEFORE the disconnect — closing must not lose what the queue already
+  accepted.
+- **The entry point is a static method, not a free `channel(T, cap)`
+  function**, because a free function's `T` has to be a `comptime(T) : Type`
+  PARAMETER, and a function with comptime-but-not-`generic` parameters has its
+  body evaluated at DEFINITION time, where `Channel(T).new(capacity)` cannot
+  resolve ("No matching call found"). Inside `impl(generic(T : Type), ...)` the
+  body is deferred to the call, where `T` is concrete. Measured 2026-09-10 and
+  recorded at the definition.
+- **`Channel(T).pair(cap) -> Tuple(Sender, Receiver)` exists for Rust parity
+  but is NOT the recommended form, and the reason is a measurement**: Yo has no
+  destructuring binding, so `pair` stays in scope beside `tx`/`rx` and holds
+  its own reference to each half — `tx := pair.0` copies a handle rather than
+  moving it out. Dropping `tx` early therefore does not drop the last sender,
+  and the auto-close cannot fire before the whole scope (the `Receiver`
+  included) goes away. The tuple-free `receiver()` + `sender()` pair gives each
+  handle its own lifetime, which is what the feature needs. (The tuple temp is
+  NOT dropped at statement end either, so `Channel(i32).pair(c).0` does not
+  silently poison the channel — measured.)
+- **Memory ordering: `Relaxed` to count up, `AcqRel` to count down.** The
+  increment publishes no data and the handle cannot be used by another thread
+  until it has been transferred there, which is itself synchronizing —
+  `Arc::clone`'s argument. The decrement needs BOTH halves: RELEASE so the
+  values this producer pushed are visible to whoever observes zero, ACQUIRE so
+  the thread that DOES observe zero sees the other producers' pushes before it
+  closes. Only the thread reading `1` closes, so exactly one close happens
+  however many senders drop at once, and `close` itself takes the channel mutex
+  and broadcasts under it — which is what stops a receiver between its
+  predicate check and its park from missing the wake. `std/async/channel`
+  counts with a plain `usize` on purpose: its runtime is single-threaded and
+  cooperative, both mutations run on the loop thread with no suspension point
+  between them, and atomics there would contradict the runtime's own rule.
+- **A dropped `Receiver` sets its own flag, not `_closed`.** `_closed` means
+  "no more values may be sent", the senders' end of the lifetime; keeping the
+  two facts apart is what lets a `Sender` that outlives its receiver report the
+  honest failure instead of looking like a normal close.
+
+**One thing the row asked for does not work across `Thread.spawn`, and it is
+not the channel's fault.** A `Sender` MOVED INTO a spawn closure never runs its
+`dispose`, because a spawn closure's captures are never released
+(`issues/spawn-closure-captures-never-dropped-leak.md`, OPEN, pre-existing,
+filed as a memory leak) — so the count never reaches zero. Measured side by
+side in `issues/repros/thread-spawn-capture-blocks-channel-autoclose.yo`: a
+sender dropped in a plain scope closes the channel, the same sender captured by
+`Thread.spawn` does not. The interim answer is a pattern rather than a trick —
+the parent holds one `keeper` sender while the workers start, and each worker
+mints its own inside its body, where the local's scope-end drop is real — and
+`plans/backlog/SPAWN_CAPTURE_AUTOCLOSE.md` records the codegen fix, the
+rejected std-side alternatives, and why the fix was not bundled here (it needs
+the dup/drop emit-diff gate and a compiler rebuild). `io.async` captures
+release correctly, so the async channel has the full behaviour, producer tasks
+included.
+
+Coverage: `tests/sync/channel.test.yo` 41/41 (+13), `tests/async/channel.test.yo`
+15/15 (+10). Verified RED-FIRST: with the auto-close disabled, six sync and five
+async cases fail. Every blocking wait in them is BOUNDED — the sync tests poll a
+verdict channel against an `Instant` deadline, the async ones wrap the handle in
+`timeout` — because a regression here parks a consumer forever, and an unbounded
+wait would burn a whole CI job's timeout instead of reporting a failure. With the
+feature broken the sync file finishes in 13 s and the async file in 8 s.
 
 ---
 

--- a/plans/backlog/SPAWN_CAPTURE_AUTOCLOSE.md
+++ b/plans/backlog/SPAWN_CAPTURE_AUTOCLOSE.md
@@ -1,0 +1,100 @@
+# Auto-close across `Thread.spawn`: a `Sender` in a spawn closure never drops
+
+**Status:** BACKLOG (written, not started) — 2026-09-11. Written while landing
+the `Sender`/`Receiver` split in `std/sync/channel.yo`
+(`plans/STD_API_STABILIZATION.md`, Concurrency).
+
+**Underlying defect:** `issues/spawn-closure-captures-never-dropped-leak.md`
+(OPEN, pre-existing, filed as a memory leak).
+
+## The gap
+
+`Sender`'s `Dispose` decrements the queue's sender count and closes the
+channel on the `1 -> 0` transition. That is what makes the split's promise
+work: a `Receiver` learns the producers are finished without anyone calling
+`close()`.
+
+A `Sender` **moved into a `Thread.spawn` closure never runs that `dispose`**.
+The spawn emitter (`src/codegen/exprs/parallelism.yo`) heap-copies the capture
+struct and emits `__yo_free(closure)` in its wrapper, but no `___drop` of the
+struct's fields, because the self-hosted compiler synthesizes no
+`___dup`/`___drop` for an anonymous closure-capture struct and both the dup at
+the call site and the drop in the wrapper are emitted only when one resolves.
+The `+1` taken when the capture struct is built is therefore never released,
+the handle's refcount never reaches zero, and its `dispose` never runs.
+
+Values still flow: only the auto-close is lost, and the channel behaves as it
+did before the split (someone must call `close()`).
+
+## Measured
+
+`issues/repros/thread-spawn-capture-blocks-channel-autoclose.yo` — the same
+sender, dropped two ways (macOS arm64, `--optimize 2`, 2026-09-10):
+
+```
+plain scope: closed after the sender's scope ended = true
+spawn capture: closed after join                   = false
+```
+
+The `false` is the whole bug. An `io.async` capture releases correctly, so
+`std/async/channel`'s producer tasks close their channel normally — this is
+specific to the OS-thread spawn path (`__yo_thread_spawn` /
+`__yo_worker_spawn`).
+
+## Blocked call site
+
+`std/sync/channel.yo`, `Sender`'s `Dispose` impl, for the shape a Rust reader
+writes first:
+
+```rust
+tx2 := tx.clone();
+t := Thread.spawn((io) => { tx2.send(v); });   // tx2's dispose never runs
+```
+
+## Options
+
+1. **Fix the codegen (RECOMMENDED).** The fix direction is already written in
+   the issue: synthesize `___dup`/`___drop` for closure-capture structs, or
+   have `_generate_spawn_wrapper` fall back to `generate_drop_code_for_value`
+   over the capture struct's runtime fields, and drop the capture value at the
+   call site once ownership has moved to the heap copy. It also removes an
+   unbounded ~344 B-per-spawn leak that every threaded program pays today.
+   Cost: a compiler change, so it needs the dup/drop emit-diff gate (a
+   mispaired drop here is a double-free, not a leak) and a compiler rebuild —
+   which is why it was not bundled with the std-side PR.
+2. **A `Sender.release()` on the std side.** REJECTED: it is exactly the manual
+   `close()` the split exists to remove, and it would be the only method in
+   std whose documented reason to exist is "the compiler leaks your capture".
+3. **A `spawn_with(sender, cb)` that hands the producer in as an argument.**
+   REJECTED: it encodes a codegen bug in a public signature, and every future
+   captured-handle type would want its own variant.
+4. **Document the mint-inside-the-thread pattern.** SHIPPED as the interim
+   answer, because it is sound rather than a trick: the parent holds one
+   `keeper` sender so the count cannot reach zero while the workers start, and
+   each worker mints its own sender inside its body, where the local's
+   scope-end drop DOES run.
+
+   ```rust
+   rx := Channel(i32).receiver(usize(16));
+   {
+     keeper := rx.sender();
+     w := Thread.spawn((io) => {
+       tx := rx.sender();
+       tx.send(i32(7));
+     });
+     w.join();
+   };                       // keeper drops -> closed
+   ```
+
+   Covered by `tests/sync/channel.test.yo`, "a sender per thread: the last one
+   to finish closes the channel".
+
+## Recommendation
+
+Do option 1 as part of whoever next touches the spawn emitter, and drop the
+`## Producers on other threads` caveat from `std/sync/channel.yo`'s header
+when it lands. Until then option 4 is the documented pattern, and the
+`Receiver`-in-the-thread direction (a consumer thread parked in `recv` while
+the parent's senders drop) needs no care at all — the parent's drops are real
+drops. That direction is what `tests/sync/channel.test.yo`'s two wake-up tests
+exercise.

--- a/std/async/channel.yo
+++ b/std/async/channel.yo
@@ -24,16 +24,43 @@
 //! v := io.await(ch.recv(io), io); // .Some(42)
 //! ```
 //!
+//! ## Two APIs over one channel
+//!
+//! `Channel(T)` is the FUSED handle both ends share, closed by hand.
+//! `Sender(T)`/`Receiver(T)` add a LIFETIME on top of it: the channel counts
+//! its live senders, so dropping the last one closes it and a suspended
+//! `recv` resolves to `Disconnected` instead of waiting for a value nobody
+//! will send. Dropping the `Receiver` makes every further `send` fail.
+//! Exactly one `Receiver` exists per channel, which is what makes "the
+//! receiver is gone" a fact a sender can act on.
+//!
+//! ```rust
+//! rx := Channel(i32).receiver(usize(4));   // channel + its one consumer
+//! {
+//!   tx := rx.sender();                     // a counted producer
+//!   io.await(tx.send(i32(1), io), io);
+//! };                                       // last sender dropped -> closed
+//! io.await(rx.recv(io), io);               // .Ok(1)
+//! io.await(rx.recv(io), io);               // .Err(Disconnected)
+//! ```
+//!
+//! A `Sender` captured by an `io.async` body IS released when the task and
+//! its future are done, so a producer task's sender closes the channel like
+//! any other — unlike a `Thread.spawn` capture on the blocking channel
+//! (`issues/spawn-closure-captures-never-dropped-leak.md`).
+//!
 //! ## Stability
 //!
-//! unstable — `recv` answers `Option(T)`, where `.None` means the channel
-//! closed, and whether that should be a `Result` the way `try_recv`'s answer
-//! now is remains open. The 1 ms timer tick above is an implementation choice
-//! a waker-based rewrite would remove, which changes handoff latency but no
-//! signature.
+//! unstable — `Channel.recv` answers `Option(T)`, where `.None` means the
+//! channel closed, and whether that should be a `Result` the way `try_recv`'s
+//! answer now is remains open. (`Receiver.recv`, the split's consumer, IS
+//! already a `Result(T, TryRecvError)`.) The 1 ms timer tick above is an
+//! implementation choice a waker-based rewrite would remove, which changes
+//! handoff latency but no signature.
 //!
 //! `new`, `send`, `try_send`, `try_recv`, `close`, `is_closed` and `len` are
-//! intended to keep their names and meanings.
+//! intended to keep their names and meanings, as are `receiver`, `pair`,
+//! `Receiver.sender` and `Sender.clone`.
 { ArrayList } :: import("../collections/array_list");
 // The SAME `TryRecvError` the blocking channel reports, so a caller that
 // polls both does not need two vocabularies for one distinction.
@@ -47,7 +74,21 @@ Channel :: (fn(comptime(T) : Type) -> comptime(Type))(
     struct(
       _buf : ArrayList(T),
       _capacity : usize,
-      _closed : bool
+      _closed : bool,
+      /// How many live `Sender(T)` handles share this channel. Zero for a
+      /// `Channel` created with `new` and used directly: nothing counts down,
+      /// so nothing auto-closes. `receiver()`/`pair()` start it at one.
+      ///
+      /// Plain `usize`, not an atomic: Yo's async runtime is per-thread and
+      /// cooperative, so every increment and decrement runs on the one loop
+      /// thread with no suspension point in between. An atomic here would buy
+      /// nothing and would contradict the runtime's own rule against
+      /// synchronizing its single-threaded state.
+      _senders : usize,
+      /// Set once the `Receiver(T)` handle has been dropped, which makes every
+      /// further `send` fail instead of suspending on a channel nobody will
+      /// drain.
+      _recv_dropped : bool
     )
   )
 );
@@ -57,17 +98,27 @@ impl(
   /// A channel holding at most `capacity` buffered values (must be > 0).
   new : (fn(capacity : usize) -> Self)({
     assert(capacity > usize(0), "Channel.new: capacity must be > 0");
-    Self(_buf : ArrayList(T).new(), _capacity : capacity, _closed : false)
+    Self(
+      _buf : ArrayList(T).new(),
+      _capacity : capacity,
+      _closed : false,
+      _senders : usize(0),
+      _recv_dropped : false
+    )
   }),
   /// Send a value, suspending while the buffer is full. Resolves to
   /// `.Ok(())` once buffered, or `.Err(value)` if the channel is (or
-  /// becomes) closed — the failed value is handed back.
+  /// becomes) closed, or its `Receiver` has been dropped — the failed value
+  /// is handed back.
   send : (fn(self : Self, value : T, io : Io) -> Impl(Future(Result(unit, T))))(
     io.async((io : Io) => {
       (waiting : bool) = true;
       while(waiting, {
         cond(
           self._closed => {
+            waiting = false;
+          },
+          self._recv_dropped => {
             waiting = false;
           },
           (self._buf.len() < self._capacity) => {
@@ -81,6 +132,7 @@ impl(
       });
       cond(
         self._closed => return(Result(unit, T).Err(value)),
+        self._recv_dropped => return(Result(unit, T).Err(value)),
         true => {
           // No suspension between the capacity check and this push, so no
           // other task can interleave (single-threaded cooperative loop).
@@ -119,10 +171,11 @@ impl(
     })
   ),
   /// Try to send without suspending: `.Ok(())` if buffered, `.Err(value)`
-  /// if the channel is full or closed.
+  /// if the channel is full, closed, or has no `Receiver` any more.
   try_send : (fn(self : Self, value : T) -> Result(unit, T))(
     cond(
       self._closed => Result(unit, T).Err(value),
+      self._recv_dropped => Result(unit, T).Err(value),
       (self._buf.len() >= self._capacity) => Result(unit, T).Err(value),
       true => {
         self._buf.push(value);
@@ -157,6 +210,12 @@ impl(
   close : (fn(self : Self) -> unit)({
     self._closed = true;
   }),
+  /// Record that this channel's `Receiver` handle is gone: every further
+  /// `send` fails, and a task suspended on a full buffer finds out on its
+  /// next tick. Internal — `Receiver`'s `dispose` is the only caller.
+  _mark_receiver_dropped : (fn(self : Self) -> unit)({
+    self._recv_dropped = true;
+  }),
   /// True once `close()` has been called.
   is_closed : (fn(self : Self) -> bool)(
     self._closed
@@ -165,5 +224,207 @@ impl(
   len : (fn(self : Self) -> usize)(
     self._buf.len()
   )
+);
+/// The sending half of an async channel pair — the same `Sender`/`Receiver`
+/// split `std/sync/channel` has, for tasks on one event loop.
+///
+/// Cloneable: every clone is another producer over the same channel, and the
+/// channel counts them. When the LAST `Sender` is dropped the channel closes
+/// itself, so a `Receiver` learns that no more values are coming without
+/// anyone remembering to call `close()` — a `recv` that would otherwise
+/// suspend forever resolves to `Disconnected` instead.
+Sender :: (fn(comptime(T) : Type) -> comptime(Type))(
+  ref(struct(_ch : Channel(T)))
+);
+export(Sender);
+/// The receiving half of an async channel pair.
+///
+/// Deliberately NOT cloneable, so that "the receiver is gone" is a fact a
+/// sender can act on; `Channel(T).receiver` mints exactly one per channel.
+Receiver :: (fn(comptime(T) : Type) -> comptime(Type))(
+  ref(struct(_ch : Channel(T)))
+);
+export(Receiver);
+impl(
+  generic(T : Type),
+  Sender(T),
+  /// Attach a new producer to `ch` and count it. Internal: `Channel.receiver`,
+  /// `Channel.pair`, `Receiver.sender` and `clone` are the callers.
+  _attach : (fn(ch : Channel(T)) -> Self)({
+    ch._senders = (ch._senders + usize(1));
+    Self(_ch : ch)
+  }),
+  /// Send a value, suspending while the buffer is full. `.Err(value)` once
+  /// the channel is closed or the `Receiver` is gone (Rust's `SendError(T)`).
+  send : (fn(self : Self, value : T, io : Io) -> Impl(Future(Result(unit, T))))(
+    self._ch.send(value, io)
+  ),
+  /// Send without suspending: `.Err(value)` if the buffer is full, the
+  /// channel is closed, or the `Receiver` is gone.
+  try_send : (fn(self : Self, value : T) -> Result(unit, T))(
+    self._ch.try_send(value)
+  ),
+  /// True once the channel is closed — by an explicit `close()`, or by the
+  /// last `Sender` being dropped.
+  is_closed : (fn(self : Self) -> bool)(
+    self._ch.is_closed()
+  ),
+  /// Number of values currently buffered.
+  len : (fn(self : Self) -> usize)(
+    self._ch.len()
+  ),
+  /// Close the channel now, without waiting for the other senders to go.
+  close : (fn(self : Self) -> unit)(
+    self._ch.close()
+  )
+);
+impl(
+  generic(T : Type),
+  Sender(T),
+  /// Another producer over the same channel, counted.
+  Clone(
+    clone : (fn(inout(self) : Self) -> Self)({
+      self._ch._senders = (self._ch._senders + usize(1));
+      Self(_ch : self._ch)
+    })
+  )
+);
+impl(
+  generic(T : Type),
+  Sender(T),
+  /// Dropping a `Sender` gives up its stake in the channel; dropping the LAST
+  /// one closes it, which is what lets a suspended `recv` resolve.
+  ///
+  /// No atomics and no ordering to get right, unlike the blocking channel's
+  /// version: the decrement and the `close` both run on the single event-loop
+  /// thread with no suspension point between them, so no other task can
+  /// observe the count between the two.
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      self._ch._senders = (self._ch._senders - usize(1));
+      if(self._ch._senders == usize(0), {
+        self._ch.close();
+      });
+    })
+  )
+);
+impl(
+  generic(T : Type),
+  Receiver(T),
+  /// Attach the consumer to `ch`. Internal: `Channel.receiver` and
+  /// `Channel.pair` are the only callers.
+  _attach : (fn(ch : Channel(T)) -> Self)(
+    Self(_ch : ch)
+  ),
+  /// Mint a producer for this channel, counted like every other `Sender`.
+  ///
+  /// This is how the first sender is created after `Channel(T).receiver(...)`
+  /// and how a fan-in of producer tasks is set up. A sender minted after the
+  /// channel has already closed does not reopen it — its sends fail.
+  sender : (fn(self : Self) -> Sender(T))(
+    Sender(T)._attach(self._ch)
+  ),
+  /// Receive the oldest value, suspending while the channel is empty.
+  ///
+  /// `.Err(TryRecvError.Disconnected)` once the channel is closed AND drained
+  /// — which happens on its own when the last `Sender` is dropped. Same
+  /// `TryRecvError` as `try_recv` rather than a second error type, and
+  /// `Empty` is impossible here: a suspending receive that found the channel
+  /// empty and open would have kept waiting.
+  ///
+  /// Values already buffered when the last sender went away are still handed
+  /// out, one per call, BEFORE the disconnect is reported.
+  recv : (fn(self : Self, io : Io) -> Impl(Future(Result(T, TryRecvError))))(
+    io.async((io : Io) => {
+      // Bound first, matched second: an `io.await` in a match SCRUTINEE is one
+      // of the async-body shapes that miscompiles to an empty value.
+      got := io.await(self._ch.recv(io), io);
+      match(
+        got,
+        .Some(v) => Result(T, TryRecvError).Ok(v),
+        .None => Result(T, TryRecvError).Err(TryRecvError.Disconnected)
+      )
+    })
+  ),
+  /// Receive without suspending: `.Ok(value)`, `Empty` while the channel is
+  /// open but has nothing buffered, `Disconnected` once it is closed and
+  /// drained.
+  try_recv : (fn(self : Self) -> Result(T, TryRecvError))(
+    self._ch.try_recv()
+  ),
+  /// True once the channel is closed — including by the last `Sender` being
+  /// dropped. Buffered values may still be waiting; `try_recv` answering
+  /// `Disconnected` is the closed-AND-drained test.
+  is_closed : (fn(self : Self) -> bool)(
+    self._ch.is_closed()
+  ),
+  /// Number of values currently buffered.
+  len : (fn(self : Self) -> usize)(
+    self._ch.len()
+  ),
+  /// Stop accepting values now. Buffered values still come out of `recv`,
+  /// then it reports `Disconnected`.
+  close : (fn(self : Self) -> unit)(
+    self._ch.close()
+  )
+);
+impl(
+  generic(T : Type),
+  Receiver(T),
+  /// Dropping the consumer disconnects the channel from the sending side:
+  /// there is nobody left to drain it, so a `send` that would suspend on a
+  /// full buffer fails instead.
+  ///
+  /// It does NOT mark the channel closed: `_closed` means "no more values may
+  /// be sent", the SENDERS' end of the lifetime, and keeping the two facts
+  /// apart is what lets a `Sender` that outlives the receiver report the
+  /// honest failure.
+  Dispose(
+    dispose : (fn(self : Self) -> unit)(
+      self._ch._mark_receiver_dropped()
+    )
+  )
+);
+impl(
+  generic(T : Type),
+  Channel(T),
+  /// Create a channel and its single consumer — the tuple-free half of the
+  /// `Sender`/`Receiver` split. Mint producers with `Receiver.sender()` and
+  /// `Sender.clone()`.
+  ///
+  /// ```rust
+  /// rx := Channel(i32).receiver(usize(4));
+  /// tx := rx.sender();
+  /// _s := io.await(tx.send(i32(1), io), io);
+  /// v := io.await(rx.recv(io), io).unwrap();
+  /// ```
+  ///
+  /// This is the form to use when the end of the stream matters: each handle
+  /// is its own binding and therefore has its own lifetime, so dropping the
+  /// last `Sender` closes the channel while the `Receiver` is still alive to
+  /// notice. `pair` cannot do that — see its note.
+  ///
+  /// A `Receiver` with no `Sender` yet is not closed, so `recv` on it
+  /// suspends; mint the senders before receiving.
+  receiver : (fn(capacity : usize) -> Receiver(T))(
+    Receiver(T)._attach(Self.new(capacity))
+  ),
+  /// Create a channel and hand back both halves at once — the shape of Rust's
+  /// `mpsc::sync_channel(capacity)` (this channel is bounded, like the
+  /// blocking one).
+  ///
+  /// **The tuple keeps both handles alive for as long as the tuple binding
+  /// lives** (measured 2026-09-10): Yo has no destructuring binding, so
+  /// `tx := pair.0` copies a handle out rather than moving it, and the tuple
+  /// holds its own reference to each half. Dropping `tx` early therefore does
+  /// NOT drop the last sender, and the auto-close fires only when the whole
+  /// scope — `Receiver` included — goes away. Use this form when the producer
+  /// tasks and the consumer share a scope, or call `close()` explicitly; use
+  /// `receiver()` + `sender()` when the receiver must learn that the
+  /// producers are finished.
+  pair : (fn(capacity : usize) -> Tuple(Sender(T), Receiver(T)))({
+    ch := Self.new(capacity);
+    (Sender(T)._attach(ch), Receiver(T)._attach(ch))
+  })
 );
 export(Channel, TryRecvError);

--- a/std/sync/channel.yo
+++ b/std/sync/channel.yo
@@ -18,6 +18,62 @@
 //! assert((val.unwrap() == i32(42)), "received value");
 //! t.join();
 //! ```
+//!
+//! ## Two APIs over one queue, and why both exist
+//!
+//! `Channel(T)` is the FUSED handle: one object that both ends hold, closed
+//! by hand. It is genuinely multi-consumer — several threads may `recv` from
+//! it — and that is what `std/thread`'s pool internals and the cross-thread
+//! tests use it for, so it stays.
+//!
+//! `Sender(T)`/`Receiver(T)` add the piece a fused handle cannot express: a
+//! LIFETIME. The queue counts its live senders, so dropping the last one
+//! closes the channel and a `Receiver` finds out that no more values are
+//! coming — no `close()` call to remember, and no consumer parked forever on
+//! a queue whose producers have all finished. Dropping the `Receiver`
+//! symmetrically makes every further `send` fail instead of blocking on a
+//! queue nobody will drain. The price is the single consumer: exactly one
+//! `Receiver` exists per queue, which is what makes "the receiver is gone" a
+//! fact worth acting on. The split is a layer ON TOP of `Channel`, sharing
+//! the same buffer, mutex and condvars.
+//!
+//! ```rust
+//! { Channel } :: import "std/sync/channel";
+//!
+//! rx := Channel(i32).receiver(usize(4));   // queue + its one consumer
+//! {
+//!   tx := rx.sender();                     // a counted producer
+//!   tx.send(i32(1));
+//! };                                       // last sender dropped -> closed
+//! rx.recv().unwrap();                      // 1
+//! rx.recv();                               // .Err(Disconnected)
+//! ```
+//!
+//! ## Producers on other threads
+//!
+//! Mint each producer's `Sender` INSIDE its thread and keep one in the parent
+//! until the workers are running:
+//!
+//! ```rust
+//! rx := Channel(i32).receiver(usize(16));
+//! {
+//!   keeper := rx.sender();                 // holds the count above zero
+//!   w := Thread.spawn((io) => {
+//!     tx := rx.sender();                   // this thread's producer
+//!     tx.send(i32(7));
+//!   });                                    // tx drops when the body ends
+//!   w.join();
+//! };                                       // keeper drops -> closed
+//! ```
+//!
+//! A `Sender` MOVED INTO a `Thread.spawn` closure instead does not work
+//! today: a spawn closure's captures are never released
+//! (`issues/spawn-closure-captures-never-dropped-leak.md`), so such a
+//! sender's `dispose` never runs and the count never reaches zero. Values
+//! still flow — only the auto-close is lost.
+//! `plans/backlog/SPAWN_CAPTURE_AUTOCLOSE.md` tracks the fix; async tasks
+//! (`std/async/channel`) release their captures correctly and need no such
+//! care.
 pragma(Pragma.AllowUnsafe);
 { GlobalAllocator } :: import("../allocator");
 { malloc, free } :: GlobalAllocator;
@@ -77,7 +133,16 @@ Channel :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type
         _mutex : Mutex(bool),
         _not_empty : Cond,
         _not_full : Cond,
-        _closed : AtomicBool
+        _closed : AtomicBool,
+        /// How many live `Sender(T)` handles share this queue. Zero for a
+        /// `Channel` created with `new` and used directly: nothing counts
+        /// down, so nothing auto-closes. `receiver()` and `pair()` start it
+        /// at one, and every `Sender.clone()` adds another.
+        _senders : AtomicUsize,
+        /// Set once the `Receiver(T)` handle has been dropped, which makes
+        /// every further `send` fail instead of blocking on a queue nobody
+        /// will drain. False forever for a directly-used `Channel`.
+        _recv_dropped : AtomicBool
       )
     )
   )
@@ -104,26 +169,36 @@ impl(
         _mutex : Mutex(bool).new(false),
         _not_empty : Cond.new(),
         _not_full : Cond.new(),
-        _closed : AtomicBool(false)
+        _closed : AtomicBool(false),
+        _senders : AtomicUsize(usize(0)),
+        _recv_dropped : AtomicBool(false)
       )
     );
   }),
   /// Send a value into the channel.
   /// Blocks if the channel is full until space becomes available.
-  /// Returns .Ok(()) on success, .Err(value) if the channel is closed —
-  /// the failed value is handed BACK to the caller instead of being
-  /// silently dropped (Rust's `SendError(T)`; plans/archive/STD_API_AUDIT.md C8).
+  /// Returns .Ok(()) on success, .Err(value) if the channel is closed or its
+  /// `Receiver` has been dropped — the failed value is handed BACK to the
+  /// caller instead of being silently dropped (Rust's `SendError(T)`;
+  /// plans/archive/STD_API_AUDIT.md C8).
   send : (fn(self : Self, value : T) -> Result(unit, T))({
     self._mutex._raw_lock();
-    // Wait while buffer is full and channel is not closed
+    // Wait while the buffer is full and there is still a point in waiting:
+    // a closed channel takes no more values, and a channel whose `Receiver`
+    // has been dropped will never be drained, so blocking on either would
+    // block forever.
     while(runtime(
       (self._len.load(MemoryOrder.Relaxed) >= self._capacity)
       && !self._closed.load(MemoryOrder.Relaxed)
+      && !self._recv_dropped.load(MemoryOrder.Relaxed)
     ), {
       self._not_full.wait(self._mutex._raw_handle_ptr());
     });
     cond(
-      self._closed.load(MemoryOrder.Relaxed) => {
+      (
+        self._closed.load(MemoryOrder.Relaxed)
+        || self._recv_dropped.load(MemoryOrder.Relaxed)
+      ) => {
         self._mutex._raw_unlock();
         return(.Err(value));
       },
@@ -176,6 +251,7 @@ impl(
     cond(
       (
         self._closed.load(MemoryOrder.Relaxed)
+        || self._recv_dropped.load(MemoryOrder.Relaxed)
         || (self._len.load(MemoryOrder.Relaxed) >= self._capacity)
       ) => {
         self._mutex._raw_unlock();
@@ -230,6 +306,20 @@ impl(
     self._not_full.broadcast();
     self._mutex._raw_unlock();
   }),
+  /// Record that this queue's `Receiver` handle is gone: every further
+  /// `send` fails, and senders parked on a full buffer wake up to find out.
+  ///
+  /// Internal — `Receiver`'s `dispose` is the only caller. The flag is set
+  /// and the waiters are woken with the mutex HELD, for the same reason
+  /// `close` does it: a sender that has evaluated its wait predicate but not
+  /// yet parked still holds the mutex, so a broadcast issued outside it could
+  /// land before the park and be lost.
+  _mark_receiver_dropped : (fn(self : Self) -> unit)({
+    self._mutex._raw_lock();
+    self._recv_dropped.store(true, MemoryOrder.Release);
+    self._not_full.broadcast();
+    self._mutex._raw_unlock();
+  }),
   /// Check if the channel is closed (lock-free atomic load).
   is_closed : (fn(self : Self) -> bool)(
     self._closed.load(MemoryOrder.Acquire)
@@ -262,5 +352,260 @@ impl(
       free(.Some((*void)(self._data)));
     })
   )
+);
+/// The sending half of a `Channel(T).receiver`/`pair` split — Rust's
+/// `mpsc::Sender<T>`.
+///
+/// Cloneable: every clone is another producer over the SAME queue, and the
+/// queue counts them. When the LAST `Sender` is dropped the channel closes
+/// itself, which is the whole point of the split — a `Receiver` learns that
+/// no more values are coming without anyone remembering to call `close()`,
+/// and a blocked `recv` wakes up rather than parking forever.
+///
+/// `atomic(ref(...))` for the same reason `Channel` is: the handle is meant
+/// to be moved into another thread, and its reference count has to be atomic
+/// for that to be sound.
+Sender :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
+  atomic(ref(struct(_ch : Channel(T))))
+);
+export(Sender);
+/// The receiving half of a `Channel(T).receiver`/`pair` split — Rust's
+/// `mpsc::Receiver<T>`.
+///
+/// Deliberately NOT cloneable, so that "the receiver is gone" is a fact a
+/// sender can act on. (The underlying `Channel` is MPMC and a second consumer
+/// is expressible by sharing the `Channel` itself; what a `Receiver` adds is
+/// the single-owner lifetime, and cloning it would take that away.)
+Receiver :: (fn(comptime(T) : Type, where(T <: (Send, Acyclic))) -> comptime(Type))(
+  atomic(ref(struct(_ch : Channel(T))))
+);
+export(Receiver);
+// Both handles hold one `Channel(T)` and nothing else, so neither can be part
+// of a cycle as long as the element type cannot — the same residual argument
+// `Channel(T)` itself carries.
+impl(generic(T : Type), where(T <: (Send, Acyclic)), Sender(T), Acyclic());
+impl(generic(T : Type), where(T <: (Send, Acyclic)), Receiver(T), Acyclic());
+impl(
+  generic(T : Type),
+  Sender(T),
+  where(T <: (Send, Acyclic)),
+  /// Attach a new producer to `ch` and count it. Internal: `Channel.receiver`,
+  /// `Channel.pair`, `Receiver.sender` and `clone` are the callers.
+  ///
+  /// The increment is `Relaxed`, exactly as `Arc::clone`'s is: it publishes
+  /// no data, and the handle it produces cannot be used by another thread
+  /// until it has been moved there, which is itself a synchronizing transfer.
+  _attach : (fn(ch : Channel(T)) -> Self)({
+    _prev := ch._senders.fetch_add(usize(1), MemoryOrder.Relaxed);
+    Self(_ch : ch)
+  }),
+  /// Send a value, blocking while the buffer is full.
+  ///
+  /// `.Err(value)` — Rust's `SendError(T)` — once the channel is closed or
+  /// the `Receiver` has been dropped; the value that could not be sent comes
+  /// back rather than being dropped on the floor.
+  send : (fn(self : Self, value : T) -> Result(unit, T))(
+    self._ch.send(value)
+  ),
+  /// Send without blocking: `.Err(value)` if the buffer is full, the channel
+  /// is closed, or the `Receiver` is gone.
+  try_send : (fn(self : Self, value : T) -> Result(unit, T))(
+    self._ch.try_send(value)
+  ),
+  /// True once the channel is closed — by an explicit `close()`, or by the
+  /// last `Sender` being dropped.
+  is_closed : (fn(self : Self) -> bool)(
+    self._ch.is_closed()
+  ),
+  /// Number of values currently buffered (a snapshot, like `Channel.len`).
+  len : (fn(self : Self) -> usize)(
+    self._ch.len()
+  ),
+  /// Close the channel now, without waiting for the other senders to go.
+  /// Every `Sender`'s subsequent `send` fails and the `Receiver` drains what
+  /// is buffered and then reports `Disconnected`.
+  close : (fn(self : Self) -> unit)(
+    self._ch.close()
+  )
+);
+impl(
+  generic(T : Type),
+  Sender(T),
+  where(T <: (Send, Acyclic)),
+  /// Another producer over the same queue, counted.
+  Clone(
+    clone : (fn(inout(self) : Self) -> Self)({
+      _prev := self._ch._senders.fetch_add(usize(1), MemoryOrder.Relaxed);
+      Self(_ch : self._ch)
+    })
+  )
+);
+impl(
+  generic(T : Type),
+  Sender(T),
+  where(T <: (Send, Acyclic)),
+  /// Dropping a `Sender` gives up its stake in the queue; dropping the LAST
+  /// one closes the channel.
+  ///
+  /// The decrement is `AcqRel`, and both halves are load-bearing. RELEASE:
+  /// everything this producer did — every value it pushed — precedes the
+  /// decrement in program order, so the release makes that work visible to
+  /// whoever observes the count reaching zero. ACQUIRE: the thread that DOES
+  /// observe zero is about to close the channel and so must see the other
+  /// producers' pushes, which their own releases published. A `Relaxed`
+  /// decrement would let the closing thread run `close` with a stale view of
+  /// the queue.
+  ///
+  /// Only the thread that reads `1` closes, so exactly one close happens no
+  /// matter how many senders drop at once. `close` itself takes the channel
+  /// mutex and broadcasts under it, which is what makes a receiver that is
+  /// between its predicate check and its park wake up instead of blocking
+  /// forever.
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      (prev : usize) = self._ch._senders.fetch_sub(usize(1), MemoryOrder.AcqRel);
+      if(prev == usize(1), {
+        self._ch.close();
+      });
+    })
+  )
+);
+impl(
+  generic(T : Type),
+  Receiver(T),
+  where(T <: (Send, Acyclic)),
+  /// Attach the consumer to `ch`. Internal: `Channel.receiver` and
+  /// `Channel.pair` are the only callers.
+  _attach : (fn(ch : Channel(T)) -> Self)(
+    Self(_ch : ch)
+  ),
+  /// Mint a producer for this queue, counted like every other `Sender`.
+  ///
+  /// This is how the first sender is created after `Channel(T).receiver(...)`,
+  /// and how a fan-in is set up: one `sender()` per producer, or one plus
+  /// `clone()`s. Each of them keeps the channel open until it is dropped.
+  ///
+  /// A sender minted after the channel has already closed does NOT reopen it
+  /// — `_closed` is one-way — so its sends fail; mint the producers while the
+  /// previous ones are still alive.
+  sender : (fn(self : Self) -> Sender(T))(
+    Sender(T)._attach(self._ch)
+  ),
+  /// Receive the oldest value, blocking while the channel is empty.
+  ///
+  /// `.Err(TryRecvError.Disconnected)` once the channel is closed AND
+  /// drained — which happens on its own when the last `Sender` is dropped.
+  /// It is the same `TryRecvError` `try_recv` reports rather than a second
+  /// error type, and `Empty` is impossible here: a blocking receive that
+  /// found the channel empty and open would have kept waiting.
+  ///
+  /// Values already queued when the last sender went away are still handed
+  /// out, one per call, BEFORE the disconnect is reported — closing a channel
+  /// must not lose what it already accepted (Rust guarantees the same).
+  recv : (fn(self : Self) -> Result(T, TryRecvError))(
+    match(
+      self._ch.recv(),
+      .Some(v) => Result(T, TryRecvError).Ok(v),
+      .None => Result(T, TryRecvError).Err(TryRecvError.Disconnected)
+    )
+  ),
+  /// Receive without blocking: `.Ok(value)`, `Empty` while the channel is
+  /// open but has nothing buffered, `Disconnected` once it is closed and
+  /// drained.
+  try_recv : (fn(self : Self) -> Result(T, TryRecvError))(
+    self._ch.try_recv()
+  ),
+  /// True once the channel is closed — including by the last `Sender` being
+  /// dropped. Buffered values may still be waiting; `try_recv` answering
+  /// `Disconnected` is the closed-AND-drained test.
+  is_closed : (fn(self : Self) -> bool)(
+    self._ch.is_closed()
+  ),
+  /// Number of values currently buffered (a snapshot, like `Channel.len`).
+  len : (fn(self : Self) -> usize)(
+    self._ch.len()
+  ),
+  /// True while nothing is buffered (a snapshot).
+  is_empty : (fn(self : Self) -> bool)(
+    self._ch.is_empty()
+  ),
+  /// Stop accepting values now. Buffered values still come out of `recv`,
+  /// then it reports `Disconnected`.
+  close : (fn(self : Self) -> unit)(
+    self._ch.close()
+  )
+);
+impl(
+  generic(T : Type),
+  Receiver(T),
+  where(T <: (Send, Acyclic)),
+  /// Dropping the consumer disconnects the queue from the sending side:
+  /// there is nobody left to drain it, so a `send` that would block on a full
+  /// buffer fails instead, and senders already parked are woken to find out.
+  ///
+  /// It does NOT mark the channel closed: `_closed` means "no more values may
+  /// be sent", which is the SENDERS' end of the lifetime, and keeping the two
+  /// facts apart is what lets a `Sender` that outlives the receiver report
+  /// the honest failure. The buffered values are released when the last
+  /// handle drops the `Channel` itself (its `dispose`).
+  Dispose(
+    dispose : (fn(self : Self) -> unit)(
+      self._ch._mark_receiver_dropped()
+    )
+  )
+);
+impl(
+  generic(T : Type),
+  Channel(T),
+  where(T <: (Send, Acyclic)),
+  /// Create a bounded queue and its single consumer — the tuple-free half of
+  /// the `Sender`/`Receiver` split. Mint producers with `Receiver.sender()`
+  /// and `Sender.clone()`.
+  ///
+  /// ```rust
+  /// { Channel } :: import "std/sync/channel";
+  /// rx := Channel(i32).receiver(usize(4));
+  /// tx := rx.sender();
+  /// tx.send(i32(1));
+  /// v := rx.recv().unwrap();
+  /// ```
+  ///
+  /// This is the form to use when the end of the stream matters, because each
+  /// handle is its own binding and therefore has its own lifetime: dropping
+  /// the last `Sender` closes the channel while the `Receiver` is still
+  /// alive to notice. `pair` below cannot do that — see its note.
+  ///
+  /// Exactly one `Receiver` exists per queue by construction, which is what
+  /// makes "the receiver is gone" a fact a sender can act on.
+  ///
+  /// A `Receiver` that has no `Sender` yet is not closed — nothing has been
+  /// dropped — so `recv` on it blocks, exactly as `Channel.recv` on a queue
+  /// nobody sends to does. Mint the senders before receiving.
+  receiver : (fn(capacity : usize) -> Receiver(T))(
+    Receiver(T)._attach(Self.new(capacity))
+  ),
+  /// Create a bounded queue and hand back both halves at once — the shape of
+  /// Rust's `mpsc::sync_channel(capacity)`.
+  ///
+  /// ```rust
+  /// pair := Channel(i32).pair(usize(4));
+  /// tx := pair.0;
+  /// rx := pair.1;
+  /// ```
+  ///
+  /// **The tuple keeps both handles alive for as long as the tuple binding
+  /// lives** (measured 2026-09-10). Yo has no destructuring binding, so `pair`
+  /// stays in scope beside `tx` and `rx` and holds its own reference to each
+  /// half; `tx := pair.0` copies a handle rather than moving it out. The
+  /// consequence is specific: dropping `tx` early does NOT drop the last
+  /// sender, so the auto-close does not fire until the whole scope — the
+  /// `Receiver` included — goes away. Use this form when the producers and
+  /// the consumer share a scope and the count of values is known, or call
+  /// `close()` explicitly; use `receiver()` + `sender()` when the receiver
+  /// needs to learn that the producers are finished.
+  pair : (fn(capacity : usize) -> Tuple(Sender(T), Receiver(T)))({
+    ch := Self.new(capacity);
+    (Sender(T)._attach(ch), Receiver(T)._attach(ch))
+  })
 );
 export(Channel);

--- a/tests/async/channel.test.yo
+++ b/tests/async/channel.test.yo
@@ -2,7 +2,9 @@
 //! (`plans/archive/STD_API_AUDIT.md` §7 P0 item 6 / D7).
 pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
-{ Channel } :: import("std/async/channel");
+{ Channel, Sender, Receiver, TryRecvError } :: import("std/async/channel");
+{ timeout } :: import("std/async");
+{ Duration } :: import("std/time/duration");
 { sleep } :: import("std/sys/timer");
 
 // ---------------------------------------------------------------------------
@@ -108,4 +110,172 @@ test("Test channel recv waits for sender", {
   r := io.await(ch.recv(io), io);
   assert(match(r, .Some(v) => (v == i32(99)), .None => false), "recv should wake for the late send");
   _done := h.await(io);
+});
+// ---------------------------------------------------------------------------
+// 5. Sender / Receiver split — auto-close when the last Sender is dropped
+// ---------------------------------------------------------------------------
+// The suspending cases below are BOUNDED with `timeout`: a regression in the
+// auto-close leaves the consumer task suspended forever, and an unbounded
+// `await` here would burn a whole CI job's timeout instead of reporting a
+// failure.
+test("async Sender/Receiver deliver values in order", {
+  rx := Channel(i32).receiver(usize(4));
+  tx := rx.sender();
+  s1 := io.await(tx.send(i32(1), io), io);
+  s2 := io.await(tx.send(i32(2), io), io);
+  assert(match(s1, .Ok(_) => true, .Err(_) => false), "first send");
+  assert(match(s2, .Ok(_) => true, .Err(_) => false), "second send");
+  r1 := io.await(rx.recv(io), io);
+  r2 := io.await(rx.recv(io), io);
+  assert(match(r1, .Ok(v) => (v == i32(1)), .Err(_) => false), "FIFO: 1 first");
+  assert(match(r2, .Ok(v) => (v == i32(2)), .Err(_) => false), "FIFO: then 2");
+  assert(!rx.is_closed(), "a live sender keeps the channel open");
+});
+test("async Channel.pair hands back both halves over one channel", {
+  pair := Channel(i32).pair(usize(2));
+  tx := pair.0;
+  rx := pair.1;
+  s := io.await(tx.send(i32(11), io), io);
+  assert(match(s, .Ok(_) => true, .Err(_) => false), "the pair's sender sends");
+  r := io.await(rx.recv(io), io);
+  assert(match(r, .Ok(v) => (v == i32(11)), .Err(_) => false), "the pair's receiver receives it");
+});
+test("async: dropping the LAST Sender closes the channel", {
+  rx := Channel(i32).receiver(usize(4));
+  {
+    tx := rx.sender();
+    assert(!rx.is_closed(), "open while a sender lives");
+    _s := io.await(tx.send(i32(5), io), io);
+  };
+  assert(rx.is_closed(), "the last sender's drop closed the channel");
+});
+test("async: dropping ONE of several Senders does NOT close the channel", {
+  rx := Channel(i32).receiver(usize(4));
+  tx := rx.sender();
+  {
+    tx2 := tx.clone();
+    _s := io.await(tx2.send(i32(1), io), io);
+  };
+  assert(!rx.is_closed(), "one of two senders going away is not the end of the stream");
+  s := io.await(tx.send(i32(2), io), io);
+  assert(match(s, .Ok(_) => true, .Err(_) => false), "the surviving sender still sends");
+});
+test("async: buffered values arrive before the disconnect", {
+  rx := Channel(i32).receiver(usize(4));
+  {
+    tx := rx.sender();
+    _a := io.await(tx.send(i32(7), io), io);
+    _b := io.await(tx.send(i32(8), io), io);
+  };
+  assert(rx.is_closed(), "closed by the drop");
+  r1 := io.await(rx.recv(io), io);
+  r2 := io.await(rx.recv(io), io);
+  r3 := io.await(rx.recv(io), io);
+  assert(match(r1, .Ok(v) => (v == i32(7)), .Err(_) => false), "buffered 7 survives the close");
+  assert(match(r2, .Ok(v) => (v == i32(8)), .Err(_) => false), "buffered 8 survives the close");
+  assert(
+    match(r3, .Ok(_) => false, .Err(e) => (e == TryRecvError.Disconnected)),
+    "only THEN is it Disconnected"
+  );
+});
+test("async: try_recv is Empty while open and Disconnected once senders are gone", {
+  rx := Channel(i32).receiver(usize(4));
+  {
+    tx := rx.sender();
+    assert(
+      match(rx.try_recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Empty)),
+      "open and empty says Empty — the producer may still send"
+    );
+    _s := io.await(tx.send(i32(3), io), io);
+  };
+  assert(match(rx.try_recv(), .Ok(v) => (v == i32(3)), .Err(_) => false), "the buffered value first");
+  assert(
+    match(rx.try_recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Disconnected)),
+    "closed AND drained says Disconnected"
+  );
+});
+test("async: send fails once the Receiver has been dropped", {
+  ch := Channel(i32).new(usize(1));
+  tx := Sender(i32)._attach(ch);
+  {
+    rx := Receiver(i32)._attach(ch);
+    _v := rx.try_recv();
+  };
+  s := io.await(tx.send(i32(9), io), io);
+  assert(
+    match(s, .Ok(_) => false, .Err(v) => (v == i32(9))),
+    "a send with no receiver fails and hands the value back, rather than suspending"
+  );
+  assert(
+    match(tx.try_send(i32(10)), .Ok(_) => false, .Err(v) => (v == i32(10))),
+    "try_send fails the same way"
+  );
+});
+test("async: dropping the last Sender resolves a SUSPENDED recv as Disconnected", {
+  rx := Channel(i32).receiver(usize(4));
+  consumer := io.async((io : Io) => {
+    // Suspends here: the channel is empty and open. Only the auto-close can
+    // resolve it, and it must resolve to Disconnected rather than a value.
+    r := io.await(rx.recv(io), io);
+    (code : i32) = match(
+      r,
+      .Ok(_v) => i32(1),
+      .Err(e) => cond((e == TryRecvError.Disconnected) => i32(-1), true => i32(-2))
+    );
+    return(code);
+  });
+  h := io.spawn(consumer, io);
+  {
+    tx := rx.sender();
+    // Let the consumer reach its suspension point before the sender goes.
+    io.await(sleep(u64(5)), io);
+  };
+  verdict := match(
+    timeout(h, Duration.from_millis(i64(2000)), io),
+    .Ok(v) => v,
+    .Err(_te) => i32(-9)
+  );
+  assert(verdict == i32(-1), "the suspended recv resolved Disconnected when the last sender dropped");
+});
+test("async: producer tasks with cloned Senders fan in, and the last one closes", {
+  rx := Channel(i32).receiver(usize(8));
+  {
+    tx1 := rx.sender();
+    tx2 := tx1.clone();
+    p1 := io.async((io : Io) => {
+      _a := io.await(tx1.send(i32(1), io), io);
+      _b := io.await(tx1.send(i32(2), io), io);
+      return(());
+    });
+    p2 := io.async((io : Io) => {
+      _a := io.await(tx2.send(i32(10), io), io);
+      _b := io.await(tx2.send(i32(20), io), io);
+      return(());
+    });
+    h1 := io.spawn(p1, io);
+    h2 := io.spawn(p2, io);
+    _d1 := h1.await(io);
+    _d2 := h2.await(io);
+  };
+  // Both senders and both tasks' captures are gone: the channel closed itself.
+  assert(rx.is_closed(), "the last of the cloned senders closed the channel");
+  (total : i32) = i32(0);
+  (count : i32) = i32(0);
+  v := rx.try_recv();
+  while(runtime(match(v, .Ok(_) => true, .Err(_) => false)), {
+    total = (total + match(v, .Ok(x) => x, .Err(_) => i32(0)));
+    count = (count + i32(1));
+    v = rx.try_recv();
+  });
+  assert(count == i32(4), "all four values from two cloned senders arrived");
+  assert(total == i32(33), "and none was corrupted (1+2+10+20)");
+  assert(
+    match(rx.try_recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Disconnected)),
+    "the drained channel reports Disconnected"
+  );
+});
+test("async Sender implements Clone", {
+  assert_clone :: (fn(comptime(T) : Type, where(T <: Clone)) -> comptime(unit))(());
+  assert_clone(Sender(i32));
+  assert(true, "checked at comptime");
 });

--- a/tests/sync/channel.test.yo
+++ b/tests/sync/channel.test.yo
@@ -2,10 +2,11 @@ pragma(Pragma.SkipWasm32Wasi); // no pthread support in standalone WASI
 { assert } :: import("std/assert");
 { arch, Arch } :: import("std/process");
 import("std/libc/stdio");
-{ Channel, TryRecvError } :: import("std/sync/channel");
+{ Channel, Sender, Receiver, TryRecvError } :: import("std/sync/channel");
 { Thread, ThreadPool, spawn } :: import("std/thread");
 { sleep_blocking } :: import("std/time/sleep");
 { Duration } :: import("std/time/duration");
+{ Instant } :: import("std/time/instant");
 { WaitGroup } :: import("std/sync/waitgroup");
 // ============================================================================
 // Basic Operations
@@ -374,4 +375,282 @@ test("O7: a cyclic element type is rejected — atomic RC cannot collect cycles"
   comptime_assert(Type.impls(CyclicNode, Send), "the pin payload must be Send so the error is Acyclic's");
   comptime_expect_error(Channel(CyclicNode));
   assert(true, "rejected at comptime");
+});
+// ============================================================================
+// Sender / Receiver split — auto-close when the last Sender is dropped
+// ============================================================================
+// Every blocking wait below is BOUNDED. A regression in the auto-close leaves
+// a consumer parked in `recv` forever, and an unbounded wait here would burn a
+// whole CI job's timeout instead of reporting a failure — so the verdict
+// always travels back over a second channel that the main thread POLLS with a
+// deadline. Verified: with `Sender`'s `dispose` removed, the two wake-up tests
+// report their assertion in ~2 s instead of hanging.
+_recv_within :: (fn(ch : Channel(i32), budget_ms : i64) -> Option(i32))({
+  start := Instant.now();
+  (found : Option(i32)) = .None;
+  (waiting : bool) = true;
+  while(runtime(waiting), {
+    match(
+      ch.try_recv(),
+      .Ok(v) => {
+        found = .Some(v);
+        waiting = false;
+      },
+      .Err(_e) => cond(
+        (start.elapsed().as_millis() > budget_ms) => {
+          waiting = false;
+        },
+        true => sleep_blocking(Duration.from_millis(i64(5)))
+      )
+    );
+  });
+  found
+});
+test("Sender/Receiver deliver values in send order", {
+  rx := Channel(i32).receiver(usize(4));
+  tx := rx.sender();
+  assert(tx.send(i32(1)).is_ok(), "first send");
+  assert(tx.send(i32(2)).is_ok(), "second send");
+  assert(tx.send(i32(3)).is_ok(), "third send");
+  assert(rx.len() == usize(3), "three values buffered");
+  assert(rx.recv().unwrap() == i32(1), "FIFO: 1 first");
+  assert(rx.recv().unwrap() == i32(2), "FIFO: then 2");
+  assert(rx.recv().unwrap() == i32(3), "FIFO: then 3");
+  assert(!rx.is_closed(), "a live sender keeps the channel open");
+});
+test("Channel.pair hands back both halves over one queue", {
+  pair := Channel(i32).pair(usize(2));
+  tx := pair.0;
+  rx := pair.1;
+  assert(tx.send(i32(11)).is_ok(), "the pair's sender sends");
+  assert(rx.recv().unwrap() == i32(11), "the pair's receiver receives the same queue");
+  assert(tx.len() == usize(0), "both halves see one length");
+});
+test("dropping the LAST Sender closes the channel", {
+  rx := Channel(i32).receiver(usize(4));
+  {
+    tx := rx.sender();
+    assert(!rx.is_closed(), "open while a sender lives");
+    assert(tx.send(i32(5)).is_ok(), "send while open");
+  };
+  // The sender's scope ended: nothing called close(), the count reaching zero
+  // did it. THIS is the behaviour the split exists for.
+  assert(rx.is_closed(), "the last sender's drop closed the channel");
+});
+test("dropping ONE of several Senders does NOT close the channel", {
+  rx := Channel(i32).receiver(usize(4));
+  tx := rx.sender();
+  {
+    tx2 := tx.clone();
+    assert(tx2.send(i32(1)).is_ok(), "the clone sends into the same queue");
+  };
+  assert(!rx.is_closed(), "one of two senders going away is not the end of the stream");
+  assert(tx.send(i32(2)).is_ok(), "the surviving sender still sends");
+  assert(rx.recv().unwrap() == i32(1), "the clone's value arrived");
+  assert(rx.recv().unwrap() == i32(2), "and the original's after it");
+});
+test("values queued when the last Sender drops are still received first", {
+  // Rust's guarantee: closing must not lose what the channel already
+  // accepted. The disconnect is reported only once the buffer is drained.
+  rx := Channel(i32).receiver(usize(4));
+  {
+    tx := rx.sender();
+    assert(tx.send(i32(7)).is_ok(), "queued before the drop");
+    assert(tx.send(i32(8)).is_ok(), "queued before the drop");
+  };
+  assert(rx.is_closed(), "closed by the drop");
+  assert(rx.recv().unwrap() == i32(7), "buffered 7 survives the close");
+  assert(rx.recv().unwrap() == i32(8), "buffered 8 survives the close");
+  assert(
+    match(rx.recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Disconnected)),
+    "only THEN is it Disconnected"
+  );
+});
+test("Receiver.try_recv is Empty while open and Disconnected once senders are gone", {
+  rx := Channel(i32).receiver(usize(4));
+  {
+    tx := rx.sender();
+    assert(
+      match(rx.try_recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Empty)),
+      "open and empty says Empty — the producer may still send"
+    );
+    assert(tx.send(i32(3)).is_ok(), "send one");
+  };
+  assert(match(rx.try_recv(), .Ok(v) => (v == i32(3)), .Err(_) => false), "the buffered value first");
+  assert(
+    match(rx.try_recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Disconnected)),
+    "closed AND drained says Disconnected — stop polling"
+  );
+});
+test("send fails once the Receiver has been dropped", {
+  // Rust's SendError: the value that could not be sent comes back.
+  ch := Channel(i32).new(usize(1));
+  tx := Sender(i32)._attach(ch);
+  {
+    rx := Receiver(i32)._attach(ch);
+    assert(rx.len() == usize(0), "nothing buffered");
+  };
+  match(
+    tx.send(i32(9)),
+    .Err(v) => assert(v == i32(9), "the unsent value is handed back"),
+    .Ok(_) => assert(false, "a send with no receiver must fail, not block")
+  );
+  match(
+    tx.try_send(i32(10)),
+    .Err(v) => assert(v == i32(10), "try_send fails the same way"),
+    .Ok(_) => assert(false, "try_send with no receiver must fail")
+  );
+});
+test("dropping the last Sender wakes a Receiver already blocked in recv", {
+  if(arch == Arch.Wasm32, return(()));
+  rx := Channel(i32).receiver(usize(4));
+  verdict := Channel(i32).new(usize(2));
+  consumer := Thread.spawn(io => {
+    // Parks here: the channel is empty and open. Only the auto-close can
+    // wake it, and it must wake with Disconnected rather than a value.
+    match(
+      rx.recv(),
+      .Ok(_v) => {
+        _a := verdict.send(i32(1));
+      },
+      .Err(e) => {
+        _b := verdict.send(cond((e == TryRecvError.Disconnected) => i32(-1), true => i32(-2)));
+      }
+    );
+  });
+  {
+    tx := rx.sender();
+    // Give the consumer time to be genuinely parked in `recv`, so this
+    // exercises the broadcast-under-the-mutex wake path and not the
+    // already-closed fast path.
+    sleep_blocking(Duration.from_millis(i64(50)));
+  };
+  answer := _recv_within(verdict, i64(3000));
+  assert(
+    match(answer, .Some(v) => (v == i32(-1)), .None => false),
+    "the blocked recv woke up Disconnected when the last sender dropped"
+  );
+  consumer.join();
+});
+test("buffered values reach a blocked Receiver before the disconnect", {
+  if(arch == Arch.Wasm32, return(()));
+  rx := Channel(i32).receiver(usize(4));
+  verdict := Channel(i32).new(usize(4));
+  consumer := Thread.spawn(io => {
+    (going : bool) = true;
+    while(going, {
+      match(
+        rx.recv(),
+        .Ok(v) => {
+          _a := verdict.send(v);
+        },
+        .Err(_e) => {
+          going = false;
+          _b := verdict.send(i32(-1));
+        }
+      );
+    });
+  });
+  {
+    tx := rx.sender();
+    sleep_blocking(Duration.from_millis(i64(50)));
+    assert(tx.send(i32(21)).is_ok(), "sent while the consumer is parked");
+    assert(tx.send(i32(22)).is_ok(), "and a second one");
+  };
+  v1 := _recv_within(verdict, i64(3000));
+  v2 := _recv_within(verdict, i64(3000));
+  v3 := _recv_within(verdict, i64(3000));
+  assert(match(v1, .Some(v) => (v == i32(21)), .None => false), "21 arrived");
+  assert(match(v2, .Some(v) => (v == i32(22)), .None => false), "22 arrived");
+  assert(match(v3, .Some(v) => (v == i32(-1)), .None => false), "and only then the disconnect");
+  consumer.join();
+});
+test("cloned Senders in several threads all fan in to one Receiver", {
+  if(arch == Arch.Wasm32, return(()));
+  rx := Channel(i32).receiver(usize(16));
+  tx1 := rx.sender();
+  tx2 := tx1.clone();
+  tx3 := tx1.clone();
+  t1 := Thread.spawn(io => {
+    _a := tx1.send(i32(1));
+    _b := tx1.send(i32(2));
+  });
+  t2 := Thread.spawn(io => {
+    _a := tx2.send(i32(10));
+    _b := tx2.send(i32(20));
+  });
+  t3 := Thread.spawn(io => {
+    _a := tx3.send(i32(100));
+    _b := tx3.send(i32(200));
+  });
+  t1.join();
+  t2.join();
+  t3.join();
+  // Drained with try_recv, never recv: every value is already buffered once
+  // the threads have joined, so a lost value fails an assertion instead of
+  // parking the test.
+  (total : i32) = i32(0);
+  (count : i32) = i32(0);
+  v := rx.try_recv();
+  while(runtime(v.is_ok()), {
+    total = (total + v.unwrap());
+    count = (count + i32(1));
+    v = rx.try_recv();
+  });
+  assert(count == i32(6), "all six values from three cloned senders arrived");
+  assert(total == i32(333), "and none of them was corrupted (1+2+10+20+100+200)");
+});
+test("a sender per thread: the last one to finish closes the channel", {
+  if(arch == Arch.Wasm32, return(()));
+  // Each worker mints its OWN sender inside the thread, so the sender's
+  // lifetime IS the thread's work. `keeper` is minted BEFORE the workers
+  // start and holds the count above zero while they do: without it the first
+  // worker to finish would take the count 1 -> 0 and close the channel under
+  // the ones still minting (measured — this test failed exactly that way
+  // when the keeper was created after the spawns).
+  //
+  // This is the cross-thread shape that reaches zero today. A `Sender` moved
+  // into a `Thread.spawn` closure is captured by reference and that reference
+  // is never released (issues/spawn-closure-captures-never-dropped-leak.md),
+  // so its `dispose` — and with it the auto-close — would never run.
+  rx := Channel(i32).receiver(usize(16));
+  wg := WaitGroup.new();
+  wg.add(i32(2));
+  {
+    keeper := rx.sender();
+    w1 := Thread.spawn(io => {
+      tx := rx.sender();
+      _a := tx.send(i32(4));
+      wg.done();
+    });
+    w2 := Thread.spawn(io => {
+      tx := rx.sender();
+      _a := tx.send(i32(5));
+      wg.done();
+    });
+    wg.wait();
+    assert(!rx.is_closed(), "the keeper holds the channel open while workers run");
+    w1.join();
+    w2.join();
+  };
+  // The workers' senders and the keeper are all gone now.
+  assert(rx.is_closed(), "the last sender to go closed the channel");
+  (sum : i32) = i32(0);
+  v := rx.try_recv();
+  while(runtime(v.is_ok()), {
+    sum = (sum + v.unwrap());
+    v = rx.try_recv();
+  });
+  assert(sum == i32(9), "both workers' values arrived before the close");
+  assert(
+    match(rx.try_recv(), .Ok(_) => false, .Err(e) => (e == TryRecvError.Disconnected)),
+    "and the drained channel reports Disconnected"
+  );
+});
+test("Sender implements Send and Clone, Receiver implements Send", {
+  assert_send :: (fn(comptime(T) : Type, where(T <: Send)) -> comptime(unit))(());
+  assert_clone :: (fn(comptime(T) : Type, where(T <: Clone)) -> comptime(unit))(());
+  assert_send(Sender(i32));
+  assert_send(Receiver(i32));
+  assert_clone(Sender(i32));
 });


### PR DESCRIPTION
Closes the `Sender`/`Receiver` row in `plans/STD_API_STABILIZATION.md`'s
Concurrency section (STILL OPEN → landed).

`Channel` was a fused handle that stayed open until somebody remembered to call
`close()`, so a consumer could not tell "nothing yet" from "the producers are
finished", and a blocked `recv` parked forever. This adds the piece a fused
handle cannot express — a lifetime.

## What landed

- **`std/sync/channel.yo`** (blocking, cross-thread): `Sender(T)`,
  `Receiver(T)`, `Channel(T).receiver(capacity)`, `Channel(T).pair(capacity)`,
  `Receiver.sender()`, `Sender: Clone`, `Dispose` on both halves.
- **`std/async/channel.yo`** (one event loop): the same surface, counted with a
  plain `usize` because that runtime is single-threaded.
- The queue counts its live senders; the `1 -> 0` transition closes the channel.
  Dropping the `Receiver` makes every further `send` fail with the unsent value
  instead of blocking on a queue nobody will drain.
- `Receiver.recv() -> Result(T, TryRecvError)` reuses the EXISTING error type
  (`Err` is always `Disconnected`); buffered values still come out one per call
  before the disconnect, so a close loses nothing the queue accepted.

`TryRecvError` and the value-returning `send` (Rust's `SendError(T)`) already
existed and are reused, not re-invented.

## Shape decisions

- **`Channel(T)` survives.** It is genuinely multi-consumer and 40-odd call
  sites use it that way (`std/thread`'s pool internals, `imm_threading`, the
  `RwLock`/`Cond` handshakes). The split layers on top, sharing the same
  buffer, mutex and condvars, and pays for its lifetime with a single
  consumer: exactly one `Receiver` per queue, not cloneable — which is what
  makes "the receiver is gone" a fact a sender can act on.
- **The entry point is a static method, not a free `channel(T, cap)`.** A free
  function's `T` must be a `comptime(T) : Type` parameter, and a function with
  comptime-but-not-`generic` parameters has its body evaluated at DEFINITION
  time, where `Channel(T).new(capacity)` cannot resolve. Inside
  `impl(generic(T), ...)` the body is deferred to the call. Measured.
- **`pair()` exists for Rust parity but is the lesser form.** Yo has no
  destructuring binding, so the tuple stays in scope beside `tx`/`rx` and holds
  its own reference to each half; dropping `tx` early therefore does NOT drop
  the last sender. The tuple-free `receiver()` + `sender()` gives each handle
  its own lifetime, which is what the auto-close needs. (The tuple temp is not
  dropped at statement end either, so `pair(c).0` does not silently poison the
  channel — also measured.)
- **Ordering: `Relaxed` up, `AcqRel` down.** The increment publishes no data
  and the handle cannot be used by another thread until it has been transferred
  there (`Arc::clone`'s argument). The decrement needs both halves: RELEASE so
  this producer's pushes are visible to whoever observes zero, ACQUIRE so the
  thread that observes zero sees the other producers' pushes before it closes.
  Only the thread reading `1` closes, and `close` broadcasts with the mutex
  held — which is what stops a receiver between its predicate check and its
  park from missing the wake.
- **A dropped `Receiver` sets its own flag, not `_closed`**, which means "no
  more values may be sent" — the senders' end of the lifetime. Keeping them
  apart lets a `Sender` that outlives its receiver report the honest failure.

## One thing does not work across `Thread.spawn`

A `Sender` MOVED INTO a spawn closure never runs its `dispose`, because
spawn-closure captures are never released
(`issues/spawn-closure-captures-never-dropped-leak.md` — open, pre-existing,
filed as a memory leak). Values still flow; only the auto-close is lost.
Measured side by side in
`issues/repros/thread-spawn-capture-blocks-channel-autoclose.yo`.

The documented pattern is a real one rather than a trick: the parent holds one
`keeper` sender while the workers start, and each worker mints its own inside
its body, where the local's scope-end drop is real.
`plans/backlog/SPAWN_CAPTURE_AUTOCLOSE.md` records the codegen fix, the
rejected std-side alternatives (a `Sender.release()`, a `spawn_with`), and why
the fix is not bundled here — it needs the dup/drop emit-diff gate and a
compiler rebuild. `io.async` captures release correctly, so the async channel
has the full behaviour, producer tasks included.

## Verification

- `yo check ./std --std-path ./std` — 173/173
- `tests/sync/channel.test.yo` 41/41 (+13), `tests/async/channel.test.yo` 15/15 (+10)
- **Red-first:** with the auto-close disabled, 6 sync and 5 async cases fail.
- Every blocking wait in the new tests is BOUNDED (sync: poll a verdict channel
  against an `Instant` deadline; async: `timeout` on the handle), so a
  regression reports in seconds instead of burning a CI job's timeout — the
  broken runs finish in 13 s and 8 s.
- Regression surface: `tests/sync` 208/208, `tests/async` 36/36,
  `tests/thread.test.yo` 10/10, `tests/thread_pool.test.yo` 14/14,
  `tests/imm_threading.test.yo` 30/30.
- `yo fmt --check` clean; user docs updated in both `docs/en-US/PARALLELISM.md`
  and `docs/zh-CN/PARALLELISM.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)