### PR TITLE
std/async: a `Stream` trait — async iteration, and `TcpListener.incoming`

### DIFF
--- a/.github/instructions/yo-design.instructions.md
+++ b/.github/instructions/yo-design.instructions.md
@@ -222,6 +222,43 @@ my_fn :: (fn(io : Io) -> Impl(Future(Result(i32, IoError), Io)))(
 );
 ```
 
+## Async iteration — the `Stream` trait (`std/async/stream.yo`)
+
+The async analogue of `Iterator`, landed 2026-09-11
+(`plans/reference/ASYNC_ITERATION_STREAM.md`):
+
+```rust
+Stream :: trait(
+  Item : Type,
+  next : (fn(self : Self, io : Io) -> Impl(Future(Option(Self.Item), Io)))
+);
+```
+
+Four rules to keep when extending it or implementing it on a new type:
+
+- **The future's bundle is `Io`, never `IoExn` — a stream does not throw.** A
+  fallible stream puts the failure IN the item (`Item = Result(T, E)`, e.g.
+  `TcpListener.incoming`'s `Result(TcpStream, NetError)`), so one bad item
+  does not end the sequence and no consumer installs a handler. The knock-on:
+  an API that THROWS (`Reader.read`, `BufReader.read_line`) cannot become a
+  stream until it can return its failure —
+  `plans/backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md`.
+- **`next` takes `self : Self`, not `inout(self)`** (`Iterator` uses `inout`):
+  the future outlives the call and an `inout` borrow cannot cross a
+  suspension. So every source is a `ref(struct(...))`.
+- **`.None` is terminal and stays terminal.** Every combinator preserves it.
+- **The associated type is named `Item`**, with the same uncheckable coherence
+  rule `DoubleEndedIterator` documents: the assoc-type registry is keyed by
+  (type id, label) with no trait discrimination, so a type implementing both
+  `Stream` and `Iterator` must give them the SAME `Item`. (`FromIterator` chose
+  `Elem` to dodge this; here no std type implements both.)
+
+There is deliberately **no `for_await` macro**: an `io.await` reached only
+through a macro expansion is compiled as a BLOCKING await and deadlocks inside
+a task (`plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md`). The
+loop is `for_each`, or a hand-written `while` + `io.await(s.next(io), io)` +
+`match`.
+
 ## JoinHandle(T) — spawned task handle
 
 `JoinHandle(T)` is a builtin generic type returned by `io.spawn`. It wraps a pointer to the spawned future and allows awaiting its result.

--- a/.github/skills/yo-async-effects/async-effects-recipes.md
+++ b/.github/skills/yo-async-effects/async-effects-recipes.md
@@ -227,6 +227,59 @@ process_dir :: (fn(root: Path, ctx : WalkCtx) -> Impl(Future(unit, WalkCtx)))(
   a segfaulting binary with the branch body dropped. See
   `issues/fixed/yo-self-init-segfaults-on-first-run.md` and
   `issues/fixed/await-in-branch-positions-matrix.md`.
+- **An `io.await` reached only through a MACRO EXPANSION is compiled as a
+  BLOCKING await** (measured 2026-09-11). Codegen looks for awaits in the
+  body's own AST, and a macro call keeps the macro head there — the expansion
+  lives in `ExprInfo.macro_expansion`. So a body whose only awaits come from a
+  macro is emitted as a plain closure (no state machine) with
+  `// Synchronous await (io.await outside state machine)` in the C. Inside a
+  spawned task that is a DEADLOCK: `io.spawn` never returns from the cold
+  start, so the caller never reaches whatever would satisfy the await. It only
+  shows up when the awaited future depends on the caller — a timer completes
+  on its own and the program merely serialises, so an awaiting macro can pass
+  a whole test suite and then hang. This is why `std/async/stream.yo` ships NO
+  `for_await` macro
+  (`issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md`,
+  `plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md`).
+- **Build a combinator chain OUTSIDE the `io.async` body that awaits it.** An
+  `=>` closure passed to a generic callback parameter INSIDE an async body
+  leaves the enclosing future's result type unresolved, and the error lands on
+  the SPAWN site (`No matching call found with arguments: (h.await)(io)`), not
+  on the closure. A `(fn(x : T) -> R)(...)` literal in the same position works,
+  and so does the same call outside the body
+  (`issues/closure-argument-inside-an-io-async-body-loses-the-future-result-type.md`).
+- **Do not bind a captured value to a local and then call a SUSPENDING method
+  on the local** inside an async body: `local := captured_stream;` followed by
+  `io.await(local.next(io), io)` emits invalid C (a state-machine field
+  assigned from the wrong capture type). Await on the captured NAME itself.
+
+## Async iteration — `Stream`
+
+`std/async/stream` is the async analogue of `Iterator`: `next(self, io)`
+answers `Impl(Future(Option(Self.Item), Io))`, and `.None` is terminal.
+
+```rust
+{ Stream } :: import("std/async/stream");
+
+conns := listener.incoming().take(usize(3));    // lazy chain, built out here
+io.await(conns.for_each(c => serve(c), io), io);
+```
+
+- The future's effect bundle is **`Io`, not `IoExn`** — a stream never throws.
+  A fallible stream carries the failure in the ITEM (`Item = Result(T, E)`,
+  e.g. `incoming`'s `Result(TcpStream, NetError)`).
+- `next` takes `self : Self` (not `inout(self)`), so every source is a
+  `ref(struct(...))` — a future cannot hold an `inout` borrow across a
+  suspension.
+- Implementors: `TcpListener.incoming()`, `Watcher`, `Channel(T)`.
+  Combinators: `map`, `filter`, `filter_map`, `take`, `skip`; consumers:
+  `for_each`, `collect`.
+- A generic consumer uses a BARE bound (`where(S <: Stream)`) or a CONCRETE
+  one (`Item := i32`). `where(S <: Stream(Item := A))` with a generic `A`
+  binds nothing and rejects every argument — `Iterator` behaves the same way
+  (`plans/backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md`). A blanket-impl
+  combinator method also cannot be called on a generic stream PARAMETER
+  (`s.collect(io)` → `No matching call found`); the trait's own `next` can.
 
 ## Exception (non-resumable)
 

--- a/docs/en-US/ASYNC_AWAIT.md
+++ b/docs/en-US/ASYNC_AWAIT.md
@@ -801,6 +801,131 @@ State machines are small (~32-500 bytes):
 - No synchronization overhead
 - Cache-friendly (small state machines)
 
+## Async iteration: the `Stream` trait
+
+`Iterator` yields values now. `Future` yields one value later. A **`Stream`**
+is both — "a value, later, repeatedly":
+
+```rust
+Stream :: trait(
+  Item : Type,
+  next : (fn(self : Self, io : Io) -> Impl(Future(Option(Self.Item), Io)))
+);
+```
+
+It lives in `std/async/stream` and `.None` means the stream is finished —
+terminal, and it stays terminal.
+
+```rust
+{ Stream } :: import("std/async/stream");
+{ TcpListener } :: import("std/net/tcp");
+
+conns := listener.incoming().take(usize(3));       // a Stream, lazily
+accepted := io.await(conns.collect(io), io);       // ArrayList(Result(TcpStream, NetError))
+```
+
+### Who implements it
+
+| type | its stream |
+| --- | --- |
+| `TcpListener.incoming()` (`std/net/tcp`) | `Item = Result(TcpStream, NetError)` — one connection per item |
+| `Watcher` (`std/fs/watch`) | `Item = FsEvent` — `.None` once the watcher is closed and drained |
+| `Channel(T)` (`std/async/channel`) | `Item = T` — `next` IS `recv`; `.None` once closed AND drained |
+
+### Combinators and consumers
+
+Written once over `where(S <: Stream)`, mirroring the `Iterator` combinators:
+
+| lazy | what it does |
+| --- | --- |
+| `map(f)` | transform each item |
+| `filter(pred)` | keep the items satisfying `pred` (by value, like `map`) |
+| `filter_map(f)` | `f` answers `Option(B)`; the `.Some`s are yielded |
+| `take(n)` | at most `n` items, then finished — without touching upstream again |
+| `skip(n)` | discard the first `n` |
+
+| consumer | what it does |
+| --- | --- |
+| `for_each(f, io)` | drive the stream to its end, calling `f` on each item |
+| `collect(io)` | drive it to its end, gathering the items into an `ArrayList` |
+
+```rust
+// Every third event's name, at most five of them.
+names := watcher.filter(e => (e.kind == FsEventKind.Change)).map(e => e.name).take(usize(5));
+io.await(names.for_each(n => println(n), io), io);
+```
+
+### Implementing one
+
+`next` takes `self : Self`, NOT `inout(self)` the way `Iterator` does: the
+future outlives the call, and an `inout` borrow cannot be held across a
+suspension. So a stream source is a reference-semantics type
+(`ref(struct(...))`) and its field writes propagate through the handle:
+
+```rust
+Countdown :: ref(struct(_n : i32));
+impl(
+  Countdown,
+  Stream(
+    Item : i32,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(i32), Io)))(
+      io.async((io : Io) =>
+        cond(
+          (self._n <= i32(0)) => Option(i32).None,
+          true => {
+            v := self._n;
+            self._n = (self._n - i32(1));
+            Option(i32).Some(v)
+          }
+        )
+      )
+    )
+  )
+);
+```
+
+A stream whose items can FAIL carries the failure IN the item — `Item =
+Result(T, E)`, the way `incoming` yields `Result(TcpStream, NetError)`. That
+is why `next`'s future is `Future(_, Io)` and not `Future(_, IoExn)`: **a
+stream never throws**, so one failed item does not end the sequence and a
+consumer needs no `Exception` handler.
+
+### Four things to know before writing one
+
+1. **Build a chain OUTSIDE the `io.async` body that awaits it.** A closure
+   passed to a generic callback INSIDE an async body leaves the enclosing
+   future's result type unresolved, and the error lands on the caller's
+   `await`. Make the chain first, then await it — including from inside a
+   spawned task:
+
+   ```rust
+   chain := source.map(x => f(x));            // out here
+   task := io.async((io : Io) => io.await(chain.collect(io), io));   // awaited in there
+   ```
+
+2. **There is no `for_await`.** An async loop written as a MACRO compiles its
+   `io.await` to the BLOCKING form (a macro's expansion is not scanned for
+   suspension points), which deadlocks inside a spawned task. Use `for_each`,
+   or the hand-written loop, which works everywhere:
+
+   ```rust
+   (done : bool) = false;
+   while(done == false, {
+     nx := io.await(stream.next(io), io);
+     match(nx, .Some(x) => { … }, .None => { done = true; });
+   });
+   ```
+
+3. **A generic consumer takes a bare or a concrete bound.**
+   `where(S <: Stream)` and `where(S <: Stream(Item := i32))` both accept
+   sources and combinator chains; `where(S <: Stream(Item := A))` with a
+   generic `A` binds nothing and rejects both. A consumer that must be
+   generic over the item type is written as a blanket impl method, which is
+   how `collect` and `for_each` themselves are written.
+
+4. **`.None` is terminal.** A consumer stops on it, so an implementor must
+   keep answering `.None` afterwards — never resume after finishing.
+
 ## API
 
 ### Core Operations
@@ -1146,4 +1271,5 @@ r2 := handle2.await(io);  // Option(T)
 | CPU-bound parallel computation | `Thread.spawn` (see PARALLELISM.md) |
 | Background processing          | `Thread.spawn` (see PARALLELISM.md) |
 | Waiting for multiple IOs       | `io.spawn` + `handle.await`       |
+| Consuming an async sequence    | `Stream` + `for_each`/`collect` (see [Async iteration](#async-iteration-the-stream-trait)) |
 | Utilizing multiple CPU cores   | `Thread.spawn` (see PARALLELISM.md) |

--- a/docs/zh-CN/ASYNC_AWAIT.md
+++ b/docs/zh-CN/ASYNC_AWAIT.md
@@ -787,6 +787,124 @@ __yo_decr_rc(future);  // 释放运行中任务的引用
 - 无同步开销
 - 缓存友好（小型状态机）
 
+## 异步迭代：`Stream` trait
+
+`Iterator` 现在就产出值，`Future` 稍后产出一个值。**`Stream`** 兼具两者 ——
+“稍后产出一个值，而且反复产出”：
+
+```rust
+Stream :: trait(
+  Item : Type,
+  next : (fn(self : Self, io : Io) -> Impl(Future(Option(Self.Item), Io)))
+);
+```
+
+它位于 `std/async/stream`，`.None` 表示流已结束 —— 这是终止状态，并且会一直保持
+终止。
+
+```rust
+{ Stream } :: import("std/async/stream");
+{ TcpListener } :: import("std/net/tcp");
+
+conns := listener.incoming().take(usize(3));       // 惰性的 Stream
+accepted := io.await(conns.collect(io), io);       // ArrayList(Result(TcpStream, NetError))
+```
+
+### 谁实现了它
+
+| 类型 | 它的流 |
+| --- | --- |
+| `TcpListener.incoming()`（`std/net/tcp`） | `Item = Result(TcpStream, NetError)` —— 每一项是一条连接 |
+| `Watcher`（`std/fs/watch`） | `Item = FsEvent` —— watcher 关闭且队列排空后为 `.None` |
+| `Channel(T)`（`std/async/channel`） | `Item = T` —— `next` 就是 `recv`；关闭且排空后为 `.None` |
+
+### 组合器与消费者
+
+它们只写一次，定义在 `where(S <: Stream)` 上，与 `Iterator` 的组合器一一对应：
+
+| 惰性组合器 | 作用 |
+| --- | --- |
+| `map(f)` | 变换每一项 |
+| `filter(pred)` | 只保留满足 `pred` 的项（按值传入，与 `map` 对称） |
+| `filter_map(f)` | `f` 返回 `Option(B)`，只产出其中的 `.Some` |
+| `take(n)` | 最多产出 `n` 项后结束，之后不再触碰上游 |
+| `skip(n)` | 丢弃前 `n` 项 |
+
+| 消费者 | 作用 |
+| --- | --- |
+| `for_each(f, io)` | 驱动流直到结束，对每一项调用 `f` |
+| `collect(io)` | 驱动流直到结束，把所有项收集进 `ArrayList` |
+
+```rust
+// 最多取五个“内容变更”事件的名字。
+names := watcher.filter(e => (e.kind == FsEventKind.Change)).map(e => e.name).take(usize(5));
+io.await(names.for_each(n => println(n), io), io);
+```
+
+### 如何实现一个流
+
+`next` 的接收者是 `self : Self`，而不是 `Iterator` 用的 `inout(self)`：它返回的
+future 的生命周期超出这次调用，而 `inout` 借用无法跨越挂起点。因此流的源头都是
+引用语义类型（`ref(struct(...))`），字段写入通过句柄传播：
+
+```rust
+Countdown :: ref(struct(_n : i32));
+impl(
+  Countdown,
+  Stream(
+    Item : i32,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(i32), Io)))(
+      io.async((io : Io) =>
+        cond(
+          (self._n <= i32(0)) => Option(i32).None,
+          true => {
+            v := self._n;
+            self._n = (self._n - i32(1));
+            Option(i32).Some(v)
+          }
+        )
+      )
+    )
+  )
+);
+```
+
+如果流的项**可能失败**，就把失败装进项里 —— `Item = Result(T, E)`，正如
+`incoming` 产出 `Result(TcpStream, NetError)`。这也是 `next` 的 future 是
+`Future(_, Io)` 而不是 `Future(_, IoExn)` 的原因：**流从不抛异常**，所以单项失败
+不会结束整个序列，消费者也不需要 `Exception` 处理器。
+
+### 动手前需要知道的四件事
+
+1. **组合链要在 `io.async` 体的外面构造。** 在 async 体内部把闭包传给泛型回调
+   参数，会让外层 future 的结果类型无法确定，而错误会报在调用方的 `await` 上。
+   先构造链，再在任意位置 await 它 —— 包括在 spawn 出去的任务里：
+
+   ```rust
+   chain := source.map(x => f(x));            // 在外面构造
+   task := io.async((io : Io) => io.await(chain.collect(io), io));   // 在里面 await
+   ```
+
+2. **没有 `for_await`。** 用宏写的异步循环，其 `io.await` 会被编译成**阻塞**形式
+   （宏展开体不会被扫描挂起点），在 spawn 出去的任务里会死锁。请用 `for_each`，
+   或者用到处都能工作的手写循环：
+
+   ```rust
+   (done : bool) = false;
+   while(done == false, {
+     nx := io.await(stream.next(io), io);
+     match(nx, .Some(x) => { … }, .None => { done = true; });
+   });
+   ```
+
+3. **泛型消费者要用裸约束或具体约束。** `where(S <: Stream)` 与
+   `where(S <: Stream(Item := i32))` 都能接受流的源头和组合链；而带泛型 `A` 的
+   `where(S <: Stream(Item := A))` 什么也绑不上，两者都会被拒绝。需要对项类型泛型
+   的消费者应写成 blanket impl 方法 —— `collect` 和 `for_each` 本身就是这样写的。
+
+4. **`.None` 是终止状态。** 消费者据此停止，所以实现者结束之后必须继续回答
+   `.None`，绝不能“结束后又恢复”。
+
 ## API
 
 ### 核心操作
@@ -1094,4 +1212,5 @@ r2 := handle2.await(io);  // Option(T)
 | CPU 密集型并行计算 | `Task.spawn`（参见 PARALLELISM.md） |
 | 后台处理           | `Task.spawn`（参见 PARALLELISM.md） |
 | 等待多个 Io        | `io.spawn` + `handle.await`         |
+| 消费异步序列       | `Stream` + `for_each`/`collect`（参见[异步迭代](#异步迭代stream-trait)） |
 | 利用多个 CPU 核心  | `Task.spawn`（参见 PARALLELISM.md） |

--- a/issues/closure-argument-inside-an-io-async-body-loses-the-future-result-type.md
+++ b/issues/closure-argument-inside-an-io-async-body-loses-the-future-result-type.md
@@ -1,0 +1,69 @@
+# A `=>` closure argument inside an `io.async` body loses the future's result type
+
+**Status: OPEN** (found 2026-09-11 while implementing `std/async/stream.yo`,
+`plans/reference/ASYNC_ITERATION_STREAM.md`). **Severity:** MEDIUM — the error
+lands on the caller's `await`, nowhere near the closure, and the working
+spelling (build the chain outside the async body, or use a `fn` literal) is
+not discoverable from the message.
+
+## Symptom
+
+Passing an `=>` closure to a generic callback parameter from INSIDE an
+`io.async` body compiles the body but leaves the enclosing future's result
+type unresolved, so the SPAWN SITE fails:
+
+```
+error: No matching call found with arguments:
+(h.await)(io)
+```
+
+Minimal reproducer:
+`issues/repros/closure-argument-inside-an-io-async-body-loses-the-future-result-type.yo`
+
+```rust
+task := io.async((io : Io) => {
+  r := apply(i32(5), x => (x + i32(1)));   // generic callee, closure argument
+  r
+});
+h := io.spawn(task, io);
+got := h.await(io);            // error[no matching call]: (h.await)(io)
+```
+
+Three one-line variations that all COMPILE and run, which is what pins the
+trigger to "closure argument + generic callee + inside an async body":
+
+| variation | result |
+| --- | --- |
+| `apply(i32(5), (fn(x : i32) -> i32)(x + i32(1)))` — `fn` literal, same place | works, prints 6 |
+| the same closure call moved OUTSIDE the `io.async` body | works |
+| a generic call with no callback argument inside the body (`mk(i32(7))` returning `Wrap(i32)`) | works |
+
+## Why it matters
+
+It is exactly the shape a stream/iterator chain has:
+`s.map(x => …).collect(io)` written inside a task body. The workaround is to
+build the chain in the enclosing scope and await it inside the task — which
+works, and is what `std/async/stream.yo`'s doc and `tests/async/*.test.yo`
+now say to do — but the failure mode (an error attributed to `await`, on a
+line that mentions neither the closure nor the generic call) costs a session
+to diagnose.
+
+## Suspected root cause (NOT yet confirmed)
+
+The async body is evaluated as a deferred trial (the same swallow that makes
+`yo check` blind to async bodies — see the testing instructions' table). A
+closure argument whose result type must be bound into the generic callee's
+type variable is synthesized during that trial; the binding does not survive
+into the state-machine's own env, so the body's tail type stays an unresolved
+SomeT and the future is typed `Future(<unresolved>, Io)`. The
+`No matching call` on `await` is that unresolved carrier reaching a method
+lookup. `plans/backlog/DEFTIME_BODY_EVAL.md` and
+`issues/fixed/generic-impl-async-method-closure-param-return-type-collapse.md`
+(C27) are the neighbourhood — C27 was the same family, one substitution
+channel over.
+
+## Next step
+
+Instrument the deferred-trial path in `src/evaluator/calls/` for the
+closure-argument case and compare the bound result type inside the trial with
+the one the spawn site reads. The C27 fix is the model.

--- a/issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md
+++ b/issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md
@@ -1,0 +1,78 @@
+# An `io.await` inside a macro expansion is emitted as a BLOCKING await (no state machine)
+
+**Status: OPEN** (found 2026-09-11 while implementing `for_await` for
+`std/async/stream.yo`). **Severity:** HIGH for anyone writing a macro that
+awaits — the failure is a silent DEADLOCK inside a spawned task, with no
+diagnostic, no untranspiled marker and a clean `yo check`.
+
+## Symptom
+
+Codegen decides whether an `io.async` body becomes a state machine by looking
+for `io.await` calls in the body's AST. A macro CALL keeps the macro head in
+the AST — the awaits live in `ExprInfo.macro_expansion` — so a body whose only
+awaits come from a macro expansion is compiled as a plain C closure and each
+await becomes the blocking form:
+
+```c
+static inline void closure_yo_id_18173(void* closure_context, __yo_t23 io) {
+  ...
+  // Synchronous await (io.await outside state machine)
+  ...
+  while (__await_state != -1 && __await_state != -2) { __yo_async_poll_step(); ... }
+```
+
+A blocking await inside a task nests the event loop, so `io.spawn` never
+returns from the task's cold start. When the awaited future can only complete
+because of something the CALLER does after the spawn, that is a deadlock:
+
+`issues/repros/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.yo`
+— a 20-line reproducer: a macro that expands to `io.await(ch.recv(io), io)`,
+called inside `io.async`, spawned; the caller's `try_send` is never reached.
+`timeout 10 ./repro` → **rc=124, no output**. Writing the same await directly
+in the async body prints both lines and exits 0.
+
+It does NOT always deadlock, which is what makes it dangerous: when the
+awaited future completes autonomously (a timer), the blocking poll loop drives
+it to completion and the program merely serializes where it should have
+suspended. The same macro is then "working" until the awaited operation starts
+depending on the caller.
+
+## Why it matters
+
+It makes an awaiting macro impossible to ship. `for_await(stream, io, (x) =>
+body)` — the `for` loop of `plans/reference/ASYNC_ITERATION_STREAM.md`, whose
+whole point is a loop body that can `break`/`continue`/`return` — was written,
+tested and then REMOVED from `std/async/stream.yo` for exactly this: it is
+correct from `main` and deadlocks inside a task, which is the shape a server
+loop has. The stream consumers that survive (`for_each`, `collect`) put their
+await inside an ordinary function body, where codegen sees it.
+
+`plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md` records the
+design consequences and the options.
+
+## Root cause (located, not yet fixed)
+
+The async-body detection and the state-machine split walk the body's AST
+without following `ExprInfo.macro_expansion`. AGENTS.md already carries the
+general form of this rule for the dup/drop optimizer family:
+
+> any tree walk in that optimizer family must follow `ExprInfo.macro_expansion`
+> for macro calls (`for`, collection literals, user macros — their calls keep
+> the macro head in the AST; the expansion is where branch structure is
+> visible)
+
+The async transform is another member of that family and does not follow it.
+Start at the "does this body contain an await" predicate and the suspension
+point collector in `src/codegen/async/`, and at the `Synchronous await
+(io.await outside state machine)` emitter that produces the marker above.
+
+## Fix sketch
+
+1. Make the await/suspension-point walk descend into `ExprInfo.macro_expansion`
+   (the same helper the dup/drop optimizer uses).
+2. Make the state-machine splitter emit the macro EXPANSION rather than the
+   macro call for bodies that contain awaits, so the split points land inside
+   it.
+3. Regression test: the reproducer above, plus a `for_await` over a channel
+   fed by a sibling task (the test that was removed from
+   `tests/async/channel.test.yo` in the same commit — see the plan doc).

--- a/issues/repros/closure-argument-inside-an-io-async-body-loses-the-future-result-type.yo
+++ b/issues/repros/closure-argument-inside-an-io-async-body-loses-the-future-result-type.yo
@@ -1,0 +1,27 @@
+// A `=>` closure passed to a generic callback parameter INSIDE an `io.async`
+// body leaves the enclosing future's result type unresolved: the async body
+// itself is fine, but `h.await(io)` on the spawned handle fails with
+// "No matching call found with arguments: (h.await)(io)".
+//
+//   yo compile issues/repros/closure-argument-inside-an-io-async-body-loses-the-future-result-type.yo \
+//     --std-path ./std --optimize 2 -o /tmp/repro.bin
+//
+// Replacing the closure with the `(fn(x : i32) -> i32)(...)` literal form —
+// see the commented line — makes the same program compile and print 6.
+{ println } :: import("std/fmt");
+apply :: (
+  fn(generic(A : Type, B : Type, F : Type), v : A, f : F, where(F <: (Fn(item : A) -> B))) -> B
+)(
+  (f)(v)
+);
+main :: (fn(io : Io) -> unit)({
+  task := io.async((io : Io) => {
+    r := apply(i32(5), x => (x + i32(1)));
+    // r := apply(i32(5), (fn(x : i32) -> i32)(x + i32(1)));   // this works
+    r
+  });
+  h := io.spawn(task, io);
+  got := h.await(io);
+  println(`got=${match(got, .Some(v) => v, .None => i32(-1))}`);
+});
+export(main);

--- a/issues/repros/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.yo
+++ b/issues/repros/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.yo
@@ -1,0 +1,37 @@
+// An `io.await` reached only through a MACRO EXPANSION is not counted as a
+// suspension point: the enclosing `io.async` body is emitted as a plain
+// closure (not a state machine) and the await becomes the blocking form
+// (`// Synchronous await (io.await outside state machine)` in the C). Inside
+// a spawned task that is a deadlock — the task's cold start never returns,
+// so the caller never reaches the `try_send` the task is waiting for.
+//
+//   yo compile issues/repros/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.yo \
+//     --std-path ./std --optimize 2 -o /tmp/repro.bin
+//   timeout 10 /tmp/repro.bin       # rc=124, prints nothing
+//
+// Writing the SAME await directly in the async body (no macro) prints both
+// lines and exits 0.
+pragma(Pragma.AllowMacroDef);
+{ eprintln } :: import("std/fmt");
+{ Channel } :: import("std/async/channel");
+// A macro whose expansion contains an `io.await`.
+recv_one :: (fn(quote(io_arg) : Expr, quote(ch) : Expr) -> unquote(Expr))(
+  return(
+    quote({
+      unquote(io_arg).await(unquote(ch).recv(unquote(io_arg)), unquote(io_arg));
+    })
+  )
+);
+main :: (fn(io : Io) -> unit)({
+  ch := Channel(i32).new(usize(1));
+  task := io.async((io : Io) => {
+    recv_one(io, ch);
+    i32(1)
+  });
+  h := io.spawn(task, io);
+  eprintln(`spawn returned — with a state machine this prints; with a blocking await it never does`);
+  _s := ch.try_send(i32(5));
+  r := h.await(io);
+  eprintln(`got ${match(r, .Some(v) => v, .None => i32(-1))}`);
+});
+export(main);

--- a/plans/README.md
+++ b/plans/README.md
@@ -69,6 +69,9 @@ designs: [`reference/BUILD_SYSTEM.md`](reference/BUILD_SYSTEM.md),
 [`reference/VERSION_MANAGEMENT.md`](reference/VERSION_MANAGEMENT.md),
 [`reference/ERROR_DIAGNOSTICS_OVERHAUL.md`](reference/ERROR_DIAGNOSTICS_OVERHAUL.md),
 [`reference/PORTABLE_C_DISTRIBUTION.md`](reference/PORTABLE_C_DISTRIBUTION.md),
+[`reference/ASYNC_ITERATION_STREAM.md`](reference/ASYNC_ITERATION_STREAM.md)
+(the `Stream` trait — async iteration, LANDED 2026-09-11 with `for_await` and
+`BufReader.lines` parked in `backlog/`),
 …. Policy decisions:
 [`reference/MACRO_POLICY.md`](reference/MACRO_POLICY.md),
 [`reference/TARGET_TRIPLES.md`](reference/TARGET_TRIPLES.md),
@@ -93,7 +96,18 @@ expensive — with probes and a Rust/Swift comparison),
 mechanism was built and rejected twice; kept because the failure modes
 generalize) and
 [`backlog/ZEROLANG_AGENT_FIRST_LESSONS.md`](backlog/ZEROLANG_AGENT_FIRST_LESSONS.md)
-(a keep/reject audit, explicitly not a commitment).
+(a keep/reject audit, explicitly not a commitment). Three landed 2026-09-11
+alongside `reference/ASYNC_ITERATION_STREAM.md`, each parking a piece of it
+with the blocker measured:
+[`backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md`](backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md)
+(an `io.await` inside a macro expansion compiles to a BLOCKING await, so an
+awaiting macro deadlocks in a task),
+[`backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md`](backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md)
+(an async `BufReader.lines` needs a `Reader` that returns its failure instead
+of throwing it) and
+[`backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md`](backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md)
+(`where(T <: Trait(Assoc := A))` binds nothing when `A` is a generic — true of
+`Iterator` too).
 
 **Language features the std campaign is blocked on** (added 2026-09-10, each
 written from the std row that needs it, with the blocked call sites named):

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -437,7 +437,7 @@ Text — every listed `String` method, `next_back`, `is_ascii_*` renames. Encodi
 — `Url.join/query_pairs/path_segments`, `JsonValue` mutation/`as_i64`/`pointer`,
 regex naming, `glob()`. I/O — `Watcher`
 `Dispose`, `SocketAddr` `Eq`/`Hash`,
-`TcpStream.local_addr` (it is on `TcpListener`), `TcpListener.incoming`. Core — **all of it**: every `checked_/wrapping_/
+`TcpStream.local_addr` (it is on `TcpListener`). Core — **all of it**: every `checked_/wrapping_/
 saturating_/overflowing_`, `abs/pow/clamp/count_ones/leading_zeros`, every
 `f64`/`f32` method and const (only raw `libc/math` today), `Error.is`,
 `ErrorChain`, `Context`, `derive_rule(Error)`, `black_box`, log `Sink`/`YO_LOG`,
@@ -564,9 +564,10 @@ non-test caller existed in the whole tree (`src/main.yo`'s
 **I/O.** Verified against the code 2026-09-09 — LANDED:
 `Stdout.write_string`; `Reader.read_exact`; lazy `read_dir`;
 `Metadata.modified`; `SocketAddr`/`IpAddr` `Eq`/`Hash`/`Ord`/`Clone` + `parse`;
-`TcpStream.local_addr`; `TcpListener.incoming`. STILL OPEN: HTTP keep-alive —
-its FRAMING half landed 2026-09-10 (described just below), the pooling client
-is the remaining piece. (`Child` stdin/stdout/stderr as `Reader`/`Writer`
+`TcpStream.local_addr`; `TcpListener.incoming` (this one 2026-09-11, on the
+new `Stream` trait — described below). STILL OPEN: HTTP keep-alive — its
+FRAMING half landed 2026-09-10 (described just below), the pooling client is
+the remaining piece. (`Child` stdin/stdout/stderr as `Reader`/`Writer`
 handles and `Watcher` `Dispose` also landed 2026-09-10, described below.)
 (`Seek`, `OpenOptions`, `SystemTime`, `IpAddr.parse_v6`,
 `UdpSocket.recv_from -> (n, from)`, `StatusCode` and `HeaderMap` all landed
@@ -1737,20 +1738,78 @@ emitted C, so it could not be randomized even if that were wanted.
    read-back that `TcpListener.bind` and `UdpSocket.bind` each open-coded is
    now one `_read_local_addr` helper.
 
-   Still open in this group: `TcpListener.incoming` and `Watcher` `Dispose`.
-   (`Seek`, `OpenOptions`, `SystemTime`, `UdpSocket.recv_from -> (n, from)`,
-   `IpAddr.parse_v6`, `StatusCode`, `HeaderMap` and the byte-sliced response
-   body all landed 2026-09-09; lazy `read_dir` and the request-side byte bodies
-   were already in.)
+   Nothing is open in this group any more. (`Seek`, `OpenOptions`,
+   `SystemTime`, `UdpSocket.recv_from -> (n, from)`, `IpAddr.parse_v6`,
+   `StatusCode`, `HeaderMap` and the byte-sliced response body all landed
+   2026-09-09; lazy `read_dir` and the request-side byte bodies were already
+   in; `Watcher` `Dispose` landed 2026-09-10; `TcpListener.incoming` landed
+   2026-09-11 — below.)
 
-   **`TcpListener.incoming` is deferred, and this is why.** Rust's `incoming()`
-   is a BLOCKING iterator of `io::Result<TcpStream>`. Yo's `accept` is
-   `Impl(Future(TcpStream, IoExn))`, and there is no `Stream` trait — no async
-   analogue of `Iterator` — for an iterator of futures to implement. Giving
-   `incoming` an `Iterator` that blocks the event loop per element would be
-   worse than not having it (a blocking await inside a task nests the loop and
-   deadlocks). The row wants an async-iteration abstraction first; it is a
-   language/std design question, not a missing method.
+   **`TcpListener.incoming` — LANDED 2026-09-11, on a new `Stream` trait.**
+   This row was deferred for one reason: Rust's `incoming()` is a BLOCKING
+   iterator of `io::Result<TcpStream>`, Yo's `accept` is
+   `Impl(Future(TcpStream, IoExn))`, and there was no async analogue of
+   `Iterator` for an iterator of futures to implement. Giving `incoming` an
+   `Iterator` that blocks the event loop per element would have been worse
+   than not having it — a blocking await inside a task nests the loop and
+   deadlocks. So the abstraction came first: `std/async/stream.yo`
+   (`plans/reference/ASYNC_ITERATION_STREAM.md`), and `incoming()` returns
+   `Incoming`, a `Stream` whose `Item` is `Result(TcpStream, NetError)`.
+
+   Four shape decisions are worth keeping, because each was measured against
+   the compiler rather than chosen on taste:
+
+   - **`next` returns `Impl(Future(Option(Self.Item), Io))` — `Io`, not
+     `IoExn`.** A stream never throws: it reports failure IN the item, so its
+     bundle needs no `Exception` and a consumer needs no handler. The plan doc
+     had written `IoExn`; `Watcher.next` — which already had this exact shape
+     before the trait existed — had `Io`, and `Io` is what compiles. The
+     consequence is the `Reader` asymmetry recorded in
+     `plans/backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md`: an async
+     `BufReader.lines` cannot be built until `Reader` has a read that returns
+     its failure instead of throwing it, because a `ctl` handler can neither
+     be installed across a suspension nor stored in a `ref` struct.
+   - **`Item = Result(TcpStream, NetError)`, not a bare `TcpStream` and not
+     `IoError`.** A single failed `accept` — a client that vanished between
+     the SYN and the accept, a per-process descriptor limit — is one bad
+     connection, not the end of the listener, which is exactly why Rust's
+     item is a `Result` too. The error type is `NetError` because that is
+     what `accept` THROWS (`NetError.from_io(IoError.from_errno(...))`), so a
+     server loop moving from `accept` to `incoming` keeps one error
+     vocabulary; `NetError.Io(IoError)` still carries the raw errno case. The
+     stream's `next` therefore calls the RAW `IO_tcp.accept` rather than the
+     throwing `accept` method.
+   - **`self : Self`, not `inout(self)` as `Iterator` has.** The future
+     outlives the call, and an `inout` borrow cannot be held across a
+     suspension. So every stream source is a reference-semantics type and
+     field writes propagate through the handle — the same reason `File.close`
+     takes `self : Self`.
+   - **`.None` is terminal and STAYS terminal**, and each combinator
+     preserves it: `take` stops touching upstream once its count is spent or
+     upstream ends, `skip`/`filter` treat upstream's `.None` as their own.
+     `incoming` finishes when the listener is closed — including by another
+     task while a `next` is pending — which mirrors `Watcher` and gives a
+     server loop a termination condition it otherwise lacks.
+
+   The trait's other two implementors came for three lines each: `Watcher`'s
+   hand-rolled `next` BECAME the trait method with no signature change, and
+   `Channel(T)`'s `next` IS `recv` (whose "closed and drained" `.None` is
+   already the stream's terminal answer). The combinators —
+   `map`/`filter`/`filter_map`/`take`/`skip` lazily, `for_each`/`collect` as
+   consumers — are one blanket impl over `where(S <: Stream)`, mirroring the
+   `Iterator` combinators in `std/prelude.yo`.
+
+   **What did NOT land, and why it is not a shortcut.** The plan's `for_await`
+   macro was written, worked from `main`, and DEADLOCKED inside a spawned
+   task: an `io.await` reached only through a macro expansion is not counted
+   as a suspension point, so codegen emits the enclosing `io.async` body as a
+   plain closure with a blocking await
+   (`issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md`,
+   `plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md`). It was
+   removed rather than shipped with a caveat, because "correct from `main`,
+   hangs in a task" is the wrong way round for a server loop. `for_each`,
+   `take` and the hand-written `while` + `await next()` + `match` loop cover
+   the ground until the async transform follows `ExprInfo.macro_expansion`.
    **`f64`/`f32` non-finite constants: DONE (2026-09-09), unblocked by the
    v0.2.29 seed.** `INFINITY`, `NEG_INFINITY` and `NAN` are the last three
    names `std/math` was missing. They had to wait for a seed because the

--- a/plans/backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md
+++ b/plans/backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md
@@ -1,0 +1,100 @@
+# `where(T <: Trait(Assoc := A))` binds nothing when `A` is a generic
+
+**Status:** BACKLOG — measured 2026-09-11 while implementing
+`plans/reference/ASYNC_ITERATION_STREAM.md`. Not specific to `Stream`:
+`Iterator` behaves identically, so this is a property of associated-type
+bounds in general and has been latent for as long as they have existed.
+
+## The gap
+
+Inside an `impl(...)` a bound may name the associated type and bind it to one
+of the impl's own generics — the prelude does it in a dozen places:
+
+```rust
+impl(
+  generic(I : Type, A : Type),
+  where(I <: DoubleEndedIterator(Item := A)),
+  IterRev(I),
+  Iterator(Item : A, next : … )
+);
+```
+
+The same spelling on a **free function** rejects every argument:
+
+```rust
+// error[E0602]: Type ArrayListIter(i32) does not implement required trait Iterator.
+count :: (fn(generic(I : Type, A : Type), it : I, where(I <: Iterator(Item := A))) -> usize)( … );
+count(list.into_iter());
+```
+
+Measured, with `Stream` and with `Iterator`, same result:
+
+| free-function bound | a SOURCE argument | a COMBINATOR argument |
+| --- | --- | --- |
+| `where(S <: Stream)` (bare) | ✓ | ✓ |
+| `where(S <: Stream(Item := i32))` (concrete) | ✓ | ✓ |
+| `where(S <: Stream(Item := A))`, `generic(A : Type)` | ✗ E0602 | ✗ E0602 |
+
+A related failure, same root: a blanket-impl METHOD cannot be called on a
+generic parameter even when the bound is concrete —
+
+```rust
+// error: No matching call found with arguments: (s.collect)(io)
+drain :: (fn(generic(S : Type), s : S, io : Io, where(S <: Stream(Item := i32))) -> ArrayList(i32))(
+  … s.collect(io) …
+);
+```
+
+The trait's OWN methods (`s.next(io)`) work on such a parameter; only the
+blanket-impl combinators fail, because their own
+`where(Self <: Stream(Item := A))` has no concrete impl to read `Item` off.
+
+## Why it matters
+
+It decides how a consumer generic over a sequence must be WRITTEN, and the
+compiler does not say so:
+
+- A free function that must accept both sources and chains uses a bare bound,
+  or spells the item type concretely.
+- A consumer that must be generic over the item type has to be a
+  blanket-impl method (`impl(generic(S : Type), where(S <: Stream), S, …)`),
+  which is how `collect` / `for_each` / `map` in `std/async/stream.yo` and
+  every `Iterator` combinator in `std/prelude.yo` are written. That is not a
+  coincidence — it is the only shape that works.
+- A test helper hits it immediately: `tests/async/combinators.test.yo`'s
+  `_bounded` takes the collect FUTURE rather than the stream for exactly this
+  reason, and its comment says so.
+
+Nothing in std is blocked by it today, which is why this is backlog and not a
+bug report against the stream work.
+
+## Options
+
+1. **Resolve the associated type at bound-check time (RECOMMENDED).** When a
+   bound is `T <: Trait(Assoc := A)` and `A` is an unbound generic of the same
+   signature, look up `T`'s impl of `Trait`, read the `Assoc` field, and BIND
+   `A` to it — the same lookup that already succeeds inside an impl. The
+   impl-level path is the reference implementation; the free-function path
+   evidently tests the constraint before (or instead of) binding.
+2. **Make the second failure follow from the first.** Once `A` binds from a
+   concrete impl, a blanket method called on a generic parameter can resolve
+   its own `Item := A` the same way, which removes the `s.collect(io)`
+   restriction too. Worth checking whether one fix covers both before
+   treating them separately.
+3. **Diagnose instead of fixing.** E0602 currently reads "Type X does not
+   implement required trait Y" about a type that plainly does. Even without
+   the inference, saying "the associated-type binding `Item := A` cannot be
+   inferred here; use a bare bound or name the type" would save the hour this
+   cost.
+
+Recommendation: (3) immediately — it is a message change — and (1)+(2) as one
+piece of work in `src/evaluator/` where where-clause constraints are applied
+before argument binding (`yo-design.instructions.md`, "Implementation
+details" under trait method disambiguation).
+
+## Cross-references
+
+- `plans/reference/ASYNC_ITERATION_STREAM.md` — the closing record naming
+  this as one of the two shape constraints found while landing it.
+- `tests/async/combinators.test.yo` — `_bounded` / `_count_items` /
+  `_sum_i32` are the three working spellings, with the reasons in comments.

--- a/plans/backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md
+++ b/plans/backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md
@@ -1,0 +1,91 @@
+# An async `BufReader.lines` needs a non-throwing read
+
+**Status:** BACKLOG — designed here, blocked on a `Reader` decision. Written
+2026-09-11 while implementing `plans/reference/ASYNC_ITERATION_STREAM.md`,
+whose "Order of work" item 5 asked for `BufReader.lines` as a `Stream` and
+found it is not a stream problem but an error-style one.
+
+## What was wanted
+
+```rust
+lines := BufReader(File).new(f).lines();
+io.await(lines.for_each(l => println(l), io), io);
+```
+
+`std/io/bufio.yo` has said `lines()` is "deliberately absent: Yo has no async
+iterator protocol" since D5. That protocol now exists (`std/async/stream.yo`),
+so `lines()` should follow — `Channel` and `TcpListener` both gained their
+`Stream` impls in the same commit, in three lines each.
+
+## Why it does not follow
+
+`Stream.next` returns `Impl(Future(Option(Self.Item), Io))`. The effect
+bundle is **`Io`, not `IoExn`** — deliberately: a stream reports failure IN
+the item (`Item = Result(T, E)`), so a consumer needs no `Exception` handler
+and one bad item does not end the sequence. That is the decision the whole
+trait rests on.
+
+`BufReader.read_line` reports failure the other way — it THROWS
+(`Impl(Future(Option(String), IoExn))`), like every method on the `io` path
+(D1 style 1). So a `Lines(R)` stream would have to turn a throw into a value,
+and there is no way to do that inside the `next` body:
+
+- **Installing a handler inside the async body is out.** A `ctl` handler is
+  frame-bound (`docs/en-US/ALGEBRAIC_EFFECTS.md`), and `unwind` inside an
+  `io.async` body is memory-unsafe; a handler that RESUMES instead would let
+  `read_line` continue past its own failure with a fabricated value.
+- **Storing the caller's handler in the stream is out.** A `ref(struct(_exn :
+  Exception))` is rejected — pointers/references to control-bound types are
+  illegal precisely so handlers cannot outlive their install frame.
+- **Re-reading the bytes by hand does not help.** The primitive underneath is
+  `Reader.read`, which throws too.
+
+So the missing piece is a read primitive that returns its failure.
+
+## Options
+
+1. **Invert the `Reader` primitive (RECOMMENDED).** Make the required method
+   `try_read(self, buf, size, io) -> Impl(Future(Result(usize, IoError), Io))`
+   and make today's throwing `read` a trait DEFAULT over it (`match(.Err(e)
+   => e.exn.throw(dyn(e)))`). Failure-as-a-value becomes the primitive and
+   throwing becomes the convenience, which is the same direction `Stream`
+   already took. Then `Lines(R)` is a dozen lines with
+   `Item = Result(String, IoError)`.
+   Cost: every `Reader` implementor's primitive changes — `File`,
+   `TcpStream`, `Stdin`, `BufReader(R)` itself, `Dyn(Reader)`'s vtable — and
+   `std/io` is a STABLE module, so this needs the deprecation discipline of
+   `yo-design.instructions.md` ("Additive = …"): ship `try_read` as an
+   optional trait method with a default that wraps `read`, migrate the four
+   implementors, then flip which one is required.
+2. **Add `try_read` as a SECOND primitive** (both required, no default).
+   Simpler to reason about, but it puts two spellings of one operation in a
+   stable trait — the thing D2 exists to prevent.
+3. **Give `Lines(R)` an `Item = String` and let it swallow errors** (a read
+   failure ends the stream, indistinguishable from EOF). Rejected: it is the
+   `Option`-instead-of-`Result` collapse D18 removed from `timeout` and D7
+   removed from `try_recv`; a truncated file would read as a complete one.
+4. **A language feature: catch an effect as a value across a suspension**
+   (a `try`-shaped handler usable inside an async body). The general fix, and
+   much larger than this API. If it lands, option 1 stops being necessary —
+   but option 1 is worth doing anyway, because failure-in-the-item is the
+   better shape for a byte source.
+
+## Recommendation
+
+Option 1, as its own PR against `std/io`, sequenced as: add `try_read` with a
+`read`-based default (additive, nothing breaks) → migrate `File`,
+`TcpStream`, `Stdin`, `BufReader` to implement `try_read` natively and take
+`read`'s default → add `Lines(R)` with `Item = Result(String, IoError)` and
+`BufReader.lines()` → drop `read`'s requirement in the release after.
+
+Until then `read_line` in a `while` loop is the line reader, and
+`std/io/bufio.yo`'s doc keeps saying so — with this doc as the reason, instead
+of the now-stale "Yo has no async iterator protocol".
+
+## Cross-references
+
+- `plans/reference/ASYNC_ITERATION_STREAM.md` — the trait and why its future
+  is `Io`-only.
+- `plans/STD_API_STABILIZATION.md` §4 (I/O) — the std campaign's I/O section.
+- `std/io/index.yo` — `Reader`/`Writer`; the `?=` default syntax this plan
+  leans on is already used there twice.

--- a/plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md
+++ b/plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md
@@ -1,0 +1,110 @@
+# `for_await` — blocked on a macro-aware async transform
+
+**Status:** BACKLOG — blocked, with the blocker measured and filed. Written
+2026-09-11 when `for_await` was implemented for
+`plans/reference/ASYNC_ITERATION_STREAM.md`, worked from `main`, deadlocked
+inside a task, and was REMOVED from `std/async/stream.yo` rather than shipped.
+
+## What was wanted
+
+The `for` loop of async iteration — a loop whose body is ordinary code, so it
+can `break`, `continue` and `return`:
+
+```rust
+conns := listener.incoming().take(usize(3));
+io.async((io : Io) => {
+  for_await(conns, io, (c) => {
+    match(c, .Ok(s) => serve(s, io), .Err(e) => log(e));
+  });
+})
+```
+
+It was option (1) of the stream plan (a macro expanding to `while` + `await
+next()` + `match`), recommended there over making `for` polymorphic. The macro
+itself is ~40 lines and its expansion is exactly the hand-written loop that
+works today; it was written, formatted, and passed every non-suspending test.
+
+## Why it cannot ship
+
+**An `io.await` reached only through a macro expansion is not counted as a
+suspension point.** Codegen decides whether an `io.async` body becomes a state
+machine by walking the body's AST, and a macro CALL keeps the macro head in
+that AST — the expansion lives in `ExprInfo.macro_expansion`. So a body whose
+only awaits come from a macro is emitted as a plain C closure, and each await
+becomes the blocking form:
+
+```c
+static inline void closure_yo_id_18173(void* closure_context, __yo_t23 io) {
+  ...
+  // Synchronous await (io.await outside state machine)
+  while (__await_state != -1 && __await_state != -2) { __yo_async_poll_step(); ... }
+```
+
+A blocking await inside a task nests the event loop, so `io.spawn` never
+returns from the task's cold start. Measured 2026-09-11: a `for_await` over
+`TcpListener.incoming()` inside a spawned task hangs (rc=124) with no output —
+the task blocks in `accept` during the spawn, so the caller never reaches the
+`connect` that would satisfy it.
+
+Full write-up plus a 20-line reproducer that needs no network:
+`issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md`,
+`issues/repros/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.yo`.
+
+The failure is worse than a hard error, which is why the macro was removed
+rather than documented-with-a-caveat:
+
+- From `main` it is CORRECT (a blocking await is what `main`'s awaits are).
+- Inside a task it deadlocks — and a task is exactly where a server loop
+  lives.
+- When the awaited future completes autonomously (a timer), the blocking poll
+  loop drives it and the program merely serialises. So a macro can look
+  healthy for its whole test suite and hang the first time it awaits something
+  that depends on its own caller.
+
+## What ships instead
+
+`std/async/stream.yo` keeps two consumers whose awaits live in ORDINARY
+function bodies, where codegen sees them:
+
+- `for_each(f, io)` — the loop as a combinator; works from `main` and inside a
+  task (tested both ways in `tests/async/combinators.test.yo`).
+- `collect(io)` / a hand-written `while` + `io.await(s.next(io), io)` +
+  `match`, which is what `for_await` expanded to and is what the stream doc
+  and the net/channel tests now use.
+
+The only thing lost is the loop-body `break`/`continue`/`return`: a closure
+body cannot break the caller's loop, so `for_each` cannot stop early. `take(n)`
+covers the bounded case, and `filter`/`filter_map` cover skipping.
+
+## Options
+
+1. **Make the async transform macro-aware (RECOMMENDED).** Follow
+   `ExprInfo.macro_expansion` in the "does this body await" predicate and in
+   the state-machine splitter, and emit the expansion rather than the call for
+   bodies that await. AGENTS.md already states this rule for the dup/drop
+   optimizer family ("any tree walk in that optimizer family must follow
+   `ExprInfo.macro_expansion` for macro calls"); the async transform is
+   another member of it. Then land `for_await` unchanged — it is written and
+   its tests exist in this branch's history.
+2. **Reject an awaiting macro at definition time.** Cheap, and strictly better
+   than the silent deadlock: a macro whose expansion contains `io.await`
+   errors unless the enclosing body is already a state machine. It closes the
+   footgun without enabling `for_await`.
+3. **Make `for` polymorphic over `Iterator`/`Stream`** (option 2 of the stream
+   plan). Does not help: the expansion still hides the await, so it hits the
+   same wall. Any spelling of an async loop as a MACRO does.
+4. **Do nothing.** `for_each` + `take` covers most loops; the cost is that
+   early exit from a stream loop stays inexpressible.
+
+Recommendation: (2) as a small standalone guard, then (1) as the real fix,
+then land `for_await`. Sequenced that way, no window exists where an awaiting
+macro can deadlock silently.
+
+## Cross-references
+
+- `plans/reference/ASYNC_ITERATION_STREAM.md` — the stream design; its
+  "Order of work" item 4 is what this doc parks.
+- `issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md`
+  — the defect.
+- `plans/STD_API_STABILIZATION.md` §4 (Concurrency) — where the async surface's
+  open items are tracked.

--- a/plans/reference/ASYNC_ITERATION_STREAM.md
+++ b/plans/reference/ASYNC_ITERATION_STREAM.md
@@ -1,0 +1,170 @@
+# Async iteration — a `Stream` trait
+
+> **CLOSED 2026-09-11 — LANDED, with two of five items parked.** `std/async/stream.yo`
+> ships the `Stream` trait and the lazy combinators `map` / `filter` /
+> `filter_map` / `take` / `skip` plus the consumers `for_each` / `collect`.
+> Implementors: `Watcher` (`std/fs/watch.yo` — its hand-rolled `next` BECAME
+> the trait method, unchanged), `TcpListener.incoming` (`std/net/tcp.yo` — the
+> deferred `plans/STD_API_STABILIZATION.md` row, now closed) and `Channel(T)`
+> (`std/async/channel.yo` — `next` IS `recv`). Tests:
+> `tests/async/combinators.test.yo` (27), `tests/async/channel.test.yo` (8),
+> `tests/net/tcp.test.yo` (21), `tests/fs/watch.test.yo` (6) — every combinator
+> awaited from a spawned task as well as from `main`, each bounded by
+> `std/async`'s `timeout`.
+>
+> **Parked, with reasons measured rather than guessed:**
+>
+> - **`for_await` (item 4) was written and then REMOVED.** An `io.await` reached
+>   only through a MACRO EXPANSION is not counted as a suspension point, so the
+>   enclosing `io.async` body is emitted as a plain closure with a BLOCKING
+>   await — correct from `main`, a deadlock inside a task. See
+>   `issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md`
+>   and `plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md`.
+>   `for_each` + `take` and the hand-written `while` loop cover the ground
+>   meanwhile.
+> - **`BufReader.lines` (item 5, second half) needs a non-throwing read.** A
+>   stream reports failure in the ITEM, `read_line` THROWS, and a `ctl` handler
+>   cannot be installed across a suspension or stored in a `ref` struct — so the
+>   blocker is `Reader`'s error style, not the stream protocol:
+>   `plans/backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md`.
+>
+> **Two corrections to the design below**, both measured:
+>
+> 1. `next`'s future is `Impl(Future(Option(Self.Item), Io))` — the second type
+>    argument is **`Io`, not `IoExn`** as written under "Design". `Io` is what
+>    `Watcher.next` already used and what compiles; it is also the right shape,
+>    since a stream that never throws needs no `Exception` in its bundle.
+> 2. `TcpListener.incoming`'s item is `Result(TcpStream, NetError)`, not
+>    `Result(TcpStream, IoError)`. `NetError` is the type `accept` THROWS, so a
+>    server loop moving from `accept` to `incoming` keeps one error vocabulary
+>    (`NetError.Io(IoError)` still carries the raw errno case).
+>
+> Two shape constraints found while landing it, recorded for the next reader:
+> a free function's `where(S <: Stream(Item := A))` with a GENERIC `A` binds
+> nothing and rejects every argument (a bare bound or a concrete item type
+> works, and `Iterator` behaves the same —
+> `plans/backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md`), and a chain built
+> INSIDE an `io.async` body loses the future's result type
+> (`issues/closure-argument-inside-an-io-async-body-loses-the-future-result-type.md`)
+> — build the chain outside, await it inside.
+
+**Status:** LANDED 2026-09-11 (was: BACKLOG, written 2026-09-10 because
+`TcpListener.incoming` was deferred on it, and because four std APIs had
+independently invented the same shape by hand).
+
+## The problem
+
+Yo has `Iterator` (with an associated `Item` type, `docs/en-US/DESIGN.md`) and
+it has `Future`, but nothing that is both. There is no async analogue of
+`Iterator` — no type that yields *"a value, later, repeatedly"*.
+
+So every std API that produces a sequence asynchronously invents its own
+shape:
+
+| API | its hand-rolled shape |
+| --- | --- |
+| `TcpListener.accept` | `Impl(Future(TcpStream, IoExn))`, called in the caller's own loop |
+| `Watcher.next` (`std/fs/watch.yo`) | `fn(self, io) -> Impl(Future(Option(FsEvent), Io))` — `.None` means closed |
+| `Channel.recv` (`std/async/channel.yo`) | a future plus a separate `try_recv -> Result(T, TryRecvError)` |
+| `BufReader.lines` (`std/io/bufio.yo`) | synchronous only; the async form does not exist |
+
+Four spellings of one concept, none composable: there is no `map`, no `filter`,
+no `take`, no `for`-equivalent over any of them, and no way to write a function
+generic over *"something that yields values asynchronously"*.
+
+`plans/STD_API_STABILIZATION.md` records the consequence at the point where it
+bites:
+
+> **`TcpListener.incoming` is deferred, and this is why.** Rust's `incoming()`
+> is a BLOCKING iterator of `io::Result<TcpStream>`. Yo's `accept` is
+> `Impl(Future(TcpStream, IoExn))`, and there is no `Stream` trait — no async
+> analogue of `Iterator` — for an iterator of futures to implement.
+
+## Design
+
+```rust
+Stream :: trait(
+  Item : Type,
+  /// Yield the next item, or `.None` once the stream is finished.
+  next : (fn(self : Self, io : Io) -> Impl(Future(Option(Self.Item), IoExn)))
+);
+```
+
+This is the shape `Watcher.next` already has, generalised — which is the
+strongest evidence it is the right one: the API that needed it first arrived
+at it independently.
+
+Two decisions the shape encodes:
+
+- **`Option(Item)`, not a separate "done" signal.** `.None` is terminal. A
+  stream that can fail yields `Item = Result(T, E)`, exactly as Rust's
+  `TcpListener::incoming` yields `io::Result<TcpStream>` — the failure is in
+  the item, so a single failed accept does not end the stream.
+- **`self : Self`, not `inout(self)`.** `Iterator` uses `inout(self)` because
+  it is synchronous; a stream's `next` returns a future that outlives the
+  call, and an `inout` borrow cannot be held across it. Every std stream
+  source is already a `ref` type, so field writes work through the handle
+  (this is the same reason `File.close` takes `self : Self`).
+
+### Combinators
+
+Written once over `where(S <: Stream)`, mirroring the `Iterator` combinators
+the tree already has: `map`, `filter`, `filter_map`, `take`, `skip`,
+`for_each`, `collect`. Each is a `ref` struct wrapping the upstream stream
+plus its closure, with a `Stream` impl of its own — the same construction
+`std/iter` uses, and subject to the same known trap:
+[[yo-varbound-receiver-cell-recovery]] (a var-bound combinator receiver needs
+the SomeT resolution-cell channel; `flat_map`'s doubly-derived item type is
+still broken there, so `flat_map` should be LAST).
+
+### A `for`-equivalent
+
+`for(iter, body)` desugars to `next()` + `match` in a loop. The async form
+needs the loop body to `io.await` each `next()`, which means it must expand
+inside an `io.async` body. Two options:
+
+1. **`for_await(stream, io, body)` macro** — expands to the same
+   `while`/`match` with `io.await` around `next()`. Additive, no parser
+   change, and it reads acceptably.
+2. **Make `for` polymorphic over `Iterator`/`Stream`** — nicer at the call
+   site, but the macro must decide which expansion to emit from the
+   scrutinee's traits, and a macro expanding differently by type is a new
+   capability.
+
+Recommend (1) first; (2) only if the spelling proves to matter.
+
+## What it unblocks
+
+- `TcpListener.incoming() -> Impl(Stream(Item := Result(TcpStream, IoError)))`
+  — the deferred row, closed.
+- `Watcher` implements `Stream` instead of hand-rolling `next` (its current
+  `next` becomes the trait method; no signature change).
+- `Channel(T)` implements `Stream`, so a consumer loop is a combinator chain
+  rather than a `recv`/`try_recv` dance.
+- `BufReader.lines` gains an async form for free.
+- Any user API that yields asynchronously stops having to invent a shape.
+
+## Implementation sketch
+
+Nothing in the compiler. This is a `std/` change — the trait plus impls plus
+combinators — because associated types, `Impl(...)` wrappers and futures all
+already work. Verified 2026-09-10 with a probe: an associated type in a return
+position, supplied per-type and consumed from a blanket impl, compiles and
+runs.
+
+The one compiler-adjacent risk is the async state machine's treatment of an
+`io.await` inside a combinator's `next` body — the shapes recorded in
+[[yo-async-cond-shared-await-point-fixed]] and
+[[yo-blocking-await-inside-a-task-deadlocks]]. Each combinator needs a test
+that AWAITS it from inside a spawned task, not only from `main`, because a
+blocking await inside a task nests the event loop.
+
+## Order of work
+
+1. The trait, in `std/async/stream.yo`, with `Watcher` as the first
+   implementor (it already has the shape, so this is a rename that proves the
+   trait fits a real type).
+2. `TcpListener.incoming` — the row this exists for.
+3. `map`/`filter`/`take`/`for_each`, each with a spawned-task test.
+4. `for_await`.
+5. `Channel(T)` and `BufReader.lines`.

--- a/std/async/channel.yo
+++ b/std/async/channel.yo
@@ -68,6 +68,7 @@
 { TryRecvError } :: import("../sync/channel");
 { assert } :: import("../assert");
 IO_timer :: import("../sys/timer");
+{ Stream } :: import("./stream");
 
 /// A bounded FIFO channel for same-thread async tasks.
 Channel :: (fn(comptime(T) : Type) -> comptime(Type))(
@@ -427,5 +428,20 @@ impl(
     ch := Self.new(capacity);
     (Sender(T)._attach(ch), Receiver(T)._attach(ch))
   })
+);
+/// A channel IS an async stream of the values sent to it: `next` is `recv`,
+/// and `recv`'s `.None` (closed AND drained) is exactly the stream's
+/// terminal answer. Registering it means a consumer loop is a combinator
+/// chain — `ch.map(f).take(n)`, `io.await(ch.for_each(f, io), io)` — instead
+/// of a `recv`/`try_recv` dance.
+impl(
+  generic(T : Type),
+  Channel(T),
+  Stream(
+    Item : T,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(T), Io)))(
+      self.recv(io)
+    )
+  )
 );
 export(Channel, TryRecvError);

--- a/std/async/stream.yo
+++ b/std/async/stream.yo
@@ -1,0 +1,428 @@
+//! Async iteration — the `Stream` trait: "a value, later, repeatedly"
+//! (`plans/reference/ASYNC_ITERATION_STREAM.md`).
+//!
+//! `Iterator` yields values now; `Future` yields one value later. A `Stream`
+//! is both: each `next(io)` returns a FUTURE of `Option(Item)`, and `.None`
+//! means the stream is finished. Before this trait existed, every std API
+//! that produced a sequence asynchronously invented its own shape —
+//! `TcpListener.accept` in the caller's own loop, `Watcher.next` answering
+//! `Option(FsEvent)`, `Channel.recv` plus a separate `try_recv` — and none of
+//! them composed.
+//!
+//! ```rust
+//! { Stream } :: import("std/async/stream");
+//! { watch, WatchOptions } :: import("std/fs/watch");
+//!
+//! w := watch(Path.new(`./logs`), WatchOptions.defaults(), exn);
+//! names := w.map(e => e.name).take(usize(3));
+//! got := io.await(names.collect(io), io);   // ArrayList(String), 3 entries
+//! ```
+//!
+//! The combinators (`map`, `filter`, `filter_map`, `take`, `skip`) are LAZY:
+//! each wraps the upstream stream and pulls one item per `next`. The
+//! consumers (`for_each`, `collect`) drive the stream to `.None`.
+//!
+//! ## There is no `for_await`
+//!
+//! The plan called for a `for_await(stream, io, (x) => body)` macro — a loop
+//! whose body can `break`, `continue` and `return`. It was written and it
+//! deadlocks: an `io.await` reached only through a MACRO EXPANSION is not
+//! counted as a suspension point, so the enclosing `io.async` body is emitted
+//! as a plain closure with a BLOCKING await, and a blocking await inside a
+//! spawned task nests the event loop
+//! (`issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md`,
+//! `plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md`). It was
+//! removed rather than shipped, because it works from `main` and hangs in a
+//! task — the wrong way round for a server loop.
+//!
+//! Until that codegen fix lands, the loop is either `for_each` (whose await
+//! lives in an ordinary function body, so it works everywhere) or the
+//! hand-written form, which is what `for_await` expanded to:
+//!
+//! ```rust
+//! (done : bool) = false;
+//! while(done == false, {
+//!   nx := io.await(stream.next(io), io);
+//!   match(nx, .Some(x) => { … }, .None => { done = true; });
+//! });
+//! ```
+//!
+//! ## Implementing it
+//!
+//! `next` takes `self : Self` — not `inout(self)`, the way `Iterator` does —
+//! because the future it returns outlives the call, and an `inout` borrow
+//! cannot be held across a suspension. So every stream SOURCE is a
+//! reference-semantics type (`ref(struct(...))` / `ref(enum(...))`), and
+//! field writes propagate through the handle:
+//!
+//! ```rust
+//! Countdown :: ref(struct(_n : i32));
+//! impl(
+//!   Countdown,
+//!   Stream(
+//!     Item : i32,
+//!     next : (fn(self : Self, io : Io) -> Impl(Future(Option(i32), Io)))(
+//!       io.async((io : Io) =>
+//!         cond(
+//!           (self._n <= i32(0)) => Option(i32).None,
+//!           true => {
+//!             v := self._n;
+//!             self._n = (self._n - i32(1));
+//!             Option(i32).Some(v)
+//!           }
+//!         )
+//!       )
+//!     )
+//!   )
+//! );
+//! ```
+//!
+//! A stream whose items can FAIL carries the failure in the item —
+//! `Item = Result(T, E)`, the way `TcpListener.incoming` yields
+//! `Result(TcpStream, IoError)` — so one bad item does not end the stream and
+//! no consumer needs an `Exception` handler. That is why `next`'s future is
+//! `Future(_, Io)` and not `Future(_, IoExn)`: a stream never throws.
+//!
+//! ## Writing a chain
+//!
+//! **Build the chain OUTSIDE the `io.async` body that awaits it.** An `=>`
+//! closure passed to a generic callback parameter INSIDE an async body leaves
+//! the enclosing future's result type unresolved
+//! (`issues/closure-argument-inside-an-io-async-body-loses-the-future-result-type.md`),
+//! so `s.map(f)` written inside a task body fails at the task's `await`. The
+//! chain is a value: make it first, then await it wherever you like —
+//! including from inside a spawned task.
+//!
+//! ## Stability
+//!
+//! unstable — new in v0.2.27; the API may still change until the next release.
+//! Two things are most likely to move: the combinator SET (`flat_map` is
+//! deliberately absent — its doubly-derived item type is the shape a
+//! var-bound combinator receiver still resolves wrongly), and how the async
+//! `for` loop is eventually spelled (see "There is no `for_await`" above).
+{ ArrayList } :: import("../collections/array_list");
+
+/// Something that yields values asynchronously: `next(io)` resolves to the
+/// next item, or `.None` once the stream is finished.
+///
+/// `.None` is TERMINAL and must stay terminal — a stream that answered
+/// `.None` answers `.None` for every later `next`. Consumers rely on it to
+/// stop, and every combinator here preserves it.
+///
+/// COHERENCE RULE (not compiler-checked, same as `DoubleEndedIterator`'s):
+/// the associated-type registry is keyed by (type id, label) with no trait
+/// discrimination and takes the FIRST match, so a type implementing BOTH
+/// `Stream` and `Iterator` would have one `Item` silently serve both. No std
+/// type does; a user type that wants both must give them the same `Item`.
+Stream :: trait(
+  /// The type of the values yielded.
+  Item : Type,
+  /// Yield the next item, or `.None` once the stream is finished.
+  next :
+    (
+      fn(self : Self, io : Io) -> Impl(Future(Option(Self.Item), Io))
+    )
+);
+export(Stream);
+// ---------------------------------------------------------------------------
+// StreamMap
+// ---------------------------------------------------------------------------
+/// Lazy stream that maps each item through `F`. Created by `.map(f)`.
+StreamMap :: (fn(comptime(S) : Type, comptime(B) : Type, comptime(F) : Type) -> comptime(Type))(
+  ref(struct(_inner : S, _f : F))
+);
+impl(
+  generic(S : Type, A : Type, B : Type, F : Type),
+  where(S <: Stream(Item := A), F <: (Fn(item : A) -> B)),
+  StreamMap(S, B, F),
+  Stream(
+    Item : B,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(B), Io)))(
+      io.async((io : Io) => {
+        nx := io.await(self._inner.next(io), io);
+        match(
+          nx,
+          .Some(item) => Option(B).Some((self._f)(item)),
+          .None => Option(B).None
+        )
+      })
+    )
+  )
+);
+export(StreamMap);
+// ---------------------------------------------------------------------------
+// StreamFilter
+// ---------------------------------------------------------------------------
+/// Lazy stream that keeps only the items for which the predicate holds.
+/// Created by `.filter(pred)`. The predicate takes the item BY VALUE,
+/// symmetric with `map`.
+StreamFilter :: (fn(comptime(S) : Type, comptime(F) : Type) -> comptime(Type))(
+  ref(struct(_inner : S, _f : F))
+);
+impl(
+  generic(S : Type, A : Type, F : Type),
+  where(S <: Stream(Item := A), F <: (Fn(item : A) -> bool)),
+  StreamFilter(S, F),
+  Stream(
+    Item : A,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(A), Io)))(
+      io.async((io : Io) => {
+        (out : Option(A)) = Option(A).None;
+        (searching : bool) = true;
+        while(searching, {
+          nx := io.await(self._inner.next(io), io);
+          match(
+            nx,
+            .Some(item) => {
+              keep := (self._f)(item);
+              if(keep, {
+                out = Option(A).Some(item);
+                searching = false;
+              });
+            },
+            .None => {
+              searching = false;
+            }
+          );
+        });
+        out
+      })
+    )
+  )
+);
+export(StreamFilter);
+// ---------------------------------------------------------------------------
+// StreamFilterMap
+// ---------------------------------------------------------------------------
+/// Lazy stream that maps each item to `Option(B)` and yields only the
+/// `.Some`s. Created by `.filter_map(f)`.
+StreamFilterMap :: (fn(comptime(S) : Type, comptime(B) : Type, comptime(F) : Type) -> comptime(Type))(
+  ref(struct(_inner : S, _f : F))
+);
+impl(
+  generic(S : Type, A : Type, B : Type, F : Type),
+  where(S <: Stream(Item := A), F <: (Fn(item : A) -> Option(B))),
+  StreamFilterMap(S, B, F),
+  Stream(
+    Item : B,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(B), Io)))(
+      io.async((io : Io) => {
+        (out : Option(B)) = Option(B).None;
+        (searching : bool) = true;
+        while(searching, {
+          nx := io.await(self._inner.next(io), io);
+          match(
+            nx,
+            .Some(item) => {
+              mapped := (self._f)(item);
+              if(mapped.is_some(), {
+                out = mapped;
+                searching = false;
+              });
+            },
+            .None => {
+              searching = false;
+            }
+          );
+        });
+        out
+      })
+    )
+  )
+);
+export(StreamFilterMap);
+// ---------------------------------------------------------------------------
+// StreamTake
+// ---------------------------------------------------------------------------
+/// Lazy stream that yields at most `n` items, then finishes — without
+/// touching the upstream stream again. Created by `.take(n)`.
+StreamTake :: (fn(comptime(S) : Type) -> comptime(Type))(
+  ref(struct(_inner : S, _remaining : usize))
+);
+impl(
+  generic(S : Type, A : Type),
+  where(S <: Stream(Item := A)),
+  StreamTake(S),
+  Stream(
+    Item : A,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(A), Io)))(
+      io.async((io : Io) => {
+        (out : Option(A)) = Option(A).None;
+        if(self._remaining > usize(0), {
+          self._remaining = (self._remaining - usize(1));
+          nx := io.await(self._inner.next(io), io);
+          out = nx;
+          // Upstream finished early: stop pulling on every later `next`.
+          if(nx.is_none(), {
+            self._remaining = usize(0);
+          });
+        });
+        out
+      })
+    )
+  )
+);
+export(StreamTake);
+// ---------------------------------------------------------------------------
+// StreamSkip
+// ---------------------------------------------------------------------------
+/// Lazy stream that discards the first `n` items, then yields the rest.
+/// Created by `.skip(n)`.
+StreamSkip :: (fn(comptime(S) : Type) -> comptime(Type))(
+  ref(struct(_inner : S, _to_skip : usize))
+);
+impl(
+  generic(S : Type, A : Type),
+  where(S <: Stream(Item := A)),
+  StreamSkip(S),
+  Stream(
+    Item : A,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(A), Io)))(
+      io.async((io : Io) => {
+        (out : Option(A)) = Option(A).None;
+        (pulling : bool) = true;
+        while(pulling, {
+          nx := io.await(self._inner.next(io), io);
+          match(
+            nx,
+            .Some(item) => {
+              cond(
+                (self._to_skip > usize(0)) => {
+                  self._to_skip = (self._to_skip - usize(1));
+                },
+                true => {
+                  out = Option(A).Some(item);
+                  pulling = false;
+                }
+              );
+            },
+            .None => {
+              self._to_skip = usize(0);
+              pulling = false;
+            }
+          );
+        });
+        out
+      })
+    )
+  )
+);
+export(StreamSkip);
+// ---------------------------------------------------------------------------
+// The combinators, once, over every `Stream`
+// ---------------------------------------------------------------------------
+impl(
+  generic(S : Type),
+  where(S <: Stream),
+  S,
+  /// Transform each item with `f`, producing a `StreamMap` stream.
+  map : (
+    fn(
+      generic(A : Type, B : Type, F : Type),
+      self : Self,
+      f : F,
+      where(Self <: Stream(Item := A), F <: (Fn(item : A) -> B))
+    ) -> StreamMap(Self, B, F)
+  )(
+    StreamMap(Self, B, F)(_inner : self, _f : f)
+  ),
+  /// Keep only the items for which `pred` returns `true`.
+  filter : (
+    fn(
+      generic(A : Type, F : Type),
+      self : Self,
+      f : F,
+      where(Self <: Stream(Item := A), F <: (Fn(item : A) -> bool))
+    ) -> StreamFilter(Self, F)
+  )(
+    StreamFilter(Self, F)(_inner : self, _f : f)
+  ),
+  /// Map each item to `Option(B)` and keep the `.Some`s — `map` and `filter`
+  /// in one pass.
+  filter_map : (
+    fn(
+      generic(A : Type, B : Type, F : Type),
+      self : Self,
+      f : F,
+      where(Self <: Stream(Item := A), F <: (Fn(item : A) -> Option(B)))
+    ) -> StreamFilterMap(Self, B, F)
+  )(
+    StreamFilterMap(Self, B, F)(_inner : self, _f : f)
+  ),
+  /// Yield at most `n` items.
+  take : (
+    fn(
+      generic(A : Type),
+      self : Self,
+      n : usize,
+      where(Self <: Stream(Item := A))
+    ) -> StreamTake(Self)
+  )(
+    StreamTake(Self)(_inner : self, _remaining : n)
+  ),
+  /// Discard the first `n` items.
+  skip : (
+    fn(
+      generic(A : Type),
+      self : Self,
+      n : usize,
+      where(Self <: Stream(Item := A))
+    ) -> StreamSkip(Self)
+  )(
+    StreamSkip(Self)(_inner : self, _to_skip : n)
+  ),
+  /// Drive the stream to its end, calling `f` on each item.
+  for_each : (
+    fn(
+      generic(A : Type, F : Type),
+      self : Self,
+      f : F,
+      io : Io,
+      where(Self <: Stream(Item := A), F <: (Fn(item : A) -> unit))
+    ) -> Impl(Future(unit, Io))
+  )(
+    io.async((io : Io) => {
+      (draining : bool) = true;
+      while(draining, {
+        nx := io.await(self.next(io), io);
+        match(
+          nx,
+          .Some(item) => {
+            (f)(item);
+          },
+          .None => {
+            draining = false;
+          }
+        );
+      });
+      ()
+    })
+  ),
+  /// Drive the stream to its end, gathering every item into an `ArrayList`.
+  collect : (
+    fn(
+      generic(A : Type),
+      self : Self,
+      io : Io,
+      where(Self <: Stream(Item := A))
+    ) -> Impl(Future(ArrayList(A), Io))
+  )(
+    io.async((io : Io) => {
+      out := ArrayList(A).new();
+      (draining : bool) = true;
+      while(draining, {
+        nx := io.await(self.next(io), io);
+        match(
+          nx,
+          .Some(item) => {
+            out.push(item);
+          },
+          .None => {
+            draining = false;
+          }
+        );
+      });
+      out
+    })
+  )
+);

