### PR TITLE
evaluator: a dup taken in a DEEPER scope cannot cancel an outer local's drop (use-after-free)

### DIFF
--- a/issues/fixed/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md
+++ b/issues/fixed/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md
@@ -1,6 +1,6 @@
 # A local stored into a struct field is dangling once the container dies
 
-**Status:** OPEN. Found 2026-09-11 while writing the Dispose-counter gate for
+**Status:** FIXED 2026-09-11. Found 2026-09-11 while writing the Dispose-counter gate for
 the spawn-capture leak fix
 (`issues/fixed/spawn-closure-captures-never-dropped-leak.md`). **Pre-existing**
 — reproduces identically under the v0.2.30 seed and under a `develop` tree
@@ -109,3 +109,40 @@ dup/drop pair again.
 Tests: the reproducer as a `tests/` case in both spellings (`atomic(ref(...))`
 and `ref(...)`), with a Dispose counter as the oracle rather than a leak
 checker, plus the same-scope canary.
+
+## Fix
+
+`_optimize_dup_drop_pairs` (`src/evaluator/exprs/begin.yo`) gains one gate: a
+dup whose own `ExprInfo.env` is DEEPER than the candidate's frame
+(`ei.env.frames.len() > v.frame_level + 1`) cannot cancel that candidate's
+scope-end drop. The pair then survives — the local keeps its dup and its drop,
+the nested container releases what it took, and the totals balance.
+
+**Measured by the dup's env depth rather than by restructuring the collector.**
+The first attempt made `_search_dup_calls` treat a nested `begin` as a unit and
+mark everything inside it. That also took ALIAS bindings (`env := env_in`) off
+the CONSUMED path the early-return drop machinery uses, and the A/B emit-diff —
+the same `src/main.yo` through the old and new compilers — showed **165 fewer
+`__yo_decr_rc` calls**, i.e. `env` never dropped at all on some paths. The
+depth gate's diff is `__yo_incr_rc` **+5** and `__yo_decr_rc` **+39**, both up:
+one restored dup and one restored drop per exit path, which is exactly what
+refusing a cancellation should cost.
+
+Cond/match arms and `while` bodies are deliberately NOT caught. Measured, with
+the `atomic(ref(...))` spelling that frees immediately: a container in a cond
+arm, in both arms of a cond, in both arms of a match, and in a `while` body all
+behave correctly today — the branch-aware collection path and the `while`
+early-return in `_search_dup_calls` already keep them — and an arm body's frame
+is not deeper than the frame being optimized.
+
+Tests in `tests/rc.test.yo`, all over a module-level Dispose counter so both
+directions are caught (an early free AND an unmatched dup that never disposes):
+
+- a container one block deep, and two blocks deep — **red before the fix**;
+- the SAME-scope container, which must keep its cancellation (the
+  over-cancellation canary: two disposes means the gate went too wide, none
+  means a dup is unmatched);
+- a cond arm and a `while` body, which must also keep theirs.
+
+Verified on the merged tree: suite **4131 passed / 0 failed**,
+`gates_fast.sh` GATE 0–8 **`failures=0`**, `fixpoint_only.sh` **`FIXPOINT_HOLDS`**.

--- a/issues/repros/local-stored-in-a-struct-field-is-dangling-after-the-container-dies.yo
+++ b/issues/repros/local-stored-in-a-struct-field-is-dangling-after-the-container-dies.yo
@@ -10,7 +10,7 @@
 // alive because main holds its own reference).
 // Measured 2026-09-11 (macOS arm64, --optimize 2, seed 0.2.30 AND a tree
 // build): rc=139, SIGSEGV inside `sink.count()`.
-// issues/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md
+// issues/fixed/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md
 { AtomicUsize, MemoryOrder } :: import("std/sync/atomic");
 { printf } :: import("std/libc/stdio");
 pragma(Pragma.AllowUnsafe);

