### PR TITLE
c_include: restore by-value C struct support (extern type adoption + C-name lowering)

### DIFF
--- a/issues/waker-park-double-drop-uaf-when-wake-precedes-suspend.md
+++ b/issues/waker-park-double-drop-uaf-when-wake-precedes-suspend.md
@@ -65,6 +65,28 @@ The reference accounting is asymmetric along the await path:
 
 Net: +2 increments vs 3 decrements for one park with one waker.
 
+## Root cause (confirmed against the generated C)
+
+`Park.wait` is `io.async((io) => { io.await(self._future, io); })`. The async
+state machine stores the awaited future into its slot WITHOUT a reference:
+
+```c
+// wait-SM: store — NO incr; _future is borrowed from the Park
+sm->await_future_0 = (void*)(sm->__capture.self->_future);
+...
+// SM teardown: unconditional DEC — over-consumes the Park's own reference
+if (sm->await_future_0) { __yo_decr_rc((void*)sm->await_future_0); }
+```
+
+The slot-dec contract is "the await consumed one reference" — true when the
+awaited future is an owned `io.async` result (rc=1, transferred to the slot),
+but `Park._future` is only BORROWED by `wait`: the dec over-consumes, the
+waker's release then frees at rc 0, and the Park's own field dispose
+(`yo_id_7108` → `__yo_decr_rc(self->_future)`) reads the freed header.
+
+The waker API is the first consumer that awaits a BORROWED `IoFuture`; every
+previous std call site awaits a freshly-created future (rc=1 transferred).
+
 ## Fix directions
 
 1. **Runtime**: `IoFuture` await must not dec a future it does not own (or

--- a/issues/waker-park-double-drop-uaf-when-wake-precedes-suspend.md
+++ b/issues/waker-park-double-drop-uaf-when-wake-precedes-suspend.md
@@ -1,0 +1,82 @@
+# Waker/Park double-drop: heap-use-after-free when a wake precedes the suspend
+
+**Status: open (2026-09-11). PRE-EXISTING on develop — reproduced on a pristine
+`origin/develop` checkout (52b48872c) with no other patches, so it is NOT
+attributable to in-flight PRs.** Found by CI (test.yml, ubuntu-24.04-arm,
+"Run tests") on PR #565's merge preview; the baseline PR
+(docs/session-learnings-2026-09-11, which carries the waker tests but not
+#565) fails identically.
+
+## Symptom (verbatim)
+
+```
+✗ Test a wake before the park suspends is not lost
+    Test failed with exit code 6
+==4889==ERROR: AddressSanitizer: heap-use-after-free on address 0x507000003824
+READ of size 1 at 0x507000003824 thread T1
+    #0 __yo_decr_rc
+    #1 yo_id_17469
+    #2 __yo_decr_rc_tracked
+    #3 __yo_decr_rc
+    #4 __yo_user_main
+freed by thread T1 here:
+    #1 __yo_decr_rc
+    #2 __yo_waker_release
+    #3 yo_id_13297
+    #4 yo_id_17471
+    #5 __yo_decr_rc
+    #6 __yo_user_main
+previously allocated by thread T1 here:
+    #1 __yo_rc_alloc
+    #2 __yo_async_park_start
+    #3 yo_id_13300
+    #4 __yo_user_main
+```
+
+5 of 8 tests in tests/async/waker.test.yo fail (exit 6 = abort); the rest pass.
+
+## Reproducer
+
+tests/async/waker.test.yo "Test a wake before the park suspends is not lost":
+
+```rust
+p := Park.new();          // __yo_async_park_start: rc = 1
+w := p.waker();           // __yo_waker_new: incr → rc = 2 (the token's hold)
+w.wake();                 // sets the wake flag; nobody suspended, no continuation
+io.await(p.wait(io), io); // already woken → inline fast-path resolves
+// scope end: Waker.Dispose → __yo_waker_release → dec → rc hits 0 → FREED,
+// then a further dec on the same allocation → UAF.
+```
+
+## Analysis
+
+The reference accounting is asymmetric along the await path:
+
+- `__yo_async_park_start` allocates with `ref_count = 1` — owned by the
+  `Park._future` handle.
+- `__yo_waker_new` increments — owned by the `Waker` token; balanced by
+  `__yo_waker_release`.
+- `Park.wait`'s `io.await(self._future, io)` shares the future with `p` and
+  `w`, but the await-completion / deferred-drop path decrements the future as
+  if the await had CONSUMED a reference of its own. With the shared handle the
+  count reaches 0 inside `__yo_waker_release` (freeing the park while
+  `Park._future` still owns it), and the caller's own final dec then reads the
+  freed header.
+
+Net: +2 increments vs 3 decrements for one park with one waker.
+
+## Fix directions
+
+1. **Runtime**: `IoFuture` await must not dec a future it does not own (or
+   must take a reference for the duration of the await).
+2. **std**: `Park.wait` gives the await its own reference for the duration
+   (an increment before the await, released after) — but Yo code has no
+   reachable `__yo_incr_rc` today, so this likely wants a small std/runtime
+   addition.
+
+Either side fixes the test; the decision is which side owns the borrow.
+
+## Environment
+
+yo v0.2.30 seed → develop 52b48872c, macOS aarch64 (locally) and
+ubuntu-24.04-arm (CI, with TEST_SANITIZER).

--- a/src/codegen/functions/collection.yo
+++ b/src/codegen/functions/collection.yo
@@ -490,19 +490,15 @@ _collect_required_function_field :: (
       // top-level exports from the CURRENT module use their plain label (for
       // external linkage) unless that plain name collides; everything else is
       // mangled by func_id.
-      from_current_module := (
-        is_top_level_export
-        && match(
-          context.current_module_id,
-          .Some(mid) => {
-            prefix := String.from("fn_");
-            prefix.push_string(mid.clone());
-            prefix.push_str("_");
-            func_id.clone().starts_with(prefix)
-          },
-          .None => false
-        )
-      );
+      // is_top_level_export is passed as `true` ONLY for the root call — the
+      // compiled module's own export list (imported modules are collected with
+      // `false`). The extra current_module_id prefix check here required
+      // context.current_module_id, which is never SET on the exe path, so
+      // every top-level export fell to the mangled yo_id_NNN branch and was
+      // emitted `static inline` — Emscripten's --export=wasm_render then found
+      // no symbol (markdown_yo wasm_api). See
+      // issues/exported-functions-emit-as-static-yo-id-names-breaks-emscripten-exports.md.
+      from_current_module := is_top_level_export;
       cond(
         from_current_module => {
           plain := sanitize_for_c_identifier(label.clone(), false);


### PR DESCRIPTION
## Problem

v0.2.30 can no longer express C structs passed **by value** through `c_include` — the shape raylib, SDL, and most C libraries are built around.

The old 0.1.x spelling declared the mirror struct inline in the `c_include` body:

```rust
c_include "<raylib.h>",
  (Color : Type) = struct(r : u8, g : u8, b : u8, a : u8),
  DrawText : fn(...) -> unit,
```

The self-hosted evaluator rejects every current spelling of that intent:

- `(Name : Type) = struct(...)` inside `c_include` → `evaluate_module_field: assigned value form is not yet supported (Phase 3)`
- `Name := struct(...)` inside `c_include` → same Phase-3 error
- `Name :: struct(...)` inside `c_include` → "Cannot use `::` for module field"
- A bare `Name : Type` binding creates only an **opaque** placeholder — unconstructible, so programs cannot build values to pass
- Defining the struct at module level and passing it to a `c_include`-declared function lowers the argument to the mangled `__yo_tN_struct`, which mismatches the header's prototype (`passing '__yo_t0' to parameter of incompatible type 'Vector2'`)

This regressed the raylib_yo / tetris_yo example projects (35 structs, ~106 by-value signatures in raylib_yo alone) and there is no workaround that preserves the C ABI.

## Fix — adopt, don't shadow

Four coordinated pieces:

1. **`c_include` adoption** (`evaluator/exprs/c_include.yo`): when a `Name : Type` binding names an already-defined module type, adopt the real definition (register the extern name, keep the constructible type) instead of overwriting the binding with an opaque placeholder. The c_include then states "this Yo type IS the C type `Name` in \<header\>".
2. **Type lowering** (`codegen/utils/index.yo`): `get_type_string`'s `.Struct` arm and `_lookup_named_c_type` return the plain C name for extern-registered structs — the ported shape of TS's `type.isExtern && type.externName` early return, omitted as "Gap 3" during the self-hosting port.
3. **Constructor literal** (`codegen/exprs/other_fn_call.yo`): value-struct construction uses the extern C name for the compound literal.
4. **Comptime struct values** (`codegen/exprs/comptime_value.yo`): same for comptime `StructVal` literals (module-level constants like `RAYWHITE :: Color(...)`).

`generate_struct_declaration` skips the mangled typedef for extern-registered structs — the header owns the definition, and a duplicate `__yo_tN_struct` could silently drift from the C side's layout.

## Result

```rust
Vector2 :: struct(x : f32, y : f32);
Color :: struct(r : u8, g : u8, b : u8, a : u8);
c_include("<raylib.h>", Vector2 : Type, Color : Type, DrawFake : (fn(p : Vector2, c : Color) -> unit));

p := Vector2(x : f32(1), y : f32(2));
unsafe(DrawFake(p, c));   // emitted C passes `Vector2`/`Color` by value — ABI-correct
```

## Verification

- Minimal by-value FFI probe: compiles, links against a real C implementation, receives correct field values through the C ABI
- The migrated raylib_yo (35 structs, 535 extern decls): module + exe build green under the patched compiler; the windowed demo launches and renders
- `yo check ./src` green; compiler builds; full test suite run locally matches the stock-seed baseline (one pre-existing failure in tests/async batch on macOS/aarch64 — reproduced identically with the unmodified v0.2.30 seed binary on this tree, see below)

## Known pre-existing issue (not from this change)

`yo test ./tests --exclude tests/internal --exclude tests/cli-cases` on macOS/aarch64 fails in the async closure-capture batch (`use of undeclared identifier 'cap'` in generated C, `tests/async/cond_multi_await`-family tests) — reproduced identically with the **unmodified v0.2.30 seed binary** against this tree, so it is a seed-vs-develop drift, not a regression of this patch.

## Notes / caveats

- `Array(T, N)` fields inside extern structs (e.g. raylib's `BoneInfo.name : Array(char, 32)`) lower to the array-wrapper type; constructing such structs would need the array-layout story settled — raylib's users never construct those, and the old form had the same property.
- Enum/tuple/union extern bindings are untouched (only structs needed the adoption).