--- a/std/fs/watch.yo
+++ b/std/fs/watch.yo
@@ -5,7 +5,9 @@
 //! backend (inotify on Linux, kqueue on macOS, ReadDirectoryChangesW on
 //! Windows; the `std/sys/events` layer). Events are delivered on the event
 //! loop and queued inside the watcher; read them with the non-blocking
-//! `poll()` or the awaitable `next(io)`.
+//! `poll()` or the awaitable `next(io)`. `next` is the `Stream` trait's
+//! method (`std/async/stream.yo`), so a watcher composes:
+//! `w.filter(…).map(…).take(n)`.
 //!
 //! ```rust
 //! { watch, WatchOptions, FsEventKind } :: import("std/fs/watch");
@@ -47,6 +49,7 @@ pragma(Pragma.AllowUnsafe);
 { ToString } :: import("../fmt");
 events :: import("../sys/events");
 { yield } :: import("../async");
+{ Stream } :: import("../async/stream");
 /// What happened to the entry.
 FsEventKind :: enum(
   /// Created, removed or moved (the backend's "rename" class).
@@ -166,17 +169,6 @@ impl(
       true => Option(FsEvent).None
     )
   ),
-  /// Wait for the next event. Resolves `.None` once the watcher is closed
-  /// and its queue drained. Suspends through `yield`, so it is safe inside
-  /// tasks (no nested event loop).
-  next : (fn(self : Self, io : Io) -> Impl(Future(Option(FsEvent), Io)))(
-    io.async((io : Io) => {
-      while(runtime((self._head >= self._queue.len()) && self._active), {
-        io.await(yield(io), io);
-      });
-      self.poll()
-    })
-  ),
   /// Stop the native watch. Queued events stay readable through `poll`;
   /// `next` no longer waits. Idempotent, and called for you when the last
   /// reference to the watcher goes away (`Dispose` below).
