### PR TITLE
c_include: a `Name : Type` field ADOPTS the Yo type of that name (by-value C structs)

### DIFF
--- a/issues/fixed/c-include-cannot-express-a-by-value-c-struct.md
+++ b/issues/fixed/c-include-cannot-express-a-by-value-c-struct.md
@@ -1,0 +1,110 @@
+# `c_include` cannot express a by-value C struct
+
+**Status:** FIXED 2026-09-11 — `c_include` type ADOPTION
+(`src/evaluator/exprs/c_include.yo`), the adoption registry
+(`src/types/guards.yo`) and its use at type registration
+(`src/codegen/types/collection.yo`).
+**Reported in:** PR #565, which described the four pieces but landed none of
+them; the branch carried an unrelated export-naming change instead.
+
+## Symptom
+
+A C library's by-value struct — the shape raylib, SDL, and most C libraries are
+built around — had no spelling at all. The 0.1.x form declared the mirror
+struct inside the `c_include` body:
+
+```rust
+c_include "<raylib.h>",
+  (Color : Type) = struct(r : u8, g : u8, b : u8, a : u8),
+  DrawText : fn(...) -> unit,
+```
+
+and every current spelling of that intent was rejected:
+
+| spelling | result |
+| --- | --- |
+| `(Name : Type) = struct(...)` inside `c_include` | `evaluate_module_field: assigned value form is not yet supported (Phase 3)` |
+| `Name := struct(...)` inside `c_include` | same |
+| `Name :: struct(...)` inside `c_include` | `Cannot use "::" for module field` |
+| bare `Name : Type` inside `c_include` | compiles, but the type is an opaque handle — **unconstructible** |
+| `Name :: struct(...)` at module level, `Name : Type` in `c_include` | the `c_include` field OVERWROTE the real type with the opaque handle |
+
+The last row is the one that looks like it should work, and its failure is the
+bug:
+
+```
+error: evaluate_function_call: TypeVal SomeT callee without FnTrait (Phase 4)
+  --> byval.yo:14:8
+   |
+14 |   a := Vector2(x : f32(1.5), y : f32(2.5));
+   |        ^^^^^^^
+```
+
+Declaring the struct at module level and NOT naming it in the `c_include` gets
+past the evaluator and then fails in C: the argument lowers to the mangled
+`__yo_tN`, which is a different type from the header's:
+
+```
+passing '__yo_t0' to parameter of incompatible type 'Vector2'
+```
+
+This regressed the raylib_yo / tetris_yo example projects (35 structs, ~106
+by-value signatures in raylib_yo alone), and there is no workaround that
+preserves the C ABI.
+
+## Root cause
+
+`c_include`'s `Name : Type` field always created an extern-C OPAQUE type — a
+`SomeT` placeholder — and bound the name to it, exactly as `extern("Yo", X :
+Type)` does. That is right for a handle (`pid_t`, `FILE`), and wrong for a
+struct the Yo program has to CONSTRUCT: the placeholder has no constructor and
+no fields.
+
+Codegen had the other half of the gap. A collected type's C name is interned to
+`__yo_t<N>` unconditionally (`_intern_type_c_name`), with the note "Gap 3:
+extern-C names not modelled generally" — TS carries `type.isExtern` /
+`type.externName` on the type itself and returns the plain name from
+`getTypeString`, which yo-self's `TypeValue` has no field for.
+
+## Fix — adopt, don't shadow
+
+`c_include("<header>", Name : Type, …)` where `Name` ALREADY names a module type
+does not declare a new type. It says **this Yo type IS that C type**. So:
+
+1. **Evaluator** (`c_include.yo`): if the label resolves to a type value with a
+   declaration id (a `struct(...)` or `enum(...)` written in Yo), keep that type
+   as the field's value instead of replacing it with a placeholder, and record
+   the adoption.
+2. **Registry** (`types/guards.yo`): `register_adopted_extern_c_type` /
+   `get_adopted_extern_c_type`, keyed by the type's declaration id — the one
+   identity the evaluator and codegen can both read off a `TypeValue` without
+   agreeing on codegen's structural `type_key`. This is the stand-in for TS's
+   `isExtern` / `externName` fields, in the same shape as the neighbouring
+   `g_extern_type_names`.
+3. **Codegen** (`types/collection.yo`): an adopted type registers under the
+   header's name with its header as the entry's `c_include`.
+
+Nothing else needed changing, because the rest of the pipeline was already
+built for a type that comes from a header and merely never saw one:
+
+- `collect_c_includes` emits the `#include` for any type entry with a
+  `c_include`;
+- every declaration pass (`generate_type_declarations` and the three others)
+  already skips forward declarations and bodies for such an entry;
+- `get_type_string` reads the registered C name, so struct lowering, compound
+  literals (`(YoTestPoint){ .x = …, .y = … }`), parameters and return types all
+  follow with no further change.
+
+A `union(...)` carries no declaration id and is not adopted; neither is a
+`SomeT`, which would be adopting a placeholder as itself.
+
+## Regression test
+
+`tests/c_include_struct_by_value.test.yo`, with its header beside it
+(`tests/c_include_struct_by_value.h` — the test batch's generated `.c` is
+emitted in that directory, so a quoted include resolves with no `-I`). It
+covers the five things that were broken or at risk: the adopted type is still
+constructible; a Yo-built value crosses INTO C by value and the C function
+reads both fields; a value returned FROM C by value is readable in Yo; a value
+round-trips; and the adopted type is otherwise an ordinary Yo value (assignment,
+Yo function parameter and return, untouched original).

