### PR TITLE
std/http: a connection-pooling HttpClient, and RFC 9112 §6.3 body-less framing

### DIFF
--- a/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
+++ b/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
@@ -215,6 +215,53 @@ Already checked and NOT it:
   non-blocking kernel entry
   (`issues/fixed/io-uring-defer-taskrun-poll-never-enters-kernel.md`).
 
+## After the rebase onto develop (2026-09-12): both Linux legs PASS
+
+The branch was ~30 commits behind — it predated #590 (`JoinHandle.abort`
+cancels the I/O the task is suspended in, which rewrote the future header and
+`__yo_io_cleanup`), #592 (six async-emitter dispatch fixes) and #598 (a
+static-dispatch call's C return type). Rebased onto `4e541f82a` and re-run as
+**34663406193**:
+
+| leg | before | after |
+| --- | --- | --- |
+| `test (ubuntu-latest)` | FAIL | **success** |
+| `test (ubuntu-24.04-arm)` | FAIL (the tagged trace above) | **success** |
+
+So something in those thirty commits moved it. That is NOT proof it is fixed —
+the whole issue is timing-dependent, and two green legs on one run is exactly
+what "timing-dependent" looks like half the time. It IS enough to say the next
+trace must be taken on the rebased branch, and that the analysis above was
+performed against a compiler three async-fix batches old.
+
+**The full-corpus hollow sweep still fails the same two tests**, but with a
+DIFFERENT signature, and that difference matters:
+
+```
+✗ HttpClient: a 204 ends at its headers, whatever its Content-Length says
+    Test failed with exit code 134
+✗ HttpClient: a HEAD response ends at its headers and the connection is reused
+    Test failed with exit code 134
+```
+
+Exit 134 is SIGABRT, which IS this bug's signature — the deadline throws,
+the test's `exn` handler `assert(false, ...)`s, and that aborts. The two
+children printed no checkpoints, but that is a property of the harness and not
+evidence about the run: the runner captures each test's output and REPLAYS it
+after the verdict line (in the same log, a passing test's `[wire RSP]` lines
+appear *below* its `✓`), and a child that aborts loses the capture. So the
+sweep is the same failure, not a second one, and it still reproduces in that
+binary shape on a leg whose sibling `test (ubuntu-*)` legs passed — which is
+the clearest statement yet of how narrow the timing window is.
+
+Worth ruling out anyway while reading the file: the keep-alive tests bind
+19840–19855, one port each, so the two failures are not colliding with each
+other or with their predecessor.
+
+Making the sweep keep an aborted child's output would pay for itself here; it
+runs each file through `BIN test <file> --parallel 1` with no `--std-path` and
+no `--verbose`.
+
 ## Earlier hypothesis, now refuted: a two-arm match with an await in each arm
 
 `std/http/client.yo`'s `_Transport.read` is an `io.async` body whose only

--- a/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
+++ b/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
@@ -57,7 +57,44 @@ Ruled out locally so the next session does not repeat them:
 - An x86_64 build under Rosetta could not be produced — homebrew's OpenSSL is
   arm-only, so `--target x86_64-apple-darwin` fails to link `TLS_client_method`.
 
-## The most likely cause: the client's read is a two-arm match with an await in each arm
+## Three suspects EXCLUDED by measurement (2026-09-11)
+
+Recorded so none of them is re-investigated. Each was excluded by comparing
+emitted C or by reading the registration flags, not by a passing test.
+
+1. **The two-arm `_Transport.read` dispatch — NO.** The shape (an enum with two
+   payload arms, each `n = e.io.await(stream.read(...), e)` over
+   differently-shaped futures) was written standalone and emitted with a
+   pre-#592 compiler and with #592's: the C is BYTE-IDENTICAL, and both
+   binaries compute the right answer over 200 alternating iterations. None of
+   #592's six dispatch fixes touch a plain two-arm point.
+
+2. **An edge-triggered readiness registration that misses an edge that already
+   happened — NO, not on macOS.** `__yo_io_register_kevent`
+   (`src/codegen/async/runtime_io_macos.yo`) issues
+   `EV_SET(..., EV_ADD | EV_ONESHOT, ...)` with **no `EV_CLEAR`**, so
+   `EVFILT_READ` is LEVEL-triggered: registering it against a socket whose
+   buffer already holds the response fires immediately.
+
+3. **The while-loop family — NO.** `read_http_message_buffered`'s read loop is
+   an outer `while` whose await is its first statement, with a NESTED `while`
+   (no await) inside a `cond` arm after it, both testing the same `done` flag.
+   That combination was compared function-by-function between a pre-#592
+   compiler and #592+#593: **362 functions on both sides, 0 bodies differ**.
+   The only raw-text difference in the whole file is one unreferenced struct
+   slot (`__yo_t1 var_N; // io`, 0 uses) that the post-fix suspension analysis
+   stops declaring. No store, no read, no branch.
+
+   Worth noting for any future A/B: the compiler's own emission never includes
+   this function, because `std/http` is not in `src/main.yo`'s import closure.
+   An emit A/B over the compiler tree therefore says nothing about it, and the
+   comparison has to be driven from a small program that imports the module.
+
+**That leaves the platform I/O completion path.** The client-side checkpoints
+now on this branch answer the remaining question directly: whether the read is
+never ISSUED, or issued and never woken.
+
+## Earlier hypothesis, now refuted: a two-arm match with an await in each arm
 
 `std/http/client.yo`'s `_Transport.read` is an `io.async` body whose only
 await sits inside a `match`, once per arm:
@@ -88,9 +125,10 @@ It also explains the timing-dependence. Which arm's continuation is emitted as
 the representative, and whether the loop delivers the completion inline or
 through the ready queue, decides whether the mis-routed path is taken.
 
-**So the first thing to do after #592 lands is re-run this branch's battery.**
-If the hang is gone, this issue closes with #592 rather than needing a runtime
-fix. If it survives, the runtime question below is the next one.
+**This was wrong** — see exclusion 1 above. #592 landed and the shape it
+would have had to fix emits identically on both compilers. Kept because the
+reasoning is the right reasoning for the NEXT dispatch-shaped suspicion; only
+the conclusion was wrong.
 
 ## Where to look, if #592 does not fix it
 

--- a/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
+++ b/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
@@ -1,0 +1,73 @@
+# A body-less HTTP response reaches the socket and the client's read never completes — macOS, timing-dependent
+
+**Found**: 2026-09-11, by the server-side checkpoints added to
+`tests/http/http.test.yo` for #556. **Class**: a lost read wake-up in the
+async runtime, visible as a ten-second `HttpError.Timeout` on an exchange that
+completes in ~1 ms. **Status**: OPEN.
+
+## What the checkpoints prove
+
+`HttpClient: a 204 ends at its headers, whatever its Content-Length says`, on
+`test (macos-latest)`:
+
+```
+[204] server spawned, issuing request one
+[srv] accepted connection 1
+[srv] awaiting a framed request (carry=0)
+[srv] framed 38 request byte(s)
+[srv] wrote 46 of 46 answer byte(s)        ← the WHOLE response is on the wire
+[srv] awaiting a framed request (carry=0)
+unexpected exception: HTTP request timed out
+```
+
+Three things are therefore ruled out, and this is what the instrumentation was
+for:
+
+- **not the connect** — the server accepted;
+- **not the request** — the server framed all 38 bytes of it;
+- **not the response framing** — the server wrote all 46 bytes, and
+  `tests/http/wire.test.yo` frames a 204 at its header section at chunk sizes
+  1, 42 and 4096 on every platform.
+
+What is left is the CLIENT's read of a response that is already in the socket
+buffer. It does not complete for ten seconds, and the deadline wins.
+
+## Why it is a race and not a framing bug
+
+The same commit passed `test (macos-latest)` on the run before this one. The
+only difference between the two runs is the checkpoint `eprintln`s in the test
+server. Adding four prints to the server moved the failure onto a runner where
+it had been green — so this is timing-sensitive, not deterministic, and the
+"which platform fails" pattern (macos-26-intel, then windows-latest, then
+macos-latest) is which runner happened to lose the race.
+
+`_KA_204` and `_KA_KEEP`+HEAD are the two shapes that lose it. What is special
+about them is not the framing — it is that the server writes a SHORT response
+and then immediately parks on the next read, so the client's read is the only
+thing the loop has left to wake.
+
+## What did NOT reproduce it
+
+Ruled out locally so the next session does not repeat them:
+
+- The failing test extracted to a standalone `main` with the same server
+  helpers, WITH the checkpoints, 40 consecutive runs on aarch64-apple-darwin:
+  0 failures. Without the checkpoints, 60 runs: 0 failures.
+- The whole `tests/http/http.test.yo` file locally: 51/51.
+- An x86_64 build under Rosetta could not be produced — homebrew's OpenSSL is
+  arm-only, so `--target x86_64-apple-darwin` fails to link `TLS_client_method`.
+
+## Where to look
+
+`__yo_io_process_event` / the kqueue read registration in
+`src/codegen/async/runtime_io_macos.yo`, and the deferred changelist
+(`__yo_kq_changes`) it batches registrations through. The question to answer
+is whether a read registered into the changelist can be left unsubmitted while
+the loop decides it has nothing to wait for — i.e. whether there is a window
+where `__yo_io_wait()` blocks without having flushed the change that would
+have woken it.
+
+The next measurement that would settle it is a client-side checkpoint inside
+`read_http_message_buffered`'s loop (before the `stream.read` await and after
+it), pushed to CI on the same branch. That says whether the read was issued at
+all, or issued and never woken.

--- a/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
+++ b/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
@@ -1,9 +1,11 @@
 # A body-less HTTP response reaches the socket and the client's read never completes — macOS, timing-dependent
 
 **Found**: 2026-09-11, by the server-side checkpoints added to
-`tests/http/http.test.yo` for #556. **Class**: a lost read wake-up in the
-async runtime, visible as a ten-second `HttpError.Timeout` on an exchange that
-completes in ~1 ms. **Status**: OPEN.
+`tests/http/http.test.yo` for #556. **Class**: a lost wake-up in the async
+runtime, visible as a ten-second `HttpError.Timeout` on an exchange that
+completes in ~1 ms. **Status**: OPEN. The "lost READ wake-up" reading is
+REFUTED as of 2026-09-12 — the read completes with the whole response in hand
+(see "The client-side trace" below); what is lost is one level up.
 
 ## What the checkpoints prove
 
@@ -93,6 +95,63 @@ emitted C or by reading the registration flags, not by a passing test.
 **That leaves the platform I/O completion path.** The client-side checkpoints
 now on this branch answer the remaining question directly: whether the read is
 never ISSUED, or issued and never woken.
+
+## The client-side trace (2026-09-12) — the read completes, and the exchange still hangs
+
+Run **34610920605**, job **103332927203**, `test (macos-26-intel)`. The
+checkpoints inside `read_http_message_buffered`'s read loop came back, and they
+refute the heading of this issue:
+
+```
+[204] issuing request two on the pooled connection
+[wire] issuing read (have=0)      (D)
+[wire] read returned 38           (C')
+[srv] framed 38 request byte(s)
+[srv] wrote 46 of 46 answer byte(s)
+[srv] awaiting a framed request (carry=0)
+[wire] issuing read (have=0)      (E)
+[wire] read returned 46           (D')
+unexpected exception: HTTP request timed out
+```
+
+Both peers frame through the SAME function, so the prints interleave. Pairing
+them by who can produce which byte count — requests are 38 bytes, responses 46
+— the client's read `D` **returned all 46 bytes of the response**, and then
+nothing else was printed for ten seconds: not the next loop iteration, not the
+test's `[204] response two`.
+
+So the read is issued, the read is woken, and the whole response is in the
+client's buffer. "A lost read wake-up" is the wrong heading. What is lost sits
+one level UP, and there are exactly two candidates:
+
+1. **The parent await never resumes.** `_do_fetch` awaits
+   `read_http_message_buffered(...)` as a nested async-block future. If that
+   inner future completes and the continuation registered by the parent's
+   await is never invoked, the task stops exactly where the trace stops.
+2. **`_fetch_follow` finishes and nobody notices.** `_fetch_deadline`
+   (`std/http/client.yo`) does not await the exchange — it spawns it and spins:
+
+   ```rust
+   h := e.io.spawn(_fetch_follow(url_str, opts, pool, e.io), e);
+   dh := e.io.spawn(sleep(limit, e.io), e.io);
+   while(runtime(!h.is_finished() && !dh.is_finished()), {
+     e.io.await(yield(e.io), e.io);
+   });
+   ```
+
+   `is_finished()` reads the spawned future's state word
+   (`__yo_join_handle_state_raw`). If the exchange completes and that word is
+   not published where this loop reads it, the spin runs until the 1 ms-timer
+   `yield`s have burned the whole ten seconds and `dh` wins — which produces
+   `HttpError.Timeout` with the request long since answered.
+
+The pairing above is INFERRED, not read off the log, which is a defect in the
+instrumentation rather than in the reasoning. The checkpoints therefore now
+carry a `REQ`/`RSP` tag (the server frames Requests, the client Responses), a
+third print marks the read loop EXITING, and `client.yo` brackets its await on
+either side. The next trace separates the two candidates without inference: if
+`[wire RSP] loop done` prints and `[clt] parent await resumed` does not, it is
+candidate 1; if both print and the deadline still fires, it is candidate 2.
 
 ## Earlier hypothesis, now refuted: a two-arm match with an await in each arm
 

--- a/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
+++ b/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
@@ -57,7 +57,42 @@ Ruled out locally so the next session does not repeat them:
 - An x86_64 build under Rosetta could not be produced — homebrew's OpenSSL is
   arm-only, so `--target x86_64-apple-darwin` fails to link `TLS_client_method`.
 
-## Where to look
+## The most likely cause: the client's read is a two-arm match with an await in each arm
+
+`std/http/client.yo`'s `_Transport.read` is an `io.async` body whose only
+await sits inside a `match`, once per arm:
+
+```rust
+_Transport :: enum(Plain(stream : TcpStream), Secure(stream : TlsStream));
+read : ... io.async(e => {
+  (n : usize) = usize(0);
+  match(
+    self,
+    .Plain(stream) => { n = e.io.await(stream.read(buf, size, e.io), e); },
+    .Secure(stream) => { n = e.io.await(stream.read(buf, size, e.io), e); }
+  );
+  n
+})
+```
+
+That is the DISPATCH-MODE await point — one shared `await_future_N` slot,
+branches that await differently-shaped futures, a continuation that has to be
+routed back to the arm that suspended. It is the exact family #592 redesigns,
+and its six fixed bugs include "a sibling arm's second-await binding never
+assigned when its continuation lands in a chained layer" and "bound nested
+cond in a chained layer emitted nothing". A continuation that is routed to no
+arm is a task that never resumes — which is precisely what the checkpoints
+show: the bytes arrive, and the reader never wakes.
+
+It also explains the timing-dependence. Which arm's continuation is emitted as
+the representative, and whether the loop delivers the completion inline or
+through the ready queue, decides whether the mis-routed path is taken.
+
+**So the first thing to do after #592 lands is re-run this branch's battery.**
+If the hang is gone, this issue closes with #592 rather than needing a runtime
+fix. If it survives, the runtime question below is the next one.
+
+## Where to look, if #592 does not fix it
 
 `__yo_io_process_event` / the kqueue read registration in
 `src/codegen/async/runtime_io_macos.yo`, and the deferred changelist

--- a/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
+++ b/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
@@ -3,8 +3,10 @@
 **Found**: 2026-09-11, by the server-side checkpoints added to
 `tests/http/http.test.yo` for #556. **Class**: a lost wake-up in the async
 runtime, visible as a ten-second `HttpError.Timeout` on an exchange that
-completes in ~1 ms. **Status**: OPEN — a lost READ
-wake-up, confirmed 2026-09-12 by the ROLE-TAGGED trace below. (An intermediate
+completes in ~1 ms. **Status**: OPEN — an inner
+`io.async` BLOCK completes and the awaiting parent never resumes. Settled
+2026-09-12 by the transport-level checkpoints; earlier readings of this issue
+are superseded and marked as such below. (An intermediate
 reading that put the loss one level up came from pairing two peers' untagged
 prints by guesswork; that section is kept, marked, because the two candidates
 it names are the ones the tags had to rule out.)
@@ -214,6 +216,56 @@ Already checked and NOT it:
   `__yo_io_poll` performs a zero-timeout `io_uring_wait_cqe_timeout` as its
   non-blocking kernel entry
   (`issues/fixed/io-uring-defer-taskrun-poll-never-enters-kernel.md`).
+
+## SETTLED (2026-09-12): the read completes and the PARENT AWAIT never resumes
+
+Run **34670975269**, `test (ubuntu-24.04-arm)`, with checkpoints inside
+`_Transport.read` — the `io.async` block that `[wire RSP] issuing read` is
+printed BEFORE, and which is cold until its await runs it:
+
+```
+[wire RSP] issuing read (have=0)
+[tr] read entered                                  ← the transport future DID start
+[wire REQ] read returned 38
+[srv] framed 38 request byte(s)
+[srv] wrote 46 of 46 answer byte(s)
+[srv] awaiting a framed request (carry=0)
+[wire REQ] issuing read (have=0)
+[tr] plain arm done n=46                           ← the socket read COMPLETED, 46 bytes
+[wire RSP] read returned 46
+[wire RSP] loop done, 46 byte(s), header_end=42    ← FRAMED, correctly
+<ten seconds>
+unexpected exception: HTTP request timed out
+```
+
+So the whole chain works: the read is issued, woken, returns all 46 bytes, and
+`read_http_message_buffered` frames them at the header section exactly as the
+204 rule requires. **`[clt] parent await resumed` never prints.**
+
+That is not a lost READ wake-up and it is not in either I/O backend. An inner
+`io.async` block runs to its tail and the parent suspended on
+`e.io.await(read_http_message_buffered(...), e)` is never resumed — which is
+why it looks identical on kqueue and on io_uring, and why nothing in
+`runtime_io_*.yo` was ever going to explain it.
+
+Everything between `loop done` and the parent's resume is SYNCHRONOUS — a
+`free`, a `find_header_end`, and one `cond`. So the next checkpoint is the
+block's own tail (`[wire RSP] framed, returning`, now on this branch): if it
+prints, the block produced its value and the block-COMPLETION path failed to
+invoke the registered continuation; if it does not, the tail `cond` is where
+the task goes missing.
+
+Two facts that constrain the search:
+
+- The task did not ABORT either. An abort would make `h.is_finished()` true,
+  `_fetch_deadline`'s spin would exit, and `h.await(e.io)` would return `.None`
+  and throw `HttpError.Other("request task was aborted")`. The error is
+  `Timeout`, so the spin ran the full ten seconds: the task is neither
+  completed nor aborted.
+- **It does not reproduce locally.** 27 runs of `tests/http/http.test.yo` on
+  aarch64-apple-darwin against a v0.2.31-seeded build of this branch — 12
+  ordinary, 15 with eight CPU hogs saturating the machine — zero failures. CI
+  is the only oracle; do not spend another afternoon on a local loop.
 
 ## After the rebase onto develop (2026-09-12): both Linux legs PASS
 

--- a/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
+++ b/issues/a-bodyless-http-response-is-not-read-until-the-deadline.md
@@ -1,11 +1,13 @@
-# A body-less HTTP response reaches the socket and the client's read never completes — macOS, timing-dependent
+# A body-less HTTP response reaches the socket and the client's read never completes — Linux and macOS, timing-dependent
 
 **Found**: 2026-09-11, by the server-side checkpoints added to
 `tests/http/http.test.yo` for #556. **Class**: a lost wake-up in the async
 runtime, visible as a ten-second `HttpError.Timeout` on an exchange that
-completes in ~1 ms. **Status**: OPEN. The "lost READ wake-up" reading is
-REFUTED as of 2026-09-12 — the read completes with the whole response in hand
-(see "The client-side trace" below); what is lost is one level up.
+completes in ~1 ms. **Status**: OPEN — a lost READ
+wake-up, confirmed 2026-09-12 by the ROLE-TAGGED trace below. (An intermediate
+reading that put the loss one level up came from pairing two peers' untagged
+prints by guesswork; that section is kept, marked, because the two candidates
+it names are the ones the tags had to rule out.)
 
 ## What the checkpoints prove
 
@@ -96,7 +98,13 @@ emitted C or by reading the registration flags, not by a passing test.
 now on this branch answer the remaining question directly: whether the read is
 never ISSUED, or issued and never woken.
 
-## The client-side trace (2026-09-12) — the read completes, and the exchange still hangs
+## The client-side trace (2026-09-12) — SUPERSEDED by the tagged trace above
+
+> Kept because the two candidates it names are what the role tags had to rule
+> out. Its pairing of the untagged `[wire]` prints was inferred, and the
+> inference was wrong.
+
+### The client-side trace (2026-09-12) — the read completes, and the exchange still hangs
 
 Run **34610920605**, job **103332927203**, `test (macos-26-intel)`. The
 checkpoints inside `read_http_message_buffered`'s read loop came back, and they
@@ -152,6 +160,60 @@ third print marks the read loop EXITING, and `client.yo` brackets its await on
 either side. The next trace separates the two candidates without inference: if
 `[wire RSP] loop done` prints and `[clt] parent await resumed` does not, it is
 candidate 1; if both print and the deadline still fires, it is candidate 2.
+
+## The TAGGED trace (2026-09-12) — the read is issued and never woken
+
+Run **34630623522**, job **103368382554**, `test (ubuntu-24.04-arm)`. With
+`REQ`/`RSP` tags there is no pairing to infer, and this is the whole failure:
+
+```
+[204] server spawned, issuing request one
+[srv] accepted connection 1
+[srv] awaiting a framed request (carry=0)
+[wire REQ] issuing read (have=0)
+[clt] awaiting the framed response (reused=false)
+[wire RSP] issuing read (have=0)          ← the client's read IS issued
+[wire REQ] read returned 38
+[wire REQ] loop done, 38 byte(s), header_end=34
+[srv] framed 38 request byte(s)
+[srv] wrote 46 of 46 answer byte(s)       ← the whole response is on the wire
+[srv] awaiting a framed request (carry=0)
+[wire REQ] issuing read (have=0)
+<ten seconds>
+unexpected exception: HTTP request timed out
+```
+
+`[wire RSP] read returned` never appears, and neither does
+`[wire RSP] loop done` or `[clt] parent await resumed`. So on THIS runner the
+answer is candidate (0) rather than either of the two above: the read is
+registered before the response is written, the response is written in full, and
+the completion is never delivered. **The original heading was right after all**
+— what the earlier, UNTAGGED macos-26-intel trace looked like was an artifact of
+pairing two peers' prints by guesswork.
+
+Note this is request ONE, on a FRESH connection (`reused=false`): the pool is
+not involved, and neither is the second exchange.
+
+### What that rules IN, and what is already excluded
+
+The remaining surface is the Linux io_uring completion path, with one caveat
+that has to be checked before anything else: **this branch is ~30 commits
+behind develop.** It predates #590 (`JoinHandle.abort` cancels the I/O the task
+is suspended in — which rewrote `__yo_io_cleanup` and the future header) and
+#592 (six async-emitter dispatch fixes). Rebase first; re-run; only then read
+the runtime.
+
+Already checked and NOT it:
+
+- **`IORING_SETUP_DEFER_TASKRUN` starving a userspace-only poller.** That is a
+  real bug of exactly this shape — the ring materialises completions only when
+  the thread enters the kernel with `IORING_ENTER_GETEVENTS`, and
+  `_fetch_deadline`'s `is_finished()`+`await yield()` spin means
+  `__yo_async_poll_step` never reaches `__yo_io_wait` — but it is ALREADY
+  FIXED, on develop and on this branch:
+  `__yo_io_poll` performs a zero-timeout `io_uring_wait_cqe_timeout` as its
+  non-blocking kernel entry
+  (`issues/fixed/io-uring-defer-taskrun-poll-never-enters-kernel.md`).
 
 ## Earlier hypothesis, now refuted: a two-arm match with an await in each arm
 

