### PR TITLE
async: JoinHandle.abort cancels the I/O the task is suspended in

### DIFF
--- a/.github/instructions/c-codegen.instructions.md
+++ b/.github/instructions/c-codegen.instructions.md
@@ -504,8 +504,25 @@ See `docs/en-US/ALGEBRAIC_EFFECTS.md` (§ Handler Functions Are Not Closures) fo
 The inline header struct assumes the standard state machine layout:
 
 ```c
-struct { __yo_ref_header_t header; int state; T result; void (*continuation_fn)(void*); void* continuation_sm; void (*__yo_resume_fn)(void*); };
+struct { __yo_ref_header_t header; int state; void (*cancel_pending_fn)(void*); T result; void (*continuation_fn)(void*); void* continuation_sm; void (*__yo_resume_fn)(void*); };
 ```
+
+**That prefix is an ABI, spelled in five places, and they must agree.**
+`__yo_ref_header_t header; int state; void (*cancel_pending_fn)(void*);` is
+the part `JoinHandle`'s type-erased helpers cast to
+(`__yo_spawned_future_header_t` in `src/codegen/async/runtime_core.yo`), so
+`result` — whose type and therefore size varies per future — may never move
+ahead of it. The five emitters are: the async-block struct and the
+sync-closure future struct (`src/codegen/exprs/async.yo`), the generic
+Future-trait interface (`src/codegen/types/generation.yo`), this inline
+`JoinHandle.await` header (`src/codegen/exprs/await.yo`), and the runtime
+header itself. Adding a field to the prefix means editing all five.
+
+`cancel_pending_fn` is how `abort()` reaches the suspension: codegen emits one
+per async block beside the resume function, and it cancels the I/O operation
+the task is parked in (`__yo_async_io_cancel`, `cancel_fn` on
+`__yo_io_future_t`) rather than waiting for that operation to complete —
+`issues/fixed/timeout-deadline-timer-future-leak.md`.
 
 For `Option(unit)` return types, the `.Some` variant has no data field — only the tag is set.
 

--- a/issues/fixed/timeout-deadline-timer-future-leak.md
+++ b/issues/fixed/timeout-deadline-timer-future-leak.md
@@ -6,7 +6,7 @@ row. `std/async/index.yo:124-127` already documents this residual and cites
 exist (`find . -name 'timeout-deadline-timer-future-leak.md'` returned
 nothing, and the only occurrence of the string in the tree was the citation
 itself). **Class**: unbounded-until-deadline memory retention on a shipped std
-API. **Status**: OPEN.
+API. **Status**: FIXED 2026-09-11 — see "Resolution" at the end.
 
 The module doc's wording is also wrong in a way that matters: it says the
 future struct "is never reclaimed". Measured below, it **is** reclaimed — but
@@ -180,3 +180,67 @@ table above rather than by an assertion:
 - Whatever `cancel_pending_fn` is added by fix (2) also needs the general
   case: a task suspended on a `sleep` far in the future, aborted, and the
   program exits immediately — verified through the same repro harness.
+
+
+## Resolution (2026-09-11)
+
+Fixed as the fix section prescribes: `abort()` now takes the I/O registration
+back instead of leaving it armed. Measured on the reproducer below, 800
+in-time calls against a 9 s deadline, aarch64-apple-darwin, both binaries from
+the same source:
+
+| | live allocations at exit | bytes |
+| --- | --- | --- |
+| before | 3387 | 233 KB |
+| after | 187 | 33 KB |
+
+187 is the 0-call baseline, so the per-call retention is gone, not reduced.
+
+**What landed.**
+
+1. **`cancel_fn` on `__yo_io_future_t`** (`codegen/types/generation.yo`) — a
+   per-operation hook the `*_start` function fills in, returning `true` only
+   when the backend is certain no completion will be delivered. `NULL` means
+   "this operation has no cancel path", which is every operation except the
+   timer today: those keep the old lazy release, so nothing regresses while
+   the rest are written.
+2. **`__yo_async_io_cancel`** (`codegen/async/runtime_core.yo`) — the
+   arbitration. It cancels only a future that is still pending AND whose
+   continuation registration this call takes (`atomic_exchange`), so a
+   completion already in flight keeps ownership of the wake and the eager path
+   stands down; a backend that refuses puts the continuation back.
+3. **Timer cancel on all four backends.** macOS keeps the kqueue ident and the
+   udata context in a new `__yo_timer_future_t` and issues `EV_DELETE`
+   (`ENOENT` — the one-shot already delivered — is a refusal, not a cancel).
+   Linux submits an `IORING_OP_ASYNC_CANCEL` SQE with NULL user data, so the
+   timerfd read reports `-ECANCELED` on the next poll and releases the ring's
+   reference there; the CQE path learned to skip a NULL-user-data completion.
+   Windows and wasm unlink the entry from their sorted timer queues.
+4. **`cancel_pending_fn` on the spawned-future header** — abort is type-erased
+   through `JoinHandle.__future`, so the hook has to live at a fixed offset in
+   every future struct (right after `state`; the five emitters that spell that
+   prefix now all carry it). Codegen emits one per async block beside the
+   resume function: it cancels whichever `await_future_N` slot holds a live
+   cancellable I/O future, drops that slot and the task's own reference — the
+   same work the resume function's aborted-entry guard does lazily, which
+   stays as the fallback. Dispatch-mode slots are excluded: they are declared
+   type-erased precisely because sibling branches store differently-shaped
+   futures there, so what is in one at abort time is not decidable.
+5. **The doc correction** (item 3 of the fix) — `std/async/index.yo` and
+   `JoinHandle.abort`'s doc comment in `std/prelude.yo` now describe
+   cancellation, not retention.
+
+**Regression cover.** `tests/async/join_handle.test.yo` — "abort cancels the
+pending timer and releases the task": a task parked on a 30 s sleep, captured
+value with a `Dispose` counter, aborted; the counter must read 1 immediately
+(verified RED on the pre-fix compiler, GREEN after — CI runs with
+`detect_leaks=0`, so a Dispose counter is the only observable for this class).
+`tests/async/combinators.test.yo` — "timeout in a loop against a long
+deadline": 200 in-time calls against a 60 s limit, the behavioural companion
+to the allocation count above.
+
+**Still open, deliberately.** Only timers have a `cancel_fn`. A task aborted
+while parked on a socket read, a `getaddrinfo`, or a waker still holds that
+operation until it completes on its own. The mechanism is now in place for
+each of them; `plans/WAKER_BASED_SCHEDULING.md` step 5 is where the rest
+belongs.