@@ -187,6 +179,29 @@ impl(
       events.fs_event_close(self._handle);
     });
   })
+);
+/// A `Watcher` IS an async stream of events, and was the shape the `Stream`
+/// trait was generalised from: `next` already answered `Option(FsEvent)`
+/// through a future, with `.None` for "closed and drained". Registering it
+/// as the trait impl (rather than an inherent method) is what lets the
+/// combinators apply — `w.filter(...)`, `w.map(...)`, `w.take(n)` — and what
+/// lets a function be generic over "something that yields events".
+impl(
+  Watcher,
+  Stream(
+    Item : FsEvent,
+    /// Wait for the next event. Resolves `.None` once the watcher is closed
+    /// and its queue drained. Suspends through `yield`, so it is safe inside
+    /// tasks (no nested event loop).
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(FsEvent), Io)))(
+      io.async((io : Io) => {
+        while(runtime((self._head >= self._queue.len()) && self._active), {
+          io.await(yield(io), io);
+        });
+        self.poll()
+      })
+    )
+  )
 );
 impl(
   Watcher,

--- a/std/io/bufio.yo
+++ b/std/io/bufio.yo
@@ -15,8 +15,13 @@
 //! sync positional syscall — buffered bytes still in the writer when it is
 //! dropped are LOST. Call `flush(io)` before letting it go.
 //!
-//! `lines()` is deliberately absent: Yo has no async iterator protocol, so
-//! the line primitive is `read_line` (`.None` on clean EOF).
+//! `lines()` is still absent, but no longer for the reason this doc used to
+//! give. The async iterator protocol EXISTS now (`std/async/stream.yo`); what
+//! blocks `lines()` is that a `Stream` reports failure IN its item while
+//! `read_line` THROWS, and a `ctl` handler can neither be installed across a
+//! suspension nor stored in a `ref` struct. So the line primitive is still
+//! `read_line` (`.None` on clean EOF), and the fix is a `Reader` that can
+//! return its failure — `plans/backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md`.
 //!
 //! The fd-based `std/sys/bufio` pair is GONE (2026-08-28): the compiler's own
 //! three consumers — `lsp/server`, `lsp/transport`, `check_watch` — read stdin

--- a/std/io/index.yo
+++ b/std/io/index.yo
@@ -32,8 +32,12 @@
 //! not I/O. Implemented by `File`; see the trait's own doc for why it takes
 //! the reference-point type as a parameter and has no `rewind`.
 //!
-//! STILL TO COME: a buffered `lines()`, which waits on an async iterator
-//! protocol rather than being faked.
+//! STILL TO COME: a buffered `lines()`. The async iterator protocol it was
+//! waiting on landed 2026-09-11 (`std/async/stream.yo`), so the remaining
+//! blocker is this trait's own error style: a `Stream` reports failure in its
+//! ITEM and `read`/`read_line` THROW, which cannot be caught inside an async
+//! body. See `plans/backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md` for the
+//! `try_read` proposal.
 pragma(Pragma.AllowUnsafe);
 { IoExn, Exception } :: import("../error");
 { IoError } :: import("../sys/errors");

--- a/std/net/tcp.yo
+++ b/std/net/tcp.yo
@@ -27,6 +27,7 @@ import("../fmt");
 { Error, AnyError, Exception, IoExn } :: import("../error");
 IO_tcp :: import("../sys/tcp");
 IoTraits :: import("../io");
+{ Stream } :: import("../async/stream");
 SockInfo :: import("../sys/sockinfo");
 { AF_INET, AF_INET6, SOCK_STREAM, SOL_SOCKET, SO_REUSEADDR, IPPROTO_TCP, TCP_NODELAY, SO_KEEPALIVE, SHUT_RD, SHUT_WR, SHUT_RDWR } :: import("../sys/socket");
 // ============================================================================
@@ -161,6 +162,66 @@ TcpListener :: ref(
     _is_closed : bool
   )
 );
