### PR TITLE
plans: the waker campaign is active, not backlog — record what landed

### DIFF
--- a/issues/fixed/a-generic-instance-in-the-type-registry-breaks-trace-monomorphization.md
+++ b/issues/fixed/a-generic-instance-in-the-type-registry-breaks-trace-monomorphization.md
@@ -2,7 +2,7 @@
 
 **Status:** FIXED 2026-09-11 — `collect_trace_methods_from_generic_impls`
 (`src/codegen/functions/collection.yo`).
-**Supersedes:** `issues/an-arraylist-of-a-waker-like-ref-loses-its-tracer-inside-std-async-channel.md`,
+**Supersedes:** `issues/fixed/an-arraylist-of-a-waker-like-ref-loses-its-tracer-inside-std-async-channel.md`,
 which reported the symptom and bisected it correctly but named the wrong
 object — see "What the earlier report got wrong" below.
 

--- a/issues/fixed/an-arraylist-of-a-waker-like-ref-loses-its-tracer-inside-std-async-channel.md
+++ b/issues/fixed/an-arraylist-of-a-waker-like-ref-loses-its-tracer-inside-std-async-channel.md
@@ -1,7 +1,7 @@
 # `ArrayList(Waker)` inside `std/async/channel` loses its GC tracer
 
 **Status:** OPEN. Found 2026-09-11 while rewriting the async `Channel` over
-wakers (`plans/backlog/WAKER_BASED_SCHEDULING.md` stage 3). It blocks that
+wakers (`plans/WAKER_BASED_SCHEDULING.md` stage 3). It blocks that
 rewrite; the async `Mutex` half of the same stage landed, because the identical
 construction works there.
 
@@ -132,7 +132,7 @@ substitution" family. Two questions to answer first:
 
 ## Impact
 
-`plans/backlog/WAKER_BASED_SCHEDULING.md` stage 3's channel half, and
+`plans/WAKER_BASED_SCHEDULING.md` stage 3's channel half, and
 therefore stage 4 (the combinators, which wait on channels). The async
 `Channel` keeps its 1 ms timer tick until this is fixed — a millisecond floor
 on every hand-off, capping a producer/consumer pair at ~1000 values/second.

--- a/issues/yield-now-costs-a-millisecond-per-turn-inside-a-test-batch.md
+++ b/issues/yield-now-costs-a-millisecond-per-turn-inside-a-test-batch.md
@@ -37,7 +37,7 @@ replaces.
 
 ## Why it matters
 
-The whole point of `plans/backlog/WAKER_BASED_SCHEDULING.md` is removing a
+The whole point of `plans/WAKER_BASED_SCHEDULING.md` is removing a
 millisecond floor from every hand-off, and the acceptance criterion is a
 measured hand-off rate. If the measurement is taken from inside the test
 harness it reads as "no improvement", which is how this nearly got mis-recorded

--- a/plans/README.md
+++ b/plans/README.md
@@ -122,10 +122,13 @@ of throwing it) and
 **Language features the std campaign is blocked on** (added 2026-09-10, each
 written from the std row that needs it, with the blocked call sites named):
 
-- [`backlog/WAKER_BASED_SCHEDULING.md`](backlog/WAKER_BASED_SCHEDULING.md) —
-  the largest one. Everything that waits on a peer (async `Mutex`, `Channel`,
-  `yield`, the combinators) polls a **1 ms timer**, which puts a millisecond
-  floor under every hand-off and makes `spawn_blocking` inexpressible.
+- [`WAKER_BASED_SCHEDULING.md`](WAKER_BASED_SCHEDULING.md) — the largest one,
+  and **now active** (moved out of `backlog/` on 2026-09-11). Everything that
+  waits on a peer used to poll a **1 ms timer**, putting a millisecond floor
+  under every hand-off and making `spawn_blocking` inexpressible. The `Waker` +
+  `park` primitive and the async `Mutex` over it have landed; `yield` is
+  seed-gated, `Channel` is blocked on a tracer defect, and the combinators and
+  cross-thread wake are open — the doc's status table says which is which.
 - [`backlog/MEMBER_VISIBILITY.md`](backlog/MEMBER_VISIBILITY.md) — Yo has no
   visibility mechanism; the leading-underscore convention standing in for it
   covers **752 members** in `std/` and enforces nothing. Blocks three

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -1394,7 +1394,7 @@ from the blocked call sites, in `plans/backlog/`:
 
 | blocked row | language feature | doc |
 | --- | --- | --- |
