### PR TITLE
codegen: awaiting a future held in a struct field must not release it

### DIFF
--- a/.github/instructions/c-codegen.instructions.md
+++ b/.github/instructions/c-codegen.instructions.md
@@ -149,9 +149,10 @@ a bare `sm->await_future_N = …` at a new one. The missing dup was a
 use-after-free in `Park.wait`, which awaits `self._future`
 (`issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md`);
 it does not reproduce by running the program locally (this box's
-`--sanitize address` does not instrument), and only the ASan-armed CI legs —
-both Linux ones and macOS — report it. An RC change around awaits is not clean
-until those legs have run; until then, read the counts in the emitted C.
+`--sanitize address` is inert — the runner prints "AddressSanitizer is not
+functional with this compiler setup … Skipping sanitizer"), while ALL SIX CI
+`test (…)` legs die on it. An RC change around awaits is not clean until those
+legs have run; until then, read the counts in the emitted C.
 
 ## `ExprInfo.variable_name` is UNTRUSTWORTHY in cond/match arm-value position
 

--- a/.github/instructions/c-codegen.instructions.md
+++ b/.github/instructions/c-codegen.instructions.md
@@ -127,6 +127,32 @@ no-ops; `windows-11-arm` gets the latest from choco). An "arm64-only" C failure
 may be a clang VERSION difference, not an architecture one — check the
 versions in the job logs first.
 
+## `sm->await_future_N` OWNS its reference — a borrowed future must be dup'd
+
+The state machine `__yo_decr_rc`s that slot in three places: when the await's
+result is extracted, when the awaited future aborts, and in the state machine's
+dispose function. So whatever is stored there must be a reference the slot owns:
+
+- a future the awaited expression **produces** (an `io.async(…)` block, a
+  `__yo_async_*_start()` extern, a call returning `Impl(Future)`) hands over the
+  reference it just created, and its temp's deferred drop is aliased onto the
+  slot rather than emitted separately (`state_machine.yo`, Phase 1b);
+- a **named** future is never stored in the slot at all — the await reads the
+  variable's own field, because storing it would hand the slot a reference it
+  does not own;
+- a future read out of a **place** (a field, or a chain of them) is BORROWED:
+  the owner still drops it, so the slot must `__yo_incr_rc` its own.
+
+All seven store sites go through `emit_await_future_store`
+(`src/codegen/async/state_code_gen.yo`) for exactly that reason — do not write
+a bare `sm->await_future_N = …` at a new one. The missing dup was a
+use-after-free in `Park.wait`, which awaits `self._future`
+(`issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md`);
+it does not reproduce by running the program locally (this box's
+`--sanitize address` does not instrument), and only the ASan-armed CI legs —
+both Linux ones and macOS — report it. An RC change around awaits is not clean
+until those legs have run; until then, read the counts in the emitted C.
+
 ## `ExprInfo.variable_name` is UNTRUSTWORTHY in cond/match arm-value position
 
 `attach_temp_variable_to_expr` can stamp a SPURIOUS temp `variable_name` onto a

