### PR TITLE
chore: GitHub issue forms — bug, codegen failure, feature request, docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Something compiles, runs, or behaves differently from what it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing. The single most useful thing you can give us is a
+        **minimal `.yo` file that reproduces it** — smaller reproducers get
+        fixed faster, because the first thing a fix needs is a test.
+
+        If the bug is a C compiler error out of `yo compile`, please use the
+        **Codegen / C compile failure** template instead: it asks for the
+        emitted C, which is where that class of bug is diagnosed.
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproducer
+      description: A complete `.yo` file, as small as you can make it. Please include `export(main);`.
+      render: rust
+      placeholder: |
+        main :: (fn() -> unit)({
+          // ...
+        });
+        export(main);
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: The command you ran
+      description: Verbatim, including flags — `--optimize`, `--sanitize` and `--target` all change behaviour.
+      render: shell
+      placeholder: yo compile repro.yo --optimize 2 -o /tmp/repro && /tmp/repro
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened
+      description: The output or error, copied verbatim rather than described. Include the exit code if the program crashed.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Yo version
+      description: Output of `yo --version`. If you built from source, the commit SHA.
+      placeholder: "yo 0.2.30"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      multiple: true
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux (x86_64)
+        - Linux (arm64)
+        - Windows
+        - WebAssembly (wasm32-wasip1 / emscripten)
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Does it reproduce at `-O0` as well as `--optimize 2`? On one platform only? Did it work in an earlier release?

--- a/.github/ISSUE_TEMPLATE/02-codegen-failure.yml
+++ b/.github/ISSUE_TEMPLATE/02-codegen-failure.yml
@@ -1,0 +1,76 @@
+name: Codegen / C compile failure
+description: "`yo compile` produced C that the C compiler rejected, or that misbehaves at runtime."
+labels: ["bug", "codegen"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Yo compiles to C11 and hands the result to clang/gcc/zig, so this class
+        of bug is diagnosed in the **emitted C**. Get it with:
+
+        ```bash
+        yo compile repro.yo --emit-c --skip-c-compiler --optimize 2
+        ```
+
+        which writes `repro.c` next to the output without invoking the C
+        compiler.
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproducer
+      description: A complete `.yo` file. `yo compile` cannot take a `*.test.yo` file — extract the case into a standalone file with a `main` and `export(main);`.
+      render: rust
+    validations:
+      required: true
+  - type: textarea
+    id: cerror
+    attributes:
+      label: The C compiler's error
+      description: Verbatim, with the line numbers it printed.
+      render: text
+      placeholder: |
+        /tmp/repro.c:934:3: warning: call to undeclared function '__yo_decr_rc_atomic'
+        /tmp/repro.c:2430:13: error: static declaration of '__yo_decr_rc_atomic' follows non-static declaration
+    validations:
+      required: true
+  - type: textarea
+    id: cfragment
+    attributes:
+      label: The emitted C around the fault
+      description: The offending function, or ~20 lines either side. This is usually what identifies the emitter at fault.
+      render: c
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Yo version and C compiler
+      placeholder: "yo 0.2.30, Apple clang 17.0.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: optlevel
+    attributes:
+      label: Does it reproduce at both optimization levels?
+      options:
+        - "Both -O0 (default) and --optimize 2"
+        - "Only at --optimize 2"
+        - "Only at -O0"
+        - "Not sure"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      multiple: true
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux (x86_64)
+        - Linux (arm64)
+        - Windows
+        - WebAssembly (wasm32-wasip1 / emscripten)
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/03-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: A language feature, a standard-library addition, or a tooling improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Yo's standard library is shaped deliberately after Rust's, and language
+        changes are weighed against a written design doc rather than added ad
+        hoc. Saying what you were trying to DO — not only what you want added —
+        is what makes a request actionable.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The concrete task, and what you had to write instead.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like?
+      description: A signature, a snippet, or a CLI flag — as specific as you can be.
+      render: rust
+    validations:
+      required: true
+  - type: textarea
+    id: prior_art
+    attributes:
+      label: Prior art
+      description: How Rust, Zig, Swift, Go or another language spells this. A close precedent is the strongest argument a request can carry.
+  - type: textarea
+    id: workaround
+    attributes:
+      label: What you are doing today instead
+      description: If there is a workaround, how bad is it? If there is none, say so — "impossible" and "verbose" get weighed very differently.
+  - type: checkboxes
+    id: breaking
+    attributes:
+      label: Compatibility
+      options:
+        - label: This would change the meaning of code that compiles today (a breaking change).

--- a/.github/ISSUE_TEMPLATE/04-docs.yml
+++ b/.github/ISSUE_TEMPLATE/04-docs.yml
@@ -1,0 +1,31 @@
+name: Documentation problem
+description: Something in the docs, a doc comment, or an error message is wrong, missing, or misleading.
+labels: ["documentation"]
+body:
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: A file path, a `yo doc` page, or the exact error message text.
+      placeholder: "docs/en-US/ASYNC_AWAIT.md, the `yield` section"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What it says, and what is wrong with it
+      description: Quote the passage. "Wrong" and "unclear" both count; so does "correct but I could not find it".
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: What it should say
+  - type: checkboxes
+    id: languages
+    attributes:
+      label: Which language versions
+      description: "`docs/` is maintained in English and Simplified Chinese, and both are expected to change together."
+      options:
+        - label: English (`docs/en-US/`)
+        - label: 简体中文 (`docs/zh-CN/`)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or idea to discuss first
+    url: https://github.com/shd101wyy/Yo/discussions
+    about: For "how do I…", design debates, and anything not yet concrete enough to be a bug or a request.


### PR DESCRIPTION
The repo had no `.github/ISSUE_TEMPLATE/`, so every report arrived in whatever shape the reporter chose and the first reply was usually a request for the same three things. Four forms, each asking for what this project actually diagnoses with.

| form | what it asks for that a free-form issue usually omits |
| --- | --- |
| **Bug report** | a minimal `.yo` reproducer *with `export(main);`* — the form that compiles; the command **verbatim**, because `--optimize`, `--sanitize` and `--target` all change behaviour; output copied rather than described; `yo --version`; platform. A closing field asks whether it reproduces at both optimization levels and on more than one platform, which is how the `-O0`-only and one-leg-only classes get separated on the first read. |
| **Codegen / C compile failure** | its own form, because Yo compiles to C11 and this class is diagnosed in the **emitted C**. It tells the reporter how to get it (`--emit-c --skip-c-compiler`), asks for the C compiler's error *with its line numbers* and the C around the fault, and notes that `yo compile` cannot take a `*.test.yo` file. |
| **Feature request** | what you were trying to DO before what you want added, plus prior art (Rust, Zig, Swift, Go) and today's workaround — "impossible" and "verbose" are weighed very differently, so the form asks which it is. A checkbox flags a breaking change. |
| **Documentation problem** | where, the quoted passage, and a checkbox pair for `docs/en-US/` and `docs/zh-CN/`, which are expected to change together. |

`config.yml` keeps blank issues enabled — a template should not be a toll gate — and points open-ended questions at Discussions.

All five files parse as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)