### PR TITLE
yo doc: a re-exported declaration carries the declaring module's docs

### DIFF
--- a/issues/fixed/yo-doc-drops-every-doc-comment-of-a-re-exported-type.md
+++ b/issues/fixed/yo-doc-drops-every-doc-comment-of-a-re-exported-type.md
@@ -1,7 +1,17 @@
 # `yo doc` drops every doc comment of a re-exported type
 
-**Status:** OPEN. Found 2026-09-11 while re-measuring the campaign's doc-coverage
-row after trait-doc inheritance (#579) landed.
+**Status:** FIXED 2026-09-11 — `_fill_re_exported_docs`
+(`src/doc/builder.yo`), a model pass beside `_inherit_trait_method_docs`.
+Found while re-measuring the campaign's doc-coverage row after trait-doc
+inheritance (#579) landed.
+
+**Result:** the two-file reproducer below now renders identically under both
+modules, and `std/`'s undocumented count drops **1554 → 1293** of 3345. `String`
+alone goes from 115 undocumented methods to 21. What remains is a DIFFERENT
+class — trait-impl methods that `_inherit_trait_method_docs` is not reaching
+(`next`/`map`/`filter` from `Iterator`, `==`/`cmp`, `to_string`) and ~304
+genuinely undocumented `libc/*` externs — so the residue is its own follow-up,
+not this bug.
 
 ## Symptom
 
@@ -92,7 +102,36 @@ get_doc_comment_lookup_key :: (fn(comment : DocComment) -> String)(
 It leads with `module_path`, so doc comments from every file in the walk can
 share ONE map without colliding — the map is simply never built that way.
 
-## Fix direction
+## The fix as landed
+
+Not the token-plumbing route sketched below — that would have meant threading a
+cross-file map through the ~12 name-keyed `doc_lookup.get` sites in the builder,
+where a naive merge collides (`new` is declared in dozens of files).
+
+Instead a MODEL pass, `_fill_re_exported_docs`, runs beside the trait-doc
+inheritance pass once every module is built: a type missing documentation takes
+it from another module's type with the same **name AND signature**. A genuine
+re-export is the same declaration, so its rendered signature matches by
+construction, while two distinct types sharing a name differ in theirs — which
+is what keeps `std/`'s several same-named types apart. Only `.None` is filled,
+so a module that documents a re-export itself keeps what it wrote.
+
+Two details that cost a measurement each:
+
+* **Write back by INDEX.** `DocType`/`DocFunction` are value structs, so
+  mutating a `.get()` result changes a copy and is silently lost. The pass
+  rebuilds each entry (`types(ti) = DocType(…)`), the same way
+  `_inherit_trait_method_docs` does.
+* **Keep the RICHEST donor, not the first.** A re-exporting module's own entry
+  can carry a doc or two — `String` in `string/index` has `format`, inherited
+  from the `Format` trait — and registering that first let it claim the key and
+  block the declaring module's fully documented entry. With first-wins the
+  count only fell to 1414; scoring donors by documented-member count took it to
+  1293.
+
+The original sketch is kept below for the record.
+
+### Original fix direction (not taken)
 
 Extract doc comments for every file in the walk FIRST, merge them into one
 lookup keyed as above, and hand that merged map to `build_doc_module` (each

--- a/issues/yo-doc-drops-every-doc-comment-of-a-re-exported-type.md
+++ b/issues/yo-doc-drops-every-doc-comment-of-a-re-exported-type.md
@@ -1,0 +1,112 @@
+# `yo doc` drops every doc comment of a re-exported type
+
+**Status:** OPEN. Found 2026-09-11 while re-measuring the campaign's doc-coverage
+row after trait-doc inheritance (#579) landed.
+
+## Symptom
+
+A type declared in one file and re-exported from another is rendered with **no
+documentation at all** — not its own doc, not any of its methods' — even though
+every one of them carries a `///` comment.
+
+Minimal reproducer, two files in one directory:
+
+```rust
+// point.yo
+/// A point in the plane.
+Point :: struct(x : i32, y : i32);
+impl(
+  Point,
+  /// Make a point at the origin.
+  origin : (fn() -> Self)(Point(x : i32(0), y : i32(0))),
+  /// The x coordinate, doubled.
+  double_x : (fn(self : Self) -> i32)((self.x * i32(2)))
+);
+export(Point);
+
+// index.yo
+{ Point } :: import("./point.yo");
+export(Point);
+```
+
+`yo doc . --format json`:
+
+```
+=== module point
+  type Point doc='A point in the plane.'
+    method origin     doc='Make a point at the origin.'
+    method double_x   doc='The x coordinate, doubled.'
+=== module index
+  type Point doc=None
+    method origin     doc=None
+    method double_x   doc=None
+```
+
+## Why it matters — the measured cost
+
+`std/` is organised as `foo/index.yo` re-exporting `foo/thing.yo`, so this hits
+almost everything a reader actually opens. Measured on develop
+(`yo doc ./std --format json`, 175 modules, 3345 functions + methods):
+
+| | count |
+| --- | --- |
+| documented | 1791 |
+| **undocumented** | **1554** |
+| of those, filled by trait inheritance (#579) | 110 |
+
+The worst modules are exactly the re-exporting ones: `string/index` 275,
+`http/index` 93, `imm/string` 62, `process/index` 50, `regex/index` 39. On
+`String` and `rune`, the ONLY methods with any doc are `format` on each — and
+they have one because #579 inherits it from the `Format` TRAIT, not because
+their own comment was found.
+
+This also makes the campaign's docs row meaningless as written:
+`plans/STD_API_STABILIZATION.md` reports "479 undocumented members" from a
+SOURCE grep for `///`, while what `yo doc` publishes is 1554 — the difference is
+almost entirely this bug, not missing comments. A doc sweep aimed at that 479
+would write comments that `yo doc` then discards.
+
+## Root cause
+
+`_build_module_doc` (`src/doc_command.yo`) documents one file at a time:
+
+```rust
+tokens := tokenize(src, `file://${file_path}`, lex_exn);
+extraction := extract_doc_comments(tokens);
+outcome := mm_load_file(file_path, …);
+… build_doc_module(module_name, module_name, outcome.module_value, …, extraction, tokens, outcome.env)
+```
+
+`extraction` holds the doc comments of **that file only**. A re-exported type's
+declaration — and therefore its `///` comments — lives in a different file, so
+every lookup misses and the member renders bare.
+
+The lookup key is already cross-file safe:
+
+```rust
+get_doc_comment_lookup_key :: (fn(comment : DocComment) -> String)(
+  `${comment.module_path}:${comment.row.to_string()}:${comment.column.to_string()}`
+);
+```
+
+It leads with `module_path`, so doc comments from every file in the walk can
+share ONE map without colliding — the map is simply never built that way.
+
+## Fix direction
+
+Extract doc comments for every file in the walk FIRST, merge them into one
+lookup keyed as above, and hand that merged map to `build_doc_module` (each
+module still needs its own token list for its `//!` header and for ordering).
+A member then resolves its doc by its own defining position regardless of which
+module is being rendered.
+
+Worth checking while in there: `issues/yo-doc-renders-std-prelude-as-an-empty-module.md`
+is plausibly the same family — the prelude is the extreme case of a module whose
+contents are declared elsewhere.
+
+## Regression test
+
+`tests/internal/doc_*.test.yo` — the two-file shape above, asserting that the
+re-exporting module's type and methods carry the same docs as the defining
+module's. The current pipeline passes its existing tests because every fixture
+declares and documents in ONE file.

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -1439,6 +1439,22 @@ removal), and the 359 here cover `std/collections/*`, `std/imm/*`,
 "8 modules" count was a subset: it listed the ones a reader was most likely to
 reach for, not the ones that lack a marker.
 
+**But 479 is a SOURCE-GREP number, and it is not what readers get — measured
+2026-09-11.** `yo doc ./std --format json` on develop reports **1554 of 3345**
+functions and methods with no documentation. The gap is not missing comments: it
+is `yo doc` DROPPING every doc comment of a re-exported type
+(`issues/yo-doc-drops-every-doc-comment-of-a-re-exported-type.md`). Each module
+is documented from its OWN file's tokens, so a type declared in `foo/thing.yo`
+and re-exported by `foo/index.yo` renders bare under the module readers actually
+open — `string/index` 275, `http/index` 93, `imm/string` 62, `process/index` 50.
+On `String` and `rune` the only methods with any doc are the two that #579
+inherits from the `Format` trait.
+
+Two consequences for this row. A doc sweep aimed at the 479 would write comments
+`yo doc` then discards, so **the extractor fix comes first**; and the row's
+"done" criterion has to be the published number, not the grep — they differ by a
+factor of three.
+
 **`## Stability` markers — DONE 2026-09-11. All 175 std modules carry one.**
 The last fifteen were the ones a doc sweep cannot write mechanically, because
 the honest answer in each case is a specific blocker rather than a status word:

--- a/src/doc/builder.yo
+++ b/src/doc/builder.yo
@@ -1795,6 +1795,297 @@ build_cross_references :: (fn(modules : ArrayList(DocModule)) -> unit)({
     mj = (mj + usize(1));
   });
   _inherit_trait_method_docs(modules);
+  _fill_re_exported_docs(modules);
+});
+/// Fill in the documentation of a RE-EXPORTED declaration from the module that
+/// declares it.
+///
+/// Each module is documented from its OWN file's tokens, so a type declared in
+/// `foo/thing.yo` and re-exported by `foo/index.yo` renders bare under the
+/// module a reader actually opens — no type doc, and no doc on any method.
+/// `std/` is organised exactly that way, which is why `yo doc ./std` reported
+/// 1554 of 3345 members undocumented while the source carries a `///` on nearly
+/// all of them
+/// (issues/fixed/yo-doc-drops-every-doc-comment-of-a-re-exported-type.md).
+///
+/// This is a fill-in, not an inheritance: a re-exported type IS the declared
+/// type, so its doc is that declaration's own text and needs no attribution.
+/// Only `.None` is filled, so a module that documents a re-export itself keeps
+/// what it wrote — and a donor that reaches itself is therefore a no-op.
+///
+/// **Matched on name AND signature.** The name alone is not safe — `std/` has
+/// several same-named types in different modules — but a genuine re-export is
+/// the same declaration, so its rendered signature is identical by
+/// construction, while two distinct types sharing a name differ in theirs. A
+/// type whose signature matches no documented donor is left alone.
+///
+/// Runs after `_inherit_trait_method_docs` so a donor that took its method docs
+/// from a trait passes those on too, attribution included — the re-export then
+/// reads exactly as the declaring module does.
+///
+/// Writes back by INDEX (`types(ti) = DocType(…)`, `methods(mi) = DocFunction(…)`)
+/// because `DocType` and `DocFunction` are value structs: mutating a `.get()`
+/// result changes a copy and is silently lost. Same reason the trait-inheritance
+/// pass above rebuilds each entry.
+_fill_re_exported_docs :: (fn(modules : ArrayList(DocModule)) -> unit)({
+  // Donors: every type that HAS documentation to give, keyed by name+signature.
+  d_keys := ArrayList(String).new();
+  d_types := ArrayList(DocType).new();
+  (mi : usize) = usize(0);
+  while(mi < modules.len(), {
+    m := match(
+      modules.get(mi),
+      .Some(x) => x,
+      .None => {
+        mi = (mi + usize(1));
+        continue;
+      }
+    );
+    (ti : usize) = usize(0);
+    while(ti < m.types.len(), {
+      match(
+        m.types.get(ti),
+        .Some(t) => {
+          score := _doc_type_doc_count(t);
+          if(score > usize(0), {
+            key := `${t.name}|${t.signature}`;
+            match(
+              d_keys.index_of(key.clone()),
+              // Keep the RICHEST donor, not the first one seen. A re-exporting
+              // module's own entry can carry a doc or two — `String` in
+              // `string/index` has `format`, inherited from the `Format` trait
+              // — and registering that would let it claim the key and block the
+              // declaring module's fully documented entry. Module walk order is
+              // not something to depend on either way.
+              .Some(di) => if(score > _doc_type_doc_count(match(d_types.get(di), .Some(x) => x, .None => t)), {
+                d_types(di) = t;
+              }),
+              .None => {
+                d_keys.push(key);
+                d_types.push(t);
+              }
+            );
+          });
+        },
+        .None => ()
+      );
+      ti = (ti + usize(1));
+    });
+    mi = (mi + usize(1));
+  });
+  // Recipients: every type missing documentation a donor can supply.
+  (mj : usize) = usize(0);
+  while(mj < modules.len(), {
+    m2 := match(
+      modules.get(mj),
+      .Some(x) => x,
+      .None => {
+        mj = (mj + usize(1));
+        continue;
+      }
+    );
+    (tj : usize) = usize(0);
+    while(tj < m2.types.len(), {
+      t2 := match(
+        m2.types.get(tj),
+        .Some(x) => x,
+        .None => {
+          tj = (tj + usize(1));
+          continue;
+        }
+      );
+      match(
+        d_keys.index_of(`${t2.name}|${t2.signature}`),
+        .Some(di) => match(
+          d_types.get(di),
+          .Some(donor) => {
+            // Methods, fields and variants live in ArrayLists, which are shared
+            // handles even through a struct copy — indexed assignment on them
+            // reaches the model.
+            _fill_doc_methods_from(t2, donor);
+            _fill_doc_fields_from(t2, donor);
+            _fill_doc_variants_from(t2, donor);
+            // The type's OWN doc is a value field, so it needs a rebuilt entry.
+            if(t2.doc.is_none() && donor.doc.is_some(), {
+              m2.types(tj) = DocType(
+                name : t2.name,
+                doc : donor.doc,
+                kind : t2.kind,
+                signature : t2.signature,
+                type_params : t2.type_params,
+                fields : t2.fields,
+                variants : t2.variants,
+                methods : t2.methods,
+                trait_impls : t2.trait_impls,
+                impls : t2.impls,
+                deprecated : match(t2.deprecated, .Some(d) => .Some(d), .None => donor.deprecated),
+                examples : match(t2.examples, .Some(e) => .Some(e), .None => donor.examples)
+              );
+            });
+          },
+          .None => ()
+        ),
+        .None => ()
+      );
+      tj = (tj + usize(1));
+    });
+    mj = (mj + usize(1));
+  });
+});
+/// How many documented items this type carries — its own doc, plus every
+/// method, field and variant that has one. Used to pick the richest donor for a
+/// given name+signature; `0` means it has nothing to give.
+_doc_type_doc_count :: (fn(t : DocType) -> usize)({
+  (n : usize) = usize(0);
+  if(t.doc.is_some(), {
+    n = (n + usize(1));
+  });
+  (i : usize) = usize(0);
+  while(i < t.methods.len(), {
+    match(
+      t.methods.get(i),
+      .Some(f) => if(f.doc.is_some(), {
+        n = (n + usize(1));
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  match(
+    t.fields,
+    .Some(fs) => {
+      (fi : usize) = usize(0);
+      while(fi < fs.len(), {
+        match(
+          fs.get(fi),
+          .Some(f2) => if(f2.doc.is_some(), {
+            n = (n + usize(1));
+          }),
+          .None => ()
+        );
+        fi = (fi + usize(1));
+      });
+    },
+    .None => ()
+  );
+  match(
+    t.variants,
+    .Some(vs) => {
+      (vi : usize) = usize(0);
+      while(vi < vs.len(), {
+        match(
+          vs.get(vi),
+          .Some(v) => if(v.doc.is_some(), {
+            n = (n + usize(1));
+          }),
+          .None => ()
+        );
+        vi = (vi + usize(1));
+      });
+    },
+    .None => ()
+  );
+  n
+});
+/// Per-name method doc fill-in, carrying the trait attribution with the text.
+_fill_doc_methods_from :: (fn(dst : DocType, src : DocType) -> unit)({
+  (i : usize) = usize(0);
+  while(i < dst.methods.len(), {
+    match(
+      dst.methods.get(i),
+      .Some(dm) => if(dm.doc.is_none(), {
+        (found : Option(String)) = Option(String).None;
+        (found_from : Option(String)) = Option(String).None;
+        (j : usize) = usize(0);
+        while(j < src.methods.len(), {
+          match(
+            src.methods.get(j),
+            .Some(sm) => if((sm.name == dm.name) && sm.doc.is_some(), {
+              found = sm.doc;
+              found_from = sm.inherited_from;
+              j = src.methods.len();
+            }),
+            .None => ()
+          );
+          j = (j + usize(1));
+        });
+        if(found.is_some(), {
+          dst.methods(i) = DocFunction(
+            name : dm.name,
+            doc : found,
+            signature : dm.signature,
+            parameters : dm.parameters,
+            return_type : dm.return_type,
+            type_params : dm.type_params,
+            effects : dm.effects,
+            is_method : dm.is_method,
+            self_type : dm.self_type,
+            returns : dm.returns,
+            errors : dm.errors,
+            deprecated : dm.deprecated,
+            examples : dm.examples,
+            inherited_from : match(dm.inherited_from, .Some(x) => .Some(x), .None => found_from)
+          );
+        });
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+});
+/// Per-name field doc fill-in (structs).
+_fill_doc_fields_from :: (fn(dst : DocType, src : DocType) -> unit)({
+  dfs := match(dst.fields, .Some(x) => x, .None => return(()));
+  sfs := match(src.fields, .Some(x) => x, .None => return(()));
+  (i : usize) = usize(0);
+  while(i < dfs.len(), {
+    match(
+      dfs.get(i),
+      .Some(df) => if(df.doc.is_none(), {
+        (j : usize) = usize(0);
+        while(j < sfs.len(), {
+          match(
+            sfs.get(j),
+            .Some(sf) => if((sf.name == df.name) && sf.doc.is_some(), {
+              dfs(i) = DocField(name : df.name, type_ : df.type_, doc : sf.doc, default_value : df.default_value);
+              j = sfs.len();
+            }),
+            .None => ()
+          );
+          j = (j + usize(1));
+        });
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+});
+/// Per-name variant doc fill-in (enums).
+_fill_doc_variants_from :: (fn(dst : DocType, src : DocType) -> unit)({
+  dvs := match(dst.variants, .Some(x) => x, .None => return(()));
+  svs := match(src.variants, .Some(x) => x, .None => return(()));
+  (i : usize) = usize(0);
+  while(i < dvs.len(), {
+    match(
+      dvs.get(i),
+      .Some(dv) => if(dv.doc.is_none(), {
+        (j : usize) = usize(0);
+        while(j < svs.len(), {
+          match(
+            svs.get(j),
+            .Some(sv) => if((sv.name == dv.name) && sv.doc.is_some(), {
+              dvs(i) = DocVariant(name : dv.name, fields : dv.fields, doc : sv.doc, discriminant : dv.discriminant);
+              j = svs.len();
+            }),
+            .None => ()
+          );
+          j = (j + usize(1));
+        });
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
 });
 /// Give every undocumented trait-impl method the TRAIT's documentation.
 ///

--- a/tests/internal/doc_reexport_docs.test.yo
+++ b/tests/internal/doc_reexport_docs.test.yo
@@ -1,0 +1,151 @@
+/// Tests for `_fill_re_exported_docs` — a re-exported declaration must carry
+/// the documentation of the module that DECLARES it.
+///
+/// Each module is documented from its own file's tokens, so a type declared in
+/// `foo/thing.yo` and re-exported by `foo/index.yo` used to render bare under
+/// the module a reader actually opens: no type doc, and no doc on any method.
+/// `std/` is organised that way throughout, which is why `yo doc ./std`
+/// reported 1554 of 3345 members undocumented while the source carries a `///`
+/// on nearly all of them
+/// (issues/fixed/yo-doc-drops-every-doc-comment-of-a-re-exported-type.md).
+{ String } :: import("std/string");
+{ ArrayList } :: import("std/collections/array_list");
+{ assert } :: import("std/assert");
+{
+  DocParam,
+  DocField,
+  DocVariant,
+  DocImpl,
+  DocFunction,
+  DocType,
+  DocTrait,
+  DocConstant,
+  DocModule
+} :: import("../../src/doc/model.yo");
+{ DocItemKind } :: import("../../src/doc/model.yo");
+{ build_cross_references } :: import("../../src/doc/builder.yo");
+/// A method entry, documented or bare.
+_method :: (fn(name : String, doc : Option(String)) -> DocFunction)(
+  DocFunction(
+    name : name,
+    doc : doc,
+    signature : `${name} :: (fn() -> i32)`,
+    parameters : ArrayList(DocParam).new(),
+    return_type : `i32`,
+    type_params : Option(ArrayList(DocParam)).None,
+    effects : Option(ArrayList(DocParam)).None,
+    is_method : true,
+    self_type : Option(String).Some(`Point`),
+    returns : Option(String).None,
+    errors : Option(String).None,
+    deprecated : Option(String).None,
+    examples : Option(String).None,
+    inherited_from : Option(String).None
+  )
+);
+/// A `Point` entry. `documented` decides whether this is the declaring
+/// module's copy or the bare re-export.
+_point :: (fn(documented : bool, signature : String) -> DocType)({
+  fields := ArrayList(DocField).new();
+  fields.push(
+    DocField(
+      name : `x`,
+      type_ : `i32`,
+      doc : if(documented, Option(String).Some(`The x coordinate.`), Option(String).None),
+      default_value : Option(String).None
+    )
+  );
+  methods := ArrayList(DocFunction).new();
+  methods.push(
+    _method(`origin`, if(documented, Option(String).Some(`Make a point at the origin.`), Option(String).None))
+  );
+  DocType(
+    name : `Point`,
+    doc : if(documented, Option(String).Some(`A point in the plane.`), Option(String).None),
+    kind : DocItemKind.Struct,
+    signature : signature,
+    type_params : Option(ArrayList(DocParam)).None,
+    fields : Option(ArrayList(DocField)).Some(fields),
+    variants : Option(ArrayList(DocVariant)).None,
+    methods : methods,
+    trait_impls : ArrayList(String).new(),
+    impls : Option(ArrayList(DocImpl)).None,
+    deprecated : Option(String).None,
+    examples : Option(String).None
+  )
+});
+_module_with :: (fn(name : String, t : DocType) -> DocModule)({
+  types := ArrayList(DocType).new();
+  types.push(t);
+  DocModule(
+    name : name,
+    path : name,
+    doc : Option(String).None,
+    stability : Option(String).None,
+    functions : ArrayList(DocFunction).new(),
+    types : types,
+    traits : ArrayList(DocTrait).new(),
+    constants : ArrayList(DocConstant).new(),
+    submodules : ArrayList(Box(DocModule)).new()
+  )
+});
+test("a re-exported type takes the declaring module's documentation", {
+  sig := `Point :: struct(x : i32, y : i32)`;
+  modules := ArrayList(DocModule).new();
+  // The re-exporting module is FIRST on purpose: the pass must not depend on
+  // walk order, and must not let the bare entry claim the donor slot.
+  modules.push(_module_with(`index`, _point(false, sig.clone())));
+  modules.push(_module_with(`point`, _point(true, sig.clone())));
+  build_cross_references(modules);
+  idx := match(modules.get(usize(0)), .Some(m) => m, .None => return(()));
+  t := match(idx.types.get(usize(0)), .Some(x) => x, .None => return(()));
+  assert(
+    match(t.doc, .Some(d) => (d == `A point in the plane.`), .None => false),
+    "the re-exported type carries the declaration's own doc"
+  );
+  m0 := match(t.methods.get(usize(0)), .Some(x) => x, .None => return(()));
+  assert(
+    match(m0.doc, .Some(d) => (d == `Make a point at the origin.`), .None => false),
+    "and so does its method"
+  );
+  fs := match(t.fields, .Some(x) => x, .None => return(()));
+  f0 := match(fs.get(usize(0)), .Some(x) => x, .None => return(()));
+  assert(
+    match(f0.doc, .Some(d) => (d == `The x coordinate.`), .None => false),
+    "and its field"
+  );
+});
+test("a DIFFERENT type of the same name is not a donor", {
+  // Same name, different declaration — the signatures differ, so nothing is
+  // copied. This is what keeps `std/`'s several same-named types apart.
+  modules := ArrayList(DocModule).new();
+  modules.push(_module_with(`index`, _point(false, `Point :: struct(x : i32, y : i32)`)));
+  modules.push(_module_with(`other`, _point(true, `Point :: struct(lat : f64, lon : f64)`)));
+  build_cross_references(modules);
+  idx := match(modules.get(usize(0)), .Some(m) => m, .None => return(()));
+  t := match(idx.types.get(usize(0)), .Some(x) => x, .None => return(()));
+  assert(t.doc.is_none(), "no doc is taken from a type that merely shares the name");
+  m0 := match(t.methods.get(usize(0)), .Some(x) => x, .None => return(()));
+  assert(m0.doc.is_none(), "and none on its methods");
+});
+test("a module that documents its own re-export keeps what it wrote", {
+  sig := `Point :: struct(x : i32, y : i32)`;
+  own := _point(false, sig.clone());
+  own.doc = Option(String).Some(`Re-exported here with a note of its own.`);
+  modules := ArrayList(DocModule).new();
+  modules.push(_module_with(`index`, own));
+  modules.push(_module_with(`point`, _point(true, sig.clone())));
+  build_cross_references(modules);
+  idx := match(modules.get(usize(0)), .Some(m) => m, .None => return(()));
+  t := match(idx.types.get(usize(0)), .Some(x) => x, .None => return(()));
+  assert(
+    match(t.doc, .Some(d) => (d == `Re-exported here with a note of its own.`), .None => false),
+    "an existing doc is never overwritten"
+  );
+  // The bare method still fills in — only `.None` is touched.
+  m0 := match(t.methods.get(usize(0)), .Some(x) => x, .None => return(()));
+  assert(
+    match(m0.doc, .Some(d) => (d == `Make a point at the origin.`), .None => false),
+    "while its undocumented method still fills in"
+  );
+});


### PR DESCRIPTION
Found while re-measuring the campaign's doc-coverage row after #579's trait-doc inheritance landed — then fixed.

## The bug

Each module is documented from its OWN file's tokens, so a type declared in `foo/thing.yo` and re-exported by `foo/index.yo` rendered **bare** under the module a reader actually opens — no type doc, and no doc on any method, field or variant:

```
=== module point          (declares it)          === module index   (re-exports it)
  type Point doc='A point in the plane.'           type Point doc=None
    method origin   doc='Make a point at…'           method origin   doc=None
    method double_x doc='The x coordinate…'          method double_x doc=None
```

`std/` is organised that way throughout. `yo doc ./std --format json` reported **1554 of 3345** members undocumented while the source carries a `///` on nearly all of them. The tell: on `String` the only documented method was `format`, and it had a doc only because #579 inherits it from the `Format` **trait**.

## The fix

`_fill_re_exported_docs` runs beside the trait-doc inheritance pass once every module is built: a type missing documentation takes it from another module's type with the same **name AND signature**. A genuine re-export is the same declaration, so its signature matches by construction, while two distinct types sharing a name differ in theirs — which keeps `std/`'s several same-named types apart. Only `.None` is filled.

Chosen over the token-plumbing alternative (threading a cross-file map through the ~12 name-keyed `doc_lookup.get` sites) because a naive merge there collides — `new` is declared in dozens of files.

Two details each cost a measurement:

- **Write back by INDEX.** `DocType`/`DocFunction` are value structs, so mutating a `.get()` result changes a copy and is silently lost. The pass rebuilds each entry, as `_inherit_trait_method_docs` does.
- **Keep the RICHEST donor, not the first.** A re-exporting module's own entry can carry a doc or two — `String` in `string/index` has the inherited `format` — and first-wins let that claim the key and block the declaring module's full entry. First-wins only reached 1414; scoring donors by documented-member count reached 1293.

## Measured

| | before | after |
| --- | --- | --- |
| `std/` undocumented (of 3345) | 1554 | **1293** |
| `String` undocumented methods | 115 | 21 |
| `string/index` | 275 | 153 |

What remains is a **different class**, and is recorded as such rather than folded into this number: trait-impl methods the inheritance pass is not reaching (`next`/`map`/`filter` from `Iterator`, `==`/`cmp`, `to_string`) and ~304 `libc/*` externs with no comment at all. Follow-up, not this bug.

## Verified

- The two-file reproducer renders identically under both modules.
- `tests/internal/doc_reexport_docs.test.yo` **3/3** — the fill-in, that a same-named **different** type is not a donor, and that an existing doc is never overwritten.
- `doc_render_markdown` 26/26, `doc_stability` 7/7, doc cli-cases **PASS 3 / GOLDEN-DIFF 0**.
- `yo check ./src` 270/270, `fmt --check` clean.

Includes the plan correction: `plans/STD_API_STABILIZATION.md`'s docs row cited "479 undocumented" from a source grep, which is not what readers get. It now records both numbers and which one counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)