--- a/issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md
+++ b/issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md
@@ -1,0 +1,118 @@
+# Awaiting a future held in a struct field releases it twice
+
+**Status:** FIXED 2026-09-11 — `src/codegen/async/state_code_gen.yo`
+(`emit_await_future_store`).
+**Found by:** develop's full battery, run 34557965609 — `test (ubuntu-latest)`,
+`test (ubuntu-24.04-arm)` and `test (macos-latest)` all report it in
+`tests/async/waker.test.yo`, "Test a wake before the park suspends is not lost".
+
+## Symptom
+
+```
+==3965==ERROR: AddressSanitizer: heap-use-after-free on address 0x507000003824
+READ of size 1 at 0x507000003824 thread T1
+    #0 __yo_decr_rc
+    #1 yo_id_17469                 <- Park's dispose, dropping self._future
+    #2 __yo_decr_rc_tracked
+    #3 __yo_decr_rc
+    #4 __yo_user_main
+
+freed by thread T1 here:
+    #1 __yo_decr_rc
+    #2 __yo_waker_release           <- the Waker's dispose
+    ...
+    #6 __yo_user_main
+
+previously allocated by thread T1 here:
+    #2 __yo_async_park_start
+```
+
+Every ASan-armed CI leg reports it — the two Linux ones and macOS (there as
+exit code 6, an abort out of ASan). It does NOT reproduce by running the
+program on this development machine: the object is freed one drop early and the
+read that follows lands on memory the allocator has not reused, and the local
+box's `--sanitize address` build does not instrument (the long-standing local
+ASan defect). The emitted C is the oracle here, not a local run.
+
+## Reproducer
+
+```rust
+{ Park } :: import("std/async/waker");
+
+main :: (fn(io : Io) -> unit)({
+  p := Park.new();
+  w := p.waker();
+  w.wake();
+  io.await(p.wait(io), io);
+  ()
+});
+export(main);
+```
+
+`Park.wait` is the whole reproducer:
+
+```rust
+wait : (fn(self : Self, io : Io) -> Impl(Future(unit, Io)))(
+  io.async((io : Io) => {
+    _r := io.await(self._future, io);
+    ()
+  })
+)
+```
+
+## Root cause
+
+`sm->await_future_N` **owns** its reference. The emitted state machine
+`__yo_decr_rc`s that slot in three places — when the await's result is
+extracted, when the awaited future aborts, and in the state machine's dispose
+function — and every other way a future reaches the slot pays for that:
+
+- a future the awaited expression **produces** (an `io.async(…)` block, a
+  `__yo_async_*_start()` extern, a call returning `Impl(Future)`) hands over the
+  reference it just created, and the temp's own deferred drop is aliased onto
+  the slot rather than emitted twice (`state_machine.yo`, Phase 1b);
+- a **named** future is never stored in the slot at all — the await reads the
+  variable's own field, and the comment at the dispatch-mode branch in
+  `state_code_gen.yo` says why: "storing it into the slot would hand the slot an
+  unowned reference (the extraction decref would over-release it)".
+
+A future read out of a **field** was the case nobody had covered. The store was
+
+```c
+sm->await_future_0 = (void*)(sm->__capture.self->_future);
+```
+
+with no `__yo_incr_rc`, while `Park`'s own dispose still drops `_future`. Two
+releases, one reference. In the failing test the `Waker` holds the second
+reference, so the ordering is: `p` allocates the future (rc 1), `p.waker()`
+takes one (rc 2), the await releases one it never took (rc 1), dropping `w`
+releases the last one and **frees** it, and `p`'s scope-end drop then reads the
+freed header.
+
+## Fix
+
+Every one of the seven await-future store sites now goes through
+`emit_await_future_store`, which takes a reference when the awaited expression
+is a borrowed place — a field, or a chain of them, rooted at an atom. That
+predicate (`_await_future_expr_is_borrowed_place`) is shaped after
+`arg_is_rc_projection_place` in `src/evaluator/utils.yo`, which asks the same
+borrow question about an ordinary call argument; the codegen form is purely
+syntactic because there is no environment to resolve the root binding in.
+
+Emitted C after the fix:
+
+```c
+sm->await_future_0 = (void*)(sm->__capture.self->_future);
+// Borrowed future (read out of a field): the slot releases what it
+// holds, so it needs a reference of its own — otherwise this await
+// frees the field's future out from under its owner.
+if (sm->await_future_0 != NULL) { __yo_incr_rc((void*)sm->await_future_0); }
+```
+
+## Regression test
+
+`tests/async/waker.test.yo` — "Test awaiting the same park twice does not
+release its future twice". The first await alone is already the bug; awaiting
+twice drives the count to zero **while the park and its waker are still live**,
+so the release is unambiguous rather than a one-off imbalance at scope end.
+The ASan-armed CI legs are what turn it red.

--- a/issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md
+++ b/issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md
@@ -2,9 +2,11 @@
 
 **Status:** FIXED 2026-09-11 — `src/codegen/async/state_code_gen.yo`
 (`emit_await_future_store`).