--- a/issues/repros/timeout-deadline-timer-retained.yo
+++ b/issues/repros/timeout-deadline-timer-retained.yo
@@ -1,0 +1,42 @@
+//! Reproducer for issues/fixed/timeout-deadline-timer-future-leak.md — every
+//! in-time `timeout` call used to leave its deadline timer armed for the whole
+//! remaining deadline, retaining exactly 4 allocations / 256 bytes per call.
+//!
+//! Measure (aarch64-apple-darwin):
+//!
+//!   yo compile issues/repros/timeout-deadline-timer-retained.yo \
+//!     --optimize 2 --allocator system --std-path ./std -o /tmp/r4.out
+//!   leaks --atExit -- /tmp/r4.out
+//!
+//! BEFORE the I/O cancel path: live allocations scale with the loop count —
+//! 186 at 0 calls, 387 at 50, 987 at 200, 3387 at 800 (233 KB).
+//! AFTER: 187 nodes / 33 KB at 800 calls — the baseline, flat whatever the
+//! loop count, because `timeout`'s `dh.abort()` now deregisters the armed
+//! timer. Measured 2026-09-11 on aarch64-apple-darwin, both binaries built
+//! from the same source with the seed (0.2.30) and with the fix in place.
+//! (`leaks` reports the same pre-existing 1 leak / 32 bytes either way.)
+//! `leaks` never FLAGS these (they stay reachable from the state-machine
+//! graph), so the count, not the leak verdict, is the measurement.
+pragma(Pragma.AllowUnsafe);
+{ println } :: import("std/fmt");
+{ timeout } :: import("std/async");
+{ assert } :: import("std/assert");
+{ Duration } :: import("std/time/duration");
+{ sleep } :: import("std/sys/timer");
+fast :: (fn(io : Io) -> Impl(Future(i32, Io)))(
+  io.async((io : Io) => {
+    io.await(sleep(u64(1)), io);
+    return(i32(7));
+  })
+);
+main :: (fn(io : Io) -> unit)({
+  n := u64(0);
+  while(n < u64(800), n = (n + u64(1)), {
+    h := io.spawn(fast(io), io);
+    // Always wins: ~1 ms of work against a 9 s deadline.
+    r := timeout(h, Duration.from_millis(i64(9000)), io);
+    assert(match(r, .Ok(v) => (v == i32(7)), .Err(_) => false), "in-time");
+  });
+  println("done");
+});
+export(main);