+/// The stream of connections arriving at a `TcpListener` — Rust's
+/// `TcpListener::incoming`, created by `listener.incoming()`.
+///
+/// Item is a `Result`, not a bare `TcpStream`, for the reason Rust's is: a
+/// single failed `accept` (a client that vanished between the SYN and the
+/// accept, a per-process descriptor limit) is ONE bad connection, not the end
+/// of the listener. Carrying the failure in the item is what lets the stream
+/// survive it — and it is why `Stream.next` needs no `Exception` handler
+/// (`std/async/stream.yo`).
+///
+/// The error is a `NetError`, the same type `accept` THROWS, so moving a
+/// server loop from `accept` to `incoming` does not change its error
+/// vocabulary.
+///
+/// The stream finishes (`.None`) once the listener is closed — including by
+/// another task while a `next` is pending — mirroring `Watcher`.
+Incoming :: ref(struct(_listener : TcpListener));
+impl(
+  Incoming,
+  Stream(
+    Item : Result(TcpStream, NetError),
+    next : (
+      fn(self : Self, io : Io) -> Impl(Future(Option(Result(TcpStream, NetError)), Io))
+    )(
+      io.async((io : Io) => {
+        (out : Option(Result(TcpStream, NetError))) = Option(Result(TcpStream, NetError)).None;
+        if(!self._listener._is_closed, {
+          // The raw accept, not the throwing `accept` method: this stream
+          // reports failure IN the item, and an `Exception` handler cannot be
+          // installed across a suspension inside an async body.
+          addr_buf := (*u8)(malloc(usize(128)).unwrap());
+          addr_len := (*u32)(malloc(usize(4)).unwrap());
+          addr_len.* = u32(128);
+          client_fd := io.await(IO_tcp.accept(self._listener._fd, addr_buf, addr_len), io);
+          // The peer address is parsed only on success: on failure the kernel
+          // filled nothing in, so `addr_buf` is still uninitialized malloc.
+          out = cond(
+            (client_fd < i32(0)) => Option(Result(TcpStream, NetError)).Some(
+              Result(TcpStream, NetError).Err(NetError.from_io(IoError.from_errno(i32(0) - client_fd)))
+            ),
+            true => Option(Result(TcpStream, NetError)).Some(
+              Result(TcpStream, NetError).Ok(
+                TcpStream(
+                  _fd : client_fd,
+                  _peer_addr : sockaddr_to_socket_addr(addr_buf),
+                  _local_addr : _read_local_addr(client_fd, SocketAddr.any(u16(0))),
+                  _is_closed : false
+                )
+              )
+            )
+          );
+          free(.Some((*void)(addr_buf)));
+          free(.Some((*void)(addr_len)));
+        });
+        out
+      })
+    )
+  )
+);
+export(Incoming);
 impl(
   TcpListener,
   /// Bind to a socket address and start listening.
@@ -236,6 +297,19 @@ impl(
       );
     })
   }),