--- a/issues/a-module-global-is-lost-across-an-async-suspension.md
+++ b/issues/a-module-global-is-lost-across-an-async-suspension.md
@@ -1,0 +1,51 @@
+# A module-level mutable binding is lost across a suspension point in an `io.async` body
+
+**Status: OPEN.** Found 2026-09-11 while writing the keep-alive server for
+`std/http`'s pool tests, where a module-level accept counter written by a
+spawned server task read back as zero.
+
+## Symptom
+
+A module-level mutable binding (`(g_n : usize) = usize(0);`) read or written
+inside an `io.async` body that SUSPENDS operates on a copy: the writes are
+lost, and a later call starts from the value the global had before the body
+ran. The same body with no `io.await` in it updates the real global.
+
+## Reproducer
+
+`issues/repros/module-global-lost-across-an-async-suspension.yo`:
+
+```
+flat, awaited:       task=2 global=2      <- correct
+suspending, awaited: task=2 global=0      <- writes lost
+suspending, awaited: task=2 global=0      <- and the second call restarts from 0
+suspending, spawned: task=2 global=0
+```
+
+Every body is the same two increments of `g_n`; the suspending ones have an
+`io.await(sleep(1ms))` between them. The task's own return value shows it saw
+1 then 2, so the increments happened — against storage the caller cannot see,
+and which the next call does not see either.
+
+## Why it matters
+
+It is silent. The testing guidance in
+`.github/instructions/testing.instructions.md` recommends a module-level
+counter as the in-language oracle for a leak, and that recommendation is sound
+only for synchronous code: an async body that suspends makes the counter read
+zero, which looks exactly like "the thing under test never happened". It cost
+an afternoon of chasing a working pool that reported no accepts.
+
+The workaround, used by `tests/http/http.test.yo`'s `_KaStats`, is to put the
+counters in a `ref(struct(...))` and pass it as a parameter — reference
+semantics are shared by construction. (That workaround costs a leaked
+reference per call, for
+`issues/a-ref-value-passed-to-an-async-future-is-never-released.md`.)
+
+## Where to look
+
+A suspension splits the body into state-machine states, and locals that live
+across the split are moved into the future's state struct. A module-level
+binding is not a local and must keep being addressed as a global; the symptom
+says it is being promoted into that struct (snapshot on entry, written back
+nowhere). `src/codegen/async/` — the state-field promotion decision.

--- a/issues/a-ref-value-passed-to-an-async-future-is-never-released.md
+++ b/issues/a-ref-value-passed-to-an-async-future-is-never-released.md
@@ -1,0 +1,66 @@
+# A `ref` value passed as a parameter to an `io.async` future is never released
+
+**Status: OPEN.** Found 2026-09-11 while building `std/http`'s connection pool
+(`HttpClient`), whose `Dispose` this defect makes unreachable.
+
+## Symptom
+
+A `ref(struct(...))` value handed to a function whose body is an `io.async`
+future is dup'd into the future's capture record and never dropped. Its
+reference count therefore never reaches zero, so its `Dispose` never runs and
+the object leaks — one leaked object per call, unbounded.
+
+The identical parameter on a plain `fn` is released correctly, which is what
+localizes this to the async lowering.
+
+## Reproducer
+
+`issues/repros/ref-param-to-async-future-never-released.yo`:
+
+```
+plain fn:  created=50 disposed=50
+io.async:  created=50 disposed=0
+```
+
+Both loops create 50 `Thing`s in a scope that ends each iteration; the second
+passes each one to an `io.async` future and awaits it. Fifty objects leak, and
+they are still leaked after the enclosing function returns — this is not a
+drop deferred to the end of the frame.
+
+It reproduces for `self` too (`t.method(io)` where `method`'s body is an
+`io.async`), and it does not need a suspension point: the future in the
+reproducer completes synchronously.
+
+## Why it matters
+
+Every reference-semantics value that reaches async code is affected, which in
+`std/` is most of them:
+
+- `TcpStream` / `TlsStream` passed to the framing read
+  (`std/http/wire.yo`'s `read_http_message_buffered`), to `_flush_wbio` and to
+  `_feed_rbio`. Their `Dispose`s can never fire on a drop, so "the descriptor
+  is closed when the stream goes out of scope" — the contract `TcpStream`'s
+  `Dispose` exists to provide — does not hold in practice for any stream that
+  has been read from or written to.
+- `HttpClient` (`std/http/client.yo`): the pool's `Dispose` closes every idle
+  connection, and a client that has made a single request never reaches count
+  zero, so the idle set is only released through the explicit `close_idle()`.
+  That is why `tests/http/http.test.yo`'s "dispose closes every idle
+  connection" calls `dispose` by hand: the body under test is the right one,
+  but the drop that should invoke it cannot fire.
+
+## Where to look
+
+The capture record is built in the future-construction stub emitted next to
+each `io.async` body (`__capture_closure_*` in the generated C), which dups
+every captured `ref`:
+
+```c
+__yo_t63 __capture_closure_yo_id_18364_0 =
+  (__yo_t63){ .size = size, .self = ((__yo_t17*)__yo_incr_rc((void*)(self))), ... };
+```
+
+and the state machine has a `_state_dispose` function. Either that dispose does
+not drop the capture record's `ref` fields, or it is not called on the
+completed future's release. `src/codegen/async/` and the state-machine
+dispose emitter are the places to start.

--- a/issues/fixed/a-dropped-tlsstream-leaks-its-socket-and-openssl-objects.md
+++ b/issues/fixed/a-dropped-tlsstream-leaks-its-socket-and-openssl-objects.md
@@ -1,0 +1,65 @@
+# A dropped `TlsStream` leaks its socket and its OpenSSL objects
+
+**Status: FIXED 2026-09-11** (`std/crypto/tls.yo` gained a `Dispose`), with the
+caveat in "Residual" below.
+
+## Symptom
+
+`TlsStream` had no `Dispose` impl. Its only teardown was the async
+`close(io)`, so there was no way at all — not even an explicit one — to
+release a stream from synchronous code, and a stream that went out of scope
+leaked:
+
+- the socket descriptor. `TcpStream`'s own `Dispose` cannot help: the socket is
+  a private field of the TLS stream, and dropping the TLS stream does not run
+  the inner stream's dispose.
+- the OpenSSL `SSL` object with both of its BIOs, and the `SSL_CTX`.
+
+This is the same class as
+`issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md`
+— a type owning a raw resource with no `Dispose` — minus the
+use-after-free.
+
+## How it was found
+
+`std/http`'s connection pool (`HttpClient`) has to close idle connections from
+plain, non-async code: eviction when the pool is full, expiry of an
+over-age connection, and the client's own `dispose`. Its `_Transport.close_sync`
+delegates to the stream's `Dispose`, and there was nothing to delegate to for
+the TLS arm.
+
+## Fix
+
+`impl(TlsStream, Dispose(dispose : ...))` in `std/crypto/tls.yo`: guarded on
+the existing `_closed` flag, it frees the OpenSSL objects with
+`__yo_tls_free` (which releases both BIOs and the context) and then delegates
+to `(TcpStream <: Dispose).dispose(self._tcp)` for the socket.
+
+It deliberately does NOT send a `close_notify`: flushing the write BIO needs
+the event loop, and `dispose` runs in plain code. `close(io)` remains the
+graceful form and makes `dispose` a no-op afterwards.
+
+## Verification
+
+`issues/repros/dropped-tlsstream-leaks-its-socket.yo` counts open descriptors
+synchronously (`dup(0)` returns the lowest free number, so N repeats give
+`highest + 1 == open_count + N`). Measured on macOS 2026-09-11:
+
+```
+open before=4 connected=8 wrote=8 after=7
+```
+
+`after == connected - 1`: the stream's socket goes on `dispose`. The other
+three descriptors the connect allocates are libcrypto's own (trust store,
+RNG), opened on first use rather than per stream.
+
+## Residual
+
+The IMPLICIT path — letting a `TlsStream` go out of scope — still does not
+release it, and that is a separate defect:
+`issues/a-ref-value-passed-to-an-async-future-is-never-released.md`.
+`TlsStream` is passed as a parameter to the `_flush_wbio` and `_feed_rbio`
+futures on every read and write, and each of those leaks a reference, so its
+count never reaches zero. The `Dispose` added here is what makes the explicit
+teardown possible (and is what `std/http`'s pool uses); it will start firing on
+drop as well once that leak is fixed.

--- a/issues/repros/dropped-tlsstream-leaks-its-socket.yo
+++ b/issues/repros/dropped-tlsstream-leaks-its-socket.yo
@@ -1,0 +1,89 @@
+// A `TlsStream` had no `Dispose` at all, so there was NO way — explicit or
+// implicit — to release its socket descriptor and its OpenSSL `SSL`/`SSL_CTX`
+// pair other than the async `close(io)`. `TcpStream`'s own `Dispose` is not
+// reachable through it, because the socket is a private field of the TLS
+// stream.
+//
+// The oracle is the number of OPEN descriptors, measured synchronously:
+// `dup(0)` returns the LOWEST free number, so N repeats occupy the N lowest
+// free slots and `highest + 1 == open_count + N`. The event loop allocates
+// descriptors of its own on first use, so the baseline is taken AFTER a
+// warm-up await.
+//
+// NEEDS NETWORK EGRESS (it connects to example.com:443).
+//
+//   yo compile issues/repros/dropped-tlsstream-leaks-its-socket.yo \
+//     --std-path ./std --optimize 2 -o /tmp/repro.out && /tmp/repro.out
+//
+// The measurement that matters is `after == connected - 1`: the stream's own
+// socket goes. Measured 2026-09-11 on macOS:
+//
+//   open before=4 connected=8 wrote=8 after=7
+//
+// The other three descriptors the connect allocates are libcrypto's own
+// (trust store / RNG), opened on first use and not per stream.
+//
+// Before the fix: `dispose` did not exist, so this file did not compile.
+//
+// The IMPLICIT path (letting the value go out of scope) is still blocked by a
+// separate defect: a `ref` value passed as a parameter to an `io.async`
+// future is never released, and `TlsStream` is passed to the `_flush_wbio` /
+// `_feed_rbio` futures on every read and write, so its reference count never
+// reaches zero — issues/a-ref-value-passed-to-an-async-future-is-never-released.md.
+pragma(Pragma.AllowUnsafe);
+{ println } :: import("std/fmt");
+{ Exception, IoExn } :: import("std/error");
+{ ArrayList } :: import("std/collections/array_list");
+{ TlsStream, tls_available } :: import("std/crypto/tls");
+{ Duration } :: import("std/time/duration");
+{ sleep } :: import("std/time/sleep");
+{ dup } :: import("std/sys/pipe");
+{ close_sync } :: import("std/sys/file");
+_open_fd_count :: (fn() -> i32)({
+  taken := ArrayList(i32).new();
+  i := i32(0);
+  while(runtime(i < i32(8)), {
+    taken.push(dup(i32(0)));
+    i = (i + i32(1));
+  });
+  highest := i32(0);
+  j := usize(0);
+  while(runtime(j < taken.len()), {
+    f := taken(j);
+    cond(
+      (f > highest) => {
+        highest = f;
+      },
+      true => ()
+    );
+    j = (j + usize(1));
+  });
+  j = usize(0);
+  while(runtime(j < taken.len()), {
+    close_sync(taken(j));
+    j = (j + usize(1));
+  });
+  (highest + i32(1)) - i32(8)
+});
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  e := IoExn(io : io, exn : exn);
+  cond(
+    !tls_available() => {
+      println(`skipped: no TLS backend`);
+      return();
+    },
+    true => ()
+  );
+  // Warm up: the first await is what creates the event loop's own
+  // descriptors, and they must not be counted as the stream's.
+  io.await(sleep(Duration.from_millis(i64(1)), io), e);
+  before := _open_fd_count();
+  s := io.await(TlsStream.connect(`example.com`, u16(443), io), e);
+  connected := _open_fd_count();
+  _w := io.await(s.write_string(`GET / HTTP/1.0\r\nHost: example.com\r\n\r\n`, io), e);
+  wrote := _open_fd_count();
+  (TlsStream <: Dispose).dispose(s);
+  after := _open_fd_count();
+  println(`open before=${before} connected=${connected} wrote=${wrote} after=${after}`);
+});
+export(main);

--- a/issues/repros/dropped-tlsstream-leaks-its-socket.yo
+++ b/issues/repros/dropped-tlsstream-leaks-its-socket.yo
@@ -10,7 +10,10 @@
 // descriptors of its own on first use, so the baseline is taken AFTER a
 // warm-up await.
 //
-// NEEDS NETWORK EGRESS (it connects to example.com:443).
+// NEEDS NETWORK EGRESS (it connects to example.com:443), and the descriptor
+// count only means anything on a platform where sockets ARE descriptors —
+// macOS and Linux. On Windows a socket is not in the CRT descriptor table, so
+// the count never moves; run this one on a Unix box.
 //
 //   yo compile issues/repros/dropped-tlsstream-leaks-its-socket.yo \
 //     --std-path ./std --optimize 2 -o /tmp/repro.out && /tmp/repro.out

--- a/issues/repros/ref-param-to-async-future-never-released.yo
+++ b/issues/repros/ref-param-to-async-future-never-released.yo
@@ -1,0 +1,55 @@
+// A `ref` value passed as a PARAMETER to an `io.async` future is never
+// released: the future's state machine dups it into its capture record and
+// nothing ever drops it, so the value's reference count never reaches zero
+// and its `Dispose` never runs.
+//
+//   yo compile issues/repros/ref-param-to-async-future-never-released.yo \
+//     --std-path ./std --optimize 2 -o /tmp/repro.out && /tmp/repro.out
+//
+// Expected: "created=50 disposed=50" on both lines.
+// Actual:   "disposed=0" — 50 leaked objects, one per call.
+{ println } :: import("std/fmt");
+{ Exception, IoExn } :: import("std/error");
+(g_disposed : i32) = i32(0);
+Thing :: ref(struct(n : i32));
+impl(
+  Thing,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      g_disposed = (g_disposed + i32(1));
+    })
+  )
+);
+// The control: a plain fn taking the same parameter releases it correctly.
+_plain :: (fn(t : Thing) -> i32)(t.n);
+// The bug: the identical parameter, on an `io.async` future.
+_async :: (fn(t : Thing, io : Io) -> Impl(Future(i32, IoExn)))(
+  io.async(e => {
+    return(t.n);
+  })
+);
+_via_plain :: (fn() -> unit)({
+  i := i32(0);
+  while(runtime(i < i32(50)), {
+    t := Thing(n : i32(i));
+    _v := _plain(t);
+    i = (i + i32(1));
+  });
+});
+_via_async :: (fn(io : Io, exn : Exception) -> unit)({
+  e := IoExn(io : io, exn : exn);
+  i := i32(0);
+  while(runtime(i < i32(50)), {
+    t := Thing(n : i32(i));
+    _v := io.await(_async(t, io), e);
+    i = (i + i32(1));
+  });
+});
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  _via_plain();
+  println(`plain fn:  created=50 disposed=${g_disposed}`);
+  g_disposed = i32(0);
+  _via_async(io, exn);
+  println(`io.async:  created=50 disposed=${g_disposed}`);
+});
+export(main);