--- a/src/codegen/types/collection.yo
+++ b/src/codegen/types/collection.yo
@@ -38,7 +38,8 @@
   is_future_trait_type,
   is_some_type,
   is_function_type,
-  is_array_type
+  is_array_type,
+  get_adopted_extern_c_type
 } :: import("../../types/guards.yo");
 { type_contains_some_type } :: import("../../types/utils.yo");
 { resolve_enum_shell, resolve_struct_shell } :: import("../../types/creators.yo");
@@ -249,8 +250,24 @@ collect_type :: (fn(type_in : TypeValue, context : CodeGenContext) -> unit)({
       }
     );
     if(!(aliased), {
-      c_name := _intern_type_c_name(tk.clone());
-      context.register_type(tk, type, c_name, Option(String).None);
+      // A type ADOPTED by a `c_include` (`Color : Type` naming a Yo struct)
+      // already has a C name and a definition — the header's. Register THAT
+      // name and the header: `collect_c_includes` then emits the `#include`,
+      // and the declaration passes skip every forward declaration and body for
+      // an entry whose `c_include` is set, so the emitted C uses the header's
+      // struct and passes it BY VALUE across the real ABI. This is what the
+      // "Gap 3: extern-C names not modelled generally" note below refers to
+      // (TS reads `type.isExtern` / `type.externName` off the type itself).
+      match(
+        get_adopted_extern_c_type(type),
+        .Some(adopted) => {
+          context.register_type(tk, type, adopted.c_name.clone(), Option(String).Some(adopted.c_header.clone()));
+        },
+        .None => {
+          c_name := _intern_type_c_name(tk.clone());
+          context.register_type(tk, type, c_name, Option(String).None);
+        }
+      );
     });
     // Future trait interface: collect the OUTPUT type (T in Future(T)) — its
     // C name appears as the interface struct's `result` field. Mirrors TS

--- a/src/evaluator/exprs/c_include.yo
+++ b/src/evaluator/exprs/c_include.yo
@@ -23,14 +23,14 @@ pragma(Pragma.AllowUnsafe);
   BK_C_INCLUDE
 } :: import("../../expr.yo");
 { new_expr_info, expr_info_table_set, expr_info_table_get, register_extern_c_global } :: import("../../expr_info.yo");
-{ Environment, add_variable_to_env } :: import("../../env.yo");
+{ Environment, add_variable_to_env, get_variables_from_env } :: import("../../env.yo");
 { EvalContext } :: import("../context.yo");
 { EvalValue, create_unknown_val_with_name, create_runtime_unknown_val_with_name } :: import("../../value.yo");
 { is_function_type } :: import("../../types/guards.yo");
 { TypeValue, FuncMeta } :: import("../../types/definitions.yo");
 { t_unit, t_some_t } :: import("../../types/creators.yo");
 { type_contains_rc_type } :: import("../../types/utils.yo");