-**Found by:** develop's full battery, run 34557965609 — `test (ubuntu-latest)`,
-`test (ubuntu-24.04-arm)` and `test (macos-latest)` all report it in
-`tests/async/waker.test.yo`, "Test a wake before the park suspends is not lost".
+**Found by:** develop's full battery, run 34557965609. **All six `test (…)`
+legs fail on it** — ubuntu-latest, ubuntu-24.04-arm, macos-latest,
+macos-26-intel, windows-latest and windows-11-arm — plus the full-corpus hollow
+sweep, which scores `tests/async/waker.test.yo` RED. The failing test is "Test a
+wake before the park suspends is not lost".
 
 ## Symptom
 
@@ -27,8 +29,8 @@ previously allocated by thread T1 here:
     #2 __yo_async_park_start
 ```
 
-Every ASan-armed CI leg reports it — the two Linux ones and macOS (there as
-exit code 6, an abort out of ASan). It does NOT reproduce by running the
+The ASan-armed legs name it (Linux; macOS as exit code 6, an abort out of
+ASan); Windows just dies, exit code 15. It does NOT reproduce by running the
 program on this development machine: the object is freed one drop early and the
 read that follows lands on memory the allocator has not reused, and the local box's ASan is inert — the test runner
 prints "AddressSanitizer is not functional with this compiler setup … Skipping

--- a/issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md
+++ b/issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md
@@ -30,9 +30,10 @@ previously allocated by thread T1 here:
 Every ASan-armed CI leg reports it — the two Linux ones and macOS (there as
 exit code 6, an abort out of ASan). It does NOT reproduce by running the
 program on this development machine: the object is freed one drop early and the
-read that follows lands on memory the allocator has not reused, and the local
-box's `--sanitize address` build does not instrument (the long-standing local
-ASan defect). The emitted C is the oracle here, not a local run.
+read that follows lands on memory the allocator has not reused, and the local box's ASan is inert — the test runner
+prints "AddressSanitizer is not functional with this compiler setup … Skipping
+sanitizer" and runs the batch uninstrumented. The emitted C is the oracle here,
+not a local run.
 
 ## Reproducer
 

--- a/src/codegen/async/state_code_gen.yo
+++ b/src/codegen/async/state_code_gen.yo
@@ -10,7 +10,7 @@
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
 { codegen_fatal } :: import("../constants.yo");
-{ AstExpr, ast_expr_id, ast_expr_is_fn_call, ast_expr_is_fn_call_of, ast_expr_is_atom_of, ast_expr_is_atom, ast_expr_token, BK_WHILE, BK_BEGIN, BK_COND, BK_MATCH, BK_TUPLE } :: import("../../expr.yo");
+{ AstExpr, ast_expr_id, ast_expr_is_fn_call, ast_expr_is_fn_call_of, ast_expr_is_atom_of, ast_expr_is_atom, ast_expr_token, BF_DOT, BK_WHILE, BK_BEGIN, BK_COND, BK_MATCH, BK_TUPLE } :: import("../../expr.yo");
 { TokenKind } :: import("../../token.yo");
 { AwaitPoint, CapturedVariable } :: import("../../evaluator/async/await_analysis_types.yo");
 { SuspensionPoint } :: import("../../evaluator/shared/suspension_analysis_types.yo");
@@ -768,6 +768,76 @@ hoist_non_splittable_awaits :: (fn(segments : ArrayList(StateSegment)) -> unit)(
     i = (i + usize(1));
   });
 });
+/// True when the awaited expression READS a future out of a place it does not
+/// own — a struct field, or a chain of them (`self._future`) — instead of
+/// producing one.
+///
+/// `sm->await_future_N` OWNS its reference: the slot is `__yo_decr_rc`'d when
+/// the await completes, when the awaited future aborts, and when the state
+/// machine is disposed. Every other way a future reaches that slot already
+/// satisfies that. A future the awaited expression PRODUCES — an `io.async(…)`
+/// block, a `__yo_async_*_start()` extern, a call returning `Impl(Future)` —
+/// hands over the reference it just created, and its temp's own deferred drop
+/// is aliased onto the slot so it is not dropped twice (`state_machine.yo`
+/// Phase 1b). A NAMED future is never stored here at all: the await reads the
+/// variable's field directly, for exactly this reason (see the dispatch-mode
+/// branch below).
+///
+/// A field read is neither. The struct keeps its reference and releases it in
+/// its own dispose, so a slot that does not take one of its own makes the
+/// await's drop a SECOND release of the same object — the use-after-free
+/// `Park.wait` hit, where `p`'s scope-end drop then read a future the await
+/// had already freed
+/// (issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md).
+///
+/// Shaped after `arg_is_rc_projection_place` (`evaluator/utils.yo`), which asks
+/// the same borrow question about an ordinary call argument. This one is purely
+/// syntactic: codegen has no environment to resolve the root binding in, and a
+/// dot chain rooted at an atom is the only borrowed form an await can take.
+_await_future_expr_is_borrowed_place :: (fn(e : AstExpr) -> bool)({
+  if(!ast_expr_is_fn_call_of(e, BF_DOT, Option(usize).Some(usize(2))), {
+    return(false);
+  });
+  e_args := match(e, .FnCall(_, _, __afp_a, _, _) => __afp_a, .Atom(_, _) => ArrayList(AstExpr).new());
+  field := match(e_args.get(usize(1)), .Some(x) => x, .None => return(false));
+  if(!ast_expr_is_atom(field), {
+    return(false);
+  });
+  (root : AstExpr) = match(e_args.get(usize(0)), .Some(x) => x, .None => return(false));
+  while(ast_expr_is_fn_call_of(root, BF_DOT, Option(usize).Some(usize(2))), {
+    r_args := match(root, .FnCall(_, _, __afp_ra, _, _) => __afp_ra, .Atom(_, _) => ArrayList(AstExpr).new());
+    r_field := match(r_args.get(usize(1)), .Some(x) => x, .None => return(false));
+    if(!ast_expr_is_atom(r_field), {
+      return(false);
+    });
+    root = match(r_args.get(usize(0)), .Some(x) => x, .None => return(false));
+  });
+  ast_expr_is_atom(root)
+});
+/// Emit the `sm->await_future_N = …` store, taking the reference the slot owns.
+///
+/// Every await-future store in this file goes through here so the borrowed case
+/// cannot be forgotten at one of the seven positions an await can appear in.
+emit_await_future_store :: (
+  fn(
+    future_expr : AstExpr,
+    future_code : String,
+    idx_s : String,
+    indent : String,
+    context : FunctionGenerationContext
+  ) -> unit
+)({
+  em := context.base.emitter;
+  em.emit_string_line(`${indent}sm->await_future_${idx_s} = (void*)(${future_code});`);
+  if(_await_future_expr_is_borrowed_place(future_expr), {
+    em.emit_string_line(`${indent}// Borrowed future (read out of a field): the slot releases what it`);
+    em.emit_string_line(`${indent}// holds, so it needs a reference of its own — otherwise this await`);
+    em.emit_string_line(`${indent}// frees the field's future out from under its owner.`);
+    em.emit_string_line(
+      `${indent}if (sm->await_future_${idx_s} != NULL) { __yo_incr_rc((void*)sm->await_future_${idx_s}); }`
+    );
+  });
+});
 /// Emit the future store for an await hoisted out of a non-splittable position.
 ///
 /// The enclosing expression now lives in the next segment, so this segment ends