--- a/src/evaluator/exprs/begin.yo
+++ b/src/evaluator/exprs/begin.yo
@@ -1237,6 +1237,48 @@ _optimize_dup_drop_pairs :: (
               // copies need their own drop — never cancel (begin.ts:1900-1909).
               value_type_with_rc := (!is_reference_struct_type(base.ty) && type_contains_rc_type(base.ty));
               partial := _ids_list_contains(merged.vars_with_partial_branch_dups, base_id.clone());
+              // A dup taken in a DEEPER SCOPE than the candidate's own frame
+              // — the body of a nested `{ … }` block — feeds a container whose
+              // scope end comes FIRST. Cancelling the pair moves this local's
+              // only count into that container, and the inner block's drop
+              // then frees a value the outer scope goes on using:
+              //
+              //   sink := S.new();
+              //   { h := H(sink : sink); };   // h dies here, taking sink's count
+              //   sink.count();               // use after free
+              //
+              // A `ref` holding a `ref` is cycle-capable and therefore
+              // GC-TRACKED, so `__yo_decr_rc` buffers a possible root instead
+              // of freeing on the spot and the fault reads as a correct
+              // answer; an `atomic(ref(…))` is an Iso type, never tracked, and
+              // faults immediately. That asymmetry is why this survived
+              // (issues/fixed/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md).
+              //
+              // Measured by the dup's own `ExprInfo.env` depth rather than by
+              // restructuring the collector: a traversal that treats a nested
+              // `begin` as a unit also takes ALIAS bindings (`env := env_in`)
+              // off the consumed path the early-return drop machinery uses,
+              // which cost 165 `__yo_decr_rc` calls in the compiler's own
+              // emit. Cond/match arms and `while` bodies are deliberately NOT
+              // caught: they are measured correct today (the branch-aware
+              // path and the while early-return above already keep them), and
+              // an arm body's frame is not deeper than this one's.
+              (nested_dup : bool) = false;
+              (ndi : usize) = usize(0);
+              while((ndi < dups.len()) && !nested_dup, {
+                match(
+                  dups.get(ndi),
+                  .Some(nd) => match(
+                    expr_info_table_get(ctx.expr_info_table, ast_expr_id(nd)),
+                    .Some(ndei) => if(ndei.env.frames.len() > (v.frame_level + usize(1)), {
+                      nested_dup = true;
+                    }),
+                    .None => ()
+                  ),
+                  .None => ()
+                );
+                ndi = (ndi + usize(1));
+              });
               // A main-path dup in a child AFTER an early-return child: the
               // early return never executes the dup, so the value is still
               // live and needs the scope-exit drop (begin.ts:1919-1935).
@@ -1283,7 +1325,7 @@ _optimize_dup_drop_pairs :: (
                   bci2 = (bci2 + usize(1));
                 });
               });