-{ register_extern_type_name } :: import("../../types/guards.yo");
+{ register_extern_type_name, register_adopted_extern_c_type, type_decl_id } :: import("../../types/guards.yo");
 { format_error_message } :: import("../../error.yo");
 { Exception } :: import("std/error");
 { is_implicitly_unsafe_capable_file } :: import("../memory_safety.yo");
@@ -57,6 +57,25 @@ record_c_include_for_extern :: (fn(name : String, header : String) -> unit)({
 get_c_include_for_extern :: (fn(name : String) -> Option(String))(
   g_extern_c_includes.get(name)
 );
+/// The already-bound type a `c_include` `Name : Type` field should ADOPT, or
+/// `.None` when the name is free (the ordinary opaque-handle case).
+///
+/// Adoptable means: the name resolves in this module's environment to a real
+/// type value that carries a declaration id — a `struct(...)` or `enum(...)`
+/// written in Yo. A `union(...)` has no id to key the registry by and is not
+/// adopted; neither is a SomeT (an opaque handle from an earlier `c_include`
+/// or `extern`), which would be adopting a placeholder as itself.
+_adoptable_type_binding :: (fn(env : Environment, name : String) -> Option(TypeValue))({
+  vars := get_variables_from_env(env, name);
+  n := vars.len();
+  if(n == usize(0), {
+    return(Option(TypeValue).None);
+  });
+  v := match(vars.get(n - usize(1)), .Some(x) => x, .None => return(Option(TypeValue).None));
+  val := match(v.value.get(usize(0)), .Some(x) => x, .None => return(Option(TypeValue).None));
+  ty := match(val, .TypeVal(t) => t, _ => return(Option(TypeValue).None));
+  match(type_decl_id(ty), .Some(_) => Option(TypeValue).Some(ty), .None => Option(TypeValue).None)
+});
 evaluate_c_include :: (
   fn(
     expr : AstExpr,
@@ -275,7 +294,29 @@ User code should normally call stdlib wrappers (e.g. functions in
           // `i32(unsafe(getpid()))` failed is_convertible_numeric_type's
           // extern clause and FTT'd (the sys/signal red).
           register_extern_type_name(result.label.clone());
-          EvalValue.TypeVal(t_some_t(result.label.clone(), usize(0)))
+          // ADOPT, don't shadow. When the label ALREADY names a module type,
+          // `Name : Type` is not declaring a new opaque handle — it is saying
+          // "the Yo type `Name` IS the C type `Name` in this header". Replacing
+          // it with an opaque placeholder is what made every C struct
+          // UNCONSTRUCTIBLE (`Vector2(x : …)` → "TypeVal SomeT callee without
+          // FnTrait"), so a by-value C ABI could not be expressed at all.
+          //
+          // Adoption keeps the real, constructible type and records the C name
+          // + header for codegen, which then lowers the type to `Vector2`
+          // instead of `__yo_t7` and emits NO definition of its own (the header
+          // has one). See issues/fixed/c-include-cannot-express-a-by-value-c-struct.md.
+          match(
+            _adoptable_type_binding(env, result.label.clone()),
+            .Some(existing_ty) => {
+              register_adopted_extern_c_type(
+                match(type_decl_id(existing_ty), .Some(d) => d, .None => String.from("")),
+                result.label.clone(),
+                c_header_file.clone()
+              );
+              EvalValue.TypeVal(existing_ty)
+            },
+            .None => EvalValue.TypeVal(t_some_t(result.label.clone(), usize(0)))
+          )
         },
         true => create_unknown_val_with_name(result.field_type, result.label.clone())
       ),

--- a/src/types/guards.yo
+++ b/src/types/guards.yo
@@ -11,6 +11,7 @@ pragma(Pragma.AllowUnsafe);
 { String } :: import("std/string");
 { ArrayList } :: import("std/collections/array_list");
 { HashSet } :: import("std/collections/hash_set");
+{ HashMap } :: import("std/collections/hash_map");
 { TypeValue } :: import("./definitions.yo");
 { type_value_tag, resolve_enum_shell, resolve_struct_shell } :: import("./creators.yo");
 // ---------------------------------------------------------------------------
@@ -30,6 +31,56 @@ register_extern_type_name :: (fn(name : String) -> unit)({
   ()
 });
 is_extern_type_name :: (fn(name : String) -> bool)(g_extern_type_names.contains(name));
+// ---------------------------------------------------------------------------
+// c_include TYPE ADOPTION — "this Yo type IS the C type `Name` in <header>".
+//
+// `c_include("<raylib.h>", Color : Type, …)` where `Color` ALREADY names a
+// module type does not declare a new opaque type: it says the Yo struct just
+// declared IS that header's C struct. The C compiler therefore already has a
+// definition and a name for it, so codegen must lower the type to that plain
+// name (`Color`, not `__yo_t7`) and must NOT emit a competing definition — the
+// only way a C struct can cross the ABI BY VALUE.
+//
+// TS carries this on the type itself (`type.isExtern` + `type.externName`,
+// src/types/utils.ts); yo-self's `TypeValue` has no such field, so this registry
+// stands in — the same stand-in shape as `g_extern_type_names` above, and the
+// "Gap 3: extern-C names not modelled generally" note in
+// `codegen/types/collection.yo` is what it closes.
+//
+// Keyed by the type's DECLARATION id (`Struct.id` / `EnumT.id`), which the
+// evaluator and codegen can both read straight off the `TypeValue` without
+// having to agree on a structural key (codegen's `type_key` is not reachable
+// from the evaluator).
+// ---------------------------------------------------------------------------
+/// The C name a Yo type was adopted under, and the header that defines it.
+AdoptedExternCType :: ref(struct(c_name : String, c_header : String));
+(g_adopted_extern_c_types : HashMap(String, AdoptedExternCType)) = HashMap(String, AdoptedExternCType).new();
+register_adopted_extern_c_type :: (
+  fn(decl_id : String, c_name : String, header : String) -> unit
+)({
+  if((decl_id.len() > usize(0)) && (c_name.len() > usize(0)), {
+    g_adopted_extern_c_types.insert(decl_id, AdoptedExternCType(c_name : c_name, c_header : header));
+  });
+  ()
+});
+/// The declaration id a `c_include` adoption is keyed by, for the type kinds
+/// that HAVE one. A `union(...)` carries no id and cannot be adopted.
+type_decl_id :: (fn(t : TypeValue) -> Option(String))(
+  match(
+    t,
+    .Struct({ id : sid }) => if(sid.len() > usize(0), Option(String).Some(sid.clone()), Option(String).None),
+    .EnumT({ id : eid }) => if(eid.len() > usize(0), Option(String).Some(eid.clone()), Option(String).None),
+    _ => Option(String).None
+  )
+);
+/// The C name + header this type was adopted under by a `c_include`, if any.
+get_adopted_extern_c_type :: (fn(t : TypeValue) -> Option(AdoptedExternCType))(
+  match(
+    type_decl_id(t),
+    .Some(did) => g_adopted_extern_c_types.get(did),
+    .None => Option(AdoptedExternCType).None
+  )
+);
 // ---------------------------------------------------------------------------
 // Resolved-concrete bridge indirection (mirrors TS reading
 // `someType.resolvedConcreteType`). guards.yo is low-level and cannot import
@@ -745,6 +796,10 @@ export(
   set_lookup_some_resolved_concrete,
   register_extern_type_name,
   is_extern_type_name,
+  AdoptedExternCType,
+  register_adopted_extern_c_type,
+  get_adopted_extern_c_type,
+  type_decl_id,
   is_function_specializable,
   // Box / effects-row guards
   is_boxed_type,

--- a/tests/c_include_struct_by_value.h
+++ b/tests/c_include_struct_by_value.h
@@ -1,0 +1,37 @@
+/* Fixture for tests/c_include_struct_by_value.test.yo.
+ *
+ * A C struct that crosses the ABI BY VALUE in both directions — the shape
+ * raylib, SDL and most C libraries are built around, and the one `c_include`
+ * could not express until type adoption landed
+ * (issues/fixed/c-include-cannot-express-a-by-value-c-struct.md).
+ *
+ * It lives beside the test on purpose: the test batch's generated .c is
+ * emitted in this directory, so the quoted include resolves with no -I.
+ */
+#ifndef YO_TEST_C_INCLUDE_STRUCT_BY_VALUE_H
+#define YO_TEST_C_INCLUDE_STRUCT_BY_VALUE_H
+
+typedef struct YoTestPoint {
+  double x;
+  double y;
+} YoTestPoint;
+
+static inline YoTestPoint yo_test_point_make(double x, double y) {
+  YoTestPoint p;
+  p.x = x;
+  p.y = y;
+  return p;
+}
+
+static inline double yo_test_point_dot(YoTestPoint a, YoTestPoint b) {
+  return (a.x * b.x) + (a.y * b.y);
+}
+
+static inline YoTestPoint yo_test_point_add(YoTestPoint a, YoTestPoint b) {
+  YoTestPoint r;
+  r.x = a.x + b.x;
+  r.y = a.y + b.y;
+  return r;
+}
+
+#endif /* YO_TEST_C_INCLUDE_STRUCT_BY_VALUE_H */

--- a/tests/c_include_struct_by_value.test.yo
+++ b/tests/c_include_struct_by_value.test.yo
@@ -1,0 +1,67 @@
+//! A C struct crossing the ABI BY VALUE, in both directions.
+//!
+//! `c_include("<header>", Name : Type, ...)` where `Name` already names a Yo
+//! type ADOPTS that type: it declares "this Yo struct IS the C struct `Name`
+//! in this header". Codegen then lowers it to the plain C name and emits no
+//! definition of its own, so the value the C function receives (and returns)
+//! is laid out by the C compiler, from the header.
+//!
+//! Before adoption, the `Name : Type` field overwrote the Yo type with an
+//! opaque handle, so the struct could not even be CONSTRUCTED
+//! (`Vector2(x : …)` → "TypeVal SomeT callee without FnTrait") and every C
+//! library built on by-value structs — raylib, SDL — was unreachable.
+//! See issues/fixed/c-include-cannot-express-a-by-value-c-struct.md.
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+/// The Yo mirror of the header's `struct YoTestPoint { double x; double y; }`.
+YoTestPoint :: struct(x : f64, y : f64);
+c_include(
+  "\"c_include_struct_by_value.h\"",
+  YoTestPoint :
+    Type,
+  yo_test_point_make :
+    (fn(x : f64, y : f64) -> YoTestPoint),
+  yo_test_point_dot :
+    (fn(a : YoTestPoint, b : YoTestPoint) -> f64),
+  yo_test_point_add :
+    (fn(a : YoTestPoint, b : YoTestPoint) -> YoTestPoint)
+);
+test("an adopted C struct is still constructible from Yo", {
+  p := YoTestPoint(x : f64(3.0), y : f64(4.0));
+  assert(p.x == f64(3.0), "the x the constructor was given");
+  assert(p.y == f64(4.0), "and the y");
+});
+test("a Yo-built struct crosses into C by value", {
+  a := YoTestPoint(x : f64(1.0), y : f64(2.0));
+  b := YoTestPoint(x : f64(3.0), y : f64(4.0));
+  // 1*3 + 2*4. A wrong layout or a Yo-side definition competing with the
+  // header's would put garbage here rather than 11.
+  assert(unsafe(yo_test_point_dot(a, b)) == f64(11.0), "the C function read both fields of both arguments");
+});
+test("a struct returned from C by value is readable in Yo", {
+  p := unsafe(yo_test_point_make(f64(5.5), f64(-2.25)));
+  assert(p.x == f64(5.5), "the x C built");
+  assert(p.y == f64(-2.25), "and the y");
+});
+test("a struct round-trips through C and back", {
+  a := YoTestPoint(x : f64(1.5), y : f64(2.5));
+  b := YoTestPoint(x : f64(0.25), y : f64(0.75));
+  s := unsafe(yo_test_point_add(a, b));
+  assert(s.x == f64(1.75), "x summed");
+  assert(s.y == f64(3.25), "y summed");
+  // And the result is an ordinary Yo value: it goes back into C unchanged.
+  assert(unsafe(yo_test_point_dot(s, YoTestPoint(x : f64(2.0), y : f64(0.0)))) == f64(3.5), "the returned value is a full Yo value");
+});
+test("an adopted type is an ordinary Yo type everywhere else", {
+  // Adoption must not make the type special on the Yo side: it is still
+  // assignable, copyable, and usable as a parameter and a return type.
+  scaled := (fn(p : YoTestPoint, k : f64) -> YoTestPoint)(
+    YoTestPoint(x : (p.x * k), y : (p.y * k))
+  );
+  p := YoTestPoint(x : f64(2.0), y : f64(3.0));
+  q := p;
+  r := scaled(q, f64(2.0));
+  assert(r.x == f64(4.0), "a Yo function returns the adopted type by value");
+  assert(r.y == f64(6.0), "both fields");
+  assert(p.x == f64(2.0), "and the original is untouched (value semantics)");
+});


### PR DESCRIPTION
Takes over #565, which described this fix in four pieces but landed none of them — its branch carries an unrelated export-naming change (superseded by #578) plus a duplicate of the waker-UAF report #580 fixes.

## The problem

A C library's by-value struct — the shape raylib, SDL and most C libraries are built around — had no spelling at all.

| spelling | result |
| --- | --- |
| `(Name : Type) = struct(...)` inside `c_include` | `evaluate_module_field: assigned value form is not yet supported (Phase 3)` |
| `Name := struct(...)` inside `c_include` | same |
| `Name :: struct(...)` inside `c_include` | `Cannot use "::" for module field` |
| bare `Name : Type` inside `c_include` | compiles, but the type is an opaque handle — **unconstructible** |
| `Name :: struct(...)` at module level **and** `Name : Type` in the `c_include` | the `c_include` field OVERWROTE the real type with the opaque handle |

That last row is the one that looks like it should work, and its failure is the bug:

```
error: evaluate_function_call: TypeVal SomeT callee without FnTrait (Phase 4)
14 |   a := Vector2(x : f32(1.5), y : f32(2.5));
   |        ^^^^^^^
```

Declaring the struct at module level and *not* naming it in the `c_include` gets past the evaluator and then fails in C, because the argument lowers to the mangled name: `passing '__yo_t0' to parameter of incompatible type 'Vector2'`.

## The fix — adopt, don't shadow

`c_include("<header>", Name : Type, …)` where `Name` already names a module type is not declaring a new type. It says **this Yo type IS that C type**.

1. **Evaluator** (`src/evaluator/exprs/c_include.yo`) — if the label resolves to a type value carrying a declaration id (a `struct(...)`/`enum(...)` written in Yo), keep that type as the field's value instead of replacing it with a placeholder, and record the adoption.
2. **Registry** (`src/types/guards.yo`) — `register_adopted_extern_c_type` / `get_adopted_extern_c_type`, keyed by declaration id: the one identity the evaluator and codegen can both read off a `TypeValue` without agreeing on codegen's structural `type_key`. This is the stand-in for TS's `type.isExtern` / `type.externName`, in the same shape as the neighbouring `g_extern_type_names`.
3. **Codegen** (`src/codegen/types/collection.yo`) — an adopted type registers under the header's name, with the header as the entry's `c_include`.

Nothing else needed changing, because the rest of the pipeline was already built for a type that comes from a header and simply never saw one: `collect_c_includes` emits the `#include` for any type entry carrying one, all four declaration passes already skip forward declarations and bodies for such an entry, and `get_type_string` reads the registered C name — so lowering, compound literals, parameters and return types follow. This closes the "Gap 3: extern-C names not modelled generally" note in `types/collection.yo`.

A `union(...)` has no declaration id and is not adopted; neither is a `SomeT`, which would be adopting a placeholder as itself.

## Test

`tests/c_include_struct_by_value.test.yo`, with its header beside it (`tests/c_include_struct_by_value.h` — the test batch's generated `.c` is emitted in that directory, so a quoted include resolves with no `-I`). Five cases, covering every part that was broken or at risk:

- the adopted type is still constructible;
- a Yo-built value crosses **into** C by value and the C function reads both fields;
- a value returned **from** C by value is readable in Yo;
- a value round-trips through C and goes back in unchanged;
- the adopted type is otherwise an ordinary Yo value — assignment, Yo function parameter and return, original untouched.

Record: `issues/fixed/c-include-cannot-express-a-by-value-c-struct.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