-| waker-based `yield`/async `channel`/async `mutex`; `spawn_blocking` | a `Waker` + `park` primitive, so one task can be woken by another's progress | [`WAKER_BASED_SCHEDULING.md`](backlog/WAKER_BASED_SCHEDULING.md) |
+| waker-based `yield`/async `channel`/async `mutex`; `spawn_blocking` | a `Waker` + `park` primitive, so one task can be woken by another's progress | [`WAKER_BASED_SCHEDULING.md`](WAKER_BASED_SCHEDULING.md) |
 | `_raw_lock`/`_raw_unlock`/`_raw_handle_ptr` off the public surface; `ctrl`/`data`/`size` private; `imm/*` internals | member visibility (`priv`, plus a path-prefix scope for the cross-module `std/` callers) | [`MEMBER_VISIBILITY.md`](backlog/MEMBER_VISIBILITY.md) |
 | `TcpListener.incoming` | a `Stream` trait — the async analogue of `Iterator`. **Needs no compiler change** | [`ASYNC_ITERATION_STREAM.md`](backlog/ASYNC_ITERATION_STREAM.md) |
 | the ten per-type byte conversions; `usize`/`isize` byte conversions at all; `Array(T, N)`'s `Default` | value substitution in a TYPE position — an associated constant as an `Array` length silently resolves to 0 (`issues/associated-constant-in-a-type-position-resolves-to-zero.md`) | [`VALUE_SUBSTITUTION_IN_TYPE_POSITIONS.md`](backlog/VALUE_SUBSTITUTION_IN_TYPE_POSITIONS.md) |

--- a/plans/WAKER_BASED_SCHEDULING.md
+++ b/plans/WAKER_BASED_SCHEDULING.md
@@ -1,9 +1,36 @@
 # Waker-based scheduling
 