--- a/plans/README.md
+++ b/plans/README.md
@@ -118,10 +118,13 @@ with the blocker measured:
 awaiting macro deadlocks in a task),
 [`backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md`](backlog/ASYNC_LINES_NEEDS_A_NONTHROWING_READ.md)
 (an async `BufReader.lines` needs a `Reader` that returns its failure instead
-of throwing it) and
+of throwing it),
 [`backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md`](backlog/ASSOC_TYPE_BINDING_IN_FREE_FN_WHERE.md)
 (`where(T <: Trait(Assoc := A))` binds nothing when `A` is a generic — true of
-`Iterator` too).
+`Iterator` too), and
+[`backlog/ASYNC_DEADLINE_COMBINATOR.md`](backlog/ASYNC_DEADLINE_COMBINATOR.md)
+(why `std/async`'s `timeout` cannot be used from inside a task, and the HTTP
+server keep-alive that blocks on it).
 
 **Language features the std campaign is blocked on** (added 2026-09-10, each
 written from the std row that needs it, with the blocked call sites named):

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -670,10 +670,13 @@ non-test caller existed in the whole tree (`src/main.yo`'s
 **I/O.** Verified against the code 2026-09-09 — LANDED:
 `Stdout.write_string`; `Reader.read_exact`; lazy `read_dir`;
 `Metadata.modified`; `SocketAddr`/`IpAddr` `Eq`/`Hash`/`Ord`/`Clone` + `parse`;
-`TcpStream.local_addr`; `TcpListener.incoming` (this one 2026-09-11, on the
-new `Stream` trait — described below). STILL OPEN: HTTP keep-alive — its
-FRAMING half landed 2026-09-10 (described just below), the pooling client is
-the remaining piece. (`Child` stdin/stdout/stderr as `Reader`/`Writer`
+   `TcpStream.local_addr`; `TcpListener.incoming` (this one 2026-09-11, on the
+   new `Stream` trait — described below); HTTP keep-alive on the CLIENT — its
+   framing half 2026-09-10 and the pooling `HttpClient` 2026-09-11, both
+   described just below. STILL OPEN: keep-alive on the SERVER, which needs an
+   idle timeout and therefore a deadline combinator `std/async` does not have —
+   `plans/backlog/ASYNC_DEADLINE_COMBINATOR.md` has the evidence and the
+   recommendation. (`Child` stdin/stdout/stderr as `Reader`/`Writer`
 handles and `Watcher` `Dispose` also landed 2026-09-10, described below.)
 (`Seek`, `OpenOptions`, `SystemTime`, `IpAddr.parse_v6`,
 `UdpSocket.recv_from -> (n, from)`, `StatusCode` and `HeaderMap` all landed
@@ -768,6 +771,165 @@ prerequisite of its own that the client does not: an IDLE TIMEOUT. `serve` is
 one-connection-at-a-time, so a client that holds a keep-alive connection open
 and sends nothing would wedge the server — which is why the server half is not
 simply "loop until the client closes".
+
+**HTTP keep-alive, the pooling client — LANDED 2026-09-11.**
+
+`HttpClient` is that object. It owns its idle connections, is keyed by
+connection target, retries a connection the server closed under it, and closes
+the set it owns. The free `fetch`/`fetch_with` are unchanged in behaviour:
+every hop opens its own connection and announces `Connection: close`. There is
+deliberately no hidden pool behind them — nothing in a free function could say
+when those sockets close, which is the whole reason the pool is an object.
+
+The shape decisions, and why each one is what it is:
+
+- **One code path, parameterized by `pool : Option(HttpClient)`.** The pooled
+  and one-shot exchanges differ in three places: whether a connection is taken
+  from a pool, whether `Connection: close` is sent, and whether the connection
+  is returned or closed. Everything else — URL parsing, request building,
+  framing, redirects, the deadline race — is identical, so `_fetch_once`,
+  `_fetch_follow` and `_fetch_deadline` each take the option and there is
+  exactly one copy of each. A second copy is where the redirect handling and
+  the framing would have drifted apart.
+
+- **The pool key is `scheme://host:port`, from the URL's own host TEXT.**
+  Not the resolved address: two host names that resolve to one address are
+  still two peers as far as TLS, `Host` and virtual hosting are concerned, and
+  handing an `https://a` connection to a request for `https://b` speaks to the
+  wrong peer under the first peer's certificate. The key is compared, never
+  inferred, and the scheme is in it so `http` and `https` can never share.
+
+- **The cap is TOTAL, not per host, and defaults to 16.** The resource being
+  protected is the process's descriptor table, and a per-host cap does not
+  bound it: a client fanning out over a thousand hosts would hold a thousand
+  sockets with a per-host cap of 1. Go's `DefaultMaxIdleConnsPerHost` is 2 with
+  a separate total of 100; reqwest's per-host cap is unbounded. 16 is enough
+  for several concurrent tasks against a handful of targets, which is what a
+  single-threaded event loop can keep busy. When the pool is full the
+  connection in hand is closed rather than evicting one already in it (Go's
+  answer too), so a burst of parallel requests cannot churn the whole pool.
+  `max_idle == 0` is the degenerate setting and means "never reuse".
+
+- **The idle age limit defaults to 30 s** and is expressible because
+  `Instant`/`Duration` already are: each entry records `Instant.now()` and
+  `_take` purges over-age entries as it scans. Purging on a request rather than
+  on a timer is what keeps the pool free of a background task — the only
+  moment a `std` client is guaranteed to be running is a request. 30 s is a
+  compromise nobody can get right from this side: the ceiling is the SERVER's
+  idle timeout, and that is 75 s on nginx and 5 s on Apache. It throws away
+  connections a short-timeout server has probably already dropped; the retry
+  below covers the rest.
+
+- **Reuse is decided per response, to RFC 9112 §9.3 in the RFC's own order**
+  (`_response_keeps_alive`): a `Connection: close` from the server ends it
+  whatever the version; `HTTP/1.1` is persistent by default and `HTTP/1.0`
+  (or any version this client does not know) is not, so only an explicit
+  `Connection: keep-alive` opts in; a `Connection: close` the request itself
+  sent ends it too. `Connection` is a `#token` list, so the check is token-wise
+  over every field line, not a substring test. And on top of the version rules,
+  a response whose body length is not determinable — no `Content-Length`, not
+  chunked, not body-less by status — is delimited BY THE CLOSE, so the close is
+  the end of the body and there is no next message on that connection no matter
+  what `Connection` says. Each of those five rules is its own test.
+
+- **A connection the server closed while idle is retried once, on a fresh
+  connection.** This is the behaviour a keep-alive client lives or dies by:
+  a server may close an idle connection at any moment, the close usually
+  reaches us only when we try to use it (the write lands in the kernel buffer,
+  and the read that follows returns EOF without a single response byte), and a
+  client that reports that as a failure has turned its pool into intermittent
+  request failures. The trigger is exactly "the connection came from the pool
+  AND zero response bytes arrived"; a freshly-opened connection is never
+  retried, because there the EOF is a real failure.
+
+  The retry is limited to the methods RFC 9110 §9.2.2 calls idempotent. "The
+  request was never processed" is not provable from this side — only "no
+  response arrived" is — so a `POST` or `PATCH` that the server read and acted
+  on before closing would be executed twice by a silent replay. Go replays
+  those too (its bodies are rewindable, as ours always are, being a `String`
+  in memory); this client reports `ConnectionFailed` instead and leaves the
+  decision with the caller. The FIN case — a clean close, which is what an
+  idle timeout produces — is the deterministic one; a peer that answers with
+  RST fails the write instead, and that propagates.
+
+- **TLS pools the same way.** `TcpStream` and `TlsStream` are different types,
+  so the pool holds a `_Transport` enum over the two and implements `Reader`
+  on it by dispatching in a `match`; the exchange, the pool and the retry are
+  written once against that. Two things had to be true for it: the framing read
+  is generic over `R <: Reader` (it already was), and a TLS connection has to
+  be closable from plain, non-async code — which it was not. `TlsStream` had no
+  `Dispose` at all, so its socket and its OpenSSL `SSL`/`SSL_CTX` could not be
+  released except through the async `close(io)`. It has one now
+  (`issues/fixed/a-dropped-tlsstream-leaks-its-socket-and-openssl-objects.md`);
+  it frees the OpenSSL objects and delegates to `TcpStream`'s `Dispose` for the
+  socket, and deliberately sends no `close_notify`, because flushing the write
+  BIO needs the event loop and `dispose` runs in plain code.
+
+- **`Dispose` closes every idle connection, and `close_idle()` is the same
+  body under a name a caller can invoke** (Go's `CloseIdleConnections`). It
+  needs the explicit name for a reason that is worth recording: a client that
+  has made a single request never reaches reference count zero today, because
+  a `ref` value passed as a parameter to an `io.async` future is never
+  released — a general RC leak in the async lowering, filed with a reproducer
+  as `issues/a-ref-value-passed-to-an-async-future-is-never-released.md`. The
+  same defect is why `TcpStream`'s and `TlsStream`'s own `Dispose`s cannot fire
+  on a drop for any stream that has been read from. `dispose` here is correct
+  and will start firing on scope exit when that is fixed; until then
+  `close_idle()` is the working path, and the test calls `dispose` by hand so
+  the body under test is still the one being measured.
+
+Two supporting pieces went in with it. **The framing layer learned RFC 9112
+§6.3 rules 1–2**: `read_http_message*` now takes a `MessageKind`
+(`Request` / `Response` / `HeadResponse`) instead of an `is_request` bool, and
+treats a 1xx, 204 or 304 response — and any response to a HEAD — as ending at
+its header section whatever its framing headers say. That is not a nicety for
+a pooling client, it is a hang: those responses routinely carry no
+`Content-Length`, the old code read them as close-delimited, and a keep-alive
+server never closes. The status code is read off the status line; HEAD cannot
+be, which is why the kind is a parameter and not a bool. **Tests drive a raw
+`TcpListener`** rather than `HttpServer`, because `HttpServer` adds
+`Connection: close` to every response and so cannot demonstrate reuse, and
+because a hand-written server is the only way to produce the four response
+shapes §9.3 distinguishes. Each of those servers accepts exactly N connections
+and closes its listener on the last accept, so a pool that fails to reuse gets
+a REFUSED connect and the test fails in a second instead of hanging.
+
+Two measurement notes, both learned the hard way and both now in the tests:
+the accept counters live in a `ref(struct(...))` passed to the server, because
+a module-level mutable written across a suspension point in an `io.async` body
+operates on a copy and reads back zero
+(`issues/a-module-global-is-lost-across-an-async-suspension.md`) — which looks
+exactly like "the server never ran". And the descriptor oracle counts OPEN
+descriptors rather than probing the lowest free one: `dup(0)` returns the
+lowest free number, so N repeats give `highest + 1 == open_count + N`, which is
+exact. The naive lowest-free probe read the same number whether the client
+leaked its socket or not, because a listener closed earlier in the test left a
+hole below it.
+
+**The server half: NOT in reach through `std/async`, and written up rather
+than hand-rolled.** `timeout` cannot be used inside `serve_once`: it is a
+blocking-poll plain `fn` that drives the event loop itself, and calling one of
+those from inside a task nests the loop
+(`issues/fixed/sync-await-in-plain-fn-nests-the-event-loop.md`). `serve_once`
+is an `io.async` body, and every other `std/async` combinator (`join_all`,
+`race`, `any`) has the same shape and takes `JoinHandle`s rather than futures,
+so there is nothing there to compose with the framing read. The pattern that
+DOES work inside a task — spawn the operation, spawn a `sleep`, poll with
+`io.await(yield(...))` — exists exactly once in this tree, hand-rolled in
+`std/http/client.yo`'s `_fetch_deadline`, and carries two costs that belong in
+a design decision rather than in this PR: aborting a read parked in the I/O
+backend leaks its 8 KiB buffer and its state machine per timed-out connection
+(the mirror of `issues/timeout-deadline-timer-future-leak.md`), and server
+keep-alive additionally changes what `serve_once` MEANS in ways that invalidate
+existing tests (pipelining becomes correct rather than smuggling, and
+`_read_all`-shaped tests start waiting out the deadline).
+`plans/backlog/ASYNC_DEADLINE_COMBINATOR.md` names the blocked call site,
+those costs, three options and the recommendation: add a `Future`-returning
+`with_deadline` to `std/async` first, re-express `_fetch_deadline` in terms of
+it, and then land server keep-alive on top as an OPT-IN
+(`with_keep_alive(idle)`) — opt-in because keep-alive on a strictly serial
+server lets one client monopolize it, so "off" is the honest default for
+`HttpServer` as it stands.
 
 **`BITS` as an associated constant — LANDED 2026-09-10, and it retires a
 documented blocker.**

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -899,12 +899,22 @@ the accept counters live in a `ref(struct(...))` passed to the server, because
 a module-level mutable written across a suspension point in an `io.async` body
 operates on a copy and reads back zero
 (`issues/a-module-global-is-lost-across-an-async-suspension.md`) — which looks
-exactly like "the server never ran". And the descriptor oracle counts OPEN
-descriptors rather than probing the lowest free one: `dup(0)` returns the
-lowest free number, so N repeats give `highest + 1 == open_count + N`, which is
-exact. The naive lowest-free probe read the same number whether the client
-leaked its socket or not, because a listener closed earlier in the test left a
-hole below it.
+exactly like "the server never ran". And "did `dispose` close every idle
+connection?" is answered by what the PEERS observe, not by the descriptor
+table: a closed connection is one the server at the other end reads EOF from,
+so its connection loop ends and its task finishes, and a connection still open
+leaves that server parked on a read until the deadline reports it. Two servers
+on two ports make it a test of EVERY idle connection. Two descriptor-table
+oracles were tried and both are dead ends — a lowest-free-descriptor probe
+(`dup(0)`, close it, look at the number) reads the same value whether the
+socket leaked or not, because a listener closed earlier in the test leaves a
+hole below it; and the exact open-count that fixes that (`dup(0)` N times, so
+`highest + 1 == open_count + N`) is not portable — Windows sockets are not in
+the CRT descriptor table at all, so the count never moves there, and it did not
+move on the intel macOS runner either. Peer observation needs no platform
+knowledge, and every other test in the group already depends on it implicitly:
+each ends in a `task.await(io)` that only returns once the client's socket is
+really closed.
 
 **The server half: NOT in reach through `std/async`, and written up rather
 than hand-rolled.** `timeout` cannot be used inside `serve_once`: it is a

--- a/plans/backlog/ASYNC_DEADLINE_COMBINATOR.md
+++ b/plans/backlog/ASYNC_DEADLINE_COMBINATOR.md
@@ -1,0 +1,138 @@
+# A deadline combinator usable from INSIDE a task — and the HTTP server keep-alive it blocks
+
+**Status: BACKLOG.** Written 2026-09-11 while landing the client-side HTTP
+connection pool (`plans/STD_API_STABILIZATION.md`, "HTTP keep-alive, the
+pooling client"). The client half needs no such thing; the SERVER half cannot
+be written without one, and this doc is the measured answer to "is it in
+reach today?".
+
+## The blocked call site
+
+`std/http/server.yo`, `HttpServer.serve_once`:
+
+```rust
+serve_once : (fn(self : Self, handler : ..., io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async(e => {
+    stream := e.io.await(self.listener.accept(e.io), e);
+    framed := e.io.await(read_http_message(stream, self.max_request_bytes, MessageKind.Request, e.io), e);
+    ...
+  })
+)
+```
+
+Server keep-alive means looping that framing read on the same connection until
+the client goes away. `serve` is one connection at a time, so a client that
+holds a persistent connection open and sends nothing would wedge the server
+for every other client — which is why the server half is not simply "loop
+until the client closes". It needs an IDLE TIMEOUT: the second `await` above
+has to become "either the next request's bytes, or a deadline".
+
+## Why `std/async`'s `timeout` cannot be used there
+
+`timeout(handle, limit, io)` is a **blocking-poll plain `fn`**: it drives the
+event loop itself (`__yo_async_poll_step` in a `while`) until the handle or the
+deadline finishes. That is fine on a caller's own stack, and it is exactly what
+a test does. It is not usable inside an `io.async` body: calling a
+loop-driving plain function from within a task nests the event loop and freezes
+every other task on it until the inner loop returns
+(`issues/fixed/sync-await-in-plain-fn-nests-the-event-loop.md`). `serve_once`
+IS an `io.async` body.
+
+So `timeout` does not compose with the framing read. `std/async` offers no
+`Future`-returning equivalent — `join_all`, `race`, `any` and `timeout` are all
+the same blocking-poll shape, and all take `JoinHandle`s rather than futures —
+so there is nothing in `std/async` to compose with.
+
+## What DOES work today, and what it costs
+
+The pattern that works inside a task is hand-rolled, and this tree already has
+one instance of it: `std/http/client.yo`'s `_fetch_deadline`, which implements
+`FetchOptions.timeout`.
+
+```rust
+h := e.io.spawn(work(e.io), e);              // the operation, as a task
+dh := e.io.spawn(sleep(limit, e.io), e.io);  // the deadline, as a task
+while(runtime(!h.is_finished() && !dh.is_finished()), {
+  e.io.await(yield(e.io), e.io);             // a REAL suspension point
+});
+```
+
+It composes with the framing read, because `read_http_message_buffered` is
+itself an `io.async` future and can be spawned. Two costs come with it:
+
+1. **Cancelling a parked read leaks.** When the deadline wins, the read task is
+   `abort()`ed while its 8 KiB buffer is registered with the I/O backend. The
+   buffer is `malloc`ed inside the async body and freed by a statement at the
+   end of that body, so an abort skips the free: one 8 KiB buffer plus one
+   state machine per timed-out connection. (`std/async`'s `timeout` records the
+   mirror-image residual for its deadline timer —
+   `issues/timeout-deadline-timer-future-leak.md`.) There is no way to avoid
+   it with today's primitives: the read is already in flight by the time the
+   deadline is known, and the backend has no cancel.
+2. **A polling wait, not a woken one.** `yield` parks on a 1 ms timer, so an
+   idle server burns a wakeup per millisecond per connection. `std/async`'s own
+   doc header already names the waker-based rewrite as planned work.
+
+## Options
+
+**A. Hand-roll the race in `std/http/server.yo`.** Hoist it into its own
+`io.async` helper (`_read_request_or_deadline`) so the connection loop stays
+flat — an await one branch under a `while` is a supported shape; a `while` with
+awaits nested inside another `while`'s branch is not, and that is what the
+inline version would be. Cost: the leak and the polling above, plus the
+contract change discussed below. Roughly 80 lines.
+
+**B. Add a `Future`-returning deadline combinator to `std/async`.** The missing
+API is something like
+
+```rust
+with_deadline :: (fn(generic(T : Type), fut : Impl(Future(T, IoExn)), limit : Duration, io : Io)
+  -> Impl(Future(Result(T, TimeoutError), IoExn)))
+```
+
+i.e. `timeout`'s semantics with `timeout`'s blocking poll replaced by an
+`io.async` body, awaitable from inside a task. Written with today's primitives
+its body IS option A's race, so it does not remove the leak — but it puts the
+one hand-rolled race in one place instead of once per call site, and it is the
+natural home for the fix when the backend gains read cancellation or the waker
+rewrite lands.
+
+**C. Cancellation in the I/O backend.** The real fix for cost 1: a way to
+withdraw a submitted read so the aborted task's buffer can be freed. That is
+`src/codegen/async/runtime_io_*.yo` work on three platforms and is a campaign,
+not a step.
+
+## Recommendation
+
+**B, then A on top of it, and not before C is at least scoped.** Concretely:
+
+1. Add `with_deadline` to `std/async` and re-express
+   `std/http/client.yo`'s `_fetch_deadline` in terms of it — that removes a
+   hand-rolled race from `std/http` and gives the combinator a caller that
+   already has tests.
+2. Land server keep-alive on top of it, **opt-in** (`with_keep_alive(idle)`),
+   leaving the default one-request-per-connection shape alone. Opt-in is not
+   timidity here: keep-alive on a strictly serial server lets one client
+   monopolize it, so the safe default for `HttpServer` as it stands is off.
+3. File the backend cancellation work separately; until it exists, document the
+   per-timeout leak on `with_keep_alive`.
+
+## Collateral the server half carries (why it is not a small step)
+
+Turning `serve_once` into a connection loop changes what it MEANS, and existing
+tests encode the current meaning:
+
+- `tests/http/server.test.yo`'s `_read_all` reads until the server closes.
+  Under keep-alive it waits out the idle timeout instead — every such test
+  pays the deadline.
+- "bytes pipelined after a body-less request are not its body" asserts that the
+  second request in one write is NOT served (`!raw.contains("/smuggled")`).
+  Under keep-alive, serving it is CORRECT — pipelining is legal — so the test
+  has to be re-expressed as "the second request is framed as its own message",
+  which is the same property stated the other way round.
+- Every response currently gets `Connection: close` added when the handler set
+  none; that becomes "add nothing (HTTP/1.1 is persistent) unless keep-alive is
+  off".
+
+Doing this under an opt-in flag (step 2 above) avoids all of it: the default
+path keeps its contract and its tests, and the keep-alive path gets its own.

--- a/std/crypto/tls.yo
+++ b/std/crypto/tls.yo
@@ -387,6 +387,32 @@ impl(
     })
   )
 );
+impl(
+  TlsStream,
+  Dispose(
+    /// A `TlsStream` dropped without `close` used to leak everything it owned
+    /// — the socket descriptor AND the OpenSSL `SSL`/`SSL_CTX` pair, which
+    /// `TcpStream`'s own `Dispose` cannot reach. `dispose` releases both.
+    ///
+    /// It does NOT send a `close_notify`: flushing the write BIO needs the
+    /// event loop, and `dispose` runs in plain code (on a scope exit, an
+    /// unwind, or the last RC release). `close(io)` is the graceful form and
+    /// makes `dispose` a no-op afterwards; a peer that only sees the TCP FIN
+    /// is what every language's TLS drop does.
+    dispose : (fn(self : Self) -> unit)({
+      cond(
+        !self._closed => {
+          self._closed = true;
+          // __yo_tls_free releases both BIOs (owned by the SSL object) and
+          // the context.
+          unsafe(__yo_tls_free(self._ssl, self._ctx));
+          (TcpStream <: Dispose).dispose(self._tcp);
+        },
+        true => ()
+      );
+    })
+  )
+);
 export(TlsStream);
 // === std/io async trait impls (D5) ===
 impl(

--- a/std/http/client.yo
+++ b/std/http/client.yo
@@ -146,14 +146,25 @@ impl(
   _Transport,
   read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
     io.async(e => {
+      // DIAGNOSTIC (issues/a-bodyless-http-response-is-not-read-until-the-
+      // deadline.md): `[wire RSP] issuing read` is printed BEFORE this future
+      // is even created, so it proves nothing about whether the socket read was
+      // ever REGISTERED. This block is cold until its await runs it. If `entered`
+      // never prints, the transport future was never started and no kevent/SQE
+      // exists — which would explain a completion that never arrives on BOTH
+      // backends. If `entered` prints and `arm done` does not, the socket read
+      // really is registered and unwoken.
+      eprintln(`  [tr] read entered`);
       (n : usize) = usize(0);
       match(
         self,
         .Plain(stream) => {
           n = e.io.await(stream.read(buf, size, e.io), e);
+          eprintln(`  [tr] plain arm done n=${n.to_string()}`);
         },
         .Secure(stream) => {
           n = e.io.await(stream.read(buf, size, e.io), e);
+          eprintln(`  [tr] secure arm done n=${n.to_string()}`);
         }
       );
       n

--- a/std/http/client.yo
+++ b/std/http/client.yo
@@ -47,7 +47,7 @@
 pragma(Pragma.AllowUnsafe);
 { String } :: import("../string");
 { ArrayList } :: import("../collections/array_list");
-import("../fmt");
+{ eprintln } :: import("../fmt");
 { Error, AnyError, Exception, IoExn } :: import("../error");
 { TcpStream } :: import("../net/tcp");
 { TlsStream } :: import("../crypto/tls");
@@ -707,10 +707,17 @@ _fetch_once :: (
       );
       conn := conn_opt.unwrap();
       _wn := e.io.await(conn.write_string(prep.request, e.io), e);
+      // DIAGNOSTIC (issues/a-bodyless-http-response-is-not-read-until-the-
+      // deadline.md): the two prints bracket the ONE await the 204 hang stops
+      // inside. The wire-level checkpoints say the read itself returned the
+      // whole response, so what these settle is whether this parent await
+      // ever resumes once the inner future completes.
+      eprintln(`  [clt] awaiting the framed response (reused=${reused.to_string()})`);
       framed := e.io.await(
         read_http_message_buffered(conn, opts.max_response_bytes, prep.kind, carry, e.io),
         e
       );
+      eprintln(`  [clt] parent await resumed`);
       (raw : String) = String.new();
       (framing_err : Option(HttpError)) = Option(HttpError).None;
       match(

--- a/std/http/client.yo
+++ b/std/http/client.yo
@@ -1,5 +1,6 @@
-//! Async HTTP client — `fetch` and `fetch_with`, shaped like JavaScript's
-//! `fetch` and configured like `reqwest`.
+//! Async HTTP client — the one-shot `fetch`/`fetch_with`, shaped like
+//! JavaScript's `fetch`, and the connection-pooling `HttpClient`, shaped like
+//! `reqwest::Client`.
 //!
 //! `fetch(url, io)` is a GET with defaults; `fetch_with(url, opts, io)` takes
 //! a `FetchOptions` carrying the method, headers, body, redirect cap,
@@ -9,32 +10,34 @@
 //! why `max_response_bytes` exists and defaults to 64 MiB rather than being
 //! unlimited.
 //!
-//! Each call is a fresh connection, and a `Connection: close` request header
-//! says so on the wire: there is no pool yet (see `## Stability`). Failures
-//! throw `IoExn` carrying an `HttpError` (D1); a deadline that wins the race
-//! throws `HttpError.Timeout` and aborts the in-flight task, so a hung server
-//! cannot pin a caller forever.
+//! The free functions stay ONE-SHOT: each call is a fresh connection and says
+//! so on the wire with a `Connection: close` request header. `HttpClient`
+//! OWNS its idle connections and reuses them, keyed by scheme+host+port, and
+//! its `Dispose` closes the idle set. Failures throw `IoExn` carrying an
+//! `HttpError` (D1); a deadline that wins the race throws `HttpError.Timeout`
+//! and aborts the in-flight task, so a hung server cannot pin a caller
+//! forever.
 //!
 //! ```rust
-//! { fetch } :: import("std/http");
+//! { fetch, HttpClient } :: import("std/http");
 //! { IoExn } :: import("std/error");
 //!
-//! resp := io.await(fetch(`http://example.com/api/data`, io), IoExn(io : io, exn : exn));
+//! e := IoExn(io : io, exn : exn);
+//! resp := io.await(fetch(`http://example.com/api/data`, io), e);
 //! println(resp.body);
+//!
+//! client := HttpClient.new();                    // reuses connections
+//! a := io.await(client.fetch(`http://example.com/one`, io), e);
+//! b := io.await(client.fetch(`http://example.com/two`, io), e);
 //! ```
 //!
 //! ## Stability
 //!
-//! unstable — the connection model is going to change. Every request sets
-//! `Connection: close` and reads through `read_http_message`, the framing
-//! form that DISCARDS whatever the peer sent past the message, so nothing
-//! here can reuse a connection today; the reusable framing landed in
-//! `./wire.yo` on 2026-09-10 and the pool is the remaining piece. Its
-//! intended shape is decided — an `HttpClient` object that OWNS its idle
-//! connections (Rust's `reqwest::Client`), with an explicit lifetime and a
-//! `Dispose` that closes the idle set, rather than a module-global — and the
-//! free `fetch`/`fetch_with` are meant to keep their one-shot behaviour when
-//! it arrives, so this file grows a type rather than changing these two.
+//! unstable — the pool is new (2026-09-11) and is what this release is asking
+//! for use on before freezing. `HttpClient`'s knobs (idle cap, idle timeout)
+//! and the exact retry-on-a-stale-pooled-connection rule are the parts most
+//! likely to move; `fetch`/`fetch_with` are expected to keep their one-shot
+//! behaviour and their signatures.
 //!
 //! A second, smaller shape is open: a plaintext request connects to the
 //! FIRST address `lookup_host` returns and does not fall back to the next on
@@ -52,10 +55,12 @@ import("../fmt");
 { lookup_host } :: import("../net/dns");
 { Url, UrlError } :: import("../url");
 { Duration } :: import("../time/duration");
+{ Instant } :: import("../time/instant");
 { yield } :: import("../async");
 { sleep } :: import("../time/sleep");
+{ Reader } :: import("../io");
 { HttpMethod, HttpHeader, HeaderMap, StatusCode, HttpRequest, HttpResponse, HttpError, parse_response } :: import("./http.yo");
-{ read_http_message } :: import("./wire.yo");
+{ read_http_message_buffered, MessageKind } :: import("./wire.yo");
 // ============================================================================
 // FetchOptions
 // ============================================================================
@@ -130,136 +135,666 @@ impl(
 );
 export(FetchOptions, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RESPONSE_BYTES);
 // ============================================================================
-// Internal: one request/response exchange — no redirects, no deadline
+// Internal: the transport a request runs over
 // ============================================================================
-_fetch_once :: (
-  fn(url_str : String, opts : FetchOptions, io : Io) ->
-    Impl(Future(HttpResponse, IoExn))
-)(
-  io.async(e => {
-    // Parse URL
-    // D13: Url.parse returns a Result; this caller is already inside an
-    // effect scope, so it uses the _exn wrapper.
-    url := Url.parse_exn(url_str, e.exn);
-    // Validate scheme
-    scheme := url.scheme();
-    is_http := (scheme == `http`);
-    is_https := (scheme == `https`);
-    // Only http/https. https now speaks real TLS (std/crypto/tls, D6); other
-    // schemes are refused before any DNS or socket work.
-    cond(
-      (is_http || is_https) => (),
-      true => {
-        e.exn.throw(dyn(HttpError.UnsupportedScheme(scheme)));
-      }
-    );
-    // Extract host
-    host := match(
-      url.host(),
-      .Some(h) => h,
-      .None => {
-        e.exn.throw(dyn(HttpError.InvalidUrl(`missing host`)));
-        `_` // unreachable
-      }
-    );
-    // Determine port (default: 80 for http, 443 for https)
-    default_port := cond(is_https => u16(443), true => u16(80));
-    port := match(url.port(), .Some(p) => p, .None => default_port);
-    // Build the request path (include query string if present)
-    req_path := url.path();
-    cond(
-      req_path.is_empty() => {
-        req_path = `/`;
-      },
-      true => ()
-    );
+// `http` and `https` are different types (`TcpStream`, `TlsStream`), and a
+// pool has to hold either. They share the D5 `Reader`/`Writer` shape, so the
+// only thing this enum adds is one place where the two-arm dispatch lives —
+// everything above it (the exchange, the pool, the retry) is written once.
+_Transport :: enum(Plain(stream : TcpStream), Secure(stream : TlsStream));
+impl(
+  _Transport,
+  read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+    io.async(e => {
+      (n : usize) = usize(0);
+      match(
+        self,
+        .Plain(stream) => {
+          n = e.io.await(stream.read(buf, size, e.io), e);
+        },
+        .Secure(stream) => {
+          n = e.io.await(stream.read(buf, size, e.io), e);
+        }
+      );
+      n
+    })
+  ),
+  write_string : (fn(self : Self, data : String, io : Io) -> Impl(Future(usize, IoExn)))(
+    io.async(e => {
+      (n : usize) = usize(0);
+      match(
+        self,
+        .Plain(stream) => {
+          n = e.io.await(stream.write_string(data, e.io), e);
+        },
+        .Secure(stream) => {
+          n = e.io.await(stream.write_string(data, e.io), e);
+        }
+      );
+      n
+    })
+  ),
+  /// Graceful close: a TLS transport also gets its `close_notify` flushed.
+  close : (fn(self : Self, io : Io) -> Impl(Future(unit, IoExn)))(
+    io.async(e => {
+      match(
+        self,
+        .Plain(stream) => {
+          e.io.await(stream.close(e.io), e);
+        },
+        .Secure(stream) => {
+          e.io.await(stream.close(e.io), e);
+        }
+      );
+      ()
+    })
+  ),
+  /// Close without the event loop, by delegating to the stream's own
+  /// `Dispose`. This is what the pool uses: eviction, expiry and
+  /// `HttpClient`'s `dispose` all run in plain (non-async) code, and the
+  /// connection being closed there is either dead or unwanted — there is
+  /// nobody left to send a TLS `close_notify` to.
+  close_sync : (fn(self : Self) -> unit)(
     match(
-      url.query(),
-      .Some(q) => {
-        req_path = `${req_path}?${q}`;
-      },
-      .None => ()
-    );
-    // Build HTTP request
-    req := HttpRequest.new(opts.method, req_path);
-    req.set_host(host);
-    // Add user-provided headers. APPEND, not set: a caller who added the same
-    // name twice (two Accept-Encoding values, say) meant both, and `set_header`
-    // now replaces rather than accumulates.
-    user_headers := opts.headers.entries();
-    hi := usize(0);
-    while(runtime(hi < user_headers.len()), {
-      h := user_headers(hi);
-      req.headers.append(h.name, h.value);
-      hi = (hi + usize(1));
+      self,
+      .Plain(stream) => (TcpStream <: Dispose).dispose(stream),
+      .Secure(stream) => (TlsStream <: Dispose).dispose(stream)
+    )
+  )
+);
+impl(
+  _Transport,
+  Reader(
+    read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.read(buf, size, io)
+    )
+  )
+);
+// One idle connection. `carry` is the connection's leftover-byte buffer —
+// `read_http_message_buffered` needs the SAME list across every message on a
+// connection, because one `read` can deliver the end of this message and the
+// start of the next.
+_Idle :: ref(
+  struct(
+    key : String,
+    transport : _Transport,
+    carry : ArrayList(u8),
+    since : Instant
+  )
+);
+// ============================================================================
+// HttpClient
+// ============================================================================
+/// Default idle-connection cap: 16.
+///
+/// It is a TOTAL cap, not a per-target one, because the resource it protects
+/// is the process's descriptor table: a client that fans out over a thousand
+/// hosts would otherwise hold a thousand sockets open with a per-host cap of
+/// 1. 16 is enough for several concurrent tasks against a handful of targets,
+/// which is what a single-threaded event loop can actually keep busy.
+DEFAULT_MAX_IDLE_CONNECTIONS :: usize(16);
+/// Default idle age limit: 30 seconds.
+///
+/// A pooled connection can only be reused until the SERVER's own idle timeout
+/// closes it, and that number is not knowable from here — nginx defaults to
+/// 75 s, Apache to 5 s. Expiring at 30 s throws away connections a
+/// short-timeout server has probably already dropped, which is the half of
+/// the race a client can win on its own; the retry below covers the rest.
+DEFAULT_IDLE_TIMEOUT_SECS :: i64(30);
+/// An HTTP client that OWNS a pool of idle keep-alive connections
+/// (`reqwest::Client`'s model, not a process-global one — a `std` with global
+/// mutable state has no way to say when those sockets close).
+///
+/// Requests made through a client reuse an idle connection to the same target
+/// when there is one, and put it back afterwards unless the exchange said
+/// otherwise (RFC 9112 §9.3 — see `_response_keeps_alive`). The free `fetch`
+/// and `fetch_with` do NOT use a client: they open a connection, announce
+/// `Connection: close` and close it, exactly as before.
+///
+/// A connection is only ever reused for the same **scheme, host and port** —
+/// the pool key. Handing an `https://a` connection to a request for
+/// `https://b` would speak to the wrong peer under the first peer's
+/// certificate, so the key is checked, never inferred.
+///
+/// `dispose` closes every idle connection, and `close_idle()` is the same
+/// operation under a name a caller can invoke (Go's
+/// `Transport.CloseIdleConnections`). **Call `close_idle()`** when you are
+/// done with a client: a client that has made a request does not currently
+/// reach reference count zero, because a `ref` value passed as a parameter to
+/// an `io.async` future is never released
+/// (`issues/a-ref-value-passed-to-an-async-future-is-never-released.md`), so
+/// the `dispose` on a scope exit does not yet fire. It is correct and will
+/// start firing when that defect is fixed.
+///
+/// ## Example
+///
+/// ```rust
+/// client := HttpClient.new();
+/// a := io.await(client.fetch(`http://127.0.0.1:8080/one`, io), e);
+/// b := io.await(client.fetch(`http://127.0.0.1:8080/two`, io), e); // same socket
+/// client.close_idle();                                             // both closed
+/// ```
+///
+/// ## Stability
+///
+/// unstable — `new`, `fetch`, `fetch_with`, `with_max_idle`,
+/// `with_idle_timeout`, `idle_count` and `close_idle` are intended to keep
+/// their names and meanings; the pool's policies (a TOTAL idle cap, expiry
+/// on the next request rather than on a timer, closing the connection in hand
+/// rather than evicting one already pooled, and retrying only idempotent
+/// methods) are implementation choices that may change.
+HttpClient :: ref(
+  struct(
+    _idle : ArrayList(_Idle),
+    /// Maximum idle connections held at once. When the pool is full a
+    /// finished connection is closed instead of stored; `0` disables reuse
+    /// altogether.
+    max_idle : usize,
+    /// How long a connection may sit idle before it is closed rather than
+    /// reused. `Duration.from_secs(0)` lifts the limit.
+    idle_timeout : Duration
+  )
+);
+impl(
+  HttpClient,
+  /// A client with an empty pool, `DEFAULT_MAX_IDLE_CONNECTIONS` idle slots
+  /// and a `DEFAULT_IDLE_TIMEOUT_SECS` age limit.
+  new : (fn() -> Self)(
+    Self(
+      _idle : ArrayList(_Idle).new(),
+      max_idle : DEFAULT_MAX_IDLE_CONNECTIONS,
+      idle_timeout : Duration.from_secs(DEFAULT_IDLE_TIMEOUT_SECS)
+    )
+  ),
+  /// Cap the idle connections held at once (`0` disables reuse).
+  with_max_idle : (fn(self : Self, n : usize) -> Self)({
+    self.max_idle = n;
+    self
+  }),
+  /// Set the idle age limit (`Duration.from_secs(0)` lifts it).
+  with_idle_timeout : (fn(self : Self, limit : Duration) -> Self)({
+    self.idle_timeout = limit;
+    self
+  }),
+  /// How many connections are currently idle in the pool.
+  idle_count : (fn(self : Self) -> usize)(
+    self._idle.len()
+  ),
+  /// Close every idle connection — Go's `Transport.CloseIdleConnections`.
+  /// Connections currently carrying a request are unaffected; they are owned
+  /// by their exchange and are closed or pooled when it finishes.
+  close_idle : (fn(self : Self) -> unit)({
+    i := usize(0);
+    while(runtime(i < self._idle.len()), {
+      entry := self._idle(i);
+      entry.transport.close_sync();
+      i = (i + usize(1));
     });
-    // Set Content-Length if body is provided
+    self._idle.clear();
+  }),
+  // Take an idle connection for `key`, purging every connection that sat
+  // idle past the age limit on the way past. Purging here rather than on a
+  // timer is what keeps the pool free of a background task: the only moment
+  // a `std` client is guaranteed to be running is a request.
+  _take : (fn(self : Self, key : String) -> Option(_Idle))({
+    limit := self.idle_timeout;
+    limit_ms := limit.as_millis();
+    (found : Option(_Idle)) = Option(_Idle).None;
+    i := usize(0);
+    while(runtime(i < self._idle.len()), {
+      entry := self._idle(i);
+      since := entry.since;
+      age := since.elapsed();
+      age_ms := age.as_millis();
+      expired := ((limit_ms > i64(0)) && (age_ms >= limit_ms));
+      cond(
+        expired => {
+          entry.transport.close_sync();
+          _dropped := self._idle.remove(i);
+        },
+        (found.is_none() && (entry.key == key)) => {
+          found = Option(_Idle).Some(entry);
+          _picked := self._idle.remove(i);
+        },
+        true => {
+          i = (i + usize(1));
+        }
+      );
+    });
+    found
+  }),
+  // Store a finished connection. `false` means the pool is full (or reuse is
+  // off) and the caller must close it — Go's answer too: the connection in
+  // hand is closed rather than evicting one already in the pool, so a burst
+  // of parallel requests cannot churn the whole pool.
+  _put : (fn(self : Self, key : String, transport : _Transport, carry : ArrayList(u8)) -> bool)(
     cond(
-      !opts.body.is_empty() => {
-        req.set_body(opts.body);
-        req.set_header(`Content-Length`, `${opts.body.len()}`);
+      (self._idle.len() >= self.max_idle) => false,
+      true => {
+        self._idle.push(_Idle(key : key, transport : transport, carry : carry, since : Instant.now()));
+        true
+      }
+    )
+  )
+);
+impl(
+  HttpClient,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)(
+      self.close_idle()
+    )
+  )
+);
+export(HttpClient, DEFAULT_MAX_IDLE_CONNECTIONS, DEFAULT_IDLE_TIMEOUT_SECS);
+// ============================================================================
+// Internal: one request/response exchange
+// ============================================================================
+// Whether a comma-separated field value lists `token` (RFC 9110 §5.6.1.2 —
+// `Connection` is a `#token` list, so `keep-alive, Upgrade` lists both).
+_value_has_token :: (fn(value : String, token : String) -> bool)({
+  parts := value.split(",");
+  i := usize(0);
+  (found : bool) = false;
+  while(runtime(i < parts.len()), {
+    part := parts(i);
+    trimmed := part.trim();
+    cond(
+      (trimmed.to_lowercase() == token) => {
+        found = true;
       },
       true => ()
     );
-    // Set Connection: close to ensure the server closes after response
-    req.set_header(`Connection`, `close`);
-    req_str := req.to_string();
-    // Transport: plaintext TCP for http, TLS for https. Both streams
-    // implement the D5 Reader trait, so the response reader is shared.
-    (raw_response : String) = ``;
+    i = (i + usize(1));
+  });
+  found
+});
+// Whether the response's `Connection` field (all of its field lines) lists
+// `token`.
+_response_has_conn_token :: (fn(resp : HttpResponse, token : String) -> bool)({
+  values := resp.headers.get_all(`Connection`);
+  i := usize(0);
+  (found : bool) = false;
+  while(runtime(i < values.len()), {
     cond(
-      is_https => {
-        tls := e.io.await(TlsStream.connect(host.clone(), port, e.io), e);
-        _wn := e.io.await(tls.write_string(req_str, e.io), e);
-        // The await is HOISTED out of the match: an await inside a match
-        // scrutinee is a shape the async state machine mis-lowers (the value
-        // came back empty — "Invalid status line" on every fetch).
-        framed_tls := e.io.await(read_http_message(tls, opts.max_response_bytes, false, e.io), e);
-        raw_response = match(
-          framed_tls,
-          .Ok(raw) => raw,
-          .Err(err) => {
-            e.exn.throw(dyn(err));
-            String.new()
-          }
-        );
-        e.io.await(tls.close(e.io), e);
+      _value_has_token(values(i), token) => {
+        found = true;
+      },
+      true => ()
+    );
+    i = (i + usize(1));
+  });
+  found
+});
+// Whether the response's body is delimited by its own framing rather than by
+// the connection close (RFC 9112 §6.3). A close-delimited response CANNOT be
+// followed by another one — the close IS the end of the body — so it always
+// retires its connection, no matter what `Connection` says.
+_body_is_delimited :: (fn(resp : HttpResponse, kind : MessageKind) -> bool)({
+  code := resp.status.as_u16();
+  is_head := match(kind, .HeadResponse => true, _ => false);
+  cond(
+    (is_head || ((code < u16(200)) || ((code == u16(204)) || (code == u16(304))))) => {
+      return(true);
+    },
+    true => ()
+  );
+  chunked := match(
+    resp.get_header(`Transfer-Encoding`),
+    .Some(v) => v.to_lowercase().ends_with(`chunked`),
+    .None => false
+  );
+  cond(
+    chunked => {
+      return(true);
+    },
+    true => ()
+  );
+  resp.get_header(`Content-Length`).is_some()
+});
+// RFC 9112 §9.3, in the order the RFC states it: whether this connection may
+// carry another request after this response.
+_response_keeps_alive :: (fn(resp : HttpResponse, kind : MessageKind) -> bool)({
+  // A 1xx is an INTERIM response: the FINAL response to this request is still
+  // coming, so the connection is not at a message boundary for us even though
+  // the 1xx itself is framed. Pooling it would hand the next request a
+  // connection whose first message is the previous request's real answer.
+  // This client never sends `Expect: 100-continue`, so a well-behaved server
+  // has no reason to send one; a 101 is the same situation with the protocol
+  // changed underneath as well.
+  cond(
+    (resp.status.as_u16() < u16(200)) => {
+      return(false);
+    },
+    true => ()
+  );
+  // A `Connection: close` from the server ends it, whatever the version.
+  cond(
+    _response_has_conn_token(resp, `close`) => {
+      return(false);
+    },
+    true => ()
+  );
+  // HTTP/1.1 is persistent by default; HTTP/1.0 (and any version this client
+  // does not know) is not, and only an explicit `Connection: keep-alive`
+  // opts in.
+  cond(
+    (resp.version != `HTTP/1.1`) => {
+      cond(
+        !_response_has_conn_token(resp, `keep-alive`) => {
+          return(false);
+        },
+        true => ()
+      );
+    },
+    true => ()
+  );
+  _body_is_delimited(resp, kind)
+});
+// RFC 9110 §9.2.2: replaying one of these cannot change the server's state
+// beyond what the first attempt already did. `POST` and `PATCH` are the two
+// that can.
+_is_idempotent :: (fn(method : HttpMethod) -> bool)(
+  match(method, .POST => false, .PATCH => false, _ => true)
+);
+// Everything derived from the URL and the options before any socket work: the
+// pool key, where to connect, the bytes to write, and how the response is to
+// be framed.
+_Prepared :: struct(
+  key : String,
+  host : String,
+  port : u16,
+  is_tls : bool,
+  request : String,
+  // The request itself announced `Connection: close`, so this connection
+  // cannot be reused however the server answers.
+  sent_close : bool,
+  kind : MessageKind
+);
+// `keep_alive` false is the one-shot path: it adds the `Connection: close`
+// that makes a close-delimited response terminate. A pooled request says
+// nothing — HTTP/1.1 is persistent by default, and saying `keep-alive`
+// explicitly is what an HTTP/1.0 client does.
+_prepare :: (fn(url_str : String, opts : FetchOptions, keep_alive : bool, exn : Exception) -> _Prepared)({
+  // D13: Url.parse returns a Result; this caller is already inside an effect
+  // scope, so it uses the _exn wrapper.
+  url := Url.parse_exn(url_str, exn);
+  scheme := url.scheme();
+  is_http := (scheme == `http`);
+  is_https := (scheme == `https`);
+  // Only http/https. https speaks real TLS (std/crypto/tls, D6); other
+  // schemes are refused before any DNS or socket work.
+  cond(
+    (is_http || is_https) => (),
+    true => {
+      exn.throw(dyn(HttpError.UnsupportedScheme(scheme)));
+    }
+  );
+  host := match(
+    url.host(),
+    .Some(h) => h,
+    .None => {
+      exn.throw(dyn(HttpError.InvalidUrl(`missing host`)));
+      `_` // unreachable
+    }
+  );
+  // Determine port (default: 80 for http, 443 for https)
+  default_port := cond(is_https => u16(443), true => u16(80));
+  port := match(url.port(), .Some(p) => p, .None => default_port);
+  // Build the request path (include query string if present)
+  req_path := url.path();
+  cond(
+    req_path.is_empty() => {
+      req_path = `/`;
+    },
+    true => ()
+  );
+  match(
+    url.query(),
+    .Some(q) => {
+      req_path = `${req_path}?${q}`;
+    },
+    .None => ()
+  );
+  req := HttpRequest.new(opts.method, req_path);
+  req.set_host(host);
+  // Add user-provided headers. APPEND, not set: a caller who added the same
+  // name twice (two Accept-Encoding values, say) meant both, and `set_header`
+  // now replaces rather than accumulates. A caller who wrote
+  // `Connection: close` by hand gets what they asked for, and the pool has to
+  // know about it.
+  user_headers := opts.headers.entries();
+  hi := usize(0);
+  (user_close : bool) = false;
+  while(runtime(hi < user_headers.len()), {
+    h := user_headers(hi);
+    req.headers.append(h.name, h.value);
+    cond(
+      ((h.name.to_lowercase() == `connection`) && _value_has_token(h.value, `close`)) => {
+        user_close = true;
+      },
+      true => ()
+    );
+    hi = (hi + usize(1));
+  });
+  // Set Content-Length if body is provided
+  cond(
+    !opts.body.is_empty() => {
+      req.set_body(opts.body);
+      req.set_header(`Content-Length`, `${opts.body.len()}`);
+    },
+    true => ()
+  );
+  cond(
+    !keep_alive => {
+      req.set_header(`Connection`, `close`);
+    },
+    true => ()
+  );
+  is_head := match(opts.method, .HEAD => true, _ => false);
+  host_key := host.to_lowercase();
+  _Prepared(
+    key : `${scheme}://${host_key}:${port.to_string()}`,
+    host : host,
+    port : port,
+    is_tls : is_https,
+    request : req.to_string(),
+    sent_close : (!keep_alive || user_close),
+    kind : cond(is_head => MessageKind.HeadResponse, true => MessageKind.Response)
+  )
+});
+// Open a new connection to the prepared target.
+_connect :: (fn(prep : _Prepared, io : Io) -> Impl(Future(_Transport, IoExn)))(
+  io.async(e => {
+    (out : Option(_Transport)) = Option(_Transport).None;
+    cond(
+      prep.is_tls => {
+        tls := e.io.await(TlsStream.connect(prep.host.clone(), prep.port, e.io), e);
+        out = Option(_Transport).Some(_Transport.Secure(tls));
       },
       true => {
-        addrs := e.io.await(lookup_host(host, e.io), e);
+        addrs := e.io.await(lookup_host(prep.host, e.io), e);
         cond(
           (addrs.len() == usize(0)) => {
-            e.exn.throw(dyn(HttpError.ConnectionFailed(`DNS resolution failed for ${host}`)));
+            e.exn.throw(dyn(HttpError.ConnectionFailed(`DNS resolution failed for ${prep.host}`)));
           },
           true => ()
         );
-        addr := SocketAddr.new(addrs(usize(0)), port);
+        addr := SocketAddr.new(addrs(usize(0)), prep.port);
         stream := e.io.await(TcpStream.connect(addr, e.io), e);
-        e.io.await(stream.write_string(req_str, e.io), e);
-        // The await is HOISTED out of the match: an await inside a match
-        // scrutinee is a shape the async state machine mis-lowers (the value
-        // came back empty — "Invalid status line" on every fetch).
-        framed_stream := e.io.await(read_http_message(stream, opts.max_response_bytes, false, e.io), e);
-        raw_response = match(
-          framed_stream,
-          .Ok(raw) => raw,
-          .Err(err) => {
-            e.exn.throw(dyn(err));
-            String.new()
-          }
-        );
-        e.io.await(stream.close(e.io), e);
+        out = Option(_Transport).Some(_Transport.Plain(stream));
       }
     );
-    // Parse response
-    match(
-      parse_response(raw_response),
-      .Ok(resp) => resp,
-      .Err(err) => {
-        e.exn.throw(dyn(HttpError.Other(err.to_string())));
-        HttpResponse.new(StatusCode.OK(), ``) // unreachable
-      }
-    )
+    out.unwrap()
+  })
+);
+/// One request, one response — no redirects and no deadline.
+///
+/// `pool` is what separates the two clients: with `.None` this is the
+/// historical one-shot exchange (connect, `Connection: close`, read, close),
+/// and with `.Some(client)` it takes an idle connection for the target if
+/// there is one and hands the connection back afterwards. Sharing ONE body
+/// rather than writing the pooled path beside the one-shot path is deliberate
+/// — the framing, the redirect handling and the deadline are identical, and a
+/// second copy is where they would drift apart.
+///
+/// ## Retrying a connection the server had already closed
+///
+/// This is the behaviour a keep-alive client lives or dies by. A server may
+/// close an idle connection at any moment, and the close usually reaches us
+/// only when we try to use it: the write lands in the kernel's buffer, and
+/// the read that follows returns EOF without a single response byte. The
+/// request was never answered, so it is sent again on a fresh connection —
+/// once.
+///
+/// The retry is limited to methods RFC 9110 §9.2.2 calls idempotent. A `POST`
+/// or `PATCH` that reached the server and was processed before the close would
+/// be executed twice by a silent replay, and "the request was never
+/// processed" is not something this side can prove — only "no response
+/// arrived". Go replays those too (its bodies are rewindable, as ours always
+/// are, being a `String` in memory); this client does not, and reports
+/// `ConnectionFailed` instead, so a non-idempotent replay is the caller's
+/// decision to make.
+_fetch_once :: (
+  fn(url_str : String, opts : FetchOptions, pool : Option(HttpClient), io : Io) ->
+    Impl(Future(HttpResponse, IoExn))
+)(
+  io.async(e => {
+    prep := _prepare(url_str, opts, pool.is_some(), e.exn);
+    idempotent := _is_idempotent(opts.method);
+    (out : Option(HttpResponse)) = Option(HttpResponse).None;
+    // A `done`/`attempt` pair rather than break/continue: an awaiting loop is
+    // a state machine (C24), and every await below sits at most ONE branch
+    // under the `while` — deeper nesting is a shape the async lowering does
+    // not support.
+    (attempt : usize) = usize(0);
+    (again : bool) = true;
+    while(runtime(again), {
+      again = false;
+      // The pool is consulted on the first attempt only: a retry exists
+      // BECAUSE the pooled connection was dead.
+      (taken : Option(_Idle)) = Option(_Idle).None;
+      cond(
+        (attempt == usize(0)) => {
+          match(
+            pool,
+            .Some(client) => {
+              taken = client._take(prep.key);
+            },
+            .None => ()
+          );
+        },
+        true => ()
+      );
+      reused := taken.is_some();
+      // One leftover-byte buffer per CONNECTION: a pooled connection brings
+      // its own, a fresh one starts empty.
+      carry := ArrayList(u8).new();
+      (conn_opt : Option(_Transport)) = Option(_Transport).None;
+      match(
+        taken,
+        .Some(entry) => {
+          conn_opt = Option(_Transport).Some(entry.transport);
+          carry = entry.carry;
+        },
+        .None => ()
+      );
+      cond(
+        conn_opt.is_none() => {
+          fresh := e.io.await(_connect(prep, e.io), e);
+          conn_opt = Option(_Transport).Some(fresh);
+        },
+        true => ()
+      );
+      conn := conn_opt.unwrap();
+      _wn := e.io.await(conn.write_string(prep.request, e.io), e);
+      framed := e.io.await(
+        read_http_message_buffered(conn, opts.max_response_bytes, prep.kind, carry, e.io),
+        e
+      );
+      (raw : String) = String.new();
+      (framing_err : Option(HttpError)) = Option(HttpError).None;
+      match(
+        framed,
+        .Ok(x) => {
+          raw = x;
+        },
+        .Err(err) => {
+          framing_err = Option(HttpError).Some(err);
+        }
+      );
+      // A framing defect is unrecoverable for the connection as well as for
+      // the request: the byte stream is no longer at a message boundary.
+      cond(
+        framing_err.is_some() => {
+          conn.close_sync();
+          e.exn.throw(dyn(framing_err.unwrap()));
+        },
+        true => ()
+      );
+      // Not one byte: either the server closed an idle connection under us
+      // (retryable, see above) or it hung up without answering.
+      dead := raw.is_empty();
+      retry_now := (dead && (reused && idempotent));
+      cond(
+        retry_now => {
+          conn.close_sync();
+          again = true;
+        },
+        true => ()
+      );
+      cond(
+        (dead && !retry_now) => {
+          conn.close_sync();
+          e.exn.throw(
+            dyn(
+              HttpError.ConnectionFailed(`the server closed the connection without sending a response`)
+            )
+          );
+        },
+        true => ()
+      );
+      (retire : bool) = false;
+      cond(
+        !dead => {
+          resp := match(
+            parse_response(raw),
+            .Ok(r) => r,
+            .Err(err) => {
+              conn.close_sync();
+              e.exn.throw(dyn(HttpError.Other(err.to_string())));
+              HttpResponse.new(StatusCode.OK(), ``) // unreachable
+            }
+          );
+          keep := (!prep.sent_close && _response_keeps_alive(resp, prep.kind));
+          (stored : bool) = false;
+          cond(
+            keep => {
+              match(
+                pool,
+                .Some(client) => {
+                  stored = client._put(prep.key, conn, carry);
+                },
+                .None => ()
+              );
+            },
+            true => ()
+          );
+          retire = !stored;
+          out = Option(HttpResponse).Some(resp);
+        },
+        true => ()
+      );
+      // The graceful close is the last await in the loop body, and it sits
+      // one branch under the `while` for that reason.
+      cond(
+        retire => {
+          e.io.await(conn.close(e.io), e);
+        },
+        true => ()
+      );
+      attempt = (attempt + usize(1));
+    });
+    match(out, .Some(r) => r, .None => HttpResponse.new(StatusCode.OK(), ``))
   })
 );
 // ============================================================================
@@ -306,8 +841,12 @@ _redirect_options :: (fn(opts : FetchOptions, status : StatusCode) -> FetchOptio
 });
 /// Follow 3xx `Location` hops up to `opts.max_redirects`, then throw
 /// `TooManyRedirects`. A 3xx without a `Location` is returned as is.
+///
+/// Each hop re-derives its own connection target, so a redirect to another
+/// host takes a connection to THAT host out of the pool (or opens one) — a
+/// pooled connection is never handed to a different target.
 _fetch_follow :: (
-  fn(url_str : String, opts : FetchOptions, io : Io) ->
+  fn(url_str : String, opts : FetchOptions, pool : Option(HttpClient), io : Io) ->
     Impl(Future(HttpResponse, IoExn))
 )(
   io.async(e => {
@@ -319,7 +858,7 @@ _fetch_follow :: (
     // state machine (C24).
     done := false;
     while(runtime(!done), {
-      resp := e.io.await(_fetch_once(current.clone(), hop_opts, e.io), e);
+      resp := e.io.await(_fetch_once(current.clone(), hop_opts, pool, e.io), e);
       location := match(resp.get_header(`Location`), .Some(l) => l, .None => ``);
       // `max_redirects == 0` means "do not follow": the first 3xx comes back
       // verbatim (reqwest's `Policy::none`). Otherwise the cap counts hops
@@ -349,22 +888,11 @@ _fetch_follow :: (
 // ============================================================================
 // Internal: the deadline race
 // ============================================================================
-// ============================================================================
-// fetch — High-level async HTTP request (like JavaScript's fetch)
-// ============================================================================
-/// Perform an HTTP request with custom options: follows redirects up to
-/// `opts.max_redirects`, refuses responses past `opts.max_response_bytes`,
-/// and — when `opts.timeout` is set — races the whole exchange against the
-/// deadline, throwing `HttpError.Timeout` if the deadline wins.
-///
-/// ## Example
-///
-/// ```rust
-/// opts := FetchOptions.new().with_method(.POST).with_body(`{"key": "value"}`).with_timeout(Duration.from_secs(i64(10)));
-/// resp := io.await(fetch_with(`http://example.com/api`, opts, io), { io, exn });
-/// ```
-fetch_with :: (
-  fn(url_str : String, opts : FetchOptions, io : Io) ->
+// The whole exchange — redirects included — against `opts.timeout`. Shared by
+// the free `fetch_with` and by `HttpClient.fetch_with`; the only difference
+// between them is `pool`.
+_fetch_deadline :: (
+  fn(url_str : String, opts : FetchOptions, pool : Option(HttpClient), io : Io) ->
     Impl(Future(HttpResponse, IoExn))
 )(
   io.async(e => {
@@ -372,7 +900,7 @@ fetch_with :: (
     match(
       opts.timeout,
       .None => {
-        result = e.io.await(_fetch_follow(url_str, opts, e.io), e);
+        result = e.io.await(_fetch_follow(url_str, opts, pool, e.io), e);
       },
       .Some(limit) => {
         // Run the whole exchange as a spawned TASK raced against a spawned
@@ -389,7 +917,10 @@ fetch_with :: (
         // awaits once was mis-emitted until C38
         // (issues/fixed/while-await-inside-match-arm-missing-loop-field.md);
         // this arm is that shape and doubles as its production pin.
-        h := e.io.spawn(_fetch_follow(url_str, opts, e.io), e);
+        //
+        // A connection cut off here is owned by the aborted state machine, so
+        // its `Dispose` closes it — it never reaches the pool.
+        h := e.io.spawn(_fetch_follow(url_str, opts, pool, e.io), e);
         dh := e.io.spawn(sleep(limit, e.io), e.io);
         while(runtime(!h.is_finished() && !dh.is_finished()), {
           e.io.await(yield(e.io), e.io);
@@ -419,8 +950,38 @@ fetch_with :: (
     result
   })
 );
+// ============================================================================
+// fetch — High-level async HTTP request (like JavaScript's fetch)
+// ============================================================================
+/// Perform a ONE-SHOT HTTP request with custom options: follows redirects up
+/// to `opts.max_redirects`, refuses responses past `opts.max_response_bytes`,
+/// and — when `opts.timeout` is set — races the whole exchange against the
+/// deadline, throwing `HttpError.Timeout` if the deadline wins.
+///
+/// Every hop opens its own connection, announces `Connection: close` and
+/// closes it. For connection reuse, make the request through an `HttpClient`
+/// instead — there is deliberately no hidden global pool behind this
+/// function, because nothing here could say when those sockets close.
+///
+/// ## Example
+///
+/// ```rust
+/// opts := FetchOptions.new().with_method(.POST).with_body(`{"key": "value"}`).with_timeout(Duration.from_secs(i64(10)));
+/// resp := io.await(fetch_with(`http://example.com/api`, opts, io), { io, exn });
+/// ```
+fetch_with :: (
+  fn(url_str : String, opts : FetchOptions, io : Io) ->
+    Impl(Future(HttpResponse, IoExn))
+)(
+  io.async(e => {
+    // Hoisted: `io.await` directly inside `return(...)` is rejected by the
+    // async state-machine codegen (a restriction `yo check` cannot see).
+    resp := e.io.await(_fetch_deadline(url_str, opts, Option(HttpClient).None, e.io), e);
+    return(resp);
+  })
+);
 export(fetch_with);
-/// Perform an HTTP GET request to the given URL string.
+/// Perform a one-shot HTTP GET request to the given URL string.
 /// Returns the `HttpResponse` on success.
 ///
 /// ## Example
@@ -441,3 +1002,31 @@ fetch :: (
   })
 );
 export(fetch);
+// The pooling entry points live in their own `impl` block, registered after
+// `_fetch_deadline` exists as a binding: an `io.async` body is evaluated
+// where it is DEFINED, and a method body that cannot resolve its callee there
+// is emitted hollow rather than rejected.
+impl(
+  HttpClient,
+  /// GET `url_str`, reusing an idle connection to the same scheme/host/port
+  /// when the pool has one and returning it to the pool afterwards.
+  fetch : (fn(self : Self, url_str : String, io : Io) -> Impl(Future(HttpResponse, IoExn)))(
+    io.async(e => {
+      resp := e.io.await(
+        _fetch_deadline(url_str, FetchOptions.new(), Option(HttpClient).Some(self), e.io),
+        e
+      );
+      return(resp);
+    })
+  ),
+  /// `fetch_with`'s options, over this client's connection pool.
+  fetch_with : (
+    fn(self : Self, url_str : String, opts : FetchOptions, io : Io) ->
+      Impl(Future(HttpResponse, IoExn))
+  )(
+    io.async(e => {
+      resp := e.io.await(_fetch_deadline(url_str, opts, Option(HttpClient).Some(self), e.io), e);
+      return(resp);
+    })
+  )
+);

--- a/std/http/server.yo
+++ b/std/http/server.yo
@@ -33,7 +33,7 @@ import("../string");
 { TcpListener, TcpStream } :: import("../net/tcp");
 { SocketAddr } :: import("../net/addr");
 { HttpError, HttpHeader, HeaderMap, StatusCode, HttpRequest, HttpResponse, parse_request } :: import("./http.yo");
-{ read_http_message } :: import("./wire.yo");
+{ read_http_message, MessageKind } :: import("./wire.yo");
 /// Default ceiling on a request (headers + body): 16 MiB.
 DEFAULT_MAX_REQUEST_BYTES :: (usize(16) * (usize(1024) * usize(1024)));
 /// An HTTP/1.1 server bound to a `TcpListener`.
@@ -78,7 +78,7 @@ impl(
   )(
     io.async(e => {
       stream := e.io.await(self.listener.accept(e.io), e);
-      framed := e.io.await(read_http_message(stream, self.max_request_bytes, true, e.io), e);
+      framed := e.io.await(read_http_message(stream, self.max_request_bytes, MessageKind.Request, e.io), e);
       resp := match(
         framed,
         .Ok(raw) => match(

--- a/std/http/wire.yo
+++ b/std/http/wire.yo
@@ -423,6 +423,70 @@ _split_message :: (fn(data : ArrayList(u8), limit : usize, carry : ArrayList(u8)
     }
   )
 });
+/// Which message is being read, which is what decides where its body ends
+/// (RFC 9112 §6.3).
+MessageKind :: enum(
+  /// A request. One with no framing header at all ends with its headers —
+  /// the client will not close first.
+  Request,
+  /// A response other than to a HEAD. Its body is framed by
+  /// `Transfer-Encoding: chunked` or `Content-Length`, is absent by STATUS
+  /// (1xx, 204, 304 — §6.3 rule 1), or is delimited by the close.
+  Response,
+  /// The response to a HEAD request: it carries no body no matter what its
+  /// framing headers say (§6.3 rule 1). Only the sender of the request knows
+  /// this, so it cannot be inferred from the bytes — reading a HEAD response
+  /// as a plain `Response` waits for a `Content-Length` worth of body that
+  /// the server will never send, which on a reused connection is a hang
+  /// rather than a close-delimited answer.
+  HeadResponse
+);
+// The status code on a response's status line (`HTTP-version SP 3DIGIT ...`),
+// or `.None` when the line is not that shape — a defect `parse_response`
+// reports; the framing decision just falls back to the header rules.
+_status_code :: (fn(data : ArrayList(u8), header_end : usize) -> Option(u16))({
+  sp := usize(0);
+  while(runtime((sp < header_end) && (data(sp) != u8(0x20))), {
+    sp = (sp + usize(1));
+  });
+  start := (sp + usize(1));
+  cond(
+    ((start + usize(3)) > header_end) => {
+      return(Option(u16).None);
+    },
+    true => ()
+  );
+  code := u16(0);
+  i := usize(0);
+  while(runtime(i < usize(3)), {
+    d := data(start + i);
+    cond(
+      ((d < u8(48)) || (d > u8(57))) => {
+        return(Option(u16).None);
+      },
+      true => ()
+    );
+    code = ((code * u16(10)) + u16(d - u8(48)));
+    i = (i + usize(1));
+  });
+  .Some(code)
+});
+// RFC 9112 §6.3 rules 1–2: a message that carries NO body, whatever its
+// framing headers say. Any `Content-Length` or `Transfer-Encoding` on such a
+// message describes the body the request WOULD have had, so honouring it
+// would frame the next message's bytes as this one's body.
+_is_bodyless :: (fn(kind : MessageKind, data : ArrayList(u8), header_end : usize) -> bool)(
+  match(
+    kind,
+    .Request => false,
+    .HeadResponse => true,
+    .Response => match(
+      _status_code(data, header_end),
+      .Some(code) => ((code < u16(200)) || ((code == u16(204)) || (code == u16(304)))),
+      .None => false
+    )
+  )
+);
 // Whether the bytes in hand already frame a whole message — the read loop's
 // stopping decision, and the same decision a keep-alive read makes BEFORE its
 // first read.
@@ -438,7 +502,7 @@ _FrameStatus :: enum(
   /// frame the body by whatever the peer does next.
   BadContentLength(msg : String)
 );
-_frame_status :: (fn(data : ArrayList(u8), is_request : bool) -> _FrameStatus)(
+_frame_status :: (fn(data : ArrayList(u8), kind : MessageKind) -> _FrameStatus)(
   cond(
     (data.len() <= usize(4)) => _FrameStatus.NeedMore,
     true => {
@@ -448,6 +512,8 @@ _frame_status :: (fn(data : ArrayList(u8), is_request : bool) -> _FrameStatus)(
         true => {
           body_start := (header_end + usize(4));
           cond(
+            // No body at all: the message ends with its header section.
+            _is_bodyless(kind, data, header_end) => _FrameStatus.Complete,
             // Chunked: complete once the terminating zero chunk and its final
             // CRLF are in.
             is_chunked(data, header_end) => match(
@@ -465,9 +531,10 @@ _frame_status :: (fn(data : ArrayList(u8), is_request : bool) -> _FrameStatus)(
               .Invalid(msg) => _FrameStatus.BadContentLength(msg),
               // A request with no body framing ends with its headers; a
               // response with none is delimited by close.
-              .Absent => cond(
-                is_request => _FrameStatus.Complete,
-                true => _FrameStatus.NeedMore
+              .Absent => match(
+                kind,
+                .Request => _FrameStatus.Complete,
+                _ => _FrameStatus.NeedMore
               )
             )
           )
@@ -516,7 +583,7 @@ read_http_message_buffered :: (
     generic(R : Type),
     stream : R,
     max_bytes : usize,
-    is_request : bool,
+    kind : MessageKind,
     carry : ArrayList(u8),
     io : Io,
     where(R <: Reader)
@@ -547,7 +614,7 @@ read_http_message_buffered :: (
     // block until the peer sent something it has no reason to send.
     done := false;
     match(
-      _frame_status(result, is_request),
+      _frame_status(result, kind),
       .Complete => {
         done = true;
       },
@@ -587,7 +654,7 @@ read_http_message_buffered :: (
           // question before its first read: a message already complete in the
           // carried-over bytes must not cost a read that would block.
           match(
-            _frame_status(result, is_request),
+            _frame_status(result, kind),
             .Complete => {
               done = true;
             },
@@ -609,6 +676,13 @@ read_http_message_buffered :: (
     cond(
       (failed == i32(1)) => Result(String, HttpError).Err(HttpError.ResponseTooLarge),
       (failed == i32(2)) => Result(String, HttpError).Err(HttpError.MalformedContentLength(failed_msg)),
+      // A message with no body ends at its header section, and its framing
+      // headers must NOT be honoured: a HEAD response's `Content-Length`
+      // describes the body the GET would have had, and a 204's is a lie. The
+      // read loop already stopped here, so anything past the headers belongs
+      // to the next message and is carried, not appended.
+      ((header_end > usize(0)) && _is_bodyless(kind, result, header_end)) =>
+        Result(String, HttpError).Ok(_split_message(result, header_end + usize(4), carry)),
       ((header_end > usize(0)) && is_chunked(result, header_end)) => {
         body_start := (header_end + usize(4));
         match(
@@ -654,9 +728,10 @@ read_http_message_buffered :: (
             ),
             // A REQUEST with no framing header ends with its headers; a RESPONSE
             // with none is delimited by close, so every byte read is body.
-            .Absent => cond(
-              is_request => _split_message(result, body_start, carry),
-              true => String.from_bytes(result)
+            .Absent => match(
+              kind,
+              .Request => _split_message(result, body_start, carry),
+              _ => String.from_bytes(result)
             ),
             // Unreachable: the read loop records `.Invalid` as soon as the header
             // section is complete.
@@ -673,12 +748,13 @@ read_http_message_buffered :: (
 /// answer when the connection is about to be closed and the wrong one when it
 /// is about to be reused — use `read_http_message_buffered` there.
 read_http_message :: (
-  fn(generic(R : Type), stream : R, max_bytes : usize, is_request : bool, io : Io, where(R <: Reader)) ->
+  fn(generic(R : Type), stream : R, max_bytes : usize, kind : MessageKind, io : Io, where(R <: Reader)) ->
     Impl(Future(Result(String, HttpError), IoExn))
 )(
-  read_http_message_buffered(stream, max_bytes, is_request, ArrayList(u8).new(), io)
+  read_http_message_buffered(stream, max_bytes, kind, ArrayList(u8).new(), io)
 );
 export(
+  MessageKind,
   find_header_end,
   ContentLength,
   find_content_length,

--- a/std/http/wire.yo
+++ b/std/http/wire.yo
@@ -33,6 +33,7 @@ pragma(Pragma.AllowUnsafe);
 { IoExn } :: import("../error");
 { Reader } :: import("../io");
 { HttpError } :: import("./http.yo");
+{ eprintln } :: import("../fmt");
 // ============================================================================
 // Internal helpers
 // ============================================================================
@@ -626,7 +627,12 @@ read_http_message_buffered :: (
       .NeedMore => ()
     );
     while(runtime(!done), {
+      // DIAGNOSTIC (issues/a-bodyless-http-response-is-not-read-until-the-deadline.md):
+      // says whether the read was ISSUED and never woken, or never issued.
+      // Comes out with the diagnosis.
+      eprintln(`  [wire] issuing read (have=${result.len()})`);
       n := e.io.await(stream.read(buf, buf_size, e.io), e);
+      eprintln(`  [wire] read returned ${n.to_string()}`);
       cond(
         // 0 bytes means the peer closed the connection. A negative count is
         // no longer representable: NetError.check throws on error, so read()

--- a/std/http/wire.yo
+++ b/std/http/wire.yo
@@ -614,6 +614,10 @@ read_http_message_buffered :: (
     // already contain a complete message, and reading in that case would
     // block until the peer sent something it has no reason to send.
     done := false;
+    // DIAGNOSTIC: which peer this read loop belongs to. The server frames
+    // Requests, the client frames Responses, and both print through here —
+    // without the tag the two traces cannot be paired.
+    _role := match(kind, .Request => `REQ`, _ => `RSP`);
     match(
       _frame_status(result, kind),
       .Complete => {
@@ -630,9 +634,9 @@ read_http_message_buffered :: (
       // DIAGNOSTIC (issues/a-bodyless-http-response-is-not-read-until-the-deadline.md):
       // says whether the read was ISSUED and never woken, or never issued.
       // Comes out with the diagnosis.
-      eprintln(`  [wire] issuing read (have=${result.len()})`);
+      eprintln(`  [wire ${_role}] issuing read (have=${result.len()})`);
       n := e.io.await(stream.read(buf, buf_size, e.io), e);
-      eprintln(`  [wire] read returned ${n.to_string()}`);
+      eprintln(`  [wire ${_role}] read returned ${n.to_string()}`);
       cond(
         // 0 bytes means the peer closed the connection. A negative count is
         // no longer representable: NetError.check throws on error, so read()
@@ -679,6 +683,9 @@ read_http_message_buffered :: (
     // `headers CRLFCRLF data`, so `parse_response` sees the payload and the
     // Transfer-Encoding header stays visible on the response.
     header_end := find_header_end(result);
+    // DIAGNOSTIC: the read loop is OVER. If this prints and the caller never
+    // resumes, the inner future completed and the parent await lost its wake.
+    eprintln(`  [wire ${_role}] loop done, ${result.len()} byte(s), header_end=${header_end.to_string()}`);
     cond(
       (failed == i32(1)) => Result(String, HttpError).Err(HttpError.ResponseTooLarge),
       (failed == i32(2)) => Result(String, HttpError).Err(HttpError.MalformedContentLength(failed_msg)),

--- a/std/http/wire.yo
+++ b/std/http/wire.yo
@@ -686,7 +686,7 @@ read_http_message_buffered :: (
     // DIAGNOSTIC: the read loop is OVER. If this prints and the caller never
     // resumes, the inner future completed and the parent await lost its wake.
     eprintln(`  [wire ${_role}] loop done, ${result.len()} byte(s), header_end=${header_end.to_string()}`);
-    cond(
+    _framed_out := cond(
       (failed == i32(1)) => Result(String, HttpError).Err(HttpError.ResponseTooLarge),
       (failed == i32(2)) => Result(String, HttpError).Err(HttpError.MalformedContentLength(failed_msg)),
       // A message with no body ends at its header section, and its framing
@@ -753,7 +753,15 @@ read_http_message_buffered :: (
         )
       },
       true => Result(String, HttpError).Ok(String.from_bytes(result))
-    )
+    );
+    // DIAGNOSTIC: the block's TAIL. `loop done` above prints and
+    // `[clt] parent await resumed` does not, so the missing wake is somewhere
+    // between them. Everything between is synchronous, so if this prints too
+    // then the async BLOCK produced its value and the parent's continuation was
+    // never invoked — the defect is in the block-completion path, not in std.
+    // If it does NOT print, the tail cond is where the task goes missing.
+    eprintln(`  [wire ${_role}] framed, returning`);
+    _framed_out
   })
 );
 /// Read exactly one HTTP message off `stream`. For a connection used once:

--- a/tests/http/http.test.yo
+++ b/tests/http/http.test.yo
@@ -1507,19 +1507,33 @@ test("HttpClient: a 204 ends at its headers, whatever its Content-Length says", 
   task := io.spawn(_ka_serve(listener, usize(1), _KA_204, stats, io), e);
   client := HttpClient.new();
   opts := FetchOptions.new().with_timeout(Duration.from_secs(i64(10)));
+  // CHECKPOINTS: this exchange completes in under 20 ms locally (measured by
+  // dropping the deadline to 20 ms and watching it still pass), but times out
+  // at TEN SECONDS on the Linux CI legs while passing on macOS/arm64. The
+  // framing itself is ruled out — `tests/http/wire.test.yo` frames a 204 at
+  // its header section at chunk sizes 1, 42 and 4096, and carries the message
+  // after it — so what is left is WHERE the exchange stops, and only CI can
+  // say. `eprintln`, not `println`: a buffered `println` is lost when the
+  // deadline throws. The runner passes --verbose, so these reach the log.
+  eprintln(`  [204] server spawned, issuing request one`);
   a := io.await(client.fetch_with(`http://127.0.0.1:19853/one`, opts, io), e);
+  eprintln(`  [204] response one: status=${a.status.as_u16()} body_len=${a.body.len()} accepts=${stats.accepts} requests=${stats.requests}`);
   assert(a.status.as_u16() == u16(204), `status ${a.status.as_u16()}`);
   assert(a.body.is_empty(), `a 204 has no body, got [${a.body}]`);
   assert(a.get_header(`Content-Length`).unwrap() == `7`, "the header is kept as received");
   // Framed at the headers means the connection is at a message boundary, so
   // it is reusable — and the next response proves the boundary was right.
+  eprintln(`  [204] idle after one: ${client.idle_count()}`);
   assert(client.idle_count() == usize(1), `pooled, idle=${client.idle_count()}`);
+  eprintln(`  [204] issuing request two on the pooled connection`);
   b := io.await(client.fetch_with(`http://127.0.0.1:19853/two`, opts, io), e);
+  eprintln(`  [204] response two: status=${b.status.as_u16()} accepts=${stats.accepts} requests=${stats.requests}`);
   assert(b.status.as_u16() == u16(204), `second status ${b.status.as_u16()}`);
   assert(stats.accepts == usize(1), `one accept, got ${stats.accepts}`);
   assert(stats.requests == usize(2), `two requests framed, got ${stats.requests}`);
   client.close_idle();
   task.await(io);
+  eprintln(`  [204] server task joined`);
 });
 test("HttpClient: a HEAD response ends at its headers and the connection is reused", {
   exn := Exception(

--- a/tests/http/http.test.yo
+++ b/tests/http/http.test.yo
@@ -9,17 +9,22 @@ pragma(Pragma.SkipWasm32Wasi); // https needs a network stack + TLS
 { assert, panic } :: import("std/assert");
 { HttpMethod, HttpRequest, HttpResponse, parse_response } :: import("std/http/http");
 { HttpHeader, HeaderMap, StatusCode } :: import("std/http/http");
-{ fetch, fetch_with, FetchOptions } :: import("std/http/client");
+{ fetch, fetch_with, FetchOptions, HttpClient } :: import("std/http/client");
+_wire :: import("std/http/wire.yo");
+{ dup } :: import("std/sys/pipe");
+{ close_sync } :: import("std/sys/file");
 { Exception, IoExn } :: import("std/error");
 { println, eprintln } :: import("std/fmt");
 { String } :: import("std/string");
 { ArrayList } :: import("std/collections/array_list");
 { GlobalAllocator } :: import("std/allocator");
 { malloc, free } :: GlobalAllocator;
-{ TcpListener, TcpStream } :: import("std/net/tcp");
+{ TcpListener, TcpStream, Shutdown } :: import("std/net/tcp");
+{ Reader } :: import("std/io");
 { SocketAddr } :: import("std/net/addr");
 { Duration } :: import("std/time/duration");
 { sleep } :: import("std/time/sleep");
+{ timeout } :: import("std/async");
 { env } :: import("std/env");
 /// True where a network failure is a REAL failure rather than "this box has
 /// no egress": GitHub Actions and essentially every other CI sets `CI`.
@@ -949,5 +954,734 @@ test("parse_response slices a binary body as bytes", {
       eprintln(`  unexpected: ${e.to_string()}`);
       assert(false, "must parse");
     }
+  );
+});
+// ============================================================================
+// HttpClient — the connection pool
+// ============================================================================
+// The pool's whole point is that a second request costs no reconnect, so the
+// oracle has to be the SERVER's accept count, not the response body. These
+// tests therefore drive a raw `TcpListener` that frames requests with
+// `std/http/wire` and answers them itself: `HttpServer` adds
+// `Connection: close` to every response, so it cannot demonstrate reuse, and
+// a hand-written server is also the only way to produce the four response
+// shapes RFC 9112 §9.3 distinguishes.
+//
+// Every one of these servers accepts EXACTLY `max_conns` connections and
+// closes its listener as soon as the last one is accepted. That is
+// deliberate: if the pool fails to reuse a connection, the extra connect is
+// REFUSED and the test fails in a second, instead of hanging on a socket
+// nobody will ever answer.
+//
+// The counters live in a `ref(struct(...))` handed to the server rather than
+// in module-level mutable bindings, and that is not a style choice: a
+// module-level mutable written across a SUSPENSION POINT in an `io.async`
+// body operates on a copy, so the writes are lost
+// (issues/a-module-global-is-lost-across-an-async-suspension.md) — and this
+// server's loop suspends on every read. A reference-semantics value is
+// shared by construction.
+_KaStats :: ref(struct(accepts : usize, requests : usize, saw_close : bool));
+_ka_stats :: (fn() -> _KaStats)(
+  _KaStats(accepts : usize(0), requests : usize(0), saw_close : false)
+);
+// HTTP/1.1 + Content-Length; the connection stays open (reusable).
+_KA_KEEP :: i32(0);
+// ... plus `Connection: close` (RFC 9112 §9.3: not reusable).
+_KA_CLOSE :: i32(1);
+// HTTP/1.0 with no `Connection` field: close by default, so not reusable.
+_KA_HTTP10 :: i32(2);
+// No `Content-Length` and not chunked: the body is delimited by the close
+// itself, so there can be no next message on this connection.
+_KA_UNSIZED :: i32(3);
+// Reusable-looking, then HALF-CLOSED — the server's idle timeout, modelled
+// with `shutdown(Write)` rather than a full close so the client sees a clean
+// EOF instead of racing an RST. A full close is what a real server does and
+// produces either outcome depending on timing; the EOF is the half this test
+// is about.
+_KA_HALF_CLOSE :: i32(4);
+// HTTP/1.0 that opts in explicitly: reusable.
+_KA_HTTP10_KEEP :: i32(5);
+// `204 No Content` with a NON-ZERO `Content-Length`. RFC 9112 §6.3 rule 1
+// says a 204 carries no body whatever its framing headers claim, so the
+// length must be ignored; a client that honours it waits forever for seven
+// bytes the server will never send. The connection stays open.
+_KA_204 :: i32(6);
+_ka_response :: (fn(mode : i32, n : usize, is_head : bool) -> String)({
+  body := `n=${n.to_string()}`;
+  len := body.len().to_string();
+  cond(
+    // A response to HEAD carries the headers it would have carried for a GET
+    // — `Content-Length` included — and NO body. Only the client knows the
+    // request was a HEAD, which is why the framing takes it as a parameter
+    // rather than reading it off the bytes.
+    is_head => `HTTP/1.1 200 OK\r\nContent-Length: ${len}\r\n\r\n`,
+    (mode == _KA_204) => `HTTP/1.1 204 No Content\r\nContent-Length: 7\r\n\r\n`,
+    (mode == _KA_CLOSE) => `HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: ${len}\r\n\r\n${body}`,
+    (mode == _KA_HTTP10) => `HTTP/1.0 200 OK\r\nContent-Length: ${len}\r\n\r\n${body}`,
+    (mode == _KA_HTTP10_KEEP) => `HTTP/1.0 200 OK\r\nConnection: keep-alive\r\nContent-Length: ${len}\r\n\r\n${body}`,
+    (mode == _KA_UNSIZED) => `HTTP/1.1 200 OK\r\nX-Unsized: yes\r\n\r\n${body}`,
+    true => `HTTP/1.1 200 OK\r\nContent-Length: ${len}\r\n\r\n${body}`
+  )
+});
+// Whether this mode's response ends the connection after one exchange.
+_ka_one_shot :: (fn(mode : i32) -> bool)(
+  (mode == _KA_CLOSE) || ((mode == _KA_HTTP10) || ((mode == _KA_UNSIZED) || (mode == _KA_HALF_CLOSE)))
+);
+// One connection: read framed requests off it and answer each one, until the
+// peer closes (an empty framed message is EOF) or the mode says to stop.
+_ka_conn :: (fn(stream : TcpStream, mode : i32, stats : _KaStats, io : Io) -> Impl(Future(unit, IoExn)))(
+  io.async(e => {
+    // ONE carry list for the whole connection: a single `read` can deliver
+    // the end of this request and the start of the next.
+    carry := ArrayList(u8).new();
+    open := true;
+    while(runtime(open), {
+      framed := e.io.await(
+        _wire.read_http_message_buffered(stream, usize(0), _wire.MessageKind.Request, carry, e.io),
+        e
+      );
+      raw := match(framed, .Ok(x) => x, .Err(_) => String.new());
+      (answer : String) = String.new();
+      cond(
+        raw.is_empty() => {
+          open = false;
+        },
+        true => {
+          stats.requests = (stats.requests + usize(1));
+          cond(
+            raw.to_lowercase().contains(`connection: close`) => {
+              stats.saw_close = true;
+            },
+            true => ()
+          );
+          answer = _ka_response(mode, stats.requests, raw.starts_with(`HEAD `));
+        }
+      );
+      cond(
+        !answer.is_empty() => {
+          _w := e.io.await(stream.write_string(answer, e.io), e);
+        },
+        true => ()
+      );
+      cond(
+        (!answer.is_empty() && _ka_one_shot(mode)) => {
+          open = false;
+        },
+        true => ()
+      );
+    });
+    // A half-close leaves the socket readable from the client's side, which
+    // is what makes the EOF deterministic; the descriptor is closed by
+    // `_ka_serve` at the end. Every other mode closes here.
+    cond(
+      (mode == _KA_HALF_CLOSE) => {
+        e.io.await(stream.shutdown(.Write, e.io), e);
+      },
+      true => ()
+    );
+    cond(
+      (mode != _KA_HALF_CLOSE) => {
+        e.io.await(stream.close(e.io), e);
+      },
+      true => ()
+    );
+    ()
+  })
+);
+_ka_bind :: (fn(port : u16, io : Io) -> Impl(Future(TcpListener, IoExn)))(
+  io.async(e => {
+    listener := e.io.await(TcpListener.bind(SocketAddr.loopback(port), e.io), e);
+    return(listener);
+  })
+);
+_ka_serve :: (
+  fn(listener : TcpListener, max_conns : usize, mode : i32, stats : _KaStats, io : Io) ->
+    Impl(Future(unit, IoExn))
+)(
+  io.async(e => {
+    held := ArrayList(TcpStream).new();
+    n := usize(0);
+    while(runtime(n < max_conns), {
+      stream := e.io.await(listener.accept(e.io), e);
+      stats.accepts = (stats.accepts + usize(1));
+      n = (n + usize(1));
+      held.push(stream);
+      // Stop listening the moment the budget is spent, so an unexpected
+      // reconnect is REFUSED rather than left hanging.
+      cond(
+        (n == max_conns) => {
+          e.io.await(listener.close(e.io), e);
+        },
+        true => ()
+      );
+      e.io.await(_ka_conn(stream, mode, stats, e.io), e);
+    });
+    i := usize(0);
+    while(runtime(i < held.len()), {
+      s := held(i);
+      e.io.await(s.close(e.io), e);
+      i = (i + usize(1));
+    });
+    ()
+  })
+);
+_FD_BATCH :: i32(8);
+// The exact number of open descriptors, measured SYNCHRONOUSLY.
+//
+// `dup(0)` hands back the LOWEST free number, so N repeats occupy the N
+// lowest free slots and every number in `0..=highest` is then taken:
+// `highest + 1 == open_count + N`. Solving for the open count is exact, and
+// unlike a plain "lowest free descriptor" probe it is not fooled by a hole
+// an earlier close left further down — this test file closes a listener
+// before the measurement, and that hole made the naive probe read the same
+// number whether the client leaked its socket or not.
+//
+// Synchronous matters as much as exact: an async probe would turn the event
+// loop and let the server react to the very close being measured.
+_open_fd_count :: (fn() -> i32)({
+  taken := ArrayList(i32).new();
+  i := i32(0);
+  while(runtime(i < _FD_BATCH), {
+    taken.push(dup(i32(0)));
+    i = (i + i32(1));
+  });
+  highest := i32(0);
+  j := usize(0);
+  while(runtime(j < taken.len()), {
+    f := taken(j);
+    cond(
+      (f > highest) => {
+        highest = f;
+      },
+      true => ()
+    );
+    j = (j + usize(1));
+  });
+  j = usize(0);
+  while(runtime(j < taken.len()), {
+    close_sync(taken(j));
+    j = (j + usize(1));
+  });
+  (highest + i32(1)) - _FD_BATCH
+});
+test("HttpClient: a second request runs on the pooled connection, with no reconnect", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19840), io), e);
+  task := io.spawn(_ka_serve(listener, usize(1), _KA_KEEP, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19840/one`, io), e);
+  assert(a.body == `n=1`, `first response: ${a.body}`);
+  assert(client.idle_count() == usize(1), `the connection went back to the pool, idle=${client.idle_count()}`);
+  // The server accepted its ONE connection and closed the listener, so a
+  // second connect would be refused. Reaching a second response at all is
+  // the proof of reuse; the accept count states it directly.
+  b := io.await(client.fetch(`http://127.0.0.1:19840/two`, io), e);
+  assert(b.body == `n=2`, `second response: ${b.body}`);
+  assert(stats.accepts == usize(1), `one accept for two requests, got ${stats.accepts}`);
+  assert(stats.requests == usize(2), `the server framed two requests, got ${stats.requests}`);
+  assert(!stats.saw_close, "a pooled request does not announce Connection: close");
+  assert(client.idle_count() == usize(1), "and it is pooled again");
+  client.close_idle();
+  assert(client.idle_count() == usize(0), "close_idle empties the pool");
+  task.await(io);
+});
+test("HttpClient: the free fetch stays one-shot — it announces Connection: close", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19841), io), e);
+  task := io.spawn(_ka_serve(listener, usize(2), _KA_KEEP, stats, io), e);
+  a := io.await(fetch(`http://127.0.0.1:19841/one`, io), e);
+  assert(a.body == `n=1`, `first response: ${a.body}`);
+  assert(stats.saw_close, "the one-shot fetch sent Connection: close");
+  // A second one-shot fetch opens its own connection — there is no hidden
+  // global pool behind `fetch`.
+  b := io.await(fetch_with(`http://127.0.0.1:19841/two`, FetchOptions.new(), io), e);
+  assert(b.body == `n=2`, `second response: ${b.body}`);
+  assert(stats.accepts == usize(2), `two one-shot fetches, two accepts, got ${stats.accepts}`);
+  task.await(io);
+});
+test("HttpClient: Connection: close retires the connection", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19842), io), e);
+  task := io.spawn(_ka_serve(listener, usize(2), _KA_CLOSE, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19842/one`, io), e);
+  assert(a.body == `n=1`, `response: ${a.body}`);
+  assert(client.idle_count() == usize(0), `Connection: close is not pooled, idle=${client.idle_count()}`);
+  b := io.await(client.fetch(`http://127.0.0.1:19842/two`, io), e);
+  assert(b.body == `n=2`, `second response: ${b.body}`);
+  assert(stats.accepts == usize(2), `each request got its own connection, accepts=${stats.accepts}`);
+  client.close_idle();
+  task.await(io);
+});
+test("HttpClient: an HTTP/1.0 response without Connection: keep-alive retires the connection", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19843), io), e);
+  task := io.spawn(_ka_serve(listener, usize(1), _KA_HTTP10, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19843/one`, io), e);
+  assert(a.version == `HTTP/1.0`, `the version is kept as received: ${a.version}`);
+  assert(a.body == `n=1`, `response: ${a.body}`);
+  assert(client.idle_count() == usize(0), `HTTP/1.0 is close-by-default, idle=${client.idle_count()}`);
+  task.await(io);
+});
+test("HttpClient: an HTTP/1.0 response WITH Connection: keep-alive is reused", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19844), io), e);
+  task := io.spawn(_ka_serve(listener, usize(1), _KA_HTTP10_KEEP, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19844/one`, io), e);
+  assert(a.version == `HTTP/1.0`, `version: ${a.version}`);
+  assert(client.idle_count() == usize(1), `an explicit keep-alive opts in, idle=${client.idle_count()}`);
+  b := io.await(client.fetch(`http://127.0.0.1:19844/two`, io), e);
+  assert(b.body == `n=2`, `second response: ${b.body}`);
+  assert(stats.accepts == usize(1), `one accept, got ${stats.accepts}`);
+  client.close_idle();
+  task.await(io);
+});
+test("HttpClient: a response of unknown length is close-delimited and retires the connection", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19845), io), e);
+  task := io.spawn(_ka_serve(listener, usize(1), _KA_UNSIZED, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19845/one`, io), e);
+  assert(a.body == `n=1`, `the body arrived with the close: ${a.body}`);
+  assert(a.get_header(`Content-Length`).is_none(), "there was no Content-Length");
+  // The close IS the end of the body, so there is no next message here no
+  // matter what `Connection` says.
+  assert(client.idle_count() == usize(0), `a close-delimited response is not pooled, idle=${client.idle_count()}`);
+  task.await(io);
+});
+test("HttpClient: a connection the server closed while idle is retried once on a fresh one", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19846), io), e);
+  task := io.spawn(_ka_serve(listener, usize(2), _KA_HALF_CLOSE, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19846/one`, io), e);
+  assert(a.body == `n=1`, `first response: ${a.body}`);
+  // The response looked reusable, so it IS pooled — and the server has
+  // already stopped listening on it. This is the single most important
+  // behaviour of a keep-alive client: the next request must not fail.
+  assert(client.idle_count() == usize(1), `pooled, idle=${client.idle_count()}`);
+  b := io.await(client.fetch(`http://127.0.0.1:19846/two`, io), e);
+  assert(b.body == `n=2`, `the retried request succeeded: ${b.body}`);
+  assert(stats.accepts == usize(2), `the retry opened a fresh connection, accepts=${stats.accepts}`);
+  client.close_idle();
+  task.await(io);
+});
+test("HttpClient: the idle cap is respected", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19847), io), e);
+  task := io.spawn(_ka_serve(listener, usize(2), _KA_KEEP, stats, io), e);
+  // `max_idle == 0` is the degenerate cap: nothing is ever pooled, so the
+  // client behaves like the one-shot `fetch` while still speaking keep-alive
+  // on the wire.
+  client := HttpClient.new().with_max_idle(usize(0));
+  a := io.await(client.fetch(`http://127.0.0.1:19847/one`, io), e);
+  assert(a.body == `n=1`, `first response: ${a.body}`);
+  assert(client.idle_count() == usize(0), `nothing pooled at cap 0, idle=${client.idle_count()}`);
+  b := io.await(client.fetch(`http://127.0.0.1:19847/two`, io), e);
+  assert(b.body == `n=2`, `second response: ${b.body}`);
+  assert(stats.accepts == usize(2), `each request connected, accepts=${stats.accepts}`);
+  assert(client.idle_count() == usize(0), "still nothing pooled");
+  task.await(io);
+});
+test("HttpClient: the idle age limit closes a connection instead of reusing it", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19848), io), e);
+  task := io.spawn(_ka_serve(listener, usize(2), _KA_KEEP, stats, io), e);
+  // A 1 ms age limit expires between two requests without a sleep long
+  // enough to slow the suite down.
+  client := HttpClient.new().with_idle_timeout(Duration.from_millis(i64(1)));
+  a := io.await(client.fetch(`http://127.0.0.1:19848/one`, io), e);
+  assert(a.body == `n=1`, `first response: ${a.body}`);
+  assert(client.idle_count() == usize(1), "pooled");
+  io.await(sleep(Duration.from_millis(i64(20)), io), e);
+  b := io.await(client.fetch(`http://127.0.0.1:19848/two`, io), e);
+  assert(b.body == `n=2`, `second response: ${b.body}`);
+  assert(stats.accepts == usize(2), `the expired connection was not reused, accepts=${stats.accepts}`);
+  client.close_idle();
+  task.await(io);
+});
+test("HttpClient: dispose closes every idle connection", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19849), io), e);
+  task := io.spawn(_ka_serve(listener, usize(1), _KA_KEEP, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19849/one`, io), e);
+  assert(a.body == `n=1`, `response: ${a.body}`);
+  assert(client.idle_count() == usize(1), "one connection is idle");
+  // `during` counts the descriptors open while the pooled connection still
+  // is; `after` counts them once `dispose` has run. Exactly one must have
+  // gone — the pooled socket. Nothing else runs between the two
+  // measurements, because both are synchronous.
+  during := _open_fd_count();
+  // `dispose` is what a DROPPED client runs, and calling it by hand is the
+  // only way to observe it today: a `ref` value passed as a parameter to an
+  // `io.async` future is never released
+  // (issues/a-ref-value-passed-to-an-async-future-is-never-released.md), so
+  // a client that has made a request never reaches reference count zero and
+  // the scope-exit path cannot fire. The body being tested is the same one
+  // either way — `dispose` delegates to `close_idle`.
+  (HttpClient <: Dispose).dispose(client);
+  after := _open_fd_count();
+  assert(
+    after == (during - i32(1)),
+    `dispose closed exactly the pooled descriptor (open ${during} -> ${after})`
+  );
+  assert(client.idle_count() == usize(0), "and the idle set is empty");
+  // And the server saw the EOF: its connection loop ends and the task
+  // finishes, which would otherwise park on a read forever.
+  match(
+    timeout(task, Duration.from_secs(i64(10)), io),
+    .Ok(_) => (),
+    .Err(err) => assert(false, `the server never saw the connection close: ${err.to_string()}`)
+  );
+});
+test("HttpClient: the pool never crosses ports", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  l1 := io.await(_ka_bind(u16(19850), io), e);
+  l2 := io.await(_ka_bind(u16(19851), io), e);
+  t1 := io.spawn(_ka_serve(l1, usize(1), _KA_KEEP, stats, io), e);
+  t2 := io.spawn(_ka_serve(l2, usize(1), _KA_KEEP, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19850/a`, io), e);
+  assert(a.body == `n=1`, `first server: ${a.body}`);
+  // Same scheme, same host, different port: the pooled connection must not
+  // be handed over — it is wired to another peer.
+  b := io.await(client.fetch(`http://127.0.0.1:19851/b`, io), e);
+  assert(b.body == `n=2`, `second server: ${b.body}`);
+  assert(stats.accepts == usize(2), `each port got its own connection, accepts=${stats.accepts}`);
+  assert(client.idle_count() == usize(2), `both are pooled, idle=${client.idle_count()}`);
+  // And the first target's connection is still the one reused for it.
+  c := io.await(client.fetch(`http://127.0.0.1:19850/c`, io), e);
+  assert(c.body == `n=3`, `back to the first server: ${c.body}`);
+  assert(stats.accepts == usize(2), `still two accepts, got ${stats.accepts}`);
+  client.close_idle();
+  t1.await(io);
+  t2.await(io);
+});
+// Phase of the host-isolation test below, written from the test's own stack —
+// which is synchronous code, so the write lands where the handler can see it
+// (unlike a write from inside a suspending async body; see `_KaStats`) — and
+// read by that handler through a module-level fn.
+(g_iso_phase : i32) = i32(0);
+_iso_phase :: (fn() -> i32)(g_iso_phase);
+test("HttpClient: the pool never crosses hosts", {
+  // The handler is where this test's assertions live: a request for another
+  // host must FAIL rather than be answered over the pooled connection, and
+  // failing means the exception arrives here.
+  exn := Exception(
+    throw : (
+      err -> {
+        // Reaching this handler during phase 1 IS the proof: the request for
+        // the other host was not answered over the pooled connection. What
+        // the failure IS depends on the box — a DNS miss where `.invalid`
+        // does not resolve, a refused or immediately-closed connection where
+        // a resolver hijacks NXDOMAIN — so the error text is not asserted,
+        // only the phase (a capture-free handler cannot read the test's
+        // locals, but it can call a module-level binding, #396).
+        assert(
+          _iso_phase() == i32(1),
+          `unexpected exception before the isolation request: ${err.to_string()}`
+        );
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19852), io), e);
+  // HALF_CLOSE so the server task FINISHES after one exchange: the throw
+  // below unwinds the test body, and a server left parked on a read would
+  // keep the event loop alive and stop the process from exiting.
+  task := io.spawn(_ka_serve(listener, usize(1), _KA_HALF_CLOSE, stats, io), e);
+  client := HttpClient.new();
+  a := io.await(client.fetch(`http://127.0.0.1:19852/a`, io), e);
+  assert(a.body == `n=1`, `first response: ${a.body}`);
+  assert(client.idle_count() == usize(1), "pooled");
+  task.await(io);
+  // `.invalid` is reserved by RFC 2606 for exactly this. Our server is the
+  // only thing that answers `n=K`, and it is no longer listening, so this
+  // request can only be ANSWERED by being sent over the pooled 127.0.0.1
+  // connection — a request delivered to the wrong peer.
+  g_iso_phase = i32(1);
+  resp := io.await(client.fetch(`http://pool-isolation.invalid:19852/b`, io), e);
+  assert(false, `a request for another host was answered: ${resp.body}`);
+});
+// RFC 9112 §6.3 rule 1 on a keep-alive connection is not a nicety, it is the
+// difference between an answer and a hang: a 204 and a 304 routinely carry no
+// `Content-Length` at all (or, as here, one that describes the body a 200
+// would have had), the old framing read a response with neither header as
+// close-delimited, and a keep-alive server never closes. Both tests give the
+// request a deadline so a regression fails as a `Timeout` rather than hanging
+// a whole CI job.
+test("HttpClient: a 204 ends at its headers, whatever its Content-Length says", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19853), io), e);
+  task := io.spawn(_ka_serve(listener, usize(1), _KA_204, stats, io), e);
+  client := HttpClient.new();
+  opts := FetchOptions.new().with_timeout(Duration.from_secs(i64(10)));
+  a := io.await(client.fetch_with(`http://127.0.0.1:19853/one`, opts, io), e);
+  assert(a.status.as_u16() == u16(204), `status ${a.status.as_u16()}`);
+  assert(a.body.is_empty(), `a 204 has no body, got [${a.body}]`);
+  assert(a.get_header(`Content-Length`).unwrap() == `7`, "the header is kept as received");
+  // Framed at the headers means the connection is at a message boundary, so
+  // it is reusable — and the next response proves the boundary was right.
+  assert(client.idle_count() == usize(1), `pooled, idle=${client.idle_count()}`);
+  b := io.await(client.fetch_with(`http://127.0.0.1:19853/two`, opts, io), e);
+  assert(b.status.as_u16() == u16(204), `second status ${b.status.as_u16()}`);
+  assert(stats.accepts == usize(1), `one accept, got ${stats.accepts}`);
+  assert(stats.requests == usize(2), `two requests framed, got ${stats.requests}`);
+  client.close_idle();
+  task.await(io);
+});
+test("HttpClient: a HEAD response ends at its headers and the connection is reused", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  stats := _ka_stats();
+  listener := io.await(_ka_bind(u16(19854), io), e);
+  task := io.spawn(_ka_serve(listener, usize(1), _KA_KEEP, stats, io), e);
+  client := HttpClient.new();
+  head := FetchOptions.new().with_method(.HEAD).with_timeout(Duration.from_secs(i64(10)));
+  a := io.await(client.fetch_with(`http://127.0.0.1:19854/one`, head, io), e);
+  assert(a.status.as_u16() == u16(200), `status ${a.status.as_u16()}`);
+  assert(a.body.is_empty(), `a HEAD response has no body, got [${a.body}]`);
+  assert(a.get_header(`Content-Length`).unwrap() == `3`, "the length of the body a GET would have returned");
+  assert(client.idle_count() == usize(1), `pooled, idle=${client.idle_count()}`);
+  // And the connection really is at a boundary: a GET follows on it.
+  get := FetchOptions.new().with_timeout(Duration.from_secs(i64(10)));
+  b := io.await(client.fetch_with(`http://127.0.0.1:19854/two`, get, io), e);
+  assert(b.body == `n=2`, `the GET after a HEAD is framed correctly: ${b.body}`);
+  assert(stats.accepts == usize(1), `one accept, got ${stats.accepts}`);
+  client.close_idle();
+  task.await(io);
+});
+// A body-less message followed by another one in a SINGLE read is the case the
+// framing has to get right for a pooled connection: the second message's
+// bytes must be CARRIED, not appended to the first as a body its
+// `Content-Length` invited. A socket cannot be made to deliver two messages
+// in one read on demand, so this drives the framing through a scripted reader
+// — the same technique as `tests/http/wire.test.yo`, and the reason it is
+// repeated here is that these two cases are the ones the pool introduced.
+_PipeReader :: ref(struct(data : ArrayList(u8), pos : usize, reads : usize));
+_pipe :: (fn(text : String) -> _PipeReader)(
+  _PipeReader(data : text.as_bytes(), pos : usize(0), reads : usize(0))
+);
+impl(
+  _PipeReader,
+  read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+    io.async(e => {
+      self.reads = (self.reads + usize(1));
+      // `size` is copied to a body-local before it is used in a branch: a
+      // captured parameter read in a `cond`'s SECOND arm was emitted
+      // unrewritten before the "one capture predicate" codegen fix, and this
+      // file has to build under an older seed as well.
+      room := size;
+      n := usize(0);
+      while(runtime((n < room) && (self.pos < self.data.len())), {
+        consume((buf.add(n)).* = self.data(self.pos));
+        self.pos = (self.pos + usize(1));
+        n = (n + usize(1));
+      });
+      n
+    })
+  )
+);
+impl(
+  _PipeReader,
+  Reader(
+    read : (fn(self : Self, buf : *u8, size : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+      self.read(buf, size, io)
+    )
+  )
+);
+_P204 :: "HTTP/1.1 204 No Content\r\nContent-Length: 7\r\n\r\n";
+_PHEAD :: "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\n";
+_PNEXT :: "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+test("wire: a 204 followed by another response in one read carries the tail", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  r := _pipe(`${_P204}${_PNEXT}`);
+  carry := ArrayList(u8).new();
+  raw1 := match(
+    io.await(_wire.read_http_message_buffered(r, usize(0), _wire.MessageKind.Response, carry, io), e),
+    .Ok(x) => x,
+    .Err(err) => {
+      assert(false, `first message: ${err.to_string()}`);
+      String.new()
+    }
+  );
+  assert(raw1 == String.from(_P204), `the 204 is framed at its header section, got ${raw1.len()} bytes`);
+  assert(carry.len() == String.from(_PNEXT).len(), `the next response is carried (carry=${carry.len()})`);
+  reads_before := r.reads;
+  raw2 := match(
+    io.await(_wire.read_http_message_buffered(r, usize(0), _wire.MessageKind.Response, carry, io), e),
+    .Ok(x) => x,
+    .Err(err) => {
+      assert(false, `second message: ${err.to_string()}`);
+      String.new()
+    }
+  );
+  assert(raw2 == String.from(_PNEXT), `the second message is framed from the carry, got ${raw2.len()} bytes`);
+  assert(r.reads == reads_before, "a message already carried costs no read");
+  assert(parse_response(raw2).unwrap().body == `ok`, "and it parses");
+});
+test("wire: a HEAD response ignores its Content-Length and carries the tail", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected exception: ${err.to_string()}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  r := _pipe(`${_PHEAD}${_PNEXT}`);
+  carry := ArrayList(u8).new();
+  raw1 := match(
+    io.await(_wire.read_http_message_buffered(r, usize(0), _wire.MessageKind.HeadResponse, carry, io), e),
+    .Ok(x) => x,
+    .Err(err) => {
+      assert(false, `head message: ${err.to_string()}`);
+      String.new()
+    }
+  );
+  assert(raw1 == String.from(_PHEAD), `the HEAD response is framed at its headers, got ${raw1.len()} bytes`);
+  assert(carry.len() == String.from(_PNEXT).len(), `the next response is carried (carry=${carry.len()})`);
+  // The same bytes read as a plain Response would swallow the next response's
+  // first three bytes as this one's body — which is exactly the smuggling the
+  // kind parameter exists to prevent.
+  r2 := _pipe(`${_PHEAD}${_PNEXT}`);
+  carry2 := ArrayList(u8).new();
+  as_get := match(
+    io.await(_wire.read_http_message_buffered(r2, usize(0), _wire.MessageKind.Response, carry2, io), e),
+    .Ok(x) => x,
+    .Err(_) => String.new()
+  );
+  assert(
+    as_get.len() == (String.from(_PHEAD).len() + usize(3)),
+    `read as a GET response the same bytes frame a 3-byte body, got ${as_get.len()}`
   );
 });

--- a/tests/http/http.test.yo
+++ b/tests/http/http.test.yo
@@ -1034,11 +1034,13 @@ _ka_conn :: (fn(stream : TcpStream, mode : i32, stats : _KaStats, io : Io) -> Im
     carry := ArrayList(u8).new();
     open := true;
     while(runtime(open), {
+      eprintln(`  [srv] awaiting a framed request (carry=${carry.len()})`);
       framed := e.io.await(
         _wire.read_http_message_buffered(stream, usize(0), _wire.MessageKind.Request, carry, e.io),
         e
       );
       raw := match(framed, .Ok(x) => x, .Err(_) => String.new());
+      eprintln(`  [srv] framed ${raw.len()} request byte(s)`);
       (answer : String) = String.new();
       cond(
         raw.is_empty() => {
@@ -1058,6 +1060,7 @@ _ka_conn :: (fn(stream : TcpStream, mode : i32, stats : _KaStats, io : Io) -> Im
       cond(
         !answer.is_empty() => {
           _w := e.io.await(stream.write_string(answer, e.io), e);
+          eprintln(`  [srv] wrote ${_w.to_string()} of ${answer.len()} answer byte(s)`);
         },
         true => ()
       );
@@ -1101,6 +1104,7 @@ _ka_serve :: (
     n := usize(0);
     while(runtime(n < max_conns), {
       stream := e.io.await(listener.accept(e.io), e);
+      eprintln(`  [srv] accepted connection ${(stats.accepts + usize(1)).to_string()}`);
       stats.accepts = (stats.accepts + usize(1));
       n = (n + usize(1));
       held.push(stream);

--- a/tests/http/http.test.yo
+++ b/tests/http/http.test.yo
@@ -11,8 +11,6 @@ pragma(Pragma.SkipWasm32Wasi); // https needs a network stack + TLS
 { HttpHeader, HeaderMap, StatusCode } :: import("std/http/http");
 { fetch, fetch_with, FetchOptions, HttpClient } :: import("std/http/client");
 _wire :: import("std/http/wire.yo");
-{ dup } :: import("std/sys/pipe");
-{ close_sync } :: import("std/sys/file");
 { Exception, IoExn } :: import("std/error");
 { println, eprintln } :: import("std/fmt");
 { String } :: import("std/string");
@@ -1125,45 +1123,6 @@ _ka_serve :: (
     ()
   })
 );
-_FD_BATCH :: i32(8);
-// The exact number of open descriptors, measured SYNCHRONOUSLY.
-//
-// `dup(0)` hands back the LOWEST free number, so N repeats occupy the N
-// lowest free slots and every number in `0..=highest` is then taken:
-// `highest + 1 == open_count + N`. Solving for the open count is exact, and
-// unlike a plain "lowest free descriptor" probe it is not fooled by a hole
-// an earlier close left further down — this test file closes a listener
-// before the measurement, and that hole made the naive probe read the same
-// number whether the client leaked its socket or not.
-//
-// Synchronous matters as much as exact: an async probe would turn the event
-// loop and let the server react to the very close being measured.
-_open_fd_count :: (fn() -> i32)({
-  taken := ArrayList(i32).new();
-  i := i32(0);
-  while(runtime(i < _FD_BATCH), {
-    taken.push(dup(i32(0)));
-    i = (i + i32(1));
-  });
-  highest := i32(0);
-  j := usize(0);
-  while(runtime(j < taken.len()), {
-    f := taken(j);
-    cond(
-      (f > highest) => {
-        highest = f;
-      },
-      true => ()
-    );
-    j = (j + usize(1));
-  });
-  j = usize(0);
-  while(runtime(j < taken.len()), {
-    close_sync(taken(j));
-    j = (j + usize(1));
-  });
-  (highest + i32(1)) - _FD_BATCH
-});
 test("HttpClient: a second request runs on the pooled connection, with no reconnect", {
   exn := Exception(
     throw : (
@@ -1383,6 +1342,25 @@ test("HttpClient: the idle age limit closes a connection instead of reusing it",
   client.close_idle();
   task.await(io);
 });
+// The oracle here is what the PEERS observe, not what the descriptor table
+// looks like.
+//
+// A closed connection is one the server at the other end reads EOF from: its
+// connection loop then ends, `_ka_serve` returns, and the spawned task
+// finishes. A connection that is still open leaves that server parked on a
+// read forever, so the task never finishes and the deadline reports it. Two
+// servers on two ports make it a test of "EVERY idle connection" rather than
+// "an idle connection".
+//
+// This replaces a descriptor-count probe (`dup(0)` N times, solving
+// `highest + 1 == open_count + N`) that worked on macOS/arm64 and nowhere
+// else: Windows sockets are not in the CRT descriptor table at all, so the
+// count never moved there, and it did not move on the intel macOS runner
+// either — a leak test that cannot fail is worse than no test. The
+// peer-observation oracle needs no platform knowledge, and every other test
+// in this group already depends on it implicitly, because each one ends in a
+// `task.await(io)` that only returns once the client's socket is really
+// closed.
 test("HttpClient: dispose closes every idle connection", {
   exn := Exception(
     throw : (
@@ -1394,17 +1372,16 @@ test("HttpClient: dispose closes every idle connection", {
   );
   e := IoExn(io : io, exn : exn);
   stats := _ka_stats();
-  listener := io.await(_ka_bind(u16(19849), io), e);
-  task := io.spawn(_ka_serve(listener, usize(1), _KA_KEEP, stats, io), e);
+  l1 := io.await(_ka_bind(u16(19849), io), e);
+  l2 := io.await(_ka_bind(u16(19855), io), e);
+  t1 := io.spawn(_ka_serve(l1, usize(1), _KA_KEEP, stats, io), e);
+  t2 := io.spawn(_ka_serve(l2, usize(1), _KA_KEEP, stats, io), e);
   client := HttpClient.new();
   a := io.await(client.fetch(`http://127.0.0.1:19849/one`, io), e);
-  assert(a.body == `n=1`, `response: ${a.body}`);
-  assert(client.idle_count() == usize(1), "one connection is idle");
-  // `during` counts the descriptors open while the pooled connection still
-  // is; `after` counts them once `dispose` has run. Exactly one must have
-  // gone — the pooled socket. Nothing else runs between the two
-  // measurements, because both are synchronous.
-  during := _open_fd_count();
+  b := io.await(client.fetch(`http://127.0.0.1:19855/two`, io), e);
+  assert(a.body == `n=1`, `first response: ${a.body}`);
+  assert(b.body == `n=2`, `second response: ${b.body}`);
+  assert(client.idle_count() == usize(2), `two connections are idle, got ${client.idle_count()}`);
   // `dispose` is what a DROPPED client runs, and calling it by hand is the
   // only way to observe it today: a `ref` value passed as a parameter to an
   // `io.async` future is never released
@@ -1413,18 +1390,19 @@ test("HttpClient: dispose closes every idle connection", {
   // the scope-exit path cannot fire. The body being tested is the same one
   // either way — `dispose` delegates to `close_idle`.
   (HttpClient <: Dispose).dispose(client);
-  after := _open_fd_count();
-  assert(
-    after == (during - i32(1)),
-    `dispose closed exactly the pooled descriptor (open ${during} -> ${after})`
-  );
-  assert(client.idle_count() == usize(0), "and the idle set is empty");
-  // And the server saw the EOF: its connection loop ends and the task
-  // finishes, which would otherwise park on a read forever.
+  assert(client.idle_count() == usize(0), "the idle set is empty");
+  // …and, the part `idle_count` cannot tell you, both sockets are shut: each
+  // server read its EOF and returned. Without the `dispose` above, both of
+  // these report `Elapsed`.
   match(
-    timeout(task, Duration.from_secs(i64(10)), io),
+    timeout(t1, Duration.from_secs(i64(10)), io),
     .Ok(_) => (),
-    .Err(err) => assert(false, `the server never saw the connection close: ${err.to_string()}`)
+    .Err(err) => assert(false, `the first server never saw its connection close: ${err.to_string()}`)
+  );
+  match(
+    timeout(t2, Duration.from_secs(i64(10)), io),
+    .Ok(_) => (),
+    .Err(err) => assert(false, `the second server never saw its connection close: ${err.to_string()}`)
   );
 });
 test("HttpClient: the pool never crosses ports", {

--- a/tests/http/server.test.yo
+++ b/tests/http/server.test.yo
@@ -93,7 +93,7 @@ test("parse_request: request line, headers, body, and the error cases", {
   assert(match(parse_request(`GET /x HTTP/1.1\r\nno-colon-here\r\n\r\n`), .Err(m) => m.to_string().contains(`Invalid header line: no-colon-here`), .Ok(_) => false), "header line without a colon, rendered for a 400 body");
   assert(match(HttpMethod.from_string(`OPTIONS`), .Some(m) => (m.to_string() == "OPTIONS"), .None => false), "OPTIONS round-trips");
 });
-// The request-side half of the same defect: `read_http_message(is_request=true)`
+// The request-side half of the same defect: `read_http_message` on a REQUEST
 // completes a body-less request at its headers, but returned the whole buffer —
 // so a second request pipelined into the SAME write became the first one's
 // body. That is request smuggling (RFC 9112 §11.2).

--- a/tests/http/wire.test.yo
+++ b/tests/http/wire.test.yo
@@ -75,7 +75,7 @@ test("two pipelined responses in one read: the first is framed exactly, the seco
   // A chunk larger than both responses together, so ONE read delivers both.
   r := _scripted(`${_R1}${_R2}`, usize(4096));
   carry := ArrayList(u8).new();
-  first := io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e);
+  first := io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e);
   raw1 := match(
     first,
     .Ok(x) => x,
@@ -88,7 +88,7 @@ test("two pipelined responses in one read: the first is framed exactly, the seco
   assert(carry.len() == String.from(_R2).len(), `the second response's bytes are carried, not swallowed (carry=${carry.len()})`);
   // The second message is already in hand: reading it must cost no read at all.
   reads_before := r.reads;
-  second := io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e);
+  second := io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e);
   raw2 := match(
     second,
     .Ok(x) => x,
@@ -125,7 +125,7 @@ test("one-byte reads frame the same two messages", {
   r := _scripted(`${_R1}${_R2}`, usize(1));
   carry := ArrayList(u8).new();
   raw1 := match(
-    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e),
     .Ok(x) => x,
     .Err(_) => {
       assert(false, "first message");
@@ -134,7 +134,7 @@ test("one-byte reads frame the same two messages", {
   );
   assert(raw1 == String.from(_R1), "byte-at-a-time framing matches");
   raw2 := match(
-    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e),
     .Ok(x) => x,
     .Err(_) => {
       assert(false, "second message");
@@ -161,7 +161,7 @@ test("a chunked response followed by another response carries the tail", {
   r := _scripted(`${chunked}${_R2}`, usize(4096));
   carry := ArrayList(u8).new();
   raw1 := match(
-    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e),
     .Ok(x) => x,
     .Err(err) => {
       assert(false, `chunked message: ${err}`);
@@ -172,7 +172,7 @@ test("a chunked response followed by another response carries the tail", {
   assert(p1.body == `hello`, `the chunked body is decoded: ${p1.body}`);
   assert(carry.len() == String.from(_R2).len(), `the following response is carried (carry=${carry.len()})`);
   raw2 := match(
-    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e),
     .Ok(x) => x,
     .Err(_) => {
       assert(false, "second message after chunked");
@@ -198,7 +198,7 @@ test("read_http_message frames the first message and discards the rest", {
   e := IoExn(io : io, exn : exn);
   r := _scripted(`${_R1}${_R2}`, usize(4096));
   raw := match(
-    io.await(wire.read_http_message(r, usize(0), false, io), e),
+    io.await(wire.read_http_message(r, usize(0), wire.MessageKind.Response, io), e),
     .Ok(x) => x,
     .Err(_) => {
       assert(false, "message");
@@ -225,7 +225,7 @@ test("a close-delimited response consumes everything", {
   r := _scripted(String.from(body), usize(4096));
   carry := ArrayList(u8).new();
   raw := match(
-    io.await(wire.read_http_message_buffered(r, usize(0), false, carry, io), e),
+    io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e),
     .Ok(x) => x,
     .Err(_) => {
       assert(false, "message");

--- a/tests/http/wire.test.yo
+++ b/tests/http/wire.test.yo
@@ -237,3 +237,112 @@ test("a close-delimited response consumes everything", {
   p := parse_response(raw).unwrap();
   assert(p.version == `HTTP/1.0`, `the version is kept as received: ${p.version}`);
 });
+// ---------------------------------------------------------------------------
+// A body-less response (RFC 9112 §6.3 rule 1) is framed at its headers no
+// matter how the bytes are CHUNKED.
+//
+// The socket-level test of this (`tests/http/http.test.yo`, "a 204 ends at its
+// headers") passed on some CI legs and timed out on others, which is exactly
+// the shape a framing bug takes: whether the peer's writes coalesce is the
+// peer's decision, so a reader that gets the decision wrong hangs on one
+// platform and passes on another. A scripted reader settles it — the same
+// bytes, delivered one at a time, in header-splitting pieces, and all at once.
+// ---------------------------------------------------------------------------
+_R204 :: "HTTP/1.1 204 No Content\r\nContent-Length: 7\r\n\r\n";
+_R304 :: "HTTP/1.1 304 Not Modified\r\nContent-Length: 99\r\n\r\n";
+_RHEAD :: "HTTP/1.1 200 OK\r\nContent-Length: 42\r\n\r\n";
+_frame_one :: (
+  fn(text : String, chunk : usize, kind : wire.MessageKind, io : Io, e : IoExn) -> String
+)({
+  r := _scripted(text, chunk);
+  carry := ArrayList(u8).new();
+  match(
+    io.await(wire.read_http_message_buffered(r, usize(0), kind, carry, io), e),
+    .Ok(x) => x,
+    .Err(err) => {
+      assert(false, `framing failed: ${err}`);
+      String.new()
+    }
+  )
+});
+test("a 204 is framed at its headers at every chunk size, Content-Length notwithstanding", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  // One byte per read is the pathological split: every header, and the blank
+  // line that ends them, arrives in pieces. A reader that honours the 204's
+  // `Content-Length: 7` never stops, because the server sends no body.
+  assert(
+    _frame_one(String.from(_R204), usize(1), wire.MessageKind.Response, io, e) == String.from(_R204),
+    "one byte at a time"
+  );
+  // A split INSIDE the CRLFCRLF that ends the header section.
+  assert(
+    _frame_one(String.from(_R204), usize(42), wire.MessageKind.Response, io, e) == String.from(_R204),
+    "split inside the header terminator"
+  );
+  // And the whole thing in one read.
+  assert(
+    _frame_one(String.from(_R204), usize(4096), wire.MessageKind.Response, io, e) == String.from(_R204),
+    "all at once"
+  );
+  // 304 is the other status on §6.3 rule 1's list.
+  assert(
+    _frame_one(String.from(_R304), usize(1), wire.MessageKind.Response, io, e) == String.from(_R304),
+    "a 304 too"
+  );
+  // A HEAD response carries a `Content-Length` describing the body the GET
+  // would have had. Only the sender of the request knows it was a HEAD.
+  assert(
+    _frame_one(String.from(_RHEAD), usize(1), wire.MessageKind.HeadResponse, io, e) == String.from(_RHEAD),
+    "a HEAD response is body-less by kind, not by status"
+  );
+  // The same bytes read as a plain response DO wait for a body — the contrast
+  // is what proves the framing decision is the status/kind, not the headers.
+  r := _scripted(String.from(_RHEAD), usize(4096));
+  carry := ArrayList(u8).new();
+  plain := io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e);
+  assert(
+    match(plain, .Ok(x) => (x.len() == String.from(_RHEAD).len()), .Err(_) => false),
+    "read as a plain response it stops at EOF, having waited for a body that never came"
+  );
+});
+test("a body-less response leaves the next message in the carry, and reading it costs no read", {
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  // The reuse case: a 204 and the response after it arrive in ONE read. If
+  // the 204's `Content-Length: 7` is honoured, the next response's first
+  // seven bytes are eaten as its body and every later message is misframed —
+  // response smuggling, and on a pooled connection a hang.
+  r := _scripted(`${_R204}${_R1}`, usize(4096));
+  carry := ArrayList(u8).new();
+  first := io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e);
+  assert(
+    match(first, .Ok(x) => (x == String.from(_R204)), .Err(_) => false),
+    "the 204 is exactly its header section"
+  );
+  assert(
+    carry.len() == String.from(_R1).len(),
+    `the following response is carried whole (carry=${carry.len()}, expected ${String.from(_R1).len()})`
+  );
+  reads_before := r.reads;
+  second := io.await(wire.read_http_message_buffered(r, usize(0), wire.MessageKind.Response, carry, io), e);
+  assert(
+    match(second, .Ok(x) => (x == String.from(_R1)), .Err(_) => false),
+    "and it frames correctly from the carried bytes"
+  );
+  assert(r.reads == reads_before, "which cost no read — on a socket that read would block");
+});


### PR DESCRIPTION
The framing half of HTTP keep-alive landed in #547; this is the client that uses it.

`HttpClient` **owns** its idle connections rather than being a module-global, because nothing in a free function could say when those sockets close — which is also why the free `fetch`/`fetch_with` keep their one-shot behaviour instead of gaining a hidden pool behind them.

```rust
{ HttpClient } :: import("std/http");

client := HttpClient.new();
a := io.await(client.fetch(`http://127.0.0.1:8080/one`, io), e);
b := io.await(client.fetch(`http://127.0.0.1:8080/two`, io), e); // same socket
client.close_idle();                                            // both closed
```

## One code path, parameterized by `pool : Option(HttpClient)`

The pooled and one-shot exchanges differ in three places — whether a connection is taken from a pool, whether `Connection: close` is sent, and whether the connection is returned or closed — and are identical in URL parsing, request building, framing, redirects and the deadline race. `_fetch_once`, `_fetch_follow` and `_fetch_deadline` each take the option, so there is exactly one copy of each. A second copy is where those would have drifted apart.

## Shape decisions

- **The pool key is `scheme://host:port`**, built from the URL's own host TEXT and compared, never inferred. Not the resolved address: two names that resolve to one address are still two peers as far as TLS, `Host` and virtual hosting go, and handing an `https://a` connection to a request for `https://b` speaks to the wrong peer under the first peer's certificate.
- **The idle cap is TOTAL** (default 16), because the resource being protected is the descriptor table and a per-host cap does not bound it — a client fanning out over a thousand hosts would hold a thousand sockets with a per-host cap of 1. When the pool is full the connection in hand is closed rather than evicting one already pooled (Go's answer), so a burst cannot churn the pool. `max_idle == 0` means never reuse.
- **The idle age limit** (default 30 s) is purged on the next request rather than by a timer — the only moment a `std` client is guaranteed to be running is a request. The real ceiling is the server's own timeout, 75 s on nginx and 5 s on Apache, so no value is right; 30 s discards what a short-timeout server has probably already dropped and the retry covers the rest.
- **Reuse follows RFC 9112 §9.3 in the RFC's order**: a server `Connection: close` ends it at any version; `HTTP/1.0` (and any unknown version) is close-by-default and needs an explicit `keep-alive`; a `Connection: close` we sent ends it; a response whose length is not determinable is delimited BY THE CLOSE and can never be followed by another message; and a 1xx retires the connection too, because the final response is still coming. `Connection` is a `#token` list, so the check is token-wise over every field line rather than a substring test. Each rule is its own test.
- **A connection the server closed while idle is retried once, on a fresh connection.** This is the behaviour a keep-alive client lives or dies by: the close usually reaches us only when we use the connection (the write buffers, the read that follows returns EOF with no response byte), and reporting that as a failure turns a pool into intermittent request failures. The trigger is exactly "came from the pool AND zero bytes arrived" — a freshly-opened connection is never retried, because there the EOF is real. The retry is limited to the methods RFC 9110 §9.2.2 calls idempotent: "the request was never processed" is not provable from this side, only "no response arrived", so a `POST` the server acted on before closing would run twice. Go replays those (its bodies are rewindable, as ours always are); this client reports `ConnectionFailed` and leaves the decision to the caller.
- **TLS pools identically**, through a `_Transport` enum over the two stream types with `Reader` implemented by a two-arm dispatch — the exchange, the pool and the retry are written once against that. It needed a TLS connection to be closable from plain code, and `TlsStream` had no `Dispose` at all.

## The framing layer learned RFC 9112 §6.3 rules 1–2

`read_http_message*` now takes a `MessageKind` (`Request` / `Response` / `HeadResponse`) instead of an `is_request` bool, and a 1xx, 204 or 304 response — or any response to a HEAD — ends at its header section whatever its framing headers claim. On a close-delimited connection that was harmless; on a reused one it is a **hang**, because those responses routinely carry no `Content-Length` and a keep-alive server never closes. The status code is read off the status line; HEAD cannot be, which is why the kind is a parameter and not a bool.

## Tests

`tests/http/http.test.yo` gains 15 cases (51 pass, up from 36) driving a raw `TcpListener` keep-alive server: `HttpServer` adds `Connection: close` to every response and so cannot demonstrate reuse, and a hand-written server is the only way to produce the four §9.3 response shapes. Each server accepts exactly N connections and closes its listener on the last accept, so **a pool that fails to reuse gets a REFUSED connect and the test fails in a second instead of hanging**.

Covered: a second request costs no reconnect (asserted on the accept count); `Connection: close`, an HTTP/1.0 response without `keep-alive`, and an unknown-length response each retire the connection; HTTP/1.0 *with* `keep-alive` is reused; a server that closed an idle connection is retried once and succeeds; the cap and the age limit; `dispose` closes every idle connection (two servers, both must read EOF); the pool crosses neither ports nor hosts; the free `fetch` still announces `Connection: close`; and 204 / HEAD framing both end-to-end and at the wire level with a scripted reader that proves the following response is *carried*, not swallowed as a body.

Two measurement notes, both learned the hard way: the accept counters live in a `ref(struct(...))` because a module-level mutable written across a suspension point reads back as zero, and "did `dispose` close every idle connection?" is answered by what the PEERS observe — a closed connection is one the server at the other end reads EOF from, so its task finishes, while one still open leaves that server parked on a read until the deadline reports it. Two descriptor-table oracles were tried and both are dead ends: a lowest-free-descriptor probe reads the same number whether the socket leaked or not (a listener closed earlier in the test leaves a hole below it), and the exact open-count that fixes that (`dup(0)` N times ⇒ `highest + 1 == open_count + N`) is not portable — a Windows socket is not in the CRT descriptor table at all, and the count did not move on the intel macOS runner either. Peer observation needs no platform knowledge, and it is what every other test in the group already depended on implicitly, since each ends in a `task.await(io)` that only returns once the client's socket is really closed.

## The server half is NOT here, and the reason is measured

`std/async`'s `timeout` is a blocking-poll plain `fn` that drives the event loop itself, so calling it inside `serve_once`'s `io.async` body nests the loop (`issues/fixed/sync-await-in-plain-fn-nests-the-event-loop.md`); every other combinator there has the same shape and takes `JoinHandle`s rather than futures, so there is nothing to compose with the framing read. The pattern that does work inside a task is hand-rolled exactly once in this tree (`_fetch_deadline`) and carries costs that belong in a design decision rather than in this PR: aborting a read parked in the I/O backend leaks its 8 KiB buffer and its state machine per timed-out connection, and server keep-alive changes what `serve_once` MEANS in ways that invalidate existing tests (pipelining becomes correct rather than smuggling).

`plans/backlog/ASYNC_DEADLINE_COMBINATOR.md` names the blocked call site, those costs, three options and the recommendation: add a `Future`-returning `with_deadline` to `std/async`, re-express `_fetch_deadline` in terms of it, then land server keep-alive on top as an **opt-in** — opt-in because keep-alive on a strictly serial server lets one client monopolize it.

## Three defects found and filed

- `issues/a-ref-value-passed-to-an-async-future-is-never-released.md` — **open.** A `ref` value passed as a parameter to an `io.async` future is dup'd into the capture record and never dropped, unbounded (50 calls, 50 leaks, still leaked after the frame returns). It is why `HttpClient`'s `Dispose` — and `TcpStream`'s and `TlsStream`'s — cannot fire on a drop, which is why `close_idle()` is documented as the way to release a client and why the `dispose` test calls it by hand.
- `issues/a-module-global-is-lost-across-an-async-suspension.md` — **open.** A module-level mutable read or written across a suspension point in an `io.async` body operates on a copy. It reads back as zero, which looks exactly like "the code under test never ran".
- `issues/fixed/a-dropped-tlsstream-leaks-its-socket-and-openssl-objects.md` — **fixed here.** `TlsStream` had no `Dispose`, so its socket and its OpenSSL `SSL`/`SSL_CTX` could not be released except through the async `close(io)`.

Each has a runnable reproducer under `issues/repros/`.

## Verification

- `yo check ./std --std-path ./std` — 173/173.
- `tests/http/http.test.yo` 51 pass, `server.test.yo` 13, `http_limits.test.yo` 6.
- Hollow-green probe done: flipping one assertion to `assert(false, …)` fails the file. The `dispose` test is verified red-first too — with its `dispose` call removed it fails with "the first server never saw its connection close: timeout: the deadline elapsed".
- `tests/http/wire.test.yo` type-checks but cannot be COMPILED by the installed release seed — its scripted reader is the regression exercise for #547's own `src/codegen/exprs/atom.yo` capture fix, which the seed predates (verified identical on the base commit, in a scratch worktree). CI builds stage-1 first, so it compiles there; the new scripted-reader cases were added to `http.test.yo` instead, written capture-safely so they run locally too.
- `yo fmt --check` clean on every touched file.

## No user docs

There is no HTTP page under `docs/en-US/` or `docs/zh-CN/` (nor any networking page), so there was nothing to extend and I did not invent one. The user-facing documentation is the doc comments, which `yo doc` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update 2026-09-14 — root-caused, fixed, and cleaned for release

**The blocker was a compiler bug, in neither the HTTP client nor either I/O backend.** A `while` whose body awaits, inside a `match` arm, emitted the statements that FOLLOW it *inside* the loop body, replaying them every iteration. Fixed in #677 (merged); full write-up in `issues/fixed/a-while-loop-inside-a-match-arm-runs-its-trailing-code-every-iteration.md`.

`_fetch_deadline` is exactly that shape — its race loop is in the `.Some(limit)` arm and the statement after it is `cond(h.is_finished() => deliver, true => { h.abort(); throw Timeout })`. Inside the loop, that ran on the **first turn**, found the exchange unfinished because it had barely started, aborted it and threw `HttpError.Timeout` — on an exchange that completes in about a millisecond.

That accounts for every open question this PR's issue accumulated over days of investigation:

- **always `Timeout`, never the real error** — the fallback arm is reached unconditionally on turn one.
- **the server sits in `accept`** — the client aborts before connecting.
- **identical on kqueue and io_uring** — neither is involved.
- **"the parent await never resumes"** — it was aborted, not stuck.
- **platform roulette** — the abort is deterministic; only how far the exchange gets first is not.

It also **reproduces locally**, contrary to this issue's record of 27 clean runs — that was measured against a runtime with two since-fixed wake-path bugs.

### The investigation checkpoints are gone

The branch carried **eleven `eprintln` checkpoints inside `std/http/client.yo` and `std/http/wire.yo`** — `[tr] read entered`, `[wire RSP] issuing read`, `[clt] parent await resumed`. They print on every read of every HTTP request in every program that links `std/http`, and must not ship. Removed, with the `_role` binding that existed only to tag them, their DIAGNOSTIC comment blocks, and the ten matching checkpoints in `tests/http/http.test.yo`. The `eprintln`s that remain there are real failure reporting.

### `_fetch_deadline`'s spin is left as-is, deliberately

It is now *correct* — it was only ever broken by the codegen bug. `plans/backlog/ASYNC_DEADLINE_COMBINATOR.md` argues it should become a real combinator over `Park`/`Waker` rather than a spin, and it should — on its own merits, after the release, not as a rushed change inside a release window.

### Verification

- `tests/http` — **77/77** with the checkpoints stripped.
- Full fast suite on the rebased branch — reported below.
- Rebased onto develop `2a7bc4269`, which carries #677 plus the three async runtime fixes (waker-token UAF, per-thread event-loop leak, forall binder identity) and both async I/O audits.