-              gates_ok := (!value_type_with_rc && (!partial && (!ret_before_dup && ((consumed_dups == usize(0)) && !base_consumed))));
+              gates_ok := (!value_type_with_rc && (!partial && (!nested_dup && (!ret_before_dup && ((consumed_dups == usize(0)) && !base_consumed)))));
               if(gates_ok, {
                 // Count RUNTIME dups — every collected dup counts
                 // (begin.ts:1930-1955).

--- a/tests/rc.test.yo
+++ b/tests/rc.test.yo
@@ -1096,3 +1096,113 @@ test("alias made in an inner block, base reassigned there, base used after", {
   };
   assert(g_alias_disposed == (before + i32(2)), "original and replacement disposed exactly once each");
 });
+// ---------------------------------------------------------------------------
+// A local stored into a struct field that lives in a NESTED block keeps its
+// own count.
+//
+// `_optimize_dup_drop_pairs` cancels a local's single dup against its
+// scope-end drop and calls the result a move. That is sound only while the
+// container the dup fed OUTLIVES the local — and it does not when the
+// container is declared in an inner block, because the inner block's scope end
+// releases the field first. The outer local was then dangling for the rest of
+// its own scope:
+//
+//   sink := S.new();
+//   { h := H(sink : sink); };   // h dies here, taking sink's only count
+//   sink.count();               // use after free
+//
+// The non-atomic path hid it behind a correct-looking answer: a `ref` holding
+// a `ref` is cycle-capable, so it is GC-TRACKED and `__yo_decr_rc` buffers a
+// possible root instead of freeing on the spot. An `atomic(ref(...))` is an
+// Iso type, never tracked, so the free is immediate and the read faults.
+// issues/fixed/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md
+//
+// The oracle is a Dispose counter rather than a value read, because it catches
+// BOTH directions: a missing dup frees early (the bug), and an unmatched dup
+// never disposes at all (the over-correction).
+// ---------------------------------------------------------------------------
+(g_nested_disposed : i32) = i32(0);
+NestedSink :: ref(struct(tag : i32));
+impl(
+  NestedSink,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      g_nested_disposed = (g_nested_disposed + i32(1));
+    })
+  )
+);
+NestedHolder :: ref(struct(label : i32, sink : NestedSink));
+test("a local stored into a container in a NESTED block outlives that block", {
+  before := g_nested_disposed;
+  {
+    sink := NestedSink(tag : i32(1));
+    {
+      h := NestedHolder(label : i32(2), sink : sink);
+      assert(h.label == i32(2), "the container sees its own field");
+    };
+    // The container is gone. `sink` must still be alive here — it is a live
+    // local of THIS scope and nothing has consumed it.
+    assert(g_nested_disposed == before, "the inner block's container did not take the outer local with it");
+    assert(sink.tag == i32(1), "and the outer local still reads correctly");
+  };
+  assert(
+    g_nested_disposed == (before + i32(1)),
+    "disposed exactly once, when its own scope ended — not twice, and not never"
+  );
+});
+test("a container two blocks deep does not take the outer local either", {
+  before := g_nested_disposed;
+  {
+    sink := NestedSink(tag : i32(3));
+    {
+      {
+        h := NestedHolder(label : i32(4), sink : sink);
+        assert(h.label == i32(4), "the container sees its own field");
+      };
+      ()
+    };
+    assert(sink.tag == i32(3), "still readable through two closed scopes");
+  };
+  assert(g_nested_disposed == (before + i32(1)), "and disposed exactly once");
+});
+// OVER-CANCELLATION CANARY. The gate above must not fire on a container in the
+// SAME scope: that cancellation is correct — drops run in reverse declaration
+// order, so the container is released before the local it borrowed from — and
+// keeping it is what stops every struct store from costing a dup/drop pair
+// again. If this ever reports two disposes the gate has gone too wide in the
+// other direction; if it reports none, a dup is unmatched.
+test("a container in the SAME scope still shares one count", {
+  before := g_nested_disposed;
+  {
+    sink := NestedSink(tag : i32(5));
+    h := NestedHolder(label : i32(6), sink : sink);
+    assert(h.label == i32(6), "the container sees its own field");
+    assert(sink.tag == i32(5), "and the local still reads");
+    assert(g_nested_disposed == before, "nothing disposed while both are live");
+  };
+  assert(g_nested_disposed == (before + i32(1)), "disposed exactly once at the shared scope end");
+});
+test("a container in a cond arm and in a while body behave the same way", {
+  before := g_nested_disposed;
+  {
+    sink := NestedSink(tag : i32(7));
+    cond(
+      true => {
+        h := NestedHolder(label : i32(8), sink : sink);
+        assert(h.label == i32(8), "the arm's container sees its field");
+      },
+      true => ()
+    );
+    assert(sink.tag == i32(7), "readable after the arm");
+    (i : i32) = i32(0);
+    while(i < i32(3), i = (i + i32(1)), {
+      w := NestedHolder(label : i, sink : sink);
+      assert(w.label == i, "the loop body's container sees its field");
+    });
+    assert(sink.tag == i32(7), "and after three loop iterations");
+  };
+  assert(
+    g_nested_disposed == (before + i32(1)),
+    "still exactly one dispose: a loop body taking a reference per iteration must release it per iteration"
+  );
+});