-**Status:** BACKLOG — designed here, not started. Written 2026-09-10. This is
-the largest remaining item in `plans/STD_API_STABILIZATION.md`'s concurrency
-group, and four std modules' `## Stability` markers name it as the thing that
-will change under them.
+**Status:** IN PROGRESS — steps 1, 3a and 3b landed 2026-09-11, step 2 is
+seed-gated, steps 4-5 are open. Written 2026-09-10. This is the largest
+remaining item in `plans/STD_API_STABILIZATION.md`'s concurrency group, and four
+std modules' `## Stability` markers name it as the thing that will change under
+them.
+
+| step | state |
+| --- | --- |
+| 1. `Waker` + `park` in the runtime | **LANDED** (#561) — `std/async/waker.yo`, `__yo_async_park_start` / `__yo_waker_new` / `__yo_waker_wake` / `__yo_waker_release` in `codegen/async/runtime_core.yo`, plus the live-waker count the loop needs to know a parked task is still wakeable |
+| 2. `yield` over `park` | **SEED-GATED.** `yield_now` is the fast form and is landed; `yield` itself cannot point at it until the seed ships `__yo_async_yield_start`, because `yield` is on the compiler's own import path (through `std/fs/watch`) and the seed emits a runtime without that symbol, so the compiler fails to LINK. Moves in the release after the one that ships this runtime |
+| 3a. `Mutex` over a waiter queue | **LANDED** (#576) — `std/async/mutex.yo` holds an `ArrayList(Waker)`, `unlock` wakes the FRONT waiter, and `waiter_count()` is the oracle the FIFO test reads |
+| 3b. `Channel` over the same queue | **LANDED** (#586) — `send`/`recv` park on a waiter queue instead of re-checking on a 1 ms timer tick. It was blocked for a day by a compiler defect that the rewrite surfaced: the trace collector tried to monomorphize a GENERIC `ArrayList(T)` instance that only this shape put in the codegen type registry, and failed inside `array_list.yo`'s `Trace` body — a file the rewrite never touched (`issues/fixed/a-generic-instance-in-the-type-registry-breaks-trace-monomorphization.md`) |
+| 4. The combinators (`race`/`any`/`timeout`) | open |
+| 5. Cross-thread wake + `spawn_blocking` | open |
+
+**Two codegen bugs fell out of this campaign, both fixed.**
+
+- **#580** — `Park.wait` awaits `self._future`, a future read out of a FIELD,
+  and the state machine's await slot took that reference without a
+  `__yo_incr_rc` while `Park`'s own dispose still dropped it. Two releases for
+  one reference: a heap-use-after-free that failed every CI `test (…)` leg and
+  the hollow sweep
+  (`issues/fixed/awaiting-a-future-held-in-a-struct-field-releases-it-twice.md`).
+- **#586** — the Trace collector force-specializes every reference-semantics
+  type in the codegen type registry, and a GENERIC instance can be in there.
+  Monomorphizing one is meaningless and fails in `ArrayList`'s own `Trace` body
+  (`issues/fixed/a-generic-instance-in-the-type-registry-breaks-trace-monomorphization.md`).
+
+Both were invisible to the local gates that pass on macOS and surfaced only
+under CI's sanitizers or a specific std shape — worth remembering before the
+remaining steps.
 
 ## The problem: everything that waits, waits on a 1 ms timer
 

--- a/src/codegen/async/runtime_core.yo
+++ b/src/codegen/async/runtime_core.yo
@@ -72,7 +72,7 @@ static int __yo_io_wait(void);
 // call them. The thread-local state has to be DEFINED here rather than
 // declared, not merely declared: a static object has no forward-declaration
 // spelling in C.
-// See plans/backlog/WAKER_BASED_SCHEDULING.md.
+// See plans/WAKER_BASED_SCHEDULING.md.
 static ${thread_local} size_t __yo_async_live_wakers = 0;
 typedef struct __yo_yield_node_t {
   __yo_io_future_t* future;
@@ -409,7 +409,7 @@ static __yo_yield_future_t __yo_async_yield(void) {
 // Waker / park — "resume THIS task"
 // ============================================================================
 // The primitive every peer-waiting primitive needs
-// (plans/backlog/WAKER_BASED_SCHEDULING.md). Without it, everything that waits
+// (plans/WAKER_BASED_SCHEDULING.md). Without it, everything that waits
 // on ANOTHER TASK's progress — yield, a contended async Mutex, a blocked
 // Channel send/recv — polls a 1 ms timer, which puts a millisecond floor under
 // every hand-off.

--- a/std/async/mutex.yo
+++ b/std/async/mutex.yo
@@ -13,7 +13,7 @@
 //! wakes the one at the front. There is no timer under it, so a hand-off costs
 //! a loop turn rather than a millisecond, and the order is the order tasks
 //! arrived in. Until 2026-09-11 this re-checked on a 1 ms tick and was
-//! explicitly unfair (`plans/backlog/WAKER_BASED_SCHEDULING.md` stage 3).
+//! explicitly unfair (`plans/WAKER_BASED_SCHEDULING.md` stage 3).
 //!
 //! ```rust
 //! { Mutex } :: import "std/async/mutex";

--- a/std/async/waker.yo
+++ b/std/async/waker.yo
@@ -6,7 +6,7 @@
 //! `async.Mutex.lock`, a blocked `async.Channel` send or recv — which puts a
 //! **millisecond floor under every hand-off**: a producer/consumer pair caps
 //! at ~1000 hand-offs per second no matter how fast the work is.
-//! (`plans/backlog/WAKER_BASED_SCHEDULING.md`.)
+//! (`plans/WAKER_BASED_SCHEDULING.md`.)
 //!
 //! ```rust
 //! { Park } :: import("std/async/waker");

--- a/std/sys/externs.yo
+++ b/std/sys/externs.yo
@@ -156,7 +156,7 @@ extern(
   // ========================================================================
   // `__yo_async_park_start` returns a future NO backend will ever complete;
   // only `__yo_waker_wake` does. See `std/async/waker.yo` for the safe
-  // ordering and `plans/backlog/WAKER_BASED_SCHEDULING.md` for why it exists.
+  // ordering and `plans/WAKER_BASED_SCHEDULING.md` for why it exists.
   __yo_async_park_start : (fn() -> IoFuture),
   // A future that is pending NOW and completed by the next ready-task drain —
   // the timer-free fairness yield. It cannot be an already-complete future:

--- a/tests/async/mutex.test.yo
+++ b/tests/async/mutex.test.yo
@@ -79,7 +79,7 @@ test("Test mutex lock waits", {
 // 4. WAKER-BASED acquisition: FIFO, and every waiter runs
 //
 // Contended acquisition used to re-check on a 1 ms timer and was explicitly
-// unfair. It is a waiter QUEUE now (`plans/backlog/WAKER_BASED_SCHEDULING.md`
+// unfair. It is a waiter QUEUE now (`plans/WAKER_BASED_SCHEDULING.md`
 // stage 3), which makes two things testable that were not before: the order
 // tasks acquire in, and that a chain of N waiters all run from N unlocks with
 // no wake lost. A lost wake is a HANG rather than a failure — invisible to a

--- a/tests/async/waker.test.yo
+++ b/tests/async/waker.test.yo
@@ -1,5 +1,5 @@
 //! `Waker` / `Park` — the "resume THIS task" primitive
-//! (`plans/backlog/WAKER_BASED_SCHEDULING.md` step 1).
+//! (`plans/WAKER_BASED_SCHEDULING.md` step 1).
 //!
 //! Before this existed, everything in `std/async` that waited on a PEER
 //! polled a 1 ms timer, so every hand-off cost up to a millisecond. The last


### PR DESCRIPTION
`WAKER_BASED_SCHEDULING.md` still said *"designed here, not started"* after four of its five steps moved. It now carries a per-step status table and moves from `plans/backlog/` to `plans/` — the taxonomy in `plans/README.md` keeps active plans at the root and written-not-started ones in `backlog/` — with every reference to the old path updated (8 files, no stragglers).

| step | state |
| --- | --- |
| 1. `Waker` + `park` in the runtime | LANDED (#561) |
| 2. `yield` over `park` | SEED-GATED — `yield` is on the compiler's own import path and the seed emits a runtime without `__yo_async_yield_start`, so pointing it at `yield_now` fails to LINK until the next seed |
| 3a. async `Mutex` over a waiter queue | LANDED (#576) |
| 3b. async `Channel` over the same queue | LANDED (#586) |
| 4. combinators (`race`/`any`/`timeout`) | open |
| 5. cross-thread wake + `spawn_blocking` | open |

It also records the two codegen bugs this campaign surfaced and fixed — #580 (the await slot taking a borrowed future's reference) and #586 (the trace collector monomorphizing a generic instance) — rather than leaving them to be rediscovered from CI logs. Both were invisible to the local gates and showed up only under CI's sanitizers or a specific std shape, which is the thing worth knowing before steps 4 and 5.

Docs and comments only; `fmt --check` clean across `./src ./std ./tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)