--- a/plans/WAKER_BASED_SCHEDULING.md
+++ b/plans/WAKER_BASED_SCHEDULING.md
@@ -12,7 +12,7 @@ them.
 | 2. `yield` over `park` | **SEED-GATED.** `yield_now` is the fast form and is landed; `yield` itself cannot point at it until the seed ships `__yo_async_yield_start`, because `yield` is on the compiler's own import path (through `std/fs/watch`) and the seed emits a runtime without that symbol, so the compiler fails to LINK. Moves in the release after the one that ships this runtime |
 | 3a. `Mutex` over a waiter queue | **LANDED** (#576) — `std/async/mutex.yo` holds an `ArrayList(Waker)`, `unlock` wakes the FRONT waiter, and `waiter_count()` is the oracle the FIFO test reads |
 | 3b. `Channel` over the same queue | **LANDED** (#586) — `send`/`recv` park on a waiter queue instead of re-checking on a 1 ms timer tick. It was blocked for a day by a compiler defect that the rewrite surfaced: the trace collector tried to monomorphize a GENERIC `ArrayList(T)` instance that only this shape put in the codegen type registry, and failed inside `array_list.yo`'s `Trace` body — a file the rewrite never touched (`issues/fixed/a-generic-instance-in-the-type-registry-breaks-trace-monomorphization.md`) |
-| 4. The combinators (`race`/`any`/`timeout`) | open |
+| 4. The combinators (`race`/`any`/`timeout`) | **PARTLY LANDED.** `timeout`'s retention is CLOSED: `abort()` now cancels the operation the task is suspended in, so the deadline timer is deregistered the moment the task wins instead of staying armed for the rest of the limit (`issues/fixed/timeout-deadline-timer-future-leak.md`). What remains is the polling SHAPE — `race`/`any` still re-check `is_finished()` around `__yo_async_poll_step()`; parking them on a wake needs a completion-notification list on `JoinHandle`, which is step 5's machinery |
 | 5. Cross-thread wake + `spawn_blocking` | open |
 
 **Two codegen bugs fell out of this campaign, both fixed.**
@@ -156,11 +156,17 @@ markers say the NAMES are stable and the MECHANISM is not.
   ([[yo-linux-loop-stays-alive-on-parked-accept]],
   [[yo-linux-only-hang-debug-via-temp-workflow]]). Every waiter list needs a
   test that wakes N waiters from one signal and asserts all N ran.
-- **`timeout`'s known residual.** `std/async/index.yo` documents that a
-  completed-before-deadline task leaves its deadline timer armed and its
-  future struct unreclaimed (`issues/timeout-deadline-timer-future-leak.md`).
-  Waker-based `timeout` should CLOSE that rather than inherit it — the
-  deadline becomes a wake to cancel, not a task to outlive.
+- **`timeout`'s known residual — CLOSED 2026-09-11.** `std/async/index.yo`
+  documented that a completed-before-deadline task left its deadline timer
+  armed and its future struct retained
+  (`issues/fixed/timeout-deadline-timer-future-leak.md`). The deadline is
+  still a task, but `abort()` is no longer only a state word: the I/O future
+  carries a `cancel_fn` the backend fills in, `__yo_async_io_cancel` takes the
+  registration back, and a per-async-block `cancel_pending_fn` on the spawned
+  future header does eagerly what the resume function's aborted-entry guard
+  did lazily. Timers on all four backends have a cancel path; every other
+  operation keeps the lazy path until one is written for it, which is the
+  natural home for `spawn_blocking`'s cancellation story in step 5.
 
 ## Acceptance for the whole change
 

--- a/src/codegen/async/runtime_core.yo
+++ b/src/codegen/async/runtime_core.yo
@@ -572,11 +572,57 @@ static void __yo_async_report_wake_deadlock(void) {
   fflush(stderr);
 }
 
+// ============================================================================
+// I/O cancellation — release what a suspended task is waiting on
+// ============================================================================
+// abort() marks a task Aborted, but the operation it is suspended IN stays
+// registered with the backend: the timer keeps counting down, and everything
+// it holds (the operation's future, the task's state machine, its captures)
+// is retained until that operation completes on its own. For a timeout that
+// the task wins, that is the whole remaining deadline
+// (issues/fixed/timeout-deadline-timer-future-leak.md).
+//
+// This is the prompt path: deregister the operation so no completion is ever
+// delivered, and hand the caller ownership of both the future and the task.
+// It returns true ONLY when the backend confirms the registration is gone AND
+// this call took the continuation — i.e. nothing can resume the task any
+// more. Every other case returns false having changed nothing, and the resume
+// function's aborted-entry guard stays the fallback: the operation completes
+// as it always did and releases the task then.
+static bool __yo_async_io_cancel(void* p) {
+  if (!p) {
+    return false;
+  }
+  __yo_io_future_t* f = (__yo_io_future_t*)p;
+  if (atomic_load(&f->state) != 0) {
+    return false;  // already terminal: the completion path owns the wake
+  }
+  if (!f->cancel_fn) {
+    return false;  // this operation has no cancel path
+  }
+  void (*cont)(void*) = atomic_exchange(&f->continuation_fn, NULL);
+  if (!cont) {
+    return false;  // nobody is suspended on it
+  }
+  if (!f->cancel_fn(f)) {
+    atomic_store(&f->continuation_fn, cont);  // backend refused — put it back
+    return false;
+  }
+  atomic_store(&f->continuation_sm, NULL);
+  atomic_store(&f->state, -2);
+  return true;
+}
+
 // JoinHandle introspection/cancellation — every spawned future starts with
 // this common header (the same layout JoinHandle.await casts to).
 typedef struct {
   __yo_ref_header_t header;
   int state;
+  // Per-async-block hook: cancel the I/O operation the task is suspended in
+  // and release the suspension's references. Emitted beside the resume
+  // function, which knows which fields are await slots; NULL for a future
+  // with no await slot to cancel.
+  void (*cancel_pending_fn)(void*);
 } __yo_spawned_future_header_t;
 
 // Non-blocking FutureState read: positive step indices read as Running (1),
@@ -594,6 +640,12 @@ static void __yo_join_handle_abort_raw(void* fut) {
   __yo_spawned_future_header_t* h = (__yo_spawned_future_header_t*)fut;
   if (h->state >= 0) {
     h->state = -2;
+    // Prompt cancellation: give back what the task was waiting on instead of
+    // outliving it. The hook may drop the task's last suspension reference,
+    // so nothing may touch h afterwards.
+    if (h->cancel_pending_fn) {
+      h->cancel_pending_fn(fut);
+    }
   }
 }`
   );

--- a/src/codegen/async/runtime_io_common.yo
+++ b/src/codegen/async/runtime_io_common.yo
@@ -675,6 +675,14 @@ static void __yo_timer_future_dispose(void* ptr) {
 // box gets undefined symbols instead of the documented graceful degradation.
 // See issues/liburing-fallback-does-not-compile.md.
 #ifdef __YO_HAS_LIBURING
+// Cancel a pending timerfd read. The kernel still delivers the read's own CQE
+// (with -ECANCELED), and that is what releases the ring's reference and frees
+// the timerfd through the dispose hook — so the retention window becomes one
+// poll turn instead of the whole remaining deadline.
+static bool __yo_timer_future_cancel(__yo_io_future_t* future) {
+  return __yo_io_ring_submit_cancel(future);
+}
+
 static __yo_io_future_t* __yo_async_sleep_start(uint64_t milliseconds) {
   __yo_io_init();
   
@@ -731,6 +739,7 @@ ${timer_dispose_init}
   timer_future->read_buf = buf;
   io_uring_prep_read(sqe, tfd, buf, sizeof(uint64_t), 0);
   io_uring_sqe_set_data(sqe, future);
+  future->cancel_fn = __yo_timer_future_cancel;
   __yo_io_ring_submit(future);
   
   ASYNC_DEBUG("[TIMER] Started async sleep: %llu ms (pending=%zu)\\n",
@@ -775,12 +784,47 @@ typedef struct __yo_timer_ctx_t {
   __yo_io_future_t* future;
 } __yo_timer_ctx_t;
 
+// Extended future for a timer: keeps the kqueue ident and the udata context,
+// which is what a cancel needs to name the registration. Before this the
+// ident was a local discarded as soon as EV_SET was issued, so an aborted
+// sleep could only be released by letting it fire
+// (issues/fixed/timeout-deadline-timer-future-leak.md).
+typedef struct {
+  __yo_io_future_t base;
+  uintptr_t timer_id;
+  __yo_timer_ctx_t* ctx;
+} __yo_timer_future_t;
+
+// Deregister the one-shot timer. EV_DELETE destroys the knote, so no event is
+// delivered for it afterwards and this path owns the context and the pending
+// count — exactly what __yo_io_process_event would otherwise have done. A
+// timer that already fired is gone from the kqueue (EV_ONESHOT deletes on
+// delivery), so kevent reports ENOENT: refuse, and let the delivered event
+// take its normal course.
+static bool __yo_timer_future_cancel(__yo_io_future_t* future) {
+  __yo_timer_future_t* tf = (__yo_timer_future_t*)future;
+  struct kevent ev;
+  EV_SET(&ev, tf->timer_id, EVFILT_TIMER, EV_DELETE, 0, 0, NULL);
+  if (kevent(__yo_io_kq, &ev, 1, NULL, 0, NULL) < 0) {
+    ASYNC_DEBUG("[TIMER] Cancel found no registration: errno=%d\\n", errno);
+    return false;
+  }
+  if (tf->ctx) {
+    __yo_free(tf->ctx);
+    tf->ctx = NULL;
+  }
+  __yo_pending_io_count--;
+  ASYNC_DEBUG("[TIMER] Cancelled timer (pending=%zu)\\n", __yo_pending_io_count);
+  return true;
+}
+
 // macOS timer using kqueue EVFILT_TIMER
 static __yo_io_future_t* __yo_async_sleep_start(uint64_t milliseconds) {
   __yo_io_init();
   
-  __yo_io_future_t* future = (__yo_io_future_t*)__yo_rc_alloc(sizeof(__yo_io_future_t));
-  memset(future, 0, sizeof(__yo_io_future_t));
+  __yo_timer_future_t* timer_future = (__yo_timer_future_t*)__yo_rc_alloc(sizeof(__yo_timer_future_t));
+  memset(timer_future, 0, sizeof(__yo_timer_future_t));
+  __yo_io_future_t* future = &timer_future->base;
   
   future->header.ref_count = 1;
   atomic_init(&future->state, 0);
@@ -792,17 +836,21 @@ static __yo_io_future_t* __yo_async_sleep_start(uint64_t milliseconds) {
   ctx->future = future;
   
   uintptr_t timer_id = __yo_timer_next_id++;
+  timer_future->timer_id = timer_id;
+  timer_future->ctx = ctx;
   
   struct kevent ev;
   EV_SET(&ev, timer_id, EVFILT_TIMER, EV_ADD | EV_ONESHOT, NOTE_USECONDS, (intptr_t)(milliseconds * 1000), (void*)ctx);
   if (kevent(__yo_io_kq, &ev, 1, NULL, 0, NULL) < 0) {
     future->result = -errno;
     atomic_store(&future->state, -1);
+    timer_future->ctx = NULL;
     __yo_free(ctx);
     ASYNC_DEBUG("[TIMER] Failed to register timer: errno=%d\\n", errno);
     return future;
   }
   
+  future->cancel_fn = __yo_timer_future_cancel;
   __yo_pending_io_count++;
   
   ASYNC_DEBUG("[TIMER] Started async sleep: %llu ms (pending=%zu)\\n",
@@ -829,6 +877,7 @@ static __yo_io_future_t* __yo_async_sleep_start(uint64_t milliseconds) {
 
 static void __yo_io_init(void);
 static void __yo_win_timer_add(__yo_io_future_t* future, uint64_t milliseconds);
+static bool __yo_win_timer_cancel(__yo_io_future_t* future);
 
 static __yo_io_future_t* __yo_async_sleep_start(uint64_t milliseconds) {
   __yo_io_init();
@@ -841,6 +890,7 @@ static __yo_io_future_t* __yo_async_sleep_start(uint64_t milliseconds) {
   atomic_init(&future->continuation_fn, NULL);
   atomic_init(&future->continuation_sm, NULL);
 
+  future->cancel_fn = __yo_win_timer_cancel;
   __yo_win_timer_add(future, milliseconds);
   
   ASYNC_DEBUG("[TIMER] Started async sleep: %llu ms\\n", (unsigned long long)milliseconds);

--- a/src/codegen/async/runtime_io_linux.yo
+++ b/src/codegen/async/runtime_io_linux.yo
@@ -596,6 +596,7 @@ static void __yo_io_cleanup(void) {
     __yo_io_future_t* future = __yo_sq_deferred_futures[__yo_sq_deferred_head];
     __yo_sq_deferred_head = (__yo_sq_deferred_head + 1) % __YO_IO_RING_ENTRIES;
     __yo_sq_unsubmitted--;
+    if (!future) continue;  // a cancellation SQE: no future, no pending slot
     __yo_pending_io_count--;
     future->result = -ECANCELED;
     future->state = -1;
@@ -624,6 +625,23 @@ static inline void __yo_io_ring_submit(__yo_io_future_t* future) {
   __yo_sq_unsubmitted++;
 }
 
+// Ask the kernel to cancel the operation submitted with target as its user
+// data. The cancellation SQE carries NULL user data (it is not an operation a
+// task awaits) and does NOT take a pending-I/O slot: the operation it cancels
+// still owns one, and still delivers its own CQE — with -ECANCELED — which is
+// what releases the ring's reference. Returns false when no SQE is available,
+// leaving the operation registered.
+static inline bool __yo_io_ring_submit_cancel(__yo_io_future_t* target) {
+  if (__yo_sq_unsubmitted >= __YO_IO_RING_ENTRIES) return false;
+  struct io_uring_sqe* sqe = io_uring_get_sqe(&__yo_io_ring);
+  if (!sqe) return false;
+  io_uring_prep_cancel(sqe, (void*)target, 0);
+  io_uring_sqe_set_data(sqe, NULL);
+  __yo_sq_deferred_futures[(__yo_sq_deferred_head + __yo_sq_unsubmitted) % __YO_IO_RING_ENTRIES] = NULL;
+  __yo_sq_unsubmitted++;
+  return true;
+}
+
 // Flush any queued SQEs to the kernel if non-empty. Returns the liburing result.
 // On failure (ret < 0), the SQEs remain in the SQ ring so __yo_sq_unsubmitted
 // is left unchanged -- the next submit attempt (via poll/wait) will retry them.
@@ -649,6 +667,13 @@ static inline int __yo_io_flush_sq(void) {
 // The future pointer is stored directly in the SQE user data
 static void __yo_io_process_cqe(struct io_uring_cqe* cqe) {
   __yo_io_future_t* future = (__yo_io_future_t*)io_uring_cqe_get_data(cqe);
+  if (!future) {
+    // Completion of a cancellation SQE (__yo_io_ring_submit_cancel): it owns
+    // no future and no pending-I/O slot. The cancelled operation reports
+    // separately, through its own CQE.
+    io_uring_cqe_seen(&__yo_io_ring, cqe);
+    return;
+  }
   __yo_pending_io_count--;
 
   // Set the result

--- a/src/codegen/async/runtime_io_macos.yo
+++ b/src/codegen/async/runtime_io_macos.yo
@@ -747,6 +747,9 @@ static void __yo_io_process_event(struct kevent* ev) {
     typedef struct { __yo_io_future_t* future; } __yo_timer_ctx_t;
     __yo_timer_ctx_t* ctx = (__yo_timer_ctx_t*)ev->udata;
     ctx->future->result = (int32_t)sizeof(uint64_t);  // Match timerfd read size on Linux
+    // Delivery destroys the one-shot registration and frees the context
+    // below, so the future is no longer cancellable.
+    ctx->future->cancel_fn = NULL;
     __yo_pending_io_count--;
     __yo_io_wake_continuation(ctx->future);
     __yo_free(ctx);

--- a/src/codegen/async/runtime_io_wasm.yo
+++ b/src/codegen/async/runtime_io_wasm.yo
@@ -430,6 +430,24 @@ static void __yo_wasm_timer_add(__yo_io_future_t* future, uint64_t milliseconds)
   cur->next = node;
 }
 
+// Drop a pending timer from the queue. The list is the whole registration, so
+// unlinking it is a complete cancellation: nothing will ever fire for this
+// future, and this path owns the node and the pending count.
+static bool __yo_wasm_timer_cancel(__yo_io_future_t* future) {
+  __yo_wasm_timer_entry_t** link = &__yo_wasm_timer_head;
+  while (*link) {
+    if ((*link)->future == future) {
+      __yo_wasm_timer_entry_t* node = *link;
+      *link = node->next;
+      __yo_free(node);
+      __yo_pending_io_count--;
+      return true;
+    }
+    link = &(*link)->next;
+  }
+  return false;
+}
+
 // Process all timers that are due
 static int __yo_wasm_timer_process_due(uint64_t now_ms) {
   int fired = 0;
@@ -707,6 +725,7 @@ static __yo_io_future_t* __yo_async_sleep_start(uint64_t milliseconds) {
   atomic_init(&future->continuation_fn, NULL);
   atomic_init(&future->continuation_sm, NULL);
 
+  future->cancel_fn = __yo_wasm_timer_cancel;
   __yo_wasm_timer_add(future, milliseconds);
 
   return future;

--- a/src/codegen/async/runtime_io_windows.yo
+++ b/src/codegen/async/runtime_io_windows.yo
@@ -2192,6 +2192,24 @@ static void __yo_win_timer_add(__yo_io_future_t* future, uint64_t milliseconds) 
   cur->next = node;
 }
 
+// Drop a pending timer from the queue. The list is the whole registration, so
+// unlinking it is a complete cancellation: nothing will ever fire for this
+// future, and this path owns the node and the pending count.
+static bool __yo_win_timer_cancel(__yo_io_future_t* future) {
+  __yo_win_timer_entry_t** link = &__yo_win_timer_head;
+  while (*link) {
+    if ((*link)->future == future) {
+      __yo_win_timer_entry_t* node = *link;
+      *link = node->next;
+      __yo_free(node);
+      __yo_pending_io_count--;
+      return true;
+    }
+    link = &(*link)->next;
+  }
+  return false;
+}
+
 static int __yo_win_timer_process_due(uint64_t now_ms) {
   int fired = 0;
   while (__yo_win_timer_head && __yo_win_timer_head->due_ms <= now_ms) {

--- a/src/codegen/async/state_machine.yo
+++ b/src/codegen/async/state_machine.yo
@@ -3632,6 +3632,100 @@ generate_async_block_resume_function :: (
   em.emit_string_line(String.from(""));
   local_var_drop_codes
 });
+/// The `await_future_N` slots that hold an I/O future, deduplicated and in
+/// await order. Only these can be cancelled: a slot holding another task's
+/// state machine is that task's business, and a park/yield future has no
+/// backend registration to take back.
+///
+/// A DISPATCH-MODE point is excluded even when its representative is an I/O
+/// future: that slot is declared type-erased precisely because sibling
+/// branches store differently-shaped futures into it, so what is in there at
+/// abort time is not decidable here — and reading an async state machine
+/// through `__yo_io_future_t*` would find a `cancel_fn` that is really the
+/// tail of some other field.
+_io_await_future_slots :: (
+  fn(analysis : AwaitAnalysisResult, context : FunctionGenerationContext) -> ArrayList(String)
+)({
+  slots := ArrayList(String).new();
+  seen := HashSet(String).new();
+  (i : usize) = usize(0);
+  while(i < analysis.await_points.len(), i = (i + usize(1)), {
+    match(
+      analysis.await_points.get(i),
+      .Some(ap) => {
+        ffn := get_future_field_name(ap, analysis);
+        if(ffn.starts_with("await_future_") && !(seen.contains(ffn.clone())) && !(cond_await_point_needs_dispatch(ap, context)), {
+          fut_ty := match(
+            ap.base.expr,
+            .FnCall(_, _, a, _, _) => match(
+              a.get(usize(0)),
+              .Some(fe) => match(context.base.get_expr_info(fe), .Some(ei) => Option(TypeValue).Some(ei.ty), .None => Option(TypeValue).None),
+              .None => Option(TypeValue).None
+            ),
+            .Atom(_, _) => Option(TypeValue).None
+          );
+          if(match(fut_ty, .Some(t) => is_io_future_type(t), .None => false), {
+            seen.insert(ffn.clone());
+            slots.push(ffn);
+          });
+        });
+      },
+      .None => ()
+    );
+  });
+  slots
+});
+/// Emit the async block's `cancel_pending_fn` — the prompt half of
+/// `JoinHandle.abort`. Abort marks the task Aborted and then calls this, which
+/// deregisters the I/O operation the task is suspended in and releases the
+/// suspension's references eagerly, instead of leaving the operation armed
+/// until it completes on its own (issues/fixed/timeout-deadline-timer-future-leak.md).
+///
+/// It does exactly what the resume function's aborted-entry guard does — drop
+/// the `await_future_N` slot and the task's own reference — but only for the
+/// ONE slot whose operation the backend confirms it has taken back
+/// (`__yo_async_io_cancel`). Any other case falls through unchanged and the
+/// guard stays the fallback, so the release still happens exactly once.
+/// Returns the emitted function's name, or `.None` when the block has no
+/// cancellable slot and needs no hook.
+generate_async_block_cancel_pending_function :: (
+  fn(
+    async_block_id : String,
+    struct_name : String,
+    analysis : AwaitAnalysisResult,
+    context : FunctionGenerationContext
+  ) -> Option(String)
+)({
+  slots := _io_await_future_slots(analysis, context);
+  if(slots.len() == usize(0), {
+    return(Option(String).None);
+  });
+  em := context.base.emitter;
+  fn_name := `${async_block_id.clone()}_cancel_pending`;
+  em.emit_declaration_string_line(`void ${fn_name.clone()}(void* sm_ptr);  // Cancel the pending I/O of an aborted task`);
+  em.emit_declaration_line("");
+  em.emit_string_line(`// Abort hook for async block ${async_block_id.clone()}`);
+  em.emit_string_line(`void ${fn_name.clone()}(void* sm_ptr) {`);
+  em.emit_string_line(`  ${struct_name.clone()}* sm = (${struct_name.clone()}*)sm_ptr;`);
+  (i : usize) = usize(0);
+  while(i < slots.len(), i = (i + usize(1)), {
+    match(
+      slots.get(i),
+      .Some(slot) => {
+        em.emit_string_line(`  if (sm->${slot.clone()} != NULL && __yo_async_io_cancel((void*)sm->${slot.clone()})) {`);
+        em.emit_string_line(`    __yo_decr_rc((void*)sm->${slot.clone()});`);
+        em.emit_string_line(`    sm->${slot.clone()} = NULL;`);
+        em.emit_string_line(`    __yo_decr_rc((void*)sm);  // the suspended task's own reference`);
+        em.emit_string_line(`    return;`);
+        em.emit_string_line(`  }`);
+      },
+      .None => ()
+    );
+  });
+  em.emit_string_line(`}`);
+  em.emit_string_line(String.from(""));
+  Option(String).Some(fn_name)
+});
 export(
   is_io_future_type,
   StateMachineInfo,
@@ -3663,5 +3757,6 @@ export(
   _emit_post_while_cond_branch,
   _emit_outer_while_continuation,
   _emit_while_continuation,
-  generate_async_block_resume_function
+  generate_async_block_resume_function,
+  generate_async_block_cancel_pending_function
 );

--- a/src/codegen/exprs/async.yo
+++ b/src/codegen/exprs/async.yo
@@ -95,7 +95,8 @@
   find_bundle_field_name,
   compute_cross_boundary_variables,
   compute_overlapping_slots,
-  generate_async_block_resume_function
+  generate_async_block_resume_function,
+  generate_async_block_cancel_pending_function
 } :: import("../async/state_machine.yo");
 { get_state_machine_field_name } :: import("../async/state_machine_naming.yo");
 { _c_string_literal } :: import("./comptime_value.yo");