@@ -795,7 +865,7 @@ emit_hoisted_await_future_store :: (
     args.get(usize(0)),
     .Some(future_expr) => {
       future_code := _call_generate_expr(future_expr, indent, context);
-      em.emit_string_line(`${indent}sm->await_future_${idx_s} = (void*)(${future_code});`);
+      emit_await_future_store(future_expr, future_code, idx_s, indent, context);
     },
     .None => ()
   );
@@ -1071,7 +1141,7 @@ generate_await_expression :: (
         .None => {
           future_code := _call_generate_expr(future_expr, indent, context);
           em.emit_string_line(`${indent}// Store pattern-matched Future for await ${idx_s}`);
-          em.emit_string_line(`${indent}sm->await_future_${idx_s} = (void*)(${future_code});`);
+          emit_await_future_store(future_expr, future_code, idx_s, indent, context);
         },
         .Some(_) => {
           em.emit_string_line(`${indent}// Prepare for await (future already stored in state machine variable)`);
@@ -1111,7 +1181,7 @@ generate_await_expression :: (
                 .None => {
                   future_code := _call_generate_expr(future_expr, indent, context);
                   em.emit_string_line(`${indent}// Store Future for await (assignment)`);
-                  em.emit_string_line(`${indent}sm->await_future_${idx_s} = (void*)(${future_code});`);
+                  emit_await_future_store(future_expr, future_code, idx_s, indent, context);
                 },
                 .Some(_) => {
                   em.emit_string_line(`${indent}// Store Future for await (assignment) - future already in state machine`);
@@ -1516,7 +1586,7 @@ generate_while_body_with_await :: (
           .Some(future_expr) => {
             future_code := _call_generate_expr(future_expr, indent, context);
             em.emit_string_line(`${indent}// Store Future for await ${idx_s} (while loop body)`);
-            em.emit_string_line(`${indent}sm->await_future_${idx_s} = (void*)(${future_code});`);
+            emit_await_future_store(future_expr, future_code, idx_s, indent, context);
           },
           .None => ()
         );
@@ -1534,7 +1604,7 @@ generate_while_body_with_await :: (
           .None => {
             future_code := _call_generate_expr(future_expr, indent, context);
             em.emit_string_line(`${indent}// Store Future for await ${idx_s} (while loop body)`);
-            em.emit_string_line(`${indent}sm->await_future_${idx_s} = (void*)(${future_code});`);
+            emit_await_future_store(future_expr, future_code, idx_s, indent, context);
           },
           .Some(_) => ()
         ),
@@ -1856,7 +1926,7 @@ generate_cond_branch_with_await :: (
                   }, {
                     future_code := _call_generate_expr(future_expr, indent, context);
                     em.emit_string_line(`${indent}// Store Future for await ${idx_s} (cond branch)`);
-                    em.emit_string_line(`${indent}sm->await_future_${idx_s} = (void*)(${future_code});`);
+                    emit_await_future_store(future_expr, future_code, idx_s, indent, context);
                   }),
                   .None => ()
                 );
@@ -1881,7 +1951,7 @@ generate_cond_branch_with_await :: (
                     .None => {
                       future_code := _call_generate_expr(future_expr, indent, context);
                       em.emit_string_line(`${indent}// Store Future for await ${idx_s} (cond branch)`);
-                      em.emit_string_line(`${indent}sm->await_future_${idx_s} = (void*)(${future_code});`);
+                      emit_await_future_store(future_expr, future_code, idx_s, indent, context);
                     },
                     .Some(fv) => {
                       em.emit_string_line(`${indent}// Await will use Future from sm->var_${fv}`);

--- a/tests/async/waker.test.yo
+++ b/tests/async/waker.test.yo
@@ -70,6 +70,28 @@ test("Test a wake before the park suspends is not lost", {
 });
 
 // ---------------------------------------------------------------------------
+// 1b. Awaiting the park does not RELEASE it.
+//
+// `Park.wait` awaits `self._future` — a future read out of a field, which the
+// struct still owns and still drops in its own dispose. An await that takes
+// that reference instead of one of its own frees the future while the park and
+// its wakers still point at it
+// (issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md).
+// Two awaits make the imbalance unambiguous: the count reaches zero with two
+// live holders left, so the ASan-armed CI legs report a use-after-free rather
+// than a one-off drop at scope end.
+// ---------------------------------------------------------------------------
+test("Test awaiting the same park twice does not release its future twice", {
+  p := Park.new();
+  w := p.waker();
+  w.wake();
+  io.await(p.wait(io), io);
+  io.await(p.wait(io), io);
+  assert(w.is_woken(), "the park survived both awaits, and is still woken");
+  assert(p.waker().is_woken(), "and it can still hand out a waker");
+});
+
+// ---------------------------------------------------------------------------
 // 2. Waking twice is a no-op, which is what lets a waiter list signal
 //    everyone without tracking who already ran.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The failure this fixes

develop's full battery (run [34557965609](https://github.com/shd101wyy/Yo/actions/runs/34557965609)) is RED, and so are every open PR's test legs — all on the same test:

```
✗ Test a wake before the park suspends is not lost
  ==3965==ERROR: AddressSanitizer: heap-use-after-free on address 0x507000003824
  READ of size 1 at 0x507000003824 thread T1
      #0 __yo_decr_rc
      #1 yo_id_17469          <- Park's dispose, dropping self._future
      #4 __yo_user_main
  freed by thread T1 here:
      #2 __yo_waker_release   <- the Waker's dispose
  previously allocated by thread T1 here:
      #2 __yo_async_park_start
```

`test (ubuntu-latest)`, `test (ubuntu-24.04-arm)` and `test (macos-latest)` all report it.

## Root cause

`sm->await_future_N` **owns** its reference: the state machine `__yo_decr_rc`s that slot when the await's result is extracted, when the awaited future aborts, and in its dispose function. Every other way a future reaches that slot already pays for it —

- a **produced** future (an `io.async(…)` block, a `__yo_async_*_start()` extern, a call returning `Impl(Future)`) hands over the reference it just created, and its temp's deferred drop is aliased onto the slot rather than emitted twice (`state_machine.yo`, Phase 1b);
- a **named** future is never stored in the slot at all — the existing comment at the dispatch-mode branch says why: "storing it into the slot would hand the slot an unowned reference (the extraction decref would over-release it)".

A future read out of a **field** was the case nobody had covered. `Park.wait` awaits `self._future`, and the store was

```c
sm->await_future_0 = (void*)(sm->__capture.self->_future);
```

with no `__yo_incr_rc`, while `Park`'s dispose still drops `_future`. Two releases, one reference: the park allocates the future (rc 1), `p.waker()` takes one (rc 2), the await releases one it never took (rc 1), dropping the waker frees it, and `p`'s scope-end drop reads freed memory.

## The fix

All seven await-future store sites now go through `emit_await_future_store`, which takes a reference when the awaited expression is a borrowed place — a field, or a chain of them, rooted at an atom. The predicate is shaped after `arg_is_rc_projection_place` (`src/evaluator/utils.yo`), which asks the same borrow question about an ordinary call argument; the codegen form is syntactic because there is no environment to resolve the root binding in.

```c
sm->await_future_0 = (void*)(sm->__capture.self->_future);
// Borrowed future (read out of a field): the slot releases what it
// holds, so it needs a reference of its own — otherwise this await
// frees the field's future out from under its owner.
if (sm->await_future_0 != NULL) { __yo_incr_rc((void*)sm->await_future_0); }
```

## Verified

- **Emit A/B on the reproducer**: old compiler `incr_slot=0 decr_slot=3`, new `incr_slot=1 decr_slot=3` — one store, one balancing dup, unchanged drops.
- **Emit A/B on `src/main.yo`**: nothing in `src/` awaits a bare field, so the compiler's own emitted C is unchanged (`__yo_incr_rc`/`__yo_decr_rc` counts identical).
- `yo fmt --check` clean; `yo check ./src` 270/270.
- `tests/async/waker.test.yo` 9/9 with the rebuilt compiler.

Note the bug does **not** reproduce by running the program on a dev machine — the freed object's memory has not been reused yet, and the local `--sanitize address` build does not instrument. The emitted C, and the ASan-armed CI legs, are the oracles.

## Also here

- `tests/async/waker.test.yo` — "Test awaiting the same park twice does not release its future twice". Two awaits drive the count to zero while the park and its waker are still live, so the release is unambiguous rather than a one-off imbalance at scope end.
- `issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md` — the record.
- `.github/instructions/c-codegen.instructions.md` — the slot-ownership rule, so a new store site does not reintroduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)