+  /// The connections arriving at this listener, as a `Stream` of
+  /// `Result(TcpStream, NetError)` — Rust's `TcpListener::incoming`.
+  ///
+  /// ```rust
+  /// conns := listener.incoming().take(usize(3));
+  /// io.await(conns.for_each(c => { handle(c); }, io), io);
+  /// ```
+  ///
+  /// Every `std/async/stream` combinator applies, and a function can be
+  /// generic over `where(S <: Stream)` instead of over this listener.
+  incoming : (fn(self : Self) -> Incoming)(
+    Incoming(_listener : self)
+  ),
   /// Get the local address this listener is bound to.
   local_addr : (fn(self : Self) -> SocketAddr)(
     self._local_addr

--- a/tests/async/channel.test.yo
+++ b/tests/async/channel.test.yo
@@ -3,6 +3,8 @@
 pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
 { Channel, Sender, Receiver, TryRecvError } :: import("std/async/channel");
+{ Stream } :: import("std/async/stream");
+{ ArrayList } :: import("std/collections/array_list");
 { timeout } :: import("std/async");
 { Duration } :: import("std/time/duration");
 { sleep } :: import("std/sys/timer");
@@ -278,4 +280,73 @@ test("async Sender implements Clone", {
   assert_clone :: (fn(comptime(T) : Type, where(T <: Clone)) -> comptime(unit))(());
   assert_clone(Sender(i32));
   assert(true, "checked at comptime");
+});
+// 5. a Channel IS a Stream (plans/reference/ASYNC_ITERATION_STREAM.md)
+// ---------------------------------------------------------------------------
+test("Test channel as a Stream: next is recv, close is the terminal .None", {
+  ch := Channel(i32).new(usize(4));
+  _a := ch.try_send(i32(1));
+  _b := ch.try_send(i32(2));
+  ch.close();
+  first := io.await(ch.next(io), io);
+  assert(match(first, .Some(v) => (v == i32(1)), .None => false), "the trait method delivers what recv would");
+  second := io.await(ch.next(io), io);
+  assert(match(second, .Some(v) => (v == i32(2)), .None => false), "FIFO through the trait too");
+  done := io.await(ch.next(io), io);
+  assert(done.is_none(), "closed AND drained is the stream's end");
+  again := io.await(ch.next(io), io);
+  assert(again.is_none(), "and the end stays the end");
+});
+test("Test channel Stream combinators", {
+  ch := Channel(i32).new(usize(8));
+  (i : i32) = i32(1);
+  while(i <= i32(5), {
+    _s := ch.try_send(i);
+    i = (i + i32(1));
+  });
+  ch.close();
+  chain := ch.filter(x => ((x % i32(2)) == i32(1))).map(x => (x * i32(10)));
+  h := io.spawn(chain.collect(io), io);
+  got := match(
+    timeout(h, Duration.from_millis(i64(5000)), io),
+    .Ok(list) => list,
+    .Err(_) => {
+      assert(false, "collecting a closed channel must not hang");
+      ArrayList(i32).new()
+    }
+  );
+  assert(got.len() == usize(3), "1, 3 and 5 pass the filter");
+  assert(got(usize(0)) == i32(10), "and the map applied");
+  assert(got(usize(2)) == i32(50), "last");
+});
+test("Test a consumer loop over a channel fed by another task", {
+  ch := Channel(i32).new(usize(2));
+  producer := io.async((io : Io) => {
+    (n : i32) = i32(0);
+    while(n < i32(3), {
+      _s := io.await(ch.send(n, io), io);
+      n = (n + i32(1));
+    });
+    ch.close();
+    ()
+  });
+  h := io.spawn(producer, io);
+  seen := ArrayList(i32).new();
+  (draining : bool) = true;
+  while(draining, {
+    nx := io.await(ch.next(io), io);
+    match(
+      nx,
+      .Some(v) => {
+        seen.push(v);
+      },
+      .None => {
+        draining = false;
+      }
+    );
+  });
+  _done := h.await(io);
+  assert(seen.len() == usize(3), "the loop saw every value the producer sent");
+  assert(seen(usize(0)) == i32(0), "in order");
+  assert(seen(usize(2)) == i32(2), "and it ended on the producer's close");
 });

--- a/tests/async/combinators.test.yo
+++ b/tests/async/combinators.test.yo
@@ -1,10 +1,13 @@
-//! JoinHandle combinators — `join_all`, `race`, `race_first`, `any`,
-//! `any_first`, `timeout`
-//! (`plans/archive/STD_API_AUDIT.md` §7 P0 item 6).
+//! Async combinators — the `JoinHandle` family (`join_all`, `race`,
+//! `race_first`, `any`, `any_first`, `timeout`;
+//! `plans/archive/STD_API_AUDIT.md` §7 P0 item 6) and the `Stream` family
+//! (`map`, `filter`, `filter_map`, `take`, `skip`, `for_each`, `collect`;
+//! `plans/reference/ASYNC_ITERATION_STREAM.md`).
 pragma(Pragma.AllowUnsafe);
 { assert } :: import("std/assert");
 { ArrayList } :: import("std/collections/array_list");
 { join_all, race, race_first, any, any_first, timeout, TimeoutError } :: import("std/async");
+{ Stream } :: import("std/async/stream");
 { Duration } :: import("std/time/duration");
 { sleep } :: import("std/sys/timer");
 
@@ -190,4 +193,294 @@ test("Test any_first is None when every handle was aborted", {
   handles(usize(1)).abort();
   r := any_first(handles, io);
   assert(match(r, .Some(_) => false, .None => true), "no completion means .None");
+});
+
+// ===========================================================================
+// Stream — the async analogue of `Iterator`
+// (plans/reference/ASYNC_ITERATION_STREAM.md)
+// ===========================================================================
+/// A finite test stream: `n`, `n-1`, …, 1, then `.None` forever. A `ref`
+/// struct because `Stream.next` takes `self : Self` — see the trait's doc.
+Countdown :: ref(struct(_n : i32));
+impl(
+  Countdown,
+  Stream(
+    Item : i32,
+    next : (fn(self : Self, io : Io) -> Impl(Future(Option(i32), Io)))(
+      io.async(
+        (io : Io) =>
+          cond(
+            (self._n <= i32(0)) => Option(i32).None,
+            true => {
+              v := self._n;
+              self._n = (self._n - i32(1));
+              Option(i32).Some(v)
+            }
+          )
+      )
+    )
+  )
+);
+/// Run a stream's `collect` FROM INSIDE A SPAWNED TASK, with a deadline.
+///
+/// Both halves matter. Spawning is the shape a blocking await inside a task
+/// would deadlock on (the trap every combinator has to be tested against),
+/// and the deadline is what turns "a combinator loops forever because `.None`
+/// stopped being terminal" into a failed assertion instead of a burnt CI job.
+///
+/// It takes the FUTURE, not the stream, and that is not a style choice: a
+/// blanket-impl combinator method cannot be called on a generic stream
+/// PARAMETER. `s.collect(io)` where `s : S` with `where(S <: Stream(Item :=
+/// i32))` fails with `No matching call found with arguments: (s.collect)(io)`
+/// — the method's own `where(Self <: Stream(Item := A))` has no concrete impl
+/// to read `Item` off. The trait's own `next` is fine on such a parameter
+/// (see `_count_items`); only the blanket methods need a concrete receiver.
+/// Details and options: `plans/backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md`.
+_bounded :: (fn(fut : Impl(Future(ArrayList(i32), Io)), io : Io) -> ArrayList(i32))({
+  h := io.spawn(fut, io);
+  match(
+    timeout(h, Duration.from_millis(i64(5000)), io),
+    .Ok(list) => list,
+    .Err(_) => {
+      assert(false, "stream collect did not finish inside the deadline");
+      ArrayList(i32).new()
+    }
+  )
+});
+/// A consumer generic over "anything that yields values asynchronously" —
+/// the thing that was impossible before the trait existed. It never names the
+/// item type, and accepts stream sources and combinator chains alike.
+///
+/// A bare `where(S <: Stream)` and a CONCRETE binding (`Item := i32`, as in
+/// `_sum_i32`) both work here. What does not is a generic one: a free
+/// function's `where(S <: Stream(Item := A))` with `generic(A : Type)` binds
+/// nothing and rejects every argument, source and chain alike — and
+/// `Iterator` behaves identically, so it is a general property of
+/// associated-type bounds and not something about streams
+/// (`plans/backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md`).
+_count_items :: (
+  fn(generic(S : Type), s : S, io : Io, where(S <: Stream)) -> Impl(Future(usize, Io))
+)(
+  io.async((io : Io) => {
+    (n : usize) = usize(0);
+    (draining : bool) = true;
+    while(draining, {
+      nx := io.await(s.next(io), io);
+      match(
+        nx,
+        .Some(_) => {
+          n = (n + usize(1));
+        },
+        .None => {
+          draining = false;
+        }
+      );
+    });
+    n
+  })
+);
+/// The same idea with the item type spelled out, so the body can use the
+/// values.
+_sum_i32 :: (
+  fn(generic(S : Type), s : S, io : Io, where(S <: Stream(Item := i32))) -> Impl(Future(i32, Io))
+)(
+  io.async((io : Io) => {
+    (total : i32) = i32(0);
+    (draining : bool) = true;
+    while(draining, {
+      nx := io.await(s.next(io), io);
+      match(
+        nx,
+        .Some(v) => {
+          total = (total + v);
+        },
+        .None => {
+          draining = false;
+        }
+      );
+    });
+    total
+  })
+);
+// ---------------------------------------------------------------------------
+// S1. The three cardinalities, awaited straight from `main`
+// ---------------------------------------------------------------------------
+test("Test Stream over an empty source yields nothing", {
+  items := io.await(Countdown(_n : i32(0)).collect(io), io);
+  assert(items.len() == usize(0), "an empty stream collects to an empty list");
+});
+test("Test Stream with a single item", {
+  items := io.await(Countdown(_n : i32(1)).collect(io), io);
+  assert(items.len() == usize(1), "one item");
+  assert(items(usize(0)) == i32(1), "and it is the one the source yielded");
+});
+test("Test Stream with several items keeps their order", {
+  items := io.await(Countdown(_n : i32(3)).collect(io), io);
+  assert(items.len() == usize(3), "three items");
+  assert(items(usize(0)) == i32(3), "first");
+  assert(items(usize(1)) == i32(2), "second");
+  assert(items(usize(2)) == i32(1), "third");
+});
+// ---------------------------------------------------------------------------
+// S2. `.None` is terminal AND stays terminal
+// ---------------------------------------------------------------------------
+test("Test Stream .None is terminal and stays terminal", {
+  c := Countdown(_n : i32(1));
+  first := io.await(c.next(io), io);
+  assert(first.is_some(), "the one item arrives");
+  second := io.await(c.next(io), io);
+  assert(second.is_none(), "then the stream finishes");
+  third := io.await(c.next(io), io);
+  assert(third.is_none(), "and a finished stream stays finished");
+});
+// ---------------------------------------------------------------------------
+// S3. A generic consumer bounded by `where(S <: Stream)`
+// ---------------------------------------------------------------------------
+test("Test a consumer generic over Stream", {
+  n := io.await(_count_items(Countdown(_n : i32(4)), io), io);
+  assert(n == usize(4), "a function that only knows `S <: Stream` drains the stream");
+  chain := Countdown(_n : i32(5)).take(usize(2));
+  n3 := io.await(_count_items(chain, io), io);
+  assert(n3 == usize(2), "and it takes a combinator chain, not only a source");
+  total := io.await(_sum_i32(Countdown(_n : i32(3)), io), io);
+  assert(total == i32(6), "a concrete-Item consumer sums a source");
+  chained := io.await(_sum_i32(Countdown(_n : i32(3)).map(x => (x * i32(2))), io), io);
+  assert(chained == i32(12), "and it accepts a combinator chain, not just a source");
+});
+// ---------------------------------------------------------------------------
+// S4. Each combinator, awaited from inside a spawned task
+// ---------------------------------------------------------------------------
+test("Test Stream map inside a spawned task", {
+  got := _bounded(Countdown(_n : i32(3)).map(x => (x * i32(10))).collect(io), io);
+  assert(got.len() == usize(3), "map is length-preserving");
+  assert(got(usize(0)) == i32(30), "first mapped");
+  assert(got(usize(2)) == i32(10), "last mapped");
+});
+test("Test Stream filter inside a spawned task", {
+  got := _bounded(Countdown(_n : i32(6)).filter(x => ((x % i32(2)) == i32(0))).collect(io), io);
+  assert(got.len() == usize(3), "three even values in 6..1");
+  assert(got(usize(0)) == i32(6), "6 first");
+  assert(got(usize(2)) == i32(2), "2 last");
+});
+test("Test Stream filter that keeps nothing", {
+  got := _bounded(Countdown(_n : i32(4)).filter(x => (x > i32(100))).collect(io), io);
+  assert(got.len() == usize(0), "a predicate no item satisfies drains to empty, it does not hang");
+});
+test("Test Stream filter_map inside a spawned task", {
+  got := _bounded(
+    Countdown(_n : i32(5)).filter_map(
+      x => cond((x > i32(3)) => Option(i32).Some(x + i32(100)), true => Option(i32).None)
+    ).collect(io),
+    io
+  );
+  assert(got.len() == usize(2), "5 and 4 pass the filter half");
+  assert(got(usize(0)) == i32(105), "and the map half applied");
+  assert(got(usize(1)) == i32(104), "second");
+});
+test("Test Stream take inside a spawned task", {
+  got := _bounded(Countdown(_n : i32(10)).take(usize(3)).collect(io), io);
+  assert(got.len() == usize(3), "take(3) stops at three");
+  assert(got(usize(0)) == i32(10), "first");
+  assert(got(usize(2)) == i32(8), "third");
+});
+test("Test Stream take beyond the end of the stream", {
+  got := _bounded(Countdown(_n : i32(2)).take(usize(9)).collect(io), io);
+  assert(got.len() == usize(2), "take(9) over a 2-item stream yields 2, then finishes");
+});
+test("Test Stream take(0) yields nothing", {
+  got := _bounded(Countdown(_n : i32(5)).take(usize(0)).collect(io), io);
+  assert(got.len() == usize(0), "take(0) is an empty stream");
+});
+test("Test Stream skip inside a spawned task", {
+  got := _bounded(Countdown(_n : i32(5)).skip(usize(2)).collect(io), io);
+  assert(got.len() == usize(3), "5 items minus the first 2");
+  assert(got(usize(0)) == i32(3), "the third item is first now");
+});
+test("Test Stream skip past the end of the stream", {
+  got := _bounded(Countdown(_n : i32(2)).skip(usize(5)).collect(io), io);
+  assert(got.len() == usize(0), "skipping more items than exist finishes the stream");
+});
+// ---------------------------------------------------------------------------
+// S5. A chain of combinators
+// ---------------------------------------------------------------------------
+test("Test a Stream combinator chain", {
+  // 10..1 -> evens (10 8 6 4 2) -> +1 (11 9 7 5 3) -> first two.
+  got := _bounded(Countdown(_n : i32(10)).filter(x => ((x % i32(2)) == i32(0))).map(x => (x + i32(1))).take(usize(2)).collect(io), io);
+  assert(got.len() == usize(2), "the chain yields two items");
+  assert(got(usize(0)) == i32(11), "first");
+  assert(got(usize(1)) == i32(9), "second");
+});
+// ---------------------------------------------------------------------------
+// S6. for_each, from `main` and from a task
+// ---------------------------------------------------------------------------
+test("Test Stream for_each from main", {
+  seen := ArrayList(i32).new();
+  io.await(
+    Countdown(_n : i32(3)).for_each(x => {
+      seen.push(x);
+    }, io),
+    io
+  );
+  assert(seen.len() == usize(3), "the body ran once per item");
+  assert(seen(usize(0)) == i32(3), "in order");
+});
+test("Test Stream for_each inside a spawned task", {
+  seen := ArrayList(i32).new();
+  // The chain is built OUTSIDE the task body on purpose: a closure argument
+  // written inside an `io.async` body loses the future's result type
+  // (issues/closure-argument-inside-an-io-async-body-loses-the-future-result-type.md).
+  drain := Countdown(_n : i32(4)).for_each(x => {
+    seen.push(x);
+  }, io);
+  h := io.spawn(drain, io);
+  r := timeout(h, Duration.from_millis(i64(5000)), io);
+  assert(r.is_ok(), "for_each finished inside the deadline");
+  assert(seen.len() == usize(4), "every item reached the body");
+});
+// ---------------------------------------------------------------------------
+// S7. The hand-written consumer loop — what a `for_await` macro would expand
+// to, and the shape to use inside a task until one exists
+// (issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md)
+// ---------------------------------------------------------------------------
+test("Test a hand-written consumer loop inside a spawned task", {
+  seen := ArrayList(i32).new();
+  c := Countdown(_n : i32(3));
+  task := io.async((io : Io) => {
+    (done : bool) = false;
+    while(done == false, {
+      nx := io.await(c.next(io), io);
+      match(
+        nx,
+        .Some(v) => {
+          seen.push(v * i32(2));
+        },
+        .None => {
+          done = true;
+        }
+      );
+    });
+    seen.len()
+  });
+  h := io.spawn(task, io);
+  r := timeout(h, Duration.from_millis(i64(5000)), io);
+  assert(match(r, .Ok(n) => (n == usize(3)), .Err(_) => false), "the task looped over every item");
+  assert(seen(usize(0)) == i32(6), "and the body's effect is visible outside");
+});
+test("Test a hand-written consumer loop over an empty stream", {
+  seen := ArrayList(i32).new();
+  c := Countdown(_n : i32(0));
+  (done : bool) = false;
+  while(done == false, {
+    nx := io.await(c.next(io), io);
+    match(
+      nx,
+      .Some(v) => {
+        seen.push(v);
+      },
+      .None => {
+        done = true;
+      }
+    );
+  });
+  assert(seen.len() == usize(0), "no items, no body");
 });

--- a/tests/cli-cases/init-build-test/expected_tree
+++ b/tests/cli-cases/init-build-test/expected_tree
@@ -1,5 +1,5 @@
 ./.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./.agents/skills/yo-async-effects/async-effects-recipes.md	9fa0329a76e8f8ad114a11124804a023ceba824558d66da1204c959dcb4e477b
+./.agents/skills/yo-async-effects/async-effects-recipes.md	395901220a20d9862d8ee4bcc193748edbda5e2bde402f87623245a5ba022436
 ./.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
 ./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	10b0058fda8f2d07ec7a9d4c833fa07e2ac8391165631a7d277500413057e0a3
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad

--- a/tests/cli-cases/init-cwd/expected_tree
+++ b/tests/cli-cases/init-cwd/expected_tree
@@ -1,5 +1,5 @@
 ./.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./.agents/skills/yo-async-effects/async-effects-recipes.md	9fa0329a76e8f8ad114a11124804a023ceba824558d66da1204c959dcb4e477b
+./.agents/skills/yo-async-effects/async-effects-recipes.md	395901220a20d9862d8ee4bcc193748edbda5e2bde402f87623245a5ba022436
 ./.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
 ./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	10b0058fda8f2d07ec7a9d4c833fa07e2ac8391165631a7d277500413057e0a3
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad

--- a/tests/cli-cases/init-existing/expected_tree
+++ b/tests/cli-cases/init-existing/expected_tree
@@ -1,5 +1,5 @@
 ./probe/.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./probe/.agents/skills/yo-async-effects/async-effects-recipes.md	9fa0329a76e8f8ad114a11124804a023ceba824558d66da1204c959dcb4e477b
+./probe/.agents/skills/yo-async-effects/async-effects-recipes.md	395901220a20d9862d8ee4bcc193748edbda5e2bde402f87623245a5ba022436
 ./probe/.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
 ./probe/.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	10b0058fda8f2d07ec7a9d4c833fa07e2ac8391165631a7d277500413057e0a3
 ./probe/.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad

--- a/tests/cli-cases/init/expected_tree
+++ b/tests/cli-cases/init/expected_tree
@@ -1,5 +1,5 @@
 ./probe/.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./probe/.agents/skills/yo-async-effects/async-effects-recipes.md	9fa0329a76e8f8ad114a11124804a023ceba824558d66da1204c959dcb4e477b
+./probe/.agents/skills/yo-async-effects/async-effects-recipes.md	395901220a20d9862d8ee4bcc193748edbda5e2bde402f87623245a5ba022436
 ./probe/.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
 ./probe/.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	10b0058fda8f2d07ec7a9d4c833fa07e2ac8391165631a7d277500413057e0a3
 ./probe/.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad

--- a/tests/cli-cases/skills-install-zh/expected_tree
+++ b/tests/cli-cases/skills-install-zh/expected_tree
@@ -1,5 +1,5 @@
 ./.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./.agents/skills/yo-async-effects/async-effects-recipes.md	9fa0329a76e8f8ad114a11124804a023ceba824558d66da1204c959dcb4e477b
+./.agents/skills/yo-async-effects/async-effects-recipes.md	395901220a20d9862d8ee4bcc193748edbda5e2bde402f87623245a5ba022436
 ./.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
 ./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	10b0058fda8f2d07ec7a9d4c833fa07e2ac8391165631a7d277500413057e0a3
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad

--- a/tests/cli-cases/skills-install/expected_tree
+++ b/tests/cli-cases/skills-install/expected_tree
@@ -1,5 +1,5 @@
 ./.agents/skills/yo-async-effects/SKILL.md	f722756e3fd18b8727f30c2ee0e1759c185410ac7413f14fbf0e330503c9120e
-./.agents/skills/yo-async-effects/async-effects-recipes.md	9fa0329a76e8f8ad114a11124804a023ceba824558d66da1204c959dcb4e477b
+./.agents/skills/yo-async-effects/async-effects-recipes.md	395901220a20d9862d8ee4bcc193748edbda5e2bde402f87623245a5ba022436
 ./.agents/skills/yo-core-patterns/SKILL.md	e31d4efdb48a46a4061cf67c05e9b5d12e374f240ebce483c8ee9b01f585fcc8
 ./.agents/skills/yo-core-patterns/core-patterns-cheatsheet.md	10b0058fda8f2d07ec7a9d4c833fa07e2ac8391165631a7d277500413057e0a3
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad

--- a/tests/fs/watch.test.yo
+++ b/tests/fs/watch.test.yo
@@ -9,6 +9,10 @@ import("std/fmt");
 { Path } :: import("std/path");
 { watch, WatchOptions, FsEvent, FsEventKind, Watcher } :: import("std/fs/watch");
 { Exception } :: import("std/error");
+{ Stream } :: import("std/async/stream");
+{ timeout } :: import("std/async");
+{ Duration } :: import("std/time/duration");
+{ ArrayList } :: import("std/collections/array_list");
 { sleep } :: import("std/sys/timer");
 file :: import("std/sys/file");
 dir :: import("std/sys/dir");
@@ -184,4 +188,42 @@ test("a watcher dropped without close() releases its backend handle", {
   w.close();
   _unlink(target, io);
   _unlink(probe, io);
+});
+// A `Watcher` is the first `Stream` implementor — its `next` WAS this shape
+// before the trait existed (plans/reference/ASYNC_ITERATION_STREAM.md), so
+// every combinator applies to it. The chain is bounded by `take(1)` and the
+// await runs in a spawned task under a deadline, so a regression that stops
+// delivering events fails instead of hanging.
+test("a Watcher is a Stream: map + take collects one event name", {
+  t_exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  d := temp_dir();
+  target := path_join(d, `yo_watch_stream.txt`);
+  _unlink(target, io);
+  w := watch(Path.new(d), WatchOptions.defaults(), t_exn);
+  names := w.map(e => e.name).take(usize(1));
+  h := io.spawn(names.collect(io), io);
+  _touch(target, String.from("x"), io);
+  got := match(
+    timeout(h, Duration.from_millis(i64(5000)), io),
+    .Ok(list) => list,
+    .Err(_) => {
+      assert(false, "the watcher stream delivered no event inside the deadline");
+      ArrayList(String).new()
+    }
+  );
+  assert(got.len() == usize(1), "take(1) ends the stream after one event");
+  assert(got(usize(0)).len() > usize(0), "the mapped item is the entry name");
+  (more : Option(FsEvent)) = w.poll();
+  while(more.is_some(), {
+    more = w.poll();
+  });
+  w.close();
+  _unlink(target, io);
 });

--- a/tests/net/tcp.test.yo
+++ b/tests/net/tcp.test.yo
@@ -12,6 +12,9 @@ pragma(Pragma.AllowUnsafe);
 { SocketAddr, IpAddr } :: import("std/net/addr");
 { NetError } :: import("std/net/errors");
 { Error, AnyError, Exception, IoExn } :: import("std/error");
+{ Stream } :: import("std/async/stream");
+{ timeout } :: import("std/async");
+{ Duration } :: import("std/time/duration");
 // ============================================================================
 // TcpListener tests
 // ============================================================================
@@ -520,5 +523,119 @@ test("TCP local_addr is this end, and it is the peer's peer_addr", {
   assert(server_stream.local_addr().port == u16(19934), "the accepted socket is bound to the listening port");
   io.await(server_stream.close(io), IoExn(io : io, exn : exn));
   io.await(client.close(io), IoExn(io : io, exn : exn));
+  io.await(listener.close(io), IoExn(io : io, exn : exn));
+});
+// ============================================================================
+// TcpListener.incoming — the listener as a `Stream`
+// (plans/reference/ASYNC_ITERATION_STREAM.md)
+// ============================================================================
+test("TcpListener.incoming is a Stream of accepted connections", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  listener := io.await(TcpListener.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+  bound := listener.local_addr();
+  // The chain is built here, not inside the task: a closure argument written
+  // inside an `io.async` body loses the future's result type.
+  conns := listener.incoming().take(usize(2));
+  server := io.spawn(conns.collect(io), io);
+  // Both connects happen while the server task's accept is pending.
+  client1 := io.await(TcpStream.connect(bound, io), IoExn(io : io, exn : exn));
+  client2 := io.await(TcpStream.connect(bound, io), IoExn(io : io, exn : exn));
+  accepted := match(
+    timeout(server, Duration.from_millis(i64(5000)), io),
+    .Ok(list) => list,
+    .Err(_) => {
+      assert(false, "incoming().take(2) did not deliver two connections inside the deadline");
+      ArrayList(Result(TcpStream, NetError)).new()
+    }
+  );
+  assert(accepted.len() == usize(2), "take(2) ends the stream after two connections");
+  assert(
+    match(accepted(usize(0)), .Ok(st) => (st.fd() >= i32(0)), .Err(_) => false),
+    "the first item is an Ok TcpStream"
+  );
+  assert(
+    match(accepted(usize(1)), .Ok(st) => (st.fd() >= i32(0)), .Err(_) => false),
+    "so is the second — the failure lives IN the item, so one bad accept would not end the stream"
+  );
+  io.await(client1.close(io), IoExn(io : io, exn : exn));
+  io.await(client2.close(io), IoExn(io : io, exn : exn));
+  io.await(listener.close(io), IoExn(io : io, exn : exn));
+});
+test("a closed listener's incoming stream is finished", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  listener := io.await(TcpListener.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+  io.await(listener.close(io), IoExn(io : io, exn : exn));
+  conns := listener.incoming();
+  first := io.await(conns.next(io), io);
+  assert(first.is_none(), "a closed listener accepts nothing more, so the stream is over");
+  second := io.await(conns.next(io), io);
+  assert(second.is_none(), "and it stays over");
+});
+test("a consumer loop over incoming serves each connection in turn", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  listener := io.await(TcpListener.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+  bound := listener.local_addr();
+  fds := ArrayList(i32).new();
+  conns := listener.incoming().take(usize(2));
+  // The accepted streams are dropped by the loop body; `TcpStream`'s Dispose
+  // closes the descriptor, so nothing leaks while the fd is recorded. The
+  // loop is hand-written because a macro that expands to an `io.await` is
+  // emitted as a BLOCKING await inside a task and deadlocks
+  // (issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md).
+  server_task := io.async((io : Io) => {
+    (serving : bool) = true;
+    while(serving, {
+      nx := io.await(conns.next(io), io);
+      match(
+        nx,
+        .Some(c) => {
+          match(
+            c,
+            .Ok(st) => {
+              fds.push(st.fd());
+            },
+            .Err(_) => {
+              fds.push(i32(-1));
+            }
+          );
+        },
+        .None => {
+          serving = false;
+        }
+      );
+    });
+    ()
+  });
+  h := io.spawn(server_task, io);
+  client1 := io.await(TcpStream.connect(bound, io), IoExn(io : io, exn : exn));
+  client2 := io.await(TcpStream.connect(bound, io), IoExn(io : io, exn : exn));
+  r := timeout(h, Duration.from_millis(i64(5000)), io);
+  assert(r.is_ok(), "the loop finished when take(2) ended the stream");
+  assert(fds.len() == usize(2), "the body ran once per connection");
+  assert(fds(usize(0)) >= i32(0), "first connection was accepted, not an error item");
+  assert(fds(usize(1)) >= i32(0), "second too");
+  io.await(client1.close(io), IoExn(io : io, exn : exn));
+  io.await(client2.close(io), IoExn(io : io, exn : exn));
   io.await(listener.close(io), IoExn(io : io, exn : exn));
 });


### PR DESCRIPTION
Implements `plans/reference/ASYNC_ITERATION_STREAM.md` (moved out of `plans/backlog/` with a closing banner). No compiler change.

Yo had `Iterator` and it had `Future`, but nothing that was both, so every std API producing a sequence asynchronously invented its own shape — `accept` in the caller's own loop, `Watcher.next` answering `Option(FsEvent)`, `Channel.recv` plus a separate `try_recv` — and none of them composed. `std/async/stream.yo` is the missing abstraction:

```rust
Stream :: trait(
  Item : Type,
  next : (fn(self : Self, io : Io) -> Impl(Future(Option(Self.Item), Io)))
);
```

## What landed

Three implementors, all of which already had the shape by hand:

| type | its stream |
| --- | --- |
| `Watcher` (`std/fs/watch.yo`) | `Item = FsEvent` — its hand-rolled `next` BECAME the trait method, byte for byte |
| `TcpListener.incoming()` (`std/net/tcp.yo`) | `Item = Result(TcpStream, NetError)` — the deferred `STD_API_STABILIZATION` row, now closed |
| `Channel(T)` (`std/async/channel.yo`) | `Item = T` — `next` IS `recv` |

Lazy combinators `map` / `filter` / `filter_map` / `take` / `skip`, consumers `for_each` / `collect`, written once over `where(S <: Stream)` the way the `Iterator` combinators in `std/prelude.yo` are.

## Shape decisions, and why

- **`next`'s future is `Future(_, Io)`, not `Future(_, IoExn)`** as the plan doc wrote. A stream does not throw: a fallible one carries the failure IN the item (`Item = Result(T, E)`), so one bad item does not end the sequence and a consumer needs no handler. `Watcher.next` already used `Io`, and `Io` is what compiles.
- **`incoming`'s error is `NetError`, not `IoError`** as the plan wrote — it is the type `accept` THROWS, so a server loop moving from `accept` to `incoming` keeps one error vocabulary (`NetError.Io(IoError)` still carries the raw errno). The stream calls the raw `IO_tcp.accept` rather than the throwing method, because an `Exception` handler cannot be installed across a suspension.
- **`self : Self`, not `inout(self)`** as `Iterator` has: the future outlives the call and an `inout` borrow cannot cross a suspension, so every source is a reference-semantics type.
- **`.None` is terminal and stays terminal**; every combinator preserves it (`take` stops touching upstream once spent, `skip`/`filter` adopt upstream's end, `incoming` finishes when the listener closes — including from another task).
- The associated type is `Item`, carrying `DoubleEndedIterator`'s uncheckable coherence rule in its doc (the registry is keyed by (type id, label) with no trait discrimination). No std type implements both `Stream` and `Iterator`.

## What did NOT land, and why that is not a shortcut

- **`for_await` was written and then removed.** An `io.await` reached only through a MACRO EXPANSION is not counted as a suspension point, so the enclosing `io.async` body is emitted as a plain closure with a BLOCKING await — correct from `main`, a **deadlock** inside a spawned task (measured: a `for_await` over `incoming()` in a task hangs at rc=124 with no output). Shipping "correct from main, hangs in a task" for a server loop was not acceptable. `for_each`, `take` and the hand-written `while` + `io.await(s.next(io), io)` + `match` cover the ground.
- **An async `BufReader.lines` is blocked one level down.** A `Stream` reports failure in its item and `read_line` THROWS; a `ctl` handler can neither be installed across a suspension nor stored in a `ref` struct. The blocker is `Reader`'s error style, not the stream protocol.

Filed with minimal reproducers: `issues/io-await-inside-a-macro-expansion-is-emitted-as-a-blocking-await.md`, `issues/closure-argument-inside-an-io-async-body-loses-the-future-result-type.md`. Planned: `plans/backlog/FOR_AWAIT_NEEDS_MACRO_AWARE_ASYNC_TRANSFORM.md`, `plans/backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md`, `plans/backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md` (a free function's `where(T <: Trait(Assoc := A))` with a generic `A` binds nothing — true of `Iterator` too, so pre-existing).

## Verification

| gate | result |
| --- | --- |
| `yo check ./std --std-path ./std` | 174/174 |
| `yo check ./src --std-path ./std` | 270/270 |
| `yo fmt --check ./src ./std ./tests` | clean |
| `yo test ./tests/async/combinators.test.yo` | 27 passed |
| `yo test ./tests/async/channel.test.yo` | 8 passed |
| `yo test ./tests/net/tcp.test.yo` | 21 passed |
| `yo test ./tests/fs/watch.test.yo` | 6 passed |
| `yo test ./tests/io/bufio.test.yo` | 13 passed |
| `yo test ./tests/io/async_traits.test.yo` | 9 passed |
| `cli-diff-test.sh` skills-install, skills-install-zh, init, init-cwd, init-existing, init-build-test | PASS 6 |

The new tests cover every cardinality (empty, one, several), `.None` terminal AND staying terminal, each combinator (including the degenerate `take(0)`, `filter` that keeps nothing, `skip` past the end), a chain, a generic consumer, and each combinator awaited from inside a **spawned task** as well as from `main` — each bounded by `std/async`'s `timeout`, so a regression fails instead of burning a CI job. **Hollow-green probe done:** flipping one assertion to a false value turns the file red, so the batch really runs.

Six `tests/cli-cases/*/expected_tree` goldens are re-recorded because one `.github/skills/` file was edited (the hashes are `sha256` of the source); every affected case was re-scored green rather than assumed.

Docs: `docs/en-US/ASYNC_AWAIT.md` and `docs/zh-CN/ASYNC_AWAIT.md` gain an "async iteration" section; `.github/instructions/yo-design.instructions.md` and `.github/skills/yo-async-effects/async-effects-recipes.md` record the trait plus the three async-body traps measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