@@ -599,6 +600,10 @@ emit_async_block_struct_definition :: (
   em.emit_declaration_string_line(`struct ${info.struct_name.clone()}_struct {`);
   em.emit_declaration_line("  __yo_ref_header_t header;  // Reference counting header (must be first)");
   em.emit_declaration_line("  int state;  // Current state (0 = cold, 1..N = intermediate, -1 = completed, -2 = aborted)");
+  // Part of the common spawned-future header: JoinHandle.abort reaches the
+  // suspension through it (runtime_core.yo, __yo_join_handle_abort_raw), so it
+  // must sit at the same offset in every future struct.
+  em.emit_declaration_line("  void (*cancel_pending_fn)(void*);  // Cancel the I/O operation the task is suspended in");
   // Always include a result field to keep continuation_fn/continuation_sm at
   // consistent offsets. For unit type, use uint8_t as a dummy (cannot use void).
   if(is_unit_type(info.result_type), {
@@ -1355,7 +1360,7 @@ generate_async_block_state_dispose_function :: (
 /// of `generateAsyncBlockConstructor` (async.ts:1269). `async_block_id` and
 /// `future_type` are retained for signature fidelity (unused in the TS body too).
 generate_async_block_constructor :: (
-  fn(async_block_id : String, struct_name : String, resume_function_name : String, constructor_name : String, dispose_function_name : String, set_effect_function_name : String, future_type : TypeValue, result_type : TypeValue, result_type_c_name : String, capture_type : Option(TypeValue), context : FunctionGenerationContext) -> unit
+  fn(async_block_id : String, struct_name : String, resume_function_name : String, constructor_name : String, dispose_function_name : String, set_effect_function_name : String, cancel_pending_function_name : Option(String), future_type : TypeValue, result_type : TypeValue, result_type_c_name : String, capture_type : Option(TypeValue), context : FunctionGenerationContext) -> unit
 )({
   em := context.base.emitter;
   // Constructor signature (returns a pointer for a stable Future/SM address).
@@ -1393,6 +1398,11 @@ generate_async_block_constructor :: (
   });
   em.emit_line("");
   em.emit_line("  sm->state = 0;");
+  match(
+    cancel_pending_function_name,
+    .Some(cpfn) => em.emit_string_line(`  sm->cancel_pending_fn = ${cpfn};  // JoinHandle.abort cancels the pending I/O`),
+    .None => em.emit_line("  sm->cancel_pending_fn = NULL;  // no cancellable await slot")
+  );
   em.emit_line("  sm->continuation_fn = NULL;");
   em.emit_line("  sm->continuation_sm = NULL;");
   em.emit_line("");
@@ -2218,8 +2228,10 @@ _emit_one_deferred_async_block :: (fn(block : DeferredAsyncBlock, context : Func
   // Dispose function.
   generate_async_block_state_dispose_function(block.async_block_id.clone(), block.struct_name.clone(), block.dispose_function_name.clone(), block.result_type, block.capture_type, filtered_analysis, local_var_drops, cross_boundary_ids, await_future_temp_var_aliases, context);
   em.emit_string_line(String.from(""));
+  // Abort hook — cancels the I/O operation the task is suspended in.
+  cancel_pending_function_name := generate_async_block_cancel_pending_function(block.async_block_id.clone(), block.struct_name.clone(), filtered_analysis, context);
   // Constructor.
-  generate_async_block_constructor(block.async_block_id.clone(), block.struct_name.clone(), block.resume_function_name.clone(), block.constructor_name.clone(), block.dispose_function_name.clone(), block.set_effect_function_name.clone(), block.future_type, block.result_type, block.result_type_c_name.clone(), block.capture_type, context);
+  generate_async_block_constructor(block.async_block_id.clone(), block.struct_name.clone(), block.resume_function_name.clone(), block.constructor_name.clone(), block.dispose_function_name.clone(), block.set_effect_function_name.clone(), cancel_pending_function_name, block.future_type, block.result_type, block.result_type_c_name.clone(), block.capture_type, context);
   em.emit_string_line(String.from(""));
 });
 /// Generate all deferred async-block implementations (resume / set_effect / dispose
@@ -2643,6 +2655,7 @@ generate_io_async_sync_call :: (fn(expr : AstExpr, indent : String, context : Fu
   em.emit_declaration_string_line(`struct ${struct_name.clone()}_struct {`);
   em.emit_declaration_line("  __yo_ref_header_t header;");
   em.emit_declaration_line("  int state;");
+  em.emit_declaration_line("  void (*cancel_pending_fn)(void*);");
   if(is_unit_type(result_type), {
     em.emit_declaration_line("  uint8_t result;");
   }, {
@@ -2893,6 +2906,7 @@ generate_io_async_sync_call :: (fn(expr : AstExpr, indent : String, context : Fu
   });
   // State 0 = not started (lazy); resume executes the closure.
   em.emit_string_line(`${indent.clone()}${result_var.clone()}->state = 0;`);
+  em.emit_string_line(`${indent.clone()}${result_var.clone()}->cancel_pending_fn = NULL;  // no await slot to cancel`);
   em.emit_string_line(`${indent.clone()}${result_var.clone()}->__yo_resume_fn = ${resume_function_name.clone()};`);
   em.emit_string_line(`${indent.clone()}${result_var.clone()}->__yo_set_effect_fn = ${sync_set_effect_function_name.clone()};`);
   em.emit_string_line(`${indent.clone()}${result_var.clone()}->continuation_fn = NULL;`);

--- a/src/codegen/exprs/await.yo
+++ b/src/codegen/exprs/await.yo
@@ -720,6 +720,7 @@ generate_join_handle_await :: (fn(expr : AstExpr, indent : String, context : Fun
   em.emit_string_line(`${indent.clone()}  struct ${header_struct_name.clone()} {`);
   em.emit_string_line(`${indent.clone()}    __yo_ref_header_t header;`);
   em.emit_string_line(`${indent.clone()}    int state;`);
+  em.emit_string_line(`${indent.clone()}    void (*cancel_pending_fn)(void*);`);
   em.emit_string_line(`${indent.clone()}    ${result_type_name.clone()} result;`);
   em.emit_string_line(`${indent.clone()}    void (*continuation_fn)(void*);`);
   em.emit_string_line(`${indent.clone()}    void* continuation_sm;`);

--- a/src/codegen/types/generation.yo
+++ b/src/codegen/types/generation.yo
@@ -961,6 +961,12 @@ typedef struct __yo_io_future_t {
   int32_t result;
   _Atomic(void (*)(void*)) continuation_fn;
   _Atomic(void*) continuation_sm;
+  // Deregister this operation from the I/O backend. NULL means the operation
+  // has no cancel path and must be left to complete on its own; a non-NULL
+  // hook returns true only when the backend is certain no completion will be
+  // delivered for it. Set by the *_start function that registered the
+  // operation. See __yo_async_io_cancel in the async runtime core.
+  bool (*cancel_fn)(struct __yo_io_future_t*);
 } __yo_io_future_t;
 
 // Forward declarations will be added here if needed
@@ -1409,7 +1415,7 @@ generate_dyn_box_types :: (fn(context : CodeGenContext) -> unit)({
 /// Emit the generic Future trait-object interface struct for a
 /// `FutureTraitT`. Faithful port of `generateFutureTraitDeclaration`
 /// (src/codegen/types/generation.ts:982-1012). Every async state-machine
-/// struct begins with this exact prefix (header/state/result/continuation_fn/
+/// struct begins with this exact prefix (header/state/cancel_pending_fn/result/continuation_fn/
 /// continuation_sm/__yo_resume_fn/__yo_set_effect_fn), so a concrete SM
 /// future pointer casts to this interface — it is the C lowering for a
 /// FUTURE-typed function parameter (`task : Impl(Future(T, E))`).
@@ -1419,6 +1425,7 @@ generate_future_trait_declaration :: (fn(type : TypeValue, c_name : String, cont
   em.emit_declaration_string_line(`struct ${c_name.clone()}_struct { // Generic Future interface for ${type_to_string(type)}`);
   em.emit_declaration_string_line(String.from("  __yo_ref_header_t header;"));
   em.emit_declaration_string_line(String.from("  int state;  // 0 = cold, -1 = completed, -2 = aborted"));
+  em.emit_declaration_string_line(String.from("  void (*cancel_pending_fn)(void*);"));
   if(is_unit_type(result_type), {
     em.emit_declaration_string_line(String.from("  uint8_t result;"));
   }, {

--- a/std/async/index.yo
+++ b/std/async/index.yo
@@ -216,10 +216,11 @@ derive(
 /// its own. The handle is consumed either way. Millisecond granularity (the
 /// timer contract of `std/time/sleep`).
 ///
-/// KNOWN RESIDUAL (bounded): when the task finishes BEFORE the deadline, the
-/// deadline timer stays armed in the I/O backend until it fires, and its
-/// future struct (~tens of bytes) is never reclaimed — see
-/// `issues/timeout-deadline-timer-future-leak.md`.
+/// A task that finishes before the deadline leaves nothing behind: `abort()`
+/// on the deadline handle deregisters the armed timer in the I/O backend and
+/// releases the deadline task there and then. Until that cancel path existed
+/// the timer kept counting and held ~256 bytes per call for the whole
+/// remaining deadline (`issues/fixed/timeout-deadline-timer-future-leak.md`).
 timeout :: (
   fn(generic(T : Type), handle : JoinHandle(T), limit : Duration, io : Io) -> Result(T, TimeoutError)
 )({
@@ -252,9 +253,9 @@ timeout :: (
     );
   });
   // Consume the deadline handle exactly once. When the task finished first,
-  // the abort is a no-op and the await returns immediately; the aborted
-  // task's armed timer fires at `limit` into the resume entry guard, which
-  // releases the state machine then.
+  // the abort cancels the still-armed timer and releases the deadline task
+  // immediately (runtime_core.yo `__yo_async_io_cancel`), so the await that
+  // follows returns without waiting for `limit`.
   dh.abort();
   _deadline_r := dh.await(io);
   match(

--- a/std/prelude.yo
+++ b/std/prelude.yo
@@ -12050,7 +12050,8 @@ impl(
   await : __yo_join_handle_await
 );
 /// JoinHandle introspection + cancellation. The raw helpers read/write the
-/// common spawned-future header (`{__yo_ref_header_t; int state;}`) emitted
+/// common spawned-future header (`{__yo_ref_header_t; int state; void
+/// (*cancel_pending_fn)(void*);}`) emitted
 /// by the async runtime; state mapping follows `io.state`: any positive step
 /// index reads as Running.
 extern(
@@ -12075,9 +12076,11 @@ impl(
   /// resume past its current suspension point (its pending completion, if
   /// any, releases the state machine instead of resuming it). Completed and
   /// already-aborted tasks are left untouched. `await` on an aborted handle
-  /// returns `.None`. NOTE: abort cancels the TASK, not any in-flight I/O
-  /// operation it is suspended on — a task parked on I/O that never
-  /// completes stays allocated until process exit.
+  /// returns `.None`. An operation the task is suspended in is cancelled too
+  /// where the I/O backend can take the registration back (timers today):
+  /// the task and what it was waiting on are then released at once instead
+  /// of when that operation would have completed. An operation with no
+  /// cancel path still runs to completion and releases the task then.
   abort : (fn(self : JoinHandle(T)) -> unit)(
     __yo_join_handle_abort_raw((*void)(self.__future))
   )

--- a/tests/async/combinators.test.yo
+++ b/tests/async/combinators.test.yo
@@ -107,6 +107,23 @@ test("Test timeout completes in time", {
   assert(match(r, .Ok(v) => (v == i32(7)), .Err(_) => false), "task inside the limit should deliver its value");
 });
 // ---------------------------------------------------------------------------
+// 6b. timeout — repeated in-time calls against a long deadline.
+//     Every call arms a real deadline timer that the winning task never lets
+//     fire; each one used to stay armed (and hold its task, its capture and
+//     its future) for the whole remaining 60 s, ~256 bytes a call with no
+//     ceiling — issues/fixed/timeout-deadline-timer-future-leak.md. The abort
+//     now cancels it, so this loop is flat. The assertion here is the
+//     behavioural half: correctness under repetition.
+// ---------------------------------------------------------------------------
+test("Test timeout in a loop against a long deadline", {
+  (i : usize) = usize(0);
+  while(i < usize(200), i = (i + usize(1)), {
+    h := io.spawn(sleepy(i32(3), u64(0), io), io);
+    r := timeout(h, Duration.from_millis(i64(60000)), io);
+    assert(match(r, .Ok(v) => (v == i32(3)), .Err(_) => false), "every in-time call should deliver its value");
+  });
+});
+// ---------------------------------------------------------------------------
 // 7b. timeout — a SELF-aborted task is Aborted, not Elapsed (D18)
 // ---------------------------------------------------------------------------
 test("Test timeout distinguishes an aborted task from an elapsed deadline", {

--- a/tests/async/join_handle.test.yo
+++ b/tests/async/join_handle.test.yo
@@ -102,3 +102,44 @@ test("Test abort after completion is a no-op", {
   r := h.await(io);
   assert(match(r, .Some(v) => (v == u64(11)), .None => false), "completed result should be intact");
 });
+// ---------------------------------------------------------------------------
+// 6. abort() cancels the operation the task is suspended IN, and releases the
+//    task there and then — it does not wait for that operation to complete on
+//    its own. Before the I/O cancel path existed, the aborted task's state
+//    machine and everything it captured stayed alive for the whole remaining
+//    sleep, which is what made `timeout` retain ~256 bytes per call until its
+//    deadline (issues/fixed/timeout-deadline-timer-future-leak.md).
+//    The Dispose counter is the observable: CI runs with detect_leaks=0, so a
+//    retention this shape is invisible to the sanitizers.
+// ---------------------------------------------------------------------------
+(g_abort_capture_disposed : i32) = i32(0);
+AbortCaptureProbe :: ref(struct(id : i32));
+impl(
+  AbortCaptureProbe,
+  Dispose(
+    dispose : (fn(self : Self) -> unit)({
+      g_abort_capture_disposed = (g_abort_capture_disposed + i32(1));
+    })
+  )
+);
+test("Test abort cancels the pending timer and releases the task", {
+  {
+    probe := AbortCaptureProbe(id : i32(7));
+    fut := io.async((io : Io) => {
+      io.await(sleep(u64(30000)), io);
+      return(probe.id);
+    });
+    h := io.spawn(fut, io);
+    // Let the spawned task reach its suspension point.
+    io.await(yield(io), io);
+    assert(!h.is_finished(), "task should be parked on the 30 s sleep");
+    assert(g_abort_capture_disposed == i32(0), "capture is alive while the task is");
+    h.abort();
+    r := h.await(io);
+    assert(match(r, .Some(_) => false, .None => true), "aborted task should give .None");
+  };
+  // The local reference is gone and the handle is consumed, so the only thing
+  // that could still hold the capture is a state machine kept alive for a
+  // timer that will not fire for another 30 seconds.
+  assert(g_abort_capture_disposed == i32(1), "abort must release the aborted task's captures at once");
+});


### PR DESCRIPTION
`JoinHandle.abort()` was a state word and nothing else: the operation the task
was suspended IN stayed registered with the I/O backend, so everything it held
— the operation's future, the state machine, its captures — was retained until
that operation completed on its own. `timeout` does exactly this on every
call, and a task that beats its deadline left the deadline timer armed for the
whole remaining limit: **4 allocations / 256 bytes per call, unbounded**
(`issues/fixed/timeout-deadline-timer-future-leak.md`, which
`std/async/index.yo` cited as a KNOWN RESIDUAL).

Measured on `issues/repros/timeout-deadline-timer-retained.yo` — 800 in-time
calls against a 9 s deadline, `leaks --atExit`, aarch64-apple-darwin, both
binaries from the same source:

| | live allocations at exit | bytes |
| --- | --- | --- |
| before | 3387 | 233 KB |
| after | **187** | **33 KB** |

187 is the zero-call baseline, so the per-call retention is gone, not reduced.

## What landed

1. **`cancel_fn` on `__yo_io_future_t`** — a per-operation hook the `*_start`
   function fills in, returning `true` only when the backend is certain no
   completion will be delivered. `NULL` means "this operation has no cancel
   path", which is every operation except the timer today: those keep the old
   lazy release, so nothing regresses while the rest are written.
2. **`__yo_async_io_cancel`** — the arbitration. It cancels only a future that
   is still pending AND whose continuation registration this call takes
   (`atomic_exchange`), so a completion already in flight keeps ownership of
   the wake and the eager path stands down; a backend that refuses gets the
   continuation put back.
3. **Timer cancel on all four backends.** macOS keeps the kqueue ident and the
   udata context in a new `__yo_timer_future_t` and issues `EV_DELETE`
   (`ENOENT` — the one-shot already delivered — is a refusal, not a cancel).
   Linux submits an `IORING_OP_ASYNC_CANCEL` SQE with NULL user data, so the
   timerfd read reports `-ECANCELED` on the next poll and releases the ring's
   reference there; the CQE path learned to skip a NULL-user-data completion.
   Windows and wasm unlink the entry from their sorted timer queues.
4. **`cancel_pending_fn` on the spawned-future header.** Abort is type-erased
   through `JoinHandle.__future`, so the hook has to live at a fixed offset in
   every future struct — right after `state`, ahead of the per-future-typed
   `result`. The five emitters that spell that prefix now all carry it, and
   the prefix is written down as an ABI in
   `.github/instructions/c-codegen.instructions.md`. Codegen emits one hook
   per async block beside the resume function: it cancels whichever
   `await_future_N` slot holds a live cancellable I/O future and drops that
   slot and the task's own reference — the same work the resume function's
   aborted-entry guard does lazily, which stays as the fallback. Dispatch-mode
   slots are excluded: they are declared type-erased precisely because sibling
   branches store differently-shaped futures there, so what is in one at abort
   time is not decidable.
5. **The doc correction** — `JoinHandle.abort` and `timeout` describe
   cancellation now, not retention.

## Tests

- `tests/async/join_handle.test.yo` — "abort cancels the pending timer and
  releases the task": a task parked on a 30 s sleep with a `Dispose`-counted
  capture, aborted; the counter must read 1 immediately. **Verified RED on the
  pre-fix compiler (exit 6) and GREEN after.** CI runs `detect_leaks=0`, so a
  Dispose counter is the only observable for this class.
- `tests/async/combinators.test.yo` — "timeout in a loop against a long
  deadline": 200 in-time calls against a 60 s limit, the behavioural companion
  to the allocation table above.

Local: `check ./src` 270/270, `tests/async` 75/75, `fmt --check` clean.

## Not in scope, deliberately

Only timers have a `cancel_fn`. A task aborted while parked on a socket read,
a `getaddrinfo`, or a waker still holds that operation until it completes on
its own — unchanged behaviour, now with the mechanism in place to fix each.
`plans/WAKER_BASED_SCHEDULING.md` step 4 records this, and that `race`/`any`
still poll rather than park (that needs completion notification on
`JoinHandle`, which is step 5's machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