--- a/tests/thread.test.yo
+++ b/tests/thread.test.yo
@@ -173,7 +173,7 @@ test("std/log configuration and filtering are safe from several threads at once"
 // object, deliberately: putting it in a field makes the tracked object hold a
 // reference to it, and a local stored into a struct field is dangling once the
 // container dies
-// (issues/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md),
+// (issues/fixed/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md),
 // which is a different bug and would be the thing this test measured.
 // ---------------------------------------------------------------------------
 _spawn_dispose_count := AtomicUsize.new(usize(0));


### PR DESCRIPTION
Fixes `issues/a-local-stored-in-a-struct-field-is-dangling-after-the-container-dies.md`, filed earlier today while writing the Dispose-counter gate for #562.

## The bug

`_optimize_dup_drop_pairs` cancels a local's single dup against its scope-end drop and calls the result a move. That is sound only while the container the dup fed **outlives** the local — and it does not when the container is declared in an inner block, because the inner block's scope end releases the field first:

```rust
sink := S.new();
{ h := H(sink : sink); };   // h dies here, taking sink's only count
sink.count();               // use after free
```

`rc=139`, faulting inside the read. **Pre-existing** — it reproduces identically under the v0.2.30 seed, with no change of mine in the picture. Reproducer: `issues/repros/local-stored-in-a-struct-field-is-dangling-after-the-container-dies.yo`, no threads and no async.

**Why it survived.** On the non-atomic path the GC hides it. A `ref` holding a `ref` is cycle-capable, so it is GC-TRACKED and `__yo_decr_rc` buffers a possible root instead of freeing on the spot — the same program prints the right answer and exits 0. An `atomic(ref(...))` is an Iso type, never tracked, so the free is immediate and the read faults. Same wrong accounting, two different-looking outcomes.

## The gate

One condition, keyed on the dup's own `ExprInfo.env` depth: a dup whose env has more frames than `v.frame_level + 1` was taken in a deeper scope and cannot cancel that candidate's drop. The pair survives, the local keeps its dup and its drop, the nested container releases what it took, and the totals balance.

**The A/B emit-diff decided the implementation.** A first attempt restructured `_search_dup_calls` to treat a nested `begin` as a unit and mark everything inside it. Running the SAME `src/main.yo` through the old and the new compiler showed **165 fewer `__yo_decr_rc` calls** — it had taken ALIAS bindings (`env := env_in`) off the CONSUMED path that the early-return drop machinery uses, so `env` was never dropped at all on some paths. That is a leak, and exactly the direction `AGENTS.md` warns about for this family. The depth gate's diff instead:

| | old | new |
| --- | --- | --- |
| `__yo_incr_rc(` | 16493 | **16498** |
| `__yo_decr_rc(` | 388262 | **388301** |

Both up — one restored dup and one restored drop per exit path, which is what refusing a cancellation should cost.

## What is deliberately NOT caught

Cond/match arms and `while` bodies. Measured with the immediately-freeing `atomic(ref(...))` spelling: a container in a cond arm, in **both** arms of a cond, in both arms of a match, and in a `while` body all behave correctly today — the branch-aware collection path and the `while` early-return in `_search_dup_calls` already keep them — and an arm body's frame is not deeper than the frame being optimized. Widening the gate to them would add pairs for no defect.

## Tests

`tests/rc.test.yo`, all over a module-level Dispose counter so **both** directions are caught (an early free, and an unmatched dup that never disposes):

| test | before | after |
| --- | --- | --- |
| container one block deep | ✗ | ✓ |
| container two blocks deep | ✗ | ✓ |
| container in the SAME scope (over-cancellation canary) | ✓ | ✓ |
| container in a cond arm and in a `while` body | ✓ | ✓ |

The canary is the one that matters for review: the same-scope cancellation is **correct** — drops run in reverse declaration order, so the container is released before the local it borrowed from — and keeping it is what stops every struct store from costing a dup/drop pair again. Two disposes there would mean the gate went too wide; none would mean a dup is unmatched.

## Verification

| gate | result |
| --- | --- |
| `yo test ./tests --exclude tests/internal --exclude tests/cli-cases` | **4131 passed / 0 failed** |
| `scripts/bootstrap/gates_fast.sh` GATE 0–8 | **`=== T1_DONE (uaf) failures=0 ===`** |
| `scripts/bootstrap/fixpoint_only.sh` | **`FIXPOINT_HOLDS`**, stage2 hollow=0 |
| `yo check ./src` / `./std` | 270/270, 175/175 |
| `yo fmt --check ./src ./std ./tests` | clean |
| dup/drop emit A/B | +5 dups, +39 drops, no drop lost |

🤖 Generated with [Claude Code](https://claude.com/claude-code)