### PR TITLE
codegen: nested cond/match arms in async bodies dispatch by code on the shared field (fixes the yo install ref: "" dead arm and five more emitter bugs)

### DIFF
--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -1691,14 +1691,26 @@ fmt` silently destroyed non-ASCII source at rc=0. `Token.column` is likewise a
 rune column, so a width added to it must be a RUNE count
 (`value.chars().count()`), never `value.len()`.
 
-## Async: await only at the async-closure statement level
+## Async: awaits nested in cond/match arms
 
-An `e.io.await(...)` nested inside if-branches of an `io.async` closure has
-been observed to compile SILENTLY WRONG (the branch's continuation never
-ran — issues/async-await-nested-if-lost-continuation.md; `check` cannot
-catch it, and only SOME shapes are rejected at codegen). Until that bug is
-minimized and fixed: hoist every await-bearing step to a top-level
-statement of the closure and branch on plain booleans afterwards.
+Three silent mis-lowerings of an `e.io.await(...)` inside cond/match arms of an
+`io.async` closure were minimized and FIXED on 2026-09-11 (`check` never saw
+them — the state-machine emitter lives in codegen):
+
+- a cond/match with an awaiting arm NESTED inside another awaiting arm
+  (`ref_str := match(o, .Some(r) => r, .None => e.io.await(...))` followed by
+  more statements) dropped the enclosing arm's remaining statements —
+  issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md;
+- a value-producing arm that awaits TWICE lost its tail value (`out` stayed
+  zeroed), and `fetched := if(added, { … await … }, …)` after an arm's first
+  await emitted nothing —
+  issues/fixed/async-cond-arm-tail-value-lost-after-second-await.md.
+
+Each shape now has a test in `tests/async_await.test.yo`. One older report of
+this family (issues/async-await-nested-if-lost-continuation.md, a nested
+awaiting `if` after a PLAIN helper that awaits internally, 2026-08-22) was
+never minimized; its reconstructed shape passes, so if you meet it again,
+distill it and file the reproducer rather than hoisting around it.
 
 ## Block bodies cannot START with `cond(`/`match(` — and other body-statement rules
 

--- a/issues/fixed/async-chained-sibling-arm-second-await-binding-never-assigned.md
+++ b/issues/fixed/async-chained-sibling-arm-second-await-binding-never-assigned.md
@@ -1,0 +1,59 @@
+# A sibling arm's second-await binding is never assigned when its continuation lands in a chained layer
+
+**Status:** FIXED 2026-09-11 (`fix/async-nested-match-dead-arm`).
+**Found:** 2026-09-11, running `yo install shd101wyy/raylib_yo@v0.0.6` with a
+gen-2 compiler carrying the nested-dispatch fix: `deps.yo` gained the right
+line but `if(added, { … fetch … })` never ran — `run_install`'s `.Git` arm
+read its `added` as `false`. The emitted state machine confirmed the slot for
+that `added` is written nowhere. Reproduces on the pre-fix compiler with two
+plain sibling arms (no nesting).
+**Severity:** high — silent wrong control flow, `check` clean.
+
+## Reproducer
+
+`issues/repros/async-chained-sibling-arm-second-await-binding-never-assigned.yo`:
+
+```rust
+match(
+  k,
+  .A => {
+    exists := e.io.await(flag(e.io), e);
+    added := e.io.await(flag(e.io), e);   // second await
+    if(added, { log.push_str("A:added;"); });
+  },
+  .B => {
+    nm := e.io.await(name_of(e.io), e);
+    added := e.io.await(flag(e.io), e);   // second await, same type
+    if(added, { log.push_str("B:added;"); });   // never ran
+  }
+);
+```
+
+## Root cause
+
+Both arms' second awaits share one await point (uniform mode — same future
+type). The first arm to chain creates that point's entry
+(`_chain_additional_remaining`, `.None` path) and its record lives in
+`branches`, where the main continuation switch assigns the arm's own binding
+(`sm->var_<added> = sm->await_result_N`, the per-branch `await_target_variable_id`
+logic). The second arm to chain is appended as a chained LAYER
+(`chained_branches`), and both layer emitters —
+`_emit_outer_chained_branch_layers` and the same-field layer block in
+`_emit_cond_branch_continuation` — ran the layer's remaining code WITHOUT that
+assignment. The dispatch-mode path had been fixed earlier
+(issues/fixed/async-cond-dispatch-skips-chained-sibling-arm.md); the uniform
+path had not.
+
+## Fix
+
+`_emit_chained_arm_binding` (`src/codegen/async/state_machine.yo`) emits the
+binding for a chained arm under the same three conditions the main switch
+applies (not the arm the pre-switch copy covers, the binding lives in the
+state struct, it has this point's result type), before the layer's remaining
+code, in both layer emitters. Dispatch-mode points are untouched (their
+extraction assigns per arm).
+
+**Gate:** `tests/async_await.test.yo` — "a sibling arm's second-await binding
+is assigned when its continuation is a chained layer"; and `yo install
+user/repo@tag` end to end with a gen-2 compiler now prints `Fetching
+dependency...` and writes `yo.lock`.

--- a/issues/fixed/async-cond-arm-tail-value-lost-after-second-await.md
+++ b/issues/fixed/async-cond-arm-tail-value-lost-after-second-await.md
@@ -1,0 +1,72 @@
+# In an `io.async` body, a value-producing cond/match arm loses its tail value once the arm awaits a second time
+
+**Status:** FIXED 2026-09-11 (`fix/async-nested-match-dead-arm`, with the nested-dispatch fix).
+**Found:** 2026-09-11 while gating that fix — the `yo install` shape's test
+returned `""` on the pre-fix compiler with the nested match REMOVED, so this is
+a separate, older bug in the chained-layer emitter.
+**Severity:** high — the compile succeeds, `check` is clean, and the bound
+result is silently zeroed (an empty `String`, `.None`, `0`).
+
+## Reproducer
+
+`issues/repros/async-cond-arm-tail-value-lost-after-second-await.yo`:
+
+```rust
+out := cond(
+  flag => {
+    a := e.io.await(resolve(String.from("a"), e.io), e);
+    b := e.io.await(resolve(String.from("b"), e.io), e);
+    `${a}|${b}`            // computed, then DISCARDED — `out` stays ""
+  },
+  true => String.from("no")
+);
+out
+```
+
+Two sibling shapes fail the same way, and a third emits nothing at all:
+
+| shape | pre-fix result |
+| --- | --- |
+| `out := match(…, .Git => { a := await …; b := await …; \`${a}${b}\` })` | `out == ""` |
+| `out := match(…, .Git => { added := await …; if(added, { s := await …; println(s) }); \`…\` })` | the `if` body runs, `out == ""` |
+| `fetched := if(added, { s := await …; \`x:${s}\` }, "n");` after a bound await in an arm | the `if`, its await and every later statement of the arm vanish |
+
+## Root cause
+
+Three gaps in the resume side (`src/codegen/async/state_machine.yo`):
+
+1. `_chain_additional_remaining` parks an arm's statements after its SECOND
+   await in a new `AsyncCondBranchInfo` at the next await index with
+   `cond_branch_field_index = <outer field>` and **no target**. The
+   continuation of that state then ran the remaining code with
+   `cbd.target_assignment_code == None`, so the tail value was computed into a
+   temp and dropped; the outer cond's target (registered on the entry at the
+   outer field's index) was never consulted.
+2. `_emit_outer_chained_branch_layers` passed a hard-coded `Option(String).None`
+   target for the outer arm's chained remaining.
+3. `generate_remaining_expr_future` took the `x := …` path for
+   `fetched := if(cond, { … await … }, …)`, found the RHS was not an
+   `io.await`, and returned — emitting nothing for the binding, the nested
+   cond, or its future store; the arm's later statements were then keyed on a
+   state that was never entered.
+
+## Fix
+
+- `_cond_layer_target(cbd, cond_field, context)`: the entry's own target, else
+  the target of the entry at `cond_field` (the outer cond). Used by the
+  main continuation switch, the uniform tail-await handover, the
+  dispatch-mode extraction, and the nested-arm continuation; the outer chained
+  layers look the outer entry up by the layer's field.
+- `generate_remaining_expr_future`: a bound RHS that is not an `io.await`
+  delegates to `generate_await_expression`, which already emits
+  `x := cond/match(…)` with the binding as the target.
+- `_nested_level_target(branch, ninfo, enclosing_target)`: a nested instance
+  without its own `x :=` target that is the enclosing arm's TAIL hands its
+  value to the enclosing level's target (the bare
+  `true => cond(… await …)` arm shape).
+
+**Gate:** `tests/async_await.test.yo` — "a value-producing cond arm that awaits
+twice keeps its tail value", "an awaiting if statement after a bound await,
+then the arm's tail value", "the yo install shape: …" (the bound `fetched :=
+if(…)` form), and the pre-existing "nested cond arms await two DIFFERENT async
+fns". The first three fail on the pre-fix compiler.

--- a/issues/fixed/async-post-while-code-runs-for-a-sibling-nested-arm.md
+++ b/issues/fixed/async-post-while-code-runs-for-a-sibling-nested-arm.md
@@ -1,0 +1,52 @@
+# In an `io.async` body, a nested arm's post-loop statements also run when a SIBLING nested arm was taken
+
+**Status:** FIXED 2026-09-11 (`fix/async-nested-match-dead-arm`).
+**Found:** 2026-09-11, probing the nested-dispatch fix with a nested cond
+whose arm loops with an await and whose enclosing arm has trailing
+statements. Reproduces on the pre-fix compiler.
+**Severity:** medium — silent wrong control flow, `check` clean.
+
+## Reproducer
+
+`issues/repros/async-post-while-code-runs-for-a-sibling-nested-arm.yo`:
+
+```rust
+cond(
+  (mode == usize(0)) => { log.push_str("plain;"); },
+  true => {
+    cond(
+      (mode == usize(1)) => { log.push_str("no-loop;"); },
+      true => {
+        while(runtime(i < usize(3)), { r := e.io.await(step(i, e.io), e); i = r; … });
+        log.push_str("loop-done;");          // ran for mode == 1 too
+      }
+    );
+    log.push_str("outer-tail;");
+  }
+);
+```
+
+`mode == 1` printed `no-loop;loop-done;outer-tail;end`.
+
+## Root cause
+
+A while loop's `cond_branch_post_while_exprs` slot has several clients — the
+looping arm's own post-loop statements and the enclosing arm's trailing
+statements — and `merge_cond_branch_post_while_exprs` concatenated their
+statements into ONE list under ONE guard. When the clients' arms differed the
+merge set `skip_cond_branch_check` and the whole block ran unconditionally
+(and even the union guard `code ∈ {loop arm} ∪ {enclosing arm}` would have
+let the loop arm's statements run for the synchronous sibling arm, whose code
+is in the enclosing arm's set).
+
+## Fix
+
+`CondBranchPostWhileExprs` keeps the merged statement list (the order matters
+for chaining an additional await through the whole sequence) and records its
+clients (`part_codes`, `part_lens`); `_emit_post_while_cond_branch` emits each
+client's statements under that client's own `_codes_guard`. A single-client
+slot emits exactly what it did before. The `guards_disagree` unconditional
+fallback is gone.
+
+**Gate:** `tests/async_await.test.yo` — "a nested arm that loops with an
+await runs its post-loop code for that arm only".

--- a/issues/fixed/async-while-body-reassigning-an-await-result-never-stores-the-future.md
+++ b/issues/fixed/async-while-body-reassigning-an-await-result-never-stores-the-future.md
@@ -1,0 +1,38 @@
+# `i = e.io.await(...)` in an async while body stores no future — the resume reads a NULL slot (SIGSEGV)
+
+**Status:** FIXED 2026-09-11 (`fix/async-nested-match-dead-arm`).
+**Found:** 2026-09-11, probing loop shapes for the nested-dispatch fix.
+Reproduces on the pre-fix compiler with a plain `while` in an `io.async`
+body — no nesting involved.
+**Severity:** high — the program crashes (rc=139); `check` is clean.
+
+## Reproducer
+
+`issues/repros/async-while-body-reassigning-an-await-result-never-stores-the-future.yo`:
+
+```rust
+(i : usize) = usize(0);
+while(runtime(i < usize(3)), {
+  i = e.io.await(step(i, e.io), e);   // `=`, not `:=`
+});
+i
+```
+
+## Root cause
+
+`generate_while_body_with_await` (`src/codegen/async/state_code_gen.yo`)
+recognised the body's await only as `x := io.await(...)` or a bare
+`io.await(...)`. The re-assignment form `x = io.await(...)` matched neither, so
+the loop body emitted nothing for it: `sm->await_future_N` was never stored,
+while the resume state (whose target comes from `extract_target_variable_id`,
+which does accept `=`) dereferenced the NULL slot. The cond-arm and
+remaining-code emitters had already grown the `=` arm
+(issues/fixed/async-cond-dispatch-skips-chained-sibling-arm.md); the while body
+had not.
+
+## Fix
+
+The while-body store accepts `=` with two arguments alongside `:=`.
+
+**Gate:** `tests/async_await.test.yo` — "a while body that re-assigns an
+outer local from an await stores the future".

--- a/issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md
+++ b/issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md
@@ -1,6 +1,7 @@
 # In an `io.async` body, a match arm whose body holds a value-producing INNER match with an await is emitted as NOTHING
 
-**Status:** OPEN — root cause of `issues/yo-install-git-dependency-writes-an-empty-ref.md`
+**Status:** FIXED 2026-09-11 (`fix/async-nested-match-dead-arm`) — see "Fix" below.
+Was the root cause of `issues/yo-install-git-dependency-writes-an-empty-ref.md`.
 **Found:** 2026-09-11, bisecting `run_install` by body substitution. Reproduces
 with `yo 0.2.30` and with develop's codegen (a gen-1 binary built from
 `p1/imports-plumbing` compiling the reproducer).
@@ -77,7 +78,52 @@ overwritten before resume, so they never run. The fix is one dispatch slot per
 nesting level (the same "poll + store per depth" shape C36's
 `_dispatch_branches` gave `cond` arms), not another special case.
 
-## Fix direction
+## Fix (2026-09-11)
+
+One dispatch field per nesting level, in `src/codegen/async/`:
+
+- **Struct.** `AsyncBlockStructInfo.nested_cond_depth` (`max_nested_cond_depth`
+  over the body) declares `int cond_branch_N_n<d>;` next to `cond_branch_N`
+  for every nesting level `d` (`exprs/async.yo`).
+- **Store side** (`state_code_gen.yo`). `generate_cond_branch_with_await`
+  returns a `BranchEmission(remaining, nested)`. A nested cond/match in an
+  awaiting arm — bare, or the RHS of `x := …` / `x = …` (the bound form used
+  to fall through EVERY case and emit nothing) — goes through
+  `_emit_nested_cond_or_match`: a fresh `AsyncCondBranchInfo` sink is
+  installed in `context.nested_cond_sink`, `context.nested_cond_depth` is
+  bumped, and the nested instance's `sm->cond_branch_N_n<d> = k` writes
+  (`_cond_field_name`) and arm registrations (`_push_cond_branch`,
+  `_set_cond_branch_target`, `_store_cond_branch_info`) land in that sink
+  instead of the enclosing point's entry. The sink is pushed to
+  `context.nested_cond_records`; its index is the enclosing arm's
+  `CondBranch.nested` (an index, because `CondBranch` and
+  `AsyncCondBranchInfo` may not name each other).
+- **Resume side** (`state_machine.yo`). `_emit_nested_level_switch` switches
+  on the nested field, binds the taken nested arm's result (or hands it to the
+  nested instance's `x :=` target), recurses for deeper levels, runs the
+  nested arm's remaining code — and then the caller runs the ENCLOSING arm's
+  remaining code: the two-level dispatch that replaced the dead `case`.
+  Dispatch-mode points extract per nested arm through the recursive
+  `_emit_dispatch_extraction_case`. Uniform (slot-guarded) points emit the
+  nested-bearing arms AFTER the guard in `_emit_nested_branch_continuation`,
+  with the bindings under a `__yo_had_future_N` C local remembered from before
+  the guard, so a nested arm that completed synchronously (no future stored,
+  guard skipped) still runs the enclosing arm's statements — once, because
+  emitting the remaining code twice re-referenced the cached temporaries of
+  its own next await.
+- The "nested match claims the dispatch slot" fatal for dispatch-mode points
+  is gone; that shape is now emitted.
+
+Programs without nesting emit byte-identical C (checked with `--emit-c-to`
+on the direct-await control shape).
+
+**Gate:** `tests/async_await.test.yo` — "an awaiting inner match inside a
+match arm keeps the arm's trailing statements", "the yo install shape: inner
+match, a second bound await, an awaiting if, and a sibling arm binding the
+same name", "two nesting levels: an awaiting cond inside a match inside a
+match arm". All three fail (dropped arm / mis-typed slot) before the fix.
+
+## Fix direction (as filed)
 
 In `src/codegen/async/` (the match/cond FSM emitters registered by
 `register_fsm_emitters_impl`): when an await point sits inside a nested
@@ -85,5 +131,5 @@ value-producing match, the await's result binding must be the INNER match's
 result temp, allocated per nesting level, not the enclosing arm's next
 binding. Gate: this reproducer in `tests/async_await.test.yo` asserting all
 five lines, plus the `run_install` shape (two sibling arms binding `added`).
-Until fixed, avoid the shape: hoist the inner match's awaiting arm into its
-own async fn and await it directly in the outer arm.
+(The workaround — hoisting the inner match's awaiting arm into its own async
+fn — is no longer needed.)

--- a/issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md
+++ b/issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md
@@ -80,48 +80,69 @@ nesting level (the same "poll + store per depth" shape C36's
 
 ## Fix (2026-09-11)
 
-One dispatch field per nesting level, in `src/codegen/async/`:
+The dispatch codes `_alloc_cond_branch_codes` hands out are unique within a
+function, so a nested arm's code in the shared `sm->cond_branch_N` identifies
+BOTH the nested arm and the arm enclosing it. The fix keeps the single field
+and one entry per await point (every legacy consumer — chained layers,
+post-while continuations, the dispatch-mode switches, chained entries — keeps
+identifying arms by code on that field) and adds the structure the resume
+side was missing, in `src/codegen/async/`:
 
-- **Struct.** `AsyncBlockStructInfo.nested_cond_depth` (`max_nested_cond_depth`
-  over the body) declares `int cond_branch_N_n<d>;` next to `cond_branch_N`
-  for every nesting level `d` (`exprs/async.yo`).
-- **Store side** (`state_code_gen.yo`). `generate_cond_branch_with_await`
-  returns a `BranchEmission(remaining, nested)`. A nested cond/match in an
-  awaiting arm — bare, or the RHS of `x := …` / `x = …` (the bound form used
-  to fall through EVERY case and emit nothing) — goes through
-  `_emit_nested_cond_or_match`: a fresh `AsyncCondBranchInfo` sink is
-  installed in `context.nested_cond_sink`, `context.nested_cond_depth` is
-  bumped, and the nested instance's `sm->cond_branch_N_n<d> = k` writes
-  (`_cond_field_name`) and arm registrations (`_push_cond_branch`,
-  `_set_cond_branch_target`, `_store_cond_branch_info`) land in that sink
-  instead of the enclosing point's entry. The sink is pushed to
-  `context.nested_cond_records`; its index is the enclosing arm's
-  `CondBranch.nested` (an index, because `CondBranch` and
-  `AsyncCondBranchInfo` may not name each other).
-- **Resume side** (`state_machine.yo`). `_emit_nested_level_switch` switches
-  on the nested field, binds the taken nested arm's result (or hands it to the
-  nested instance's `x :=` target), recurses for deeper levels, runs the
-  nested arm's remaining code — and then the caller runs the ENCLOSING arm's
-  remaining code: the two-level dispatch that replaced the dead `case`.
-  Dispatch-mode points extract per nested arm through the recursive
-  `_emit_dispatch_extraction_case`. Uniform (slot-guarded) points emit the
-  nested-bearing arms AFTER the guard in `_emit_nested_branch_continuation`,
-  with the bindings under a `__yo_had_future_N` C local remembered from before
-  the guard, so a nested arm that completed synchronously (no future stored,
-  guard skipped) still runs the enclosing arm's statements — once, because
-  emitting the remaining code twice re-referenced the cached temporaries of
-  its own next await.
-- The "nested match claims the dispatch slot" fatal for dispatch-mode points
-  is gone; that shape is now emitted.
+- **Registration** (`state_code_gen.yo`). `generate_cond_branch_with_await`
+  returns a `BranchEmission(remaining, nested, codes)`. A nested cond/match in
+  an awaiting arm — bare, or the RHS of `x := …` / `x = …` (the bound form used
+  to fall through EVERY emitter case and emit nothing) — goes through
+  `_emit_nested_cond_or_match`: a fresh `AsyncCondBranchInfo` record is
+  pushed to `context.nested_cond_records` and handed to the cond/match emitter
+  through `context.nested_cond_sink`, which the emitter CLAIMS at entry into
+  `context.nested_cond_owner` (restored at exit) — so exactly the instance's
+  own arms register in the await point's entry as usual AND in that record
+  (`CondBranch.owner` names it), with its TARGETS going to the record only —
+  the entry's targets stay the top-level instance's. An instance emitted inside
+  one of its arm bodies some other way (a cond in a while body) finds no sink
+  and registers as an ordinary entry arm, keeping its own case. The record is
+  the enclosing arm's `CondBranch.nested`.
+  `CondBranch.codes` is the arm's own code plus every code allocated while its
+  body was emitted (nested arms, conds inside while loops, …). The legacy
+  "nested claimed the slot" special cases (`_push_chained_match_arm`, the
+  trivial-remaining post-while routing, the inner-wins store skip) are gone;
+  `_store_cond_branch_info` always unions by code.
+- **Resume** (`state_machine.yo`). The continuation switch emits an arm holding
+  a nested instance as ONE case labelled with the codes `_assign_case_labels`
+  gives it — within one switch each code goes to the arm with the smallest
+  code window containing it (a cond in a while body over the arm enclosing the
+  loop), and codes nobody more specific claims (a synchronous nested arm's,
+  which never registers) go to the enclosing arm — whose body is
+  `_emit_nested_level_switch` — a switch on the
+  same field over the nested arms' codes that binds the taken arm's result (or
+  hands it to the instance's target), recurses for deeper nesting and runs the
+  nested arm's remaining code — followed by the enclosing arm's remaining code.
+  Owned arms get no case of their own. Uniform (slot-guarded) points emit these
+  cases AFTER the guard in `_emit_nested_branch_continuation`, with the bindings
+  under a `__yo_had_future_N` C local captured before the guard, so a nested
+  arm that completed synchronously (no future stored, guard skipped) still runs
+  the enclosing arm's statements — once. Chained layers and post-while
+  continuations test `_codes_guard(field, codes)` instead of `== index`, and
+  chained records carry the arm's `codes`. Dispatch-mode suspension and
+  extraction switch over the nested arms' own cases (exact future shape and
+  named-ness per arm); the enclosing arm, whose code never holds the field at
+  the point, gets none. A nested arm whose value IS the await hands it to its
+  instance's target, resolved up the owner chain (`_branch_value_target`), and
+  a bare nested instance that is the enclosing arm's tail inherits the
+  enclosing level's target (`tail_of_enclosing_arm`).
 
-Programs without nesting emit byte-identical C (checked with `--emit-c-to`
-on the direct-await control shape).
+Programs without nesting emit byte-identical C (`codes == [index]`, so the
+labels and guards are unchanged).
 
 **Gate:** `tests/async_await.test.yo` — "an awaiting inner match inside a
 match arm keeps the arm's trailing statements", "the yo install shape: inner
 match, a second bound await, an awaiting if, and a sibling arm binding the
 same name", "two nesting levels: an awaiting cond inside a match inside a
-match arm". All three fail (dropped arm / mis-typed slot) before the fix.
+match arm", "nested cond arms mixing a named and an anonymous future await
+through their own access"; plus `tests/fs/dir.test.yo` (`create_dir_all`: a
+nested cond whose arm holds an awaiting while and a further await) as the
+regression canary for the shared-field consumers. The pre-fix compiler cannot
+C-compile the batch holding the first three (the mis-typed slot).
 
 ## Fix direction (as filed)
 

--- a/issues/repros/async-chained-sibling-arm-second-await-binding-never-assigned.yo
+++ b/issues/repros/async-chained-sibling-arm-second-await-binding-never-assigned.yo
@@ -1,0 +1,53 @@
+// Reproducer for issues/fixed/async-chained-sibling-arm-second-await-binding-never-assigned.md
+// Expected: `A:exists=true;A:added;` then `B:nm=nm;B:added;`. Pre-fix the second line lacked `B:added;`.
+{ println } :: import("std/fmt");
+{ String } :: import("std/string");
+{ Exception, IoExn } :: import("std/error");
+{ yield } :: import("std/async");
+
+flag :: (fn(io : Io) -> Impl(Future(bool, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    true
+  })
+);
+name_of :: (fn(io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    String.from("nm")
+  })
+);
+// Two sibling arms whose SECOND awaits bind same-typed locals: the arm
+// registered second lands in a chained layer of the sibling's entry.
+Kind :: enum(A, B);
+run :: (fn(k : Kind, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    (log : String) = String.new();
+    match(
+      k,
+      .A => {
+        exists := e.io.await(flag(e.io), e);
+        log.push_string(`A:exists=${exists.to_string()};`);
+        added := e.io.await(flag(e.io), e);
+        if(added, {
+          log.push_str("A:added;");
+        });
+      },
+      .B => {
+        nm := e.io.await(name_of(e.io), e);
+        log.push_string(`B:nm=${nm};`);
+        added := e.io.await(flag(e.io), e);
+        if(added, {
+          log.push_str("B:added;");
+        });
+      }
+    );
+    log
+  })
+);
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  b := IoExn(io : io, exn : exn);
+  println(io.await(run(Kind.A, io), b));
+  println(io.await(run(Kind.B, io), b));
+});
+export(main);

--- a/issues/repros/async-cond-arm-tail-value-lost-after-second-await.yo
+++ b/issues/repros/async-cond-arm-tail-value-lost-after-second-await.yo
@@ -1,0 +1,36 @@
+// Reproducer for issues/fixed/async-cond-arm-tail-value-lost-after-second-await.md
+// Compile + run: `yo compile <this> --optimize 2 -o r && ./r` — printed an EMPTY first line before the fix (expected `r-a|r-b`).
+{ println } :: import("std/fmt");
+{ String } :: import("std/string");
+{ Exception, IoExn } :: import("std/error");
+{ yield } :: import("std/async");
+
+resolve :: (fn(tag : String, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    s := String.from("r-");
+    s.push_string(tag);
+    s
+  })
+);
+// Two plain bound awaits in one arm of a VALUE-producing match: the arm's
+// tail value after the SECOND await must reach `out`.
+two_awaits :: (fn(flag : bool, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    out := cond(
+      flag => {
+        a := e.io.await(resolve(String.from("a"), e.io), e);
+        b := e.io.await(resolve(String.from("b"), e.io), e);
+        `${a}|${b}`
+      },
+      true => String.from("no")
+    );
+    out
+  })
+);
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  b := IoExn(io : io, exn : exn);
+  println(io.await(two_awaits(true, io), b));
+  println(io.await(two_awaits(false, io), b));
+});
+export(main);

--- a/issues/repros/async-post-while-code-runs-for-a-sibling-nested-arm.yo
+++ b/issues/repros/async-post-while-code-runs-for-a-sibling-nested-arm.yo
@@ -1,0 +1,52 @@
+// Reproducer for issues/fixed/async-post-while-code-runs-for-a-sibling-nested-arm.md
+// Expected: `plain;end`, `no-loop;outer-tail;end`, `i=2;i=3;loop-done;outer-tail;end`. Pre-fix the second line read `no-loop;loop-done;outer-tail;end`.
+{ println } :: import("std/fmt");
+{ String } :: import("std/string");
+{ Exception, IoExn } :: import("std/error");
+{ yield } :: import("std/async");
+
+step :: (fn(n : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    n + usize(1)
+  })
+);
+// A nested cond whose arm LOOPS with an await, followed by statements of the
+// ENCLOSING arm — the create_dir_all shape plus a trailing enclosing statement.
+walk :: (fn(mode : usize, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    (log : String) = String.new();
+    first := e.io.await(step(usize(0), e.io), e);
+    cond(
+      (mode == usize(0)) => {
+        log.push_str("plain;");
+      },
+      true => {
+        cond(
+          (mode == usize(1)) => {
+            log.push_str("no-loop;");
+          },
+          true => {
+            (i : usize) = first;
+            while(runtime(i < usize(3)), {
+              r := e.io.await(step(i, e.io), e);
+              i = r;
+              log.push_string(`i=${i.to_string()};`);
+            });
+            log.push_str("loop-done;");
+          }
+        );
+        log.push_str("outer-tail;");
+      }
+    );
+    log.push_str("end");
+    log
+  })
+);
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  b := IoExn(io : io, exn : exn);
+  println(io.await(walk(usize(0), io), b));
+  println(io.await(walk(usize(1), io), b));
+  println(io.await(walk(usize(2), io), b));
+});
+export(main);

--- a/issues/repros/async-while-body-reassigning-an-await-result-never-stores-the-future.yo
+++ b/issues/repros/async-while-body-reassigning-an-await-result-never-stores-the-future.yo
@@ -1,0 +1,28 @@
+// Reproducer for issues/fixed/async-while-body-reassigning-an-await-result-never-stores-the-future.md
+// Expected: `3`. Pre-fix: SIGSEGV (rc=139) — the loop body stored no future and the resume read a NULL slot.
+{ println } :: import("std/fmt");
+{ String } :: import("std/string");
+{ Exception, IoExn } :: import("std/error");
+{ yield } :: import("std/async");
+
+step :: (fn(n : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    n + usize(1)
+  })
+);
+// Plain while in an async body whose body RE-ASSIGNS an outer local from an await.
+run :: (fn(io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async((e : IoExn) => {
+    (i : usize) = usize(0);
+    while(runtime(i < usize(3)), {
+      i = e.io.await(step(i, e.io), e);
+    });
+    i
+  })
+);
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  b := IoExn(io : io, exn : exn);
+  println(io.await(run(io), b).to_string());
+});
+export(main);

--- a/issues/repros/nested-value-match-with-await-drops-the-enclosing-match-arm.yo
+++ b/issues/repros/nested-value-match-with-await-drops-the-enclosing-match-arm.yo
@@ -1,5 +1,5 @@
-// Reproducer for issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md
-// Compile + run: `yo compile <this> --optimize 2 -o r && ./r` — the `.Git` arm prints NOTHING.
+// Reproducer for issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md
+// Compile + run: `yo compile <this> --optimize 2 -o r && ./r` — the `.Git` arm used to print NOTHING (fixed 2026-09-11).
 { println } :: import("std/fmt");
 { String } :: import("std/string");
 { Exception, IoExn } :: import("std/error");

--- a/issues/yo-install-git-dependency-writes-an-empty-ref.md
+++ b/issues/yo-install-git-dependency-writes-an-empty-ref.md
@@ -1,6 +1,10 @@
 # `yo install user/repo[@tag]` writes `ref: ""` to `deps.yo`, skips the fetch, and exits 0
 
-**Status:** OPEN
+**Status:** OPEN — root cause FIXED 2026-09-11 (`fix/async-nested-match-dead-arm`,
+`issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md`);
+the data-path hardening in "Fix direction" item 2 is still owed, and the
+install flow itself is only fixed in a binary whose OWN body was compiled by a
+compiler carrying the fix (gen-2 — the released seed still has the old lowering).
 **Found:** 2026-09-11, auditing the dependency subsystem
 (`plans/BUILD_AND_DEPENDENCY_SYSTEM_REDESIGN.md`). Reproduced with the released
 `yo 0.2.30` on macOS and with a compiler built from `develop` (`94fae98f8`)
@@ -49,7 +53,7 @@ Three things are wrong at once:
 
 ## Root cause (found 2026-09-11 by body substitution)
 
-`issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md`: in an
+`issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md`: in an
 `io.async` body, a match arm that contains a value-producing INNER match with
 an awaiting arm is emitted as nothing. `run_install`'s `.Git(…)` arm is that
 shape (`ref_str := match(g_pinned_ref, .Some(r) => r, .None => { await
@@ -60,9 +64,9 @@ fails at the C compiler with a mis-typed state-machine slot instead.
 
 ## Fix direction
 
-1. Fix the lowering bug in `src/codegen/async/` (the nested-match issue above
-   owns the reproducer and gate). Until then, `run_install` can hoist the
-   inner match's awaiting arm into its own async fn.
+1. ~~Fix the lowering bug in `src/codegen/async/`~~ — DONE 2026-09-11 (the
+   nested-match issue above owns the reproducer and gate); `run_install` is
+   unchanged and emits correctly under a fixed compiler.
 2. Independently harden the data path: `resolve_git_ref` must fail loudly on
    an empty ref or a non-zero `git ls-remote`, and `run_install` must refuse to
    write a declaration with an empty ref. Gate: an offline cli-case that

--- a/issues/yo-install-git-dependency-writes-an-empty-ref.md
+++ b/issues/yo-install-git-dependency-writes-an-empty-ref.md
@@ -1,10 +1,16 @@
 # `yo install user/repo[@tag]` writes `ref: ""` to `deps.yo`, skips the fetch, and exits 0
 
-**Status:** OPEN — root cause FIXED 2026-09-11 (`fix/async-nested-match-dead-arm`,
-`issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md`);
-the data-path hardening in "Fix direction" item 2 is still owed, and the
-install flow itself is only fixed in a binary whose OWN body was compiled by a
-compiler carrying the fix (gen-2 — the released seed still has the old lowering).
+**Status:** OPEN — the install flow is FIXED 2026-09-11 (`fix/async-nested-match-dead-arm`):
+`yo install shd101wyy/raylib_yo@v0.0.6` with a gen-2 compiler writes
+`ref: "v0.0.6"`, prints `Fetching dependency...`, and writes `yo.lock` with the
+resolved commit and hash. Two emitter bugs had to go for that —
+`issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md`
+(the `ref: ""`) and
+`issues/fixed/async-chained-sibling-arm-second-await-binding-never-assigned.md`
+(the fetch after `added := await …` never running). Only in a binary whose OWN
+body was compiled by a compiler carrying the fixes (gen-2 — the released seed
+still has the old lowering). Kept open for the data-path hardening in "Fix
+direction" item 2.
 **Found:** 2026-09-11, auditing the dependency subsystem
 (`plans/BUILD_AND_DEPENDENCY_SYSTEM_REDESIGN.md`). Reproduced with the released
 `yo 0.2.30` on macOS and with a compiler built from `develop` (`94fae98f8`)

--- a/src/codegen/async/state_code_gen.yo
+++ b/src/codegen/async/state_code_gen.yo
@@ -1574,8 +1574,11 @@ generate_while_body_with_await :: (
     _collect_exprs_from(remaining_exprs, body_exprs, await_found_index + usize(1));
     return(remaining_exprs);
   });
-  // Assignment with await: varName := await(futureExpr).
-  if(ast_expr_is_fn_call(await_expr) && ast_expr_is_fn_call_of(await_expr, ":=", Option(usize).None), {
+  // Assignment with await: varName := await(futureExpr) | varName = await(futureExpr).
+  // Both bind the result to the LHS; `=` used to fall through every arm, so the
+  // future was never stored and the resume read a NULL slot
+  // (issues/fixed/async-while-body-reassigning-an-await-result-never-stores-the-future.md).
+  if(ast_expr_is_fn_call(await_expr) && (ast_expr_is_fn_call_of(await_expr, ":=", Option(usize).None) || ast_expr_is_fn_call_of(await_expr, "=", Option(usize).Some(usize(2)))), {
     a_args := match(await_expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
     match(
       a_args.get(usize(1)),
@@ -1863,51 +1866,6 @@ _branch_future_is_named :: (
     .None => false
   )
 );
-/// The state-machine field a cond/match instance records its taken arm in:
-/// `cond_branch_N` at the top level of await point N, `cond_branch_N_n<d>` for
-/// an instance nested `d` levels inside awaiting arms (exprs/async.yo declares
-/// them from `max_nested_cond_depth`). Distinct fields per level are what
-/// keep the enclosing arm's dispatch code alive across the nested write.
-_cond_field_name :: (fn(context : FunctionGenerationContext, idx_s : String) -> String)(
-  if(
-    context.nested_cond_depth == usize(0),
-    `cond_branch_${idx_s}`,
-    `cond_branch_${idx_s}_n${context.nested_cond_depth.to_string()}`
-  )
-);
-/// Depth of cond/match-with-await nesting inside `expr`: 1 for a cond/match
-/// that carries an await, plus the deepest such instance inside it; the
-/// maximum over children otherwise. `max_nested_cond_depth(body) - 1` is the
-/// number of `_n<d>` fields a state machine needs.
-max_nested_cond_depth :: (fn(expr : AstExpr) -> usize)({
-  is_branching := (ast_expr_is_fn_call(expr) && (ast_expr_is_fn_call_of(expr, BK_COND, Option(usize).None) || ast_expr_is_fn_call_of(expr, BK_MATCH, Option(usize).None)));
-  (best : usize) = usize(0);
-  match(
-    expr,
-    .FnCall(_, head, args, _, _) => {
-      hd := recur(head);
-      if(hd > best, {
-        best = hd;
-      });
-      (i : usize) = usize(0);
-      while(i < args.len(), {
-        match(
-          args.get(i),
-          .Some(a) => {
-            d := recur(a);
-            if(d > best, {
-              best = d;
-            });
-          },
-          .None => ()
-        );
-        i = (i + usize(1));
-      });
-    },
-    .Atom(_, _) => ()
-  );
-  if(is_branching && branch_has_await(expr), (best + usize(1)), best)
-});
 /// The result of emitting one awaiting arm body: the statements after the
 /// await point (resume-state code) and, when the await lives in a cond/match
 /// nested in the arm, that instance's dispatch record.
@@ -1915,15 +1873,34 @@ BranchEmission :: ref(
   struct(
     remaining : ArrayList(AstExpr),
     /// Index into `context.nested_cond_records`.
-    nested : Option(usize)
+    nested : Option(usize),
+    /// Every dispatch code allocated while the arm body was emitted (see
+    /// `CondBranch.codes`).
+    codes : ArrayList(usize)
   )
 );
+/// The dispatch codes handed out by `_alloc_cond_branch_codes` since the
+/// counter stood at `from`: the codes of every cond/match instance emitted
+/// inside that window.
+_codes_allocated_since :: (fn(from : usize, context : FunctionGenerationContext) -> ArrayList(usize))({
+  out := ArrayList(usize).new();
+  (c : usize) = from;
+  if(c == usize(0), {
+    c = usize(1);
+  });
+  while(c < context.cond_branch_case_seq, {
+    out.push(c);
+    c = (c + usize(1));
+  });
+  out
+});
 /// Emit a cond/match NESTED inside an awaiting arm (bare, or the RHS of
-/// `x := …` / `x = …`): its arm records go to a fresh sink that becomes the
-/// enclosing arm's `CondBranch.nested`, and its dispatch writes go to the
-/// per-depth field. The enclosing arm's statements after it are that arm's
+/// `x := …` / `x = …`): its arms register in the await point's entry like any
+/// arm (unique codes on the shared `sm->cond_branch_N`) AND in a fresh record
+/// that becomes the enclosing arm's `CondBranch.nested`; its targets go to
+/// that record only. The enclosing arm's statements after it are that arm's
 /// ordinary remaining code, run in the resume state — after the nested
-/// switch when the nested arm awaited, and through the no-future path
+/// arms' switch when the nested arm awaited, and through the no-future path
 /// (`_emit_nested_branch_continuation`, which runs it once for both) when it
 /// completed synchronously.
 _emit_nested_cond_or_match :: (
@@ -1936,29 +1913,26 @@ _emit_nested_cond_or_match :: (
     target_assignment_code : Option(String)
   ) -> usize
 )({
-  idx_s := await_point.base.index.to_string();
   prev_sink := context.nested_cond_sink;
-  prev_depth := context.nested_cond_depth;
-  depth := (prev_depth + usize(1));
-  sink := AsyncCondBranchInfo(
-    branches : ArrayList(CondBranch).new(),
-    target_variable_id : target_variable_id,
-    target_assignment_code : Option(String).None,
-    cond_branch_field_index : Option(usize).None,
-    chained_branches : Option(ArrayList(ChainedCondBranches)).None,
-    cond_field_name : Option(String).Some(`cond_branch_${idx_s}_n${depth.to_string()}`)
+  record_index := context.nested_cond_records.len();
+  context.nested_cond_records.push(
+    AsyncCondBranchInfo(
+      branches : ArrayList(CondBranch).new(),
+      target_variable_id : target_variable_id,
+      target_assignment_code : Option(String).None,
+      cond_branch_field_index : Option(usize).None,
+      chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+      nested_owner : prev_sink,
+      tail_of_enclosing_arm : false
+    )
   );
-  context.nested_cond_sink = Option(AsyncCondBranchInfo).Some(sink);
-  context.nested_cond_depth = depth;
+  context.nested_cond_sink = Option(usize).Some(record_index);
   if(ast_expr_is_fn_call_of(nested_expr, BK_COND, Option(usize).None), {
     _call_generate_cond_with_await(nested_expr, await_point, indent, context, target_variable_id, target_assignment_code);
   }, {
     _call_generate_match_with_await(nested_expr, await_point, indent, context, target_variable_id, target_assignment_code);
   });
-  context.nested_cond_depth = prev_depth;
   context.nested_cond_sink = prev_sink;
-  record_index := context.nested_cond_records.len();
-  context.nested_cond_records.push(sink);
   record_index
 });
 /// Emit a single cond/match branch body (a `begin` block) up to its first await:
@@ -1971,6 +1945,7 @@ generate_cond_branch_with_await :: (
   em := context.base.emitter;
   remaining_exprs := ArrayList(AstExpr).new();
   (nested_info : Option(usize)) = Option(usize).None;
+  codes_from := context.cond_branch_case_seq;
   idx_s := await_point.base.index.to_string();
   // Dispatch-mode points access each branch's future through its own shape:
   // a NAMED branch future is read via its own field (no slot store), an
@@ -2135,7 +2110,22 @@ generate_cond_branch_with_await :: (
     );
     i = (i + usize(1));
   });
-  BranchEmission(remaining : remaining_exprs, nested : nested_info)
+  // A nested instance that is the arm's LAST expression yields the arm's
+  // value: its arms' await values go to the enclosing level's target.
+  match(
+    nested_info,
+    .Some(k) => if(remaining_exprs.len() == usize(0), {
+      match(
+        context.nested_cond_records.get(k),
+        .Some(rec) => {
+          rec.tail_of_enclosing_arm = true;
+        },
+        .None => ()
+      );
+    }),
+    .None => ()
+  );
+  BranchEmission(remaining : remaining_exprs, nested : nested_info, codes : _codes_allocated_since(codes_from, context))
 });
 /// True when a non-await cond/match branch should emit Future completion because
 /// the cond/match IS the async block body's implicit return value (no assignment
@@ -2275,35 +2265,6 @@ _comptime_bool_value :: (fn(expr : AstExpr, context : FunctionGenerationContext)
     .None => Option(bool).None
   )
 );
-/// True when the cond/match entry already stored at `idx` has a branch with
-/// real remaining (post-await) code — the inner cond's entry should not be
-/// overwritten. Mirrors the `innerHasRemainingCode` checks in
-/// `generateCondWithAwait`.
-_cond_inner_has_remaining_code :: (fn(context : FunctionGenerationContext, idx : usize) -> bool)(
-  match(
-    context.async_cond_branch_info,
-    .Some(m) => match(
-      m.get(idx),
-      .Some(entry) => {
-        (found : bool) = false;
-        (bi : usize) = usize(0);
-        while((bi < entry.branches.len()) && !(found), {
-          match(
-            entry.branches.get(bi),
-            .Some(b) => if(b.has_await && match(b.remaining_exprs, .Some(r) => (r.len() > usize(0)), .None => false), {
-              found = true;
-            }),
-            .None => ()
-          );
-          bi = (bi + usize(1));
-        });
-        found
-      },
-      .None => false
-    ),
-    .None => false
-  )
-);
 /// Emit a non-await cond/match branch value inline: begin blocks emit each
 /// statement (break in an async while → active-flag + goto end; control-flow
 /// always; else skip empty/temp) + deferred drops; non-begin emits the single
@@ -2410,8 +2371,26 @@ _emit_branch_value_inline :: (
 /// Record the `cond_branch_post_while_exprs` on the while-loop info entry for
 /// `await_point.base.index` when an in-loop cond branch has post-await code that
 /// must run only after the loop exits. Helper for `generate_cond_with_await`.
+/// A one-client post-while slot's `part_codes` / `part_lens`.
+_single_part_codes :: (fn(codes : ArrayList(usize)) -> ArrayList(ArrayList(usize)))({
+  out := ArrayList(ArrayList(usize)).new();
+  out.push(codes);
+  out
+});
+_single_part_len :: (fn(n : usize) -> ArrayList(usize))({
+  out := ArrayList(usize).new();
+  out.push(n);
+  out
+});
 _attach_cond_branch_post_while :: (
-  fn(branch_index : usize, value : AstExpr, remaining : ArrayList(AstExpr), context : FunctionGenerationContext, idx : usize) -> unit
+  fn(
+    branch_index : usize,
+    codes : ArrayList(usize),
+    value : AstExpr,
+    remaining : ArrayList(AstExpr),
+    context : FunctionGenerationContext,
+    idx : usize
+  ) -> unit
 )({
   match(
     context.async_while_loop_info,
@@ -2426,10 +2405,13 @@ _attach_cond_branch_post_while :: (
             winfo.cond_branch_post_while_exprs,
             CondBranchPostWhileExprs(
               branch_index : branch_index,
+              codes : codes,
               cond_branch_field_index : idx,
               exprs : remaining,
+              part_codes : _single_part_codes(codes),
+              part_lens : _single_part_len(remaining.len()),
               deferred_drop_expressions : ddx,
-              skip_cond_branch_check : Option(bool).Some(_cond_inner_has_remaining_code(context, idx))
+              skip_cond_branch_check : Option(bool).None
             )
           )
         );
@@ -2515,9 +2497,29 @@ _make_cond_branch :: (
     has_await : bool,
     remaining : Option(ArrayList(AstExpr)),
     context : FunctionGenerationContext,
-    (nested : Option(usize)) ?= Option(usize).None
+    (nested : Option(usize)) ?= Option(usize).None,
+    (body_codes : Option(ArrayList(usize))) ?= Option(ArrayList(usize)).None
   ) -> CondBranch
 )({
+  codes := ArrayList(usize).new();
+  codes.push(index);
+  match(
+    body_codes,
+    .Some(bc) => {
+      (ci : usize) = usize(0);
+      while(ci < bc.len(), {
+        match(
+          bc.get(ci),
+          .Some(c) => {
+            codes.push(c);
+          },
+          .None => ()
+        );
+        ci = (ci + usize(1));
+      });
+    },
+    .None => ()
+  );
   branch_awaits := ArrayList(AstExpr).new();
   if(has_await, {
     collect_branch_await_exprs(value.clone(), branch_awaits);
@@ -2536,7 +2538,9 @@ _make_cond_branch :: (
       has_await => Option(ArrayList(AstExpr)).Some(branch_awaits),
       true => Option(ArrayList(AstExpr)).None
     ),
-    nested : nested
+    nested : nested,
+    owner : context.nested_cond_owner,
+    codes : codes
   )
 });
 /// The destination the await-branch registration names for the branch's LAST
@@ -2579,12 +2583,17 @@ _set_cond_branch_target :: (
   fn(context : FunctionGenerationContext, idx : usize, target : Option(String)) -> unit
 )({
   if(target.is_none(), return(()));
+  // A NESTED instance's target lives on its record, never on the entry.
   match(
-    context.nested_cond_sink,
-    .Some(sink) => {
-      if(sink.target_assignment_code.is_none(), {
-        sink.target_assignment_code = target;
-      });
+    context.nested_cond_owner,
+    .Some(k) => {
+      match(
+        context.nested_cond_records.get(k),
+        .Some(rec) => if(rec.target_assignment_code.is_none(), {
+          rec.target_assignment_code = target;
+        }),
+        .None => ()
+      );
       return(());
     },
     .None => ()
@@ -2602,7 +2611,8 @@ _set_cond_branch_target :: (
       target_assignment_code : Option(String).None,
       cond_branch_field_index : Option(usize).None,
       chained_branches : Option(ArrayList(ChainedCondBranches)).None,
-      cond_field_name : Option(String).None
+      nested_owner : Option(usize).None,
+      tail_of_enclosing_arm : false
     )
   );
   if(entry.target_assignment_code.is_none(), {
@@ -2620,135 +2630,91 @@ _store_cond_branch_info :: (
     idx : usize,
     branches : ArrayList(CondBranch),
     target_variable_id : Option(String),
-    target_assignment_code : Option(String),
-    /// Dispatch-mode points UNION branch records instead of overwriting:
-    /// dispatch codes are per-function unique, and the registration/extraction
-    /// switches need a case for EVERY awaiting arm at any nesting level —
-    /// overwriting the nested cond's records left its live codes caseless
-    /// (the `default:` skipped the await entirely). Uniform points keep the
-    /// overwrite: their nested remaining code rides `chained_branches`, and a
-    /// union would double-emit it.
-    merge_branches : bool
+    target_assignment_code : Option(String)
   ) -> unit
 )({
-  // A NESTED instance's records live in its sink: union by dispatch code,
-  // targets from this (final) store.
+  // A NESTED instance: its arms go to its record (union by code) and to the
+  // entry; its targets to the record ONLY — the entry's targets belong to
+  // the top-level instance, whose store runs last.
+  (entry_targets : bool) = true;
   match(
-    context.nested_cond_sink,
-    .Some(sink) => {
-      (bi0 : usize) = usize(0);
-      while(bi0 < branches.len(), {
-        match(
-          branches.get(bi0),
-          .Some(nb) => {
-            (dup0 : bool) = false;
-            (si0 : usize) = usize(0);
-            while((si0 < sink.branches.len()) && !(dup0), {
-              match(
-                sink.branches.get(si0),
-                .Some(sb) => if(sb.index == nb.index, {
-                  dup0 = true;
-                }),
-                .None => ()
-              );
-              si0 = (si0 + usize(1));
-            });
-            if(!(dup0), {
-              sink.branches.push(nb);
-            });
-          },
-          .None => ()
-        );
-        bi0 = (bi0 + usize(1));
-      });
-      if(target_variable_id.is_some(), {
-        sink.target_variable_id = target_variable_id;
-      });
-      if(target_assignment_code.is_some(), {
-        sink.target_assignment_code = target_assignment_code;
-      });
-      return(());
-    },
+    context.nested_cond_owner,
+    .Some(k) => match(
+      context.nested_cond_records.get(k),
+      .Some(rec) => {
+        _union_cond_branches(rec.branches, branches);
+        if(target_variable_id.is_some(), {
+          rec.target_variable_id = target_variable_id;
+        });
+        if(target_assignment_code.is_some(), {
+          rec.target_assignment_code = target_assignment_code;
+        });
+        entry_targets = false;
+      },
+      .None => ()
+    ),
     .None => ()
   );
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
   });
-  if(merge_branches, {
-    cmap0 := match(context.async_cond_branch_info, .Some(m) => m, .None => HashMap(usize, AsyncCondBranchInfo).new());
+  cmap := match(context.async_cond_branch_info, .Some(m) => m, .None => HashMap(usize, AsyncCondBranchInfo).new());
+  match(
+    cmap.get(idx),
+    .Some(existing) => {
+      // Union by dispatch code (codes are per-function unique, and every
+      // consumer switching on the field needs a case for EVERY awaiting arm
+      // at any nesting level); entry-level fields survive.
+      _union_cond_branches(existing.branches, branches);
+      if(entry_targets, {
+        existing.target_variable_id = target_variable_id;
+        existing.target_assignment_code = target_assignment_code;
+      });
+      cmap.insert(idx, existing);
+    },
+    .None => {
+      cmap.insert(
+        idx,
+        AsyncCondBranchInfo(
+          branches : branches,
+          target_variable_id : cond(entry_targets => target_variable_id, true => Option(String).None),
+          target_assignment_code : cond(entry_targets => target_assignment_code, true => Option(String).None),
+          cond_branch_field_index : Option(usize).None,
+          chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+          nested_owner : Option(usize).None,
+          tail_of_enclosing_arm : false
+        )
+      );
+    }
+  );
+  context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(cmap);
+});
+/// Append every arm of `incoming` whose dispatch code `into` does not hold yet.
+_union_cond_branches :: (fn(into : ArrayList(CondBranch), incoming : ArrayList(CondBranch)) -> unit)({
+  (bi : usize) = usize(0);
+  while(bi < incoming.len(), {
     match(
-      cmap0.get(idx),
-      .Some(existing) => {
-        // Union by dispatch code; entry-level fields (targets) take the
-        // OUTER store's values — it runs last and owns the value flow.
-        (bi : usize) = usize(0);
-        while(bi < existing.branches.len(), {
+      incoming.get(bi),
+      .Some(nb) => {
+        (dup : bool) = false;
+        (si : usize) = usize(0);
+        while((si < into.len()) && !(dup), {
           match(
-            existing.branches.get(bi),
-            .Some(eb) => {
-              (dup : bool) = false;
-              (ni : usize) = usize(0);
-              while((ni < branches.len()) && !(dup), {
-                match(
-                  branches.get(ni),
-                  .Some(nb) => if(nb.index == eb.index, {
-                    dup = true;
-                  }),
-                  .None => ()
-                );
-                ni = (ni + usize(1));
-              });
-              if(!(dup), {
-                branches.push(eb);
-              });
-            },
+            into.get(si),
+            .Some(sb) => if(sb.index == nb.index, {
+              dup = true;
+            }),
             .None => ()
           );
-          bi = (bi + usize(1));
+          si = (si + usize(1));
         });
-        cmap0.insert(
-          idx,
-          AsyncCondBranchInfo(
-            branches : branches,
-            target_variable_id : target_variable_id,
-            target_assignment_code : target_assignment_code,
-            cond_branch_field_index : existing.cond_branch_field_index,
-            chained_branches : existing.chained_branches,
-            cond_field_name : Option(String).None
-          )
-        );
+        if(!(dup), {
+          into.push(nb);
+        });
       },
-      .None => {
-        cmap0.insert(
-          idx,
-          AsyncCondBranchInfo(
-            branches : branches,
-            target_variable_id : target_variable_id,
-            target_assignment_code : target_assignment_code,
-            cond_branch_field_index : Option(usize).None,
-            chained_branches : Option(ArrayList(ChainedCondBranches)).None,
-            cond_field_name : Option(String).None
-          )
-        );
-      }
+      .None => ()
     );
-    context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(cmap0);
-    return(());
-  });
-  if(!(_cond_inner_has_remaining_code(context, idx)), {
-    cmap := match(context.async_cond_branch_info, .Some(m) => m, .None => HashMap(usize, AsyncCondBranchInfo).new());
-    cmap.insert(
-      idx,
-      AsyncCondBranchInfo(
-        branches : branches,
-        target_variable_id : target_variable_id,
-        target_assignment_code : target_assignment_code,
-        cond_branch_field_index : Option(usize).None,
-        chained_branches : Option(ArrayList(ChainedCondBranches)).None,
-        cond_field_name : Option(String).None
-      )
-    );
-    context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(cmap);
+    bi = (bi + usize(1));
   });
 });
 /// Emit a `cond(...)` whose branches contain await: an if-else chain that records
@@ -2788,7 +2754,7 @@ _alloc_cond_branch_codes :: (
   context.cond_branch_case_seq = (base + step);
   base
 });
-generate_cond_with_await :: (
+_generate_cond_with_await_impl :: (
   fn(
     cond_expr : AstExpr,
     await_point : AwaitPoint,
@@ -2880,15 +2846,15 @@ generate_cond_with_await :: (
               // with the recorded branch index while that index happened to be
               // 0. Dispatch codes are per-function now (_alloc_cond_branch_codes),
               // so the assignment has to be real.
-              em.emit_string_line(`${indent}sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + fi).to_string()};`);
+              em.emit_string_line(`${indent}sm->cond_branch_${idx_s} = ${(cond_branch_base + fi).to_string()};`);
               emission := generate_cond_branch_with_await(value, await_point, indent, context);
               remaining := emission.remaining;
               has_while := match(context.async_while_loop_info, .Some(m) => match(m.get(await_point.base.index), .Some(_) => true, .None => false), .None => false);
               if(has_while && (remaining.len() > usize(0)), {
-                _attach_cond_branch_post_while(cond_branch_base + fi, value, remaining, context, await_point.base.index);
-                branches_with_await.push(_make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).Some(ArrayList(AstExpr).new()), context, emission.nested));
+                _attach_cond_branch_post_while(cond_branch_base + fi, _make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).None, context, emission.nested, Option(ArrayList(usize)).Some(emission.codes)).codes, value, remaining, context, await_point.base.index);
+                branches_with_await.push(_make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).Some(ArrayList(AstExpr).new()), context, emission.nested, Option(ArrayList(usize)).Some(emission.codes)));
               }, {
-                branches_with_await.push(_make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested));
+                branches_with_await.push(_make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested, Option(ArrayList(usize)).Some(emission.codes)));
               });
             }, {
               if(_should_emit_async_branch_completion(cond_expr, value, context, target_variable_id, target_assignment_code), {
@@ -2904,7 +2870,7 @@ generate_cond_with_await :: (
       },
       .None => ()
     );
-    _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(cond_expr, context, target_variable_id.clone(), target_assignment_code.clone()), cond_await_point_needs_dispatch(await_point, context));
+    _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(cond_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
     return();
   });
   // General if-else chain.
@@ -2947,7 +2913,7 @@ generate_cond_with_await :: (
             value_indent := current_indent.clone();
             value_indent.push_str("  ");
             if(branch_has_await(value), {
-              em.emit_string_line(`${value_indent}sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + ci).to_string()};`);
+              em.emit_string_line(`${value_indent}sm->cond_branch_${idx_s} = ${(cond_branch_base + ci).to_string()};`);
               emission := generate_cond_branch_with_await(value, await_point, value_indent, context);
               remaining := emission.remaining;
               has_while := match(context.async_while_loop_info, .Some(m) => match(m.get(await_point.base.index), .Some(_) => true, .None => false), .None => false);
@@ -2958,10 +2924,10 @@ generate_cond_with_await :: (
                 // index made `_flush_inner` in std/sys/bufio/buf_writer.yo test
                 // `== 0` against a field holding `2`, so the buffer was never
                 // emptied and `BufWriter` reflushed the same bytes forever.
-                _attach_cond_branch_post_while(cond_branch_base + ci, value, remaining, context, await_point.base.index);
-                branches_with_await.push(_make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).Some(ArrayList(AstExpr).new()), context, emission.nested));
+                _attach_cond_branch_post_while(cond_branch_base + ci, _make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).None, context, emission.nested, Option(ArrayList(usize)).Some(emission.codes)).codes, value, remaining, context, await_point.base.index);
+                branches_with_await.push(_make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).Some(ArrayList(AstExpr).new()), context, emission.nested, Option(ArrayList(usize)).Some(emission.codes)));
               }, {
-                branches_with_await.push(_make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested));
+                branches_with_await.push(_make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested, Option(ArrayList(usize)).Some(emission.codes)));
               });
             }, {
               if(_should_emit_async_branch_completion(cond_expr, value, context, target_variable_id, target_assignment_code), {
@@ -2987,7 +2953,7 @@ generate_cond_with_await :: (
     em.emit_string_line(`${current_indent}}`);
     cd = (cd + usize(1));
   });
-  _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(cond_expr, context, target_variable_id.clone(), target_assignment_code.clone()), cond_await_point_needs_dispatch(await_point, context));
+  _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(cond_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
 });
 /// Index of the variant named `variant_name` in the enum's parallel arrays, or
 /// `.None`. Replaces TS `enumType.variants.find(v => v.name === ...)`.
@@ -3136,10 +3102,10 @@ generate_primitive_match_with_await :: (
             }
           );
         });
-        em.emit_string_line(`${indent}    sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + i).to_string()};`);
+        em.emit_string_line(`${indent}    sm->cond_branch_${idx_s} = ${(cond_branch_base + i).to_string()};`);
         if(branch_has_await(case_body), {
           emission := generate_cond_branch_with_await(case_body, await_point, `${indent}    `, context);
-          branches_with_await.push(_make_cond_branch(cond_branch_base + i, case_body, true, Option(ArrayList(AstExpr)).Some(emission.remaining), context, emission.nested));
+          branches_with_await.push(_make_cond_branch(cond_branch_base + i, case_body, true, Option(ArrayList(AstExpr)).Some(emission.remaining), context, emission.nested, Option(ArrayList(usize)).Some(emission.codes)));
         }, {
           if(_should_emit_async_branch_completion(match_expr, case_body, context, target_variable_id, target_assignment_code), {
             _emit_non_await_branch_async_completion(case_body, `${indent}    `, context);
@@ -3155,41 +3121,26 @@ generate_primitive_match_with_await :: (
     i = (i + usize(1));
   });
   em.emit_string_line(`${indent}}`);
-  // Primitive match always stores branch info (TS sets unconditionally).
-  // Dispatch-mode points merge instead — nested arm records must survive.
-  if(cond_await_point_needs_dispatch(await_point, context), {
-    _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()), true);
-    return(());
-  });
-  if(context.async_cond_branch_info.is_none(), {
-    context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
-  });
-  pmap := match(context.async_cond_branch_info, .Some(m) => m, .None => HashMap(usize, AsyncCondBranchInfo).new());
-  pmap.insert(
-    await_point.base.index,
-    AsyncCondBranchInfo(
-      branches : branches_with_await,
-      target_variable_id : target_variable_id,
-      target_assignment_code : _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()),
-      cond_branch_field_index : Option(usize).None,
-      chained_branches : Option(ArrayList(ChainedCondBranches)).None,
-      cond_field_name : Option(String).None
-    )
-  );
-  context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(pmap);
+  // Primitive match always stores branch info (TS sets unconditionally);
+  // the store unions with any nested arm records already at this index.
+  _store_cond_branch_info(context, await_point.base.index, branches_with_await, target_variable_id, _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
 });
 /// Append one `CondBranch` to the cond/match entry at `idx` (get-or-create the
 /// entry, push, store back). The enum/nullable match paths accumulate branches
 /// incrementally (vs cond's whole-entry store). Mirrors the
 /// `asyncCondBranchInfo.get(idx) || {branches:[]}; push; set` pattern.
 _push_cond_branch :: (fn(context : FunctionGenerationContext, idx : usize, branch : CondBranch) -> unit)({
-  // A NESTED instance registers into its own record (see _emit_nested_cond_or_match).
+  // A NESTED instance's arm registers in its record too (see
+  // _emit_nested_cond_or_match) — and then in the entry like any arm.
   match(
-    context.nested_cond_sink,
-    .Some(sink) => {
-      sink.branches.push(branch);
-      return(());
-    },
+    context.nested_cond_owner,
+    .Some(k) => match(
+      context.nested_cond_records.get(k),
+      .Some(rec) => {
+        rec.branches.push(branch);
+      },
+      .None => ()
+    ),
     .None => ()
   );
   if(context.async_cond_branch_info.is_none(), {
@@ -3205,7 +3156,8 @@ _push_cond_branch :: (fn(context : FunctionGenerationContext, idx : usize, branc
       target_assignment_code : Option(String).None,
       cond_branch_field_index : Option(usize).None,
       chained_branches : Option(ArrayList(ChainedCondBranches)).None,
-      cond_field_name : Option(String).None
+      nested_owner : Option(usize).None,
+      tail_of_enclosing_arm : false
     )
   );
   entry.branches.push(branch);
@@ -3325,80 +3277,6 @@ _extract_variant_name :: (fn(pattern : AstExpr) -> Option(String))({
   });
   Option(String).None
 });
-/// The number of branches currently recorded for the cond/match entry at
-/// `idx` — compared before/after `generate_cond_branch_with_await` to detect
-/// that a NESTED match inside the arm claimed the dispatch slot (its
-/// recursion pushed branches). Mirrors `branchCountBefore` (state-code-gen.ts).
-_cond_entry_branch_count :: (fn(context : FunctionGenerationContext, idx : usize) -> usize)(
-  match(
-    context.async_cond_branch_info,
-    .Some(m) => match(m.get(idx), .Some(e) => e.branches.len(), .None => usize(0)),
-    .None => usize(0)
-  )
-);
-/// True when every remaining expr is a trivial unit — a bare `()` atom or an
-/// empty tuple call. Mirrors `remainingIsTrivial` (state-code-gen.ts).
-_remaining_exprs_all_trivial :: (fn(remaining : ArrayList(AstExpr)) -> bool)({
-  (ri : usize) = usize(0);
-  (all_trivial : bool) = true;
-  while(ri < remaining.len(), {
-    match(
-      remaining.get(ri),
-      .Some(e) => if(!(ast_expr_is_atom_of(e, "()") || ast_expr_is_fn_call_of(e, BK_TUPLE, Option(usize).Some(usize(0)))), {
-        all_trivial = false;
-      }),
-      .None => ()
-    );
-    ri = (ri + usize(1));
-  });
-  all_trivial
-});
-/// Attach a match arm whose dispatch slot was claimed by a NESTED match as a
-/// CHAINED layer on the entry at `idx`: chained layers run AFTER the branch
-/// switch regardless of the dispatch value, which is safe because RC drops are
-/// no-ops on the zeroed slots of arms that never ran. Mirrors the
-/// `branchData.chainedBranches.push` arm of generateMatchWithAwait
-/// (state-code-gen.ts). No `await_target_variable_id` — the arm's await result
-/// (if any) belongs to the nested match's branch.
-_push_chained_match_arm :: (
-  fn(context : FunctionGenerationContext, idx : usize, case_index : usize, case_body : AstExpr, remaining : ArrayList(AstExpr)) -> unit
-)({
-  if(context.async_cond_branch_info.is_none(), {
-    context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
-  });
-  m := match(context.async_cond_branch_info, .Some(x) => x, .None => HashMap(usize, AsyncCondBranchInfo).new());
-  entry := match(
-    m.get(idx),
-    .Some(e) => e,
-    .None => AsyncCondBranchInfo(
-      branches : ArrayList(CondBranch).new(),
-      target_variable_id : Option(String).None,
-      target_assignment_code : Option(String).None,
-      cond_branch_field_index : Option(usize).None,
-      chained_branches : Option(ArrayList(ChainedCondBranches)).None,
-      cond_field_name : Option(String).None
-    )
-  );
-  chained_awaits := ArrayList(AstExpr).new();
-  collect_branch_await_exprs(case_body.clone(), chained_awaits);
-  cb := CondBranch(
-    index : case_index,
-    value : case_body,
-    has_await : true,
-    remaining_exprs : Option(ArrayList(AstExpr)).Some(remaining),
-    deferred_drop_expressions : match(context.base.get_expr_info(case_body), .Some(ei) => ei.deferred_drop_expressions, .None => Option(ArrayList(AstExpr)).None),
-    await_target_variable_id : Option(String).None,
-    await_exprs : Option(ArrayList(AstExpr)).Some(chained_awaits),
-    nested : Option(usize).None
-  );
-  chained := match(entry.chained_branches, .Some(c) => c, .None => ArrayList(ChainedCondBranches).new());
-  bl := ArrayList(CondBranch).new();
-  bl.push(cb);
-  chained.push(ChainedCondBranches(branches : bl, cond_branch_field_index : idx));
-  entry.chained_branches = Option(ArrayList(ChainedCondBranches)).Some(chained);
-  m.insert(idx, entry);
-  context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(m);
-});
 /// Handle one match case body at `case_index`: a branch with await delegates to
 /// `generate_cond_branch_with_await` (recording remaining exprs); a non-await
 /// branch emits Future completion (if it is the async-body return) or the
@@ -3418,74 +3296,14 @@ _emit_match_case_await_or_value :: (
   ) -> unit
 )({
   if(branch_has_await(case_body), {
-    branch_count_before := _cond_entry_branch_count(context, await_point.base.index);
     emission := generate_cond_branch_with_await(case_body, await_point, indent, context);
-    remaining := emission.remaining;
-    if(remaining.len() == usize(0), {
-      // Tail-await arm (the await IS the arm's value): record it anyway —
-      // dispatch-mode registration/extraction and the uniform target handover
-      // key off this record; without it the arm has no case and its value is
-      // silently dropped. Skip only when a NESTED cond/match claimed the
-      // dispatch slot during the recursion above (its arm records are the
-      // live ones).
-      if(!(_cond_entry_branch_count(context, await_point.base.index) > branch_count_before), {
-        _push_cond_branch(context, await_point.base.index, _make_cond_branch(case_index, case_body, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested));
-      });
-      _set_cond_branch_target(context, await_point.base.index, _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
-    });
-    if(remaining.len() > usize(0), {
-      // A NESTED match inside this arm claims the dispatch slot: its
-      // `sm->cond_branch_N = …` assignment overwrites this arm's, so a `case`
-      // keyed on THIS arm's code is unreachable at resume — its deferred drops
-      // never ran and the nested scrutinee leaked. When the nesting pushed
-      // branches during the recursion above and this arm has nothing left but
-      // trivial unit exprs (drops ride deferred_drop_expressions), the arm
-      // must NOT become a dead case. Two placements, by whether the arm's
-      // await sits inside a WHILE LOOP:
-      //  - inside a loop: route to the loop's post-exit slot (merged — the
-      //    slot may already be claimed), else the arm's scope-end drops would
-      //    run at the top of the loop's resume state once per ITERATION,
-      //    freeing per-outer-iteration locals during the first one.
-      //  - no loop: attach as a chained layer, which runs AFTER the branch
-      //    switch regardless of the dispatch value.
-      // Arms with REAL trailing statements keep the (dead-case) placement —
-      // running them cross-arm would be wrong; that gap is pre-existing.
-      // Mirrors generateMatchWithAwait's nestedClaimedDispatch handling
-      // (state-code-gen.ts).
-      nested_claimed := (_cond_entry_branch_count(context, await_point.base.index) > branch_count_before);
-      if(nested_claimed && _remaining_exprs_all_trivial(remaining), {
-        routed := match(
-          context.async_while_loop_info,
-          .Some(wm) => match(
-            wm.get(await_point.base.index),
-            .Some(winfo) => {
-              winfo.cond_branch_post_while_exprs = Option(CondBranchPostWhileExprs).Some(
-                merge_cond_branch_post_while_exprs(
-                  winfo.cond_branch_post_while_exprs,
-                  CondBranchPostWhileExprs(
-                    branch_index : case_index,
-                    cond_branch_field_index : await_point.base.index,
-                    exprs : remaining,
-                    deferred_drop_expressions : match(context.base.get_expr_info(case_body), .Some(ei) => ei.deferred_drop_expressions, .None => Option(ArrayList(AstExpr)).None),
-                    skip_cond_branch_check : Option(bool).Some(true)
-                  )
-                )
-              );
-              wm.insert(await_point.base.index, winfo);
-              context.async_while_loop_info = Option(HashMap(usize, WhileLoopInfo)).Some(wm);
-              true
-            },
-            .None => false
-          ),
-          .None => false
-        );
-        if(!(routed), {
-          _push_chained_match_arm(context, await_point.base.index, case_index, case_body, remaining);
-        });
-      }, {
-        _push_cond_branch(context, await_point.base.index, _make_cond_branch(case_index, case_body, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested));
-      });
-    });
+    // Record the arm whether or not anything follows its await: a tail-await
+    // arm (the await IS the arm's value) still needs its case — dispatch-mode
+    // registration/extraction and the uniform target handover key off the
+    // record — and an arm holding a NESTED cond/match needs its case to run
+    // the nested arms' remaining code and then its own (its `codes` cover the
+    // nested writes to the shared field, so the case is live).
+    _push_cond_branch(context, await_point.base.index, _make_cond_branch(case_index, case_body, true, Option(ArrayList(AstExpr)).Some(emission.remaining), context, emission.nested, Option(ArrayList(usize)).Some(emission.codes)));
     _set_cond_branch_target(context, await_point.base.index, _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
   }, {
     if(_should_emit_async_branch_completion(match_expr, case_body, context, target_variable_id, target_assignment_code), {
@@ -3502,7 +3320,7 @@ _emit_match_case_await_or_value :: (
 /// C locals), and storing each awaited Future / delegating to
 /// `generate_cond_branch_with_await`. Mirrors `generateMatchWithAwait`
 /// (state-code-gen.ts:1023).
-generate_match_with_await :: (
+_generate_match_with_await_impl :: (
   fn(
     match_expr : AstExpr,
     await_point : AwaitPoint,
@@ -3651,7 +3469,7 @@ generate_match_with_await :: (
                           },
                           .None => ()
                         );
-                        em.emit_string_line(`${indent}  sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + pci).to_string()};`);
+                        em.emit_string_line(`${indent}  sm->cond_branch_${idx_s} = ${(cond_branch_base + pci).to_string()};`);
                         _emit_match_case_await_or_value(match_expr, case_body, cond_branch_base + pci, await_point, `${indent}  `, context, target_variable_id, target_assignment_code);
                       },
                       .None => ()
@@ -3671,7 +3489,7 @@ generate_match_with_await :: (
                     match(
                       cb_body,
                       .Some(case_body) => {
-                        em.emit_string_line(`${indent}  sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + nci).to_string()};`);
+                        em.emit_string_line(`${indent}  sm->cond_branch_${idx_s} = ${(cond_branch_base + nci).to_string()};`);
                         _emit_match_case_await_or_value(match_expr, case_body, cond_branch_base + nci, await_point, `${indent}  `, context, target_variable_id, target_assignment_code);
                       },
                       .None => ()
@@ -3725,7 +3543,7 @@ generate_match_with_await :: (
                       }
                     ));
                     if(emit_case, {
-                      em.emit_string_line(`${indent}    sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + gi).to_string()};`);
+                      em.emit_string_line(`${indent}    sm->cond_branch_${idx_s} = ${(cond_branch_base + gi).to_string()};`);
                       // Destructuring: bind variant fields.
                       if(ast_expr_is_fn_call(pattern), {
                         pf := match(pattern, .FnCall(_, fb, _, _, _) => fb, _ => pattern);
@@ -3789,11 +3607,52 @@ generate_match_with_await :: (
 /// Register the three `*_with_await` emitter entries with the `_fsm.yo` registry.
 /// Call once at codegen init (before any FSM emission). The forward-reference
 /// indirection lets the branch helpers call back into these.
+/// Claims `context.nested_cond_sink` for this instance (see
+/// `FunctionGenerationContext.nested_cond_owner`), emits it, and restores the
+/// enclosing instance's owner.
+generate_cond_with_await :: (
+  fn(
+    cond_expr : AstExpr,
+    await_point : AwaitPoint,
+    indent : String,
+    context : FunctionGenerationContext,
+    target_variable_id : Option(String),
+    target_assignment_code : Option(String)
+  ) -> unit
+)({
+  owner_record := context.nested_cond_sink;
+  context.nested_cond_sink = Option(usize).None;
+  prev_owner := context.nested_cond_owner;
+  context.nested_cond_owner = owner_record;
+  _generate_cond_with_await_impl(cond_expr, await_point, indent, context, target_variable_id, target_assignment_code);
+  context.nested_cond_owner = prev_owner;
+});
+/// Claims `context.nested_cond_sink` for this instance (see
+/// `FunctionGenerationContext.nested_cond_owner`), emits it, and restores the
+/// enclosing instance's owner.
+generate_match_with_await :: (
+  fn(
+    match_expr : AstExpr,
+    await_point : AwaitPoint,
+    indent : String,
+    context : FunctionGenerationContext,
+    target_variable_id : Option(String),
+    target_assignment_code : Option(String)
+  ) -> unit
+)({
+  owner_record := context.nested_cond_sink;
+  context.nested_cond_sink = Option(usize).None;
+  prev_owner := context.nested_cond_owner;
+  context.nested_cond_owner = owner_record;
+  _generate_match_with_await_impl(match_expr, await_point, indent, context, target_variable_id, target_assignment_code);
+  context.nested_cond_owner = prev_owner;
+});
 register_fsm_emitters_impl :: (fn() -> unit)({
   register_fsm_emitters(generate_cond_with_await, generate_match_with_await, generate_while_with_await);
 });
 export(
-  max_nested_cond_depth,
+  _single_part_codes,
+  _single_part_len,
   hoist_non_splittable_awaits,
   await_is_while_condition,
   expr_is_bare_await,

--- a/src/codegen/async/state_code_gen.yo
+++ b/src/codegen/async/state_code_gen.yo
@@ -2013,7 +2013,7 @@ generate_cond_branch_with_await :: (
           // await lives in a NESTED instance whose value is bound. This case
           // used to fall through every arm and emit NOTHING — the binding, the
           // nested instance and (via the dead dispatch case) the rest of the
-          // arm all vanished (issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+          // arm all vanished (issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
           is_bind_or_assign := (ast_expr_is_fn_call(expr) && (ast_expr_is_fn_call_of(expr, ":=", Option(usize).None) || ast_expr_is_fn_call_of(expr, "=", Option(usize).Some(usize(2)))));
           bound_nested := if(is_bind_or_assign, {
             ba := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());

--- a/src/codegen/async/state_code_gen.yo
+++ b/src/codegen/async/state_code_gen.yo
@@ -1863,15 +1863,114 @@ _branch_future_is_named :: (
     .None => false
   )
 );
+/// The state-machine field a cond/match instance records its taken arm in:
+/// `cond_branch_N` at the top level of await point N, `cond_branch_N_n<d>` for
+/// an instance nested `d` levels inside awaiting arms (exprs/async.yo declares
+/// them from `max_nested_cond_depth`). Distinct fields per level are what
+/// keep the enclosing arm's dispatch code alive across the nested write.
+_cond_field_name :: (fn(context : FunctionGenerationContext, idx_s : String) -> String)(
+  if(
+    context.nested_cond_depth == usize(0),
+    `cond_branch_${idx_s}`,
+    `cond_branch_${idx_s}_n${context.nested_cond_depth.to_string()}`
+  )
+);
+/// Depth of cond/match-with-await nesting inside `expr`: 1 for a cond/match
+/// that carries an await, plus the deepest such instance inside it; the
+/// maximum over children otherwise. `max_nested_cond_depth(body) - 1` is the
+/// number of `_n<d>` fields a state machine needs.
+max_nested_cond_depth :: (fn(expr : AstExpr) -> usize)({
+  is_branching := (ast_expr_is_fn_call(expr) && (ast_expr_is_fn_call_of(expr, BK_COND, Option(usize).None) || ast_expr_is_fn_call_of(expr, BK_MATCH, Option(usize).None)));
+  (best : usize) = usize(0);
+  match(
+    expr,
+    .FnCall(_, head, args, _, _) => {
+      hd := recur(head);
+      if(hd > best, {
+        best = hd;
+      });
+      (i : usize) = usize(0);
+      while(i < args.len(), {
+        match(
+          args.get(i),
+          .Some(a) => {
+            d := recur(a);
+            if(d > best, {
+              best = d;
+            });
+          },
+          .None => ()
+        );
+        i = (i + usize(1));
+      });
+    },
+    .Atom(_, _) => ()
+  );
+  if(is_branching && branch_has_await(expr), (best + usize(1)), best)
+});
+/// The result of emitting one awaiting arm body: the statements after the
+/// await point (resume-state code) and, when the await lives in a cond/match
+/// nested in the arm, that instance's dispatch record.
+BranchEmission :: ref(
+  struct(
+    remaining : ArrayList(AstExpr),
+    /// Index into `context.nested_cond_records`.
+    nested : Option(usize)
+  )
+);
+/// Emit a cond/match NESTED inside an awaiting arm (bare, or the RHS of
+/// `x := …` / `x = …`): its arm records go to a fresh sink that becomes the
+/// enclosing arm's `CondBranch.nested`, and its dispatch writes go to the
+/// per-depth field. The enclosing arm's statements after it are that arm's
+/// ordinary remaining code, run in the resume state — after the nested
+/// switch when the nested arm awaited, and through the no-future path
+/// (`_emit_nested_branch_continuation`, which runs it once for both) when it
+/// completed synchronously.
+_emit_nested_cond_or_match :: (
+  fn(
+    nested_expr : AstExpr,
+    await_point : AwaitPoint,
+    indent : String,
+    context : FunctionGenerationContext,
+    target_variable_id : Option(String),
+    target_assignment_code : Option(String)
+  ) -> usize
+)({
+  idx_s := await_point.base.index.to_string();
+  prev_sink := context.nested_cond_sink;
+  prev_depth := context.nested_cond_depth;
+  depth := (prev_depth + usize(1));
+  sink := AsyncCondBranchInfo(
+    branches : ArrayList(CondBranch).new(),
+    target_variable_id : target_variable_id,
+    target_assignment_code : Option(String).None,
+    cond_branch_field_index : Option(usize).None,
+    chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+    cond_field_name : Option(String).Some(`cond_branch_${idx_s}_n${depth.to_string()}`)
+  );
+  context.nested_cond_sink = Option(AsyncCondBranchInfo).Some(sink);
+  context.nested_cond_depth = depth;
+  if(ast_expr_is_fn_call_of(nested_expr, BK_COND, Option(usize).None), {
+    _call_generate_cond_with_await(nested_expr, await_point, indent, context, target_variable_id, target_assignment_code);
+  }, {
+    _call_generate_match_with_await(nested_expr, await_point, indent, context, target_variable_id, target_assignment_code);
+  });
+  context.nested_cond_depth = prev_depth;
+  context.nested_cond_sink = prev_sink;
+  record_index := context.nested_cond_records.len();
+  context.nested_cond_records.push(sink);
+  record_index
+});
 /// Emit a single cond/match branch body (a `begin` block) up to its first await:
 /// pre-await expressions emit normally, the await stores its Future (or delegates
 /// to a nested cond/match/while), and post-await expressions are returned for the
 /// resume state. Mirrors `generateCondBranchWithAwait` (state-code-gen.ts:1720).
 generate_cond_branch_with_await :: (
-  fn(branch_value : AstExpr, await_point : AwaitPoint, indent : String, context : FunctionGenerationContext) -> ArrayList(AstExpr)
+  fn(branch_value : AstExpr, await_point : AwaitPoint, indent : String, context : FunctionGenerationContext) -> BranchEmission
 )({
   em := context.base.emitter;
   remaining_exprs := ArrayList(AstExpr).new();
+  (nested_info : Option(usize)) = Option(usize).None;
   idx_s := await_point.base.index.to_string();
   // Dispatch-mode points access each branch's future through its own shape:
   // a NAMED branch future is read via its own field (no slot store), an
@@ -1910,73 +2009,105 @@ generate_cond_branch_with_await :: (
           // generate_await_expression and in extract_target_variable_id —
           // all three must agree or the branch future store is silently
           // skipped).
-          if(ast_expr_is_fn_call(expr) && (ast_expr_is_fn_call_of(expr, ":=", Option(usize).None) || _is_ident_bare_await_reassign(expr)), {
-            a_args := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
+          // `x := cond/match(… await …)` and `x = cond/match(… await …)`: the
+          // await lives in a NESTED instance whose value is bound. This case
+          // used to fall through every arm and emit NOTHING — the binding, the
+          // nested instance and (via the dead dispatch case) the rest of the
+          // arm all vanished (issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+          is_bind_or_assign := (ast_expr_is_fn_call(expr) && (ast_expr_is_fn_call_of(expr, ":=", Option(usize).None) || ast_expr_is_fn_call_of(expr, "=", Option(usize).Some(usize(2)))));
+          bound_nested := if(is_bind_or_assign, {
+            ba := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
             match(
-              a_args.get(usize(1)),
-              .Some(value_expr) => if(ast_expr_is_fn_call(value_expr) && is_io_await_call(value_expr), {
-                v_args := match(value_expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
-                match(
-                  v_args.get(usize(0)),
-                  .Some(future_expr) => if(dispatch_mode && _branch_future_is_named(value_expr, await_point, context), {
-                    // Named future: the branch's own field holds it — storing
-                    // it into the slot would hand the slot an unowned
-                    // reference (the extraction decref would over-release it).
-                    em.emit_string_line(`${indent}// Await will use this branch's named Future (dispatch)`);
-                  }, {
-                    future_code := _call_generate_expr(future_expr, indent, context);
-                    em.emit_string_line(`${indent}// Store Future for await ${idx_s} (cond branch)`);
-                    emit_await_future_store(future_expr, future_code, idx_s, indent, context);
-                  }),
-                  .None => ()
-                );
-              }),
-              .None => ()
-            );
-          }, {
-            // Standalone await.
-            if(ast_expr_is_fn_call(expr) && is_io_await_call(expr), {
-              s_args := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
-              // In dispatch mode the named/anonymous decision is PER BRANCH —
-              // the representative's future_variable_id says nothing about
-              // this branch (issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md).
-              branch_named := (dispatch_mode && _branch_future_is_named(expr, await_point, context));
+              ba.get(usize(1)),
+              .Some(v) => (ast_expr_is_fn_call(v) && (ast_expr_is_fn_call_of(v, BK_COND, Option(usize).None) || ast_expr_is_fn_call_of(v, BK_MATCH, Option(usize).None))),
+              .None => false
+            )
+          }, false);
+          if(bound_nested, {
+            ba2 := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
+            lhs := match(ba2.get(usize(0)), .Some(l) => l, .None => expr);
+            rhs := match(ba2.get(usize(1)), .Some(v) => v, .None => expr);
+            (tv : Option(String)) = Option(String).None;
+            (tc : Option(String)) = Option(String).None;
+            if(ast_expr_is_fn_call_of(expr, ":=", Option(usize).None), {
+              tv = _extract_target_var_id(lhs, context);
+            }, {
+              target_code := _call_generate_expr(lhs, indent, context);
+              tc = if(target_code.len() > usize(0), Option(String).Some(target_code), Option(String).None);
+            });
+            nested_info = Option(usize).Some(_emit_nested_cond_or_match(rhs, await_point, indent, context, tv, tc));
+          });
+          if(
+            bound_nested,
+            (),
+            if(ast_expr_is_fn_call(expr) && (ast_expr_is_fn_call_of(expr, ":=", Option(usize).None) || _is_ident_bare_await_reassign(expr)), {
+              a_args := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
               match(
-                s_args.get(usize(0)),
-                .Some(future_expr) => if(branch_named, {
-                  em.emit_string_line(`${indent}// Await will use this branch's named Future (dispatch)`);
-                }, {
+                a_args.get(usize(1)),
+                .Some(value_expr) => if(ast_expr_is_fn_call(value_expr) && is_io_await_call(value_expr), {
+                  v_args := match(value_expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
                   match(
-                    cond(dispatch_mode => Option(String).None, true => await_point.future_variable_id),
-                    .None => {
+                    v_args.get(usize(0)),
+                    .Some(future_expr) => if(dispatch_mode && _branch_future_is_named(value_expr, await_point, context), {
+                      // Named future: the branch's own field holds it — storing
+                      // it into the slot would hand the slot an unowned
+                      // reference (the extraction decref would over-release it).
+                      em.emit_string_line(`${indent}// Await will use this branch's named Future (dispatch)`);
+                    }, {
                       future_code := _call_generate_expr(future_expr, indent, context);
                       em.emit_string_line(`${indent}// Store Future for await ${idx_s} (cond branch)`);
                       emit_await_future_store(future_expr, future_code, idx_s, indent, context);
-                    },
-                    .Some(fv) => {
-                      em.emit_string_line(`${indent}// Await will use Future from sm->var_${fv}`);
-                    }
+                    }),
+                    .None => ()
                   );
                 }),
                 .None => ()
               );
             }, {
-              // Nested cond.
-              if(ast_expr_is_fn_call(expr) && ast_expr_is_fn_call_of(expr, BK_COND, Option(usize).None), {
-                prev := context.async_body_return_expr;
-                if(is_last && context.async_body_return_expr.is_some(), {
-                  context.async_body_return_expr = Option(AstExpr).Some(expr);
-                });
-                _call_generate_cond_with_await(expr, await_point, indent, context, Option(String).None, Option(String).None);
-                context.async_body_return_expr = prev;
+              // Standalone await.
+              if(ast_expr_is_fn_call(expr) && is_io_await_call(expr), {
+                s_args := match(expr, .FnCall(_, _, a, _, _) => a, _ => ArrayList(AstExpr).new());
+                // In dispatch mode the named/anonymous decision is PER BRANCH —
+                // the representative's future_variable_id says nothing about
+                // this branch (issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md).
+                branch_named := (dispatch_mode && _branch_future_is_named(expr, await_point, context));
+                match(
+                  s_args.get(usize(0)),
+                  .Some(future_expr) => if(branch_named, {
+                    em.emit_string_line(`${indent}// Await will use this branch's named Future (dispatch)`);
+                  }, {
+                    match(
+                      cond(dispatch_mode => Option(String).None, true => await_point.future_variable_id),
+                      .None => {
+                        future_code := _call_generate_expr(future_expr, indent, context);
+                        em.emit_string_line(`${indent}// Store Future for await ${idx_s} (cond branch)`);
+                        emit_await_future_store(future_expr, future_code, idx_s, indent, context);
+                      },
+                      .Some(fv) => {
+                        em.emit_string_line(`${indent}// Await will use Future from sm->var_${fv}`);
+                      }
+                    );
+                  }),
+                  .None => ()
+                );
               }, {
-                // Nested match.
-                if(ast_expr_is_fn_call(expr) && ast_expr_is_fn_call_of(expr, BK_MATCH, Option(usize).None), {
+                // Nested cond / match (bare statement).
+                if(ast_expr_is_fn_call(expr) && (
+                  ast_expr_is_fn_call_of(
+                    expr,
+                    BK_COND,
+                    Option(usize).None
+                  ) || ast_expr_is_fn_call_of(
+                    expr,
+                    BK_MATCH,
+                    Option(usize).None
+                  )
+                ), {
                   prev := context.async_body_return_expr;
                   if(is_last && context.async_body_return_expr.is_some(), {
                     context.async_body_return_expr = Option(AstExpr).Some(expr);
                   });
-                  _call_generate_match_with_await(expr, await_point, indent, context, Option(String).None, Option(String).None);
+                  nested_info = Option(usize).Some(_emit_nested_cond_or_match(expr, await_point, indent, context, Option(String).None, Option(String).None));
                   context.async_body_return_expr = prev;
                 }, {
                   // Nested while.
@@ -1985,8 +2116,8 @@ generate_cond_branch_with_await :: (
                   });
                 });
               });
-            });
-          });
+            })
+          );
         }, {
           // No await — generate normally.
           code := _call_generate_expr(expr, indent, context);
@@ -2004,7 +2135,7 @@ generate_cond_branch_with_await :: (
     );
     i = (i + usize(1));
   });
-  remaining_exprs
+  BranchEmission(remaining : remaining_exprs, nested : nested_info)
 });
 /// True when a non-await cond/match branch should emit Future completion because
 /// the cond/match IS the async block body's implicit return value (no assignment
@@ -2378,7 +2509,14 @@ _find_branch_await_target_variable_id :: (
   )
 });
 _make_cond_branch :: (
-  fn(index : usize, value : AstExpr, has_await : bool, remaining : Option(ArrayList(AstExpr)), context : FunctionGenerationContext) -> CondBranch
+  fn(
+    index : usize,
+    value : AstExpr,
+    has_await : bool,
+    remaining : Option(ArrayList(AstExpr)),
+    context : FunctionGenerationContext,
+    (nested : Option(usize)) ?= Option(usize).None
+  ) -> CondBranch
 )({
   branch_awaits := ArrayList(AstExpr).new();
   if(has_await, {
@@ -2397,7 +2535,8 @@ _make_cond_branch :: (
     await_exprs : cond(
       has_await => Option(ArrayList(AstExpr)).Some(branch_awaits),
       true => Option(ArrayList(AstExpr)).None
-    )
+    ),
+    nested : nested
   )
 });
 /// The destination the await-branch registration names for the branch's LAST
@@ -2440,6 +2579,16 @@ _set_cond_branch_target :: (
   fn(context : FunctionGenerationContext, idx : usize, target : Option(String)) -> unit
 )({
   if(target.is_none(), return(()));
+  match(
+    context.nested_cond_sink,
+    .Some(sink) => {
+      if(sink.target_assignment_code.is_none(), {
+        sink.target_assignment_code = target;
+      });
+      return(());
+    },
+    .None => ()
+  );
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
   });
@@ -2452,7 +2601,8 @@ _set_cond_branch_target :: (
       target_variable_id : Option(String).None,
       target_assignment_code : Option(String).None,
       cond_branch_field_index : Option(usize).None,
-      chained_branches : Option(ArrayList(ChainedCondBranches)).None
+      chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+      cond_field_name : Option(String).None
     )
   );
   if(entry.target_assignment_code.is_none(), {
@@ -2481,6 +2631,46 @@ _store_cond_branch_info :: (
     merge_branches : bool
   ) -> unit
 )({
+  // A NESTED instance's records live in its sink: union by dispatch code,
+  // targets from this (final) store.
+  match(
+    context.nested_cond_sink,
+    .Some(sink) => {
+      (bi0 : usize) = usize(0);
+      while(bi0 < branches.len(), {
+        match(
+          branches.get(bi0),
+          .Some(nb) => {
+            (dup0 : bool) = false;
+            (si0 : usize) = usize(0);
+            while((si0 < sink.branches.len()) && !(dup0), {
+              match(
+                sink.branches.get(si0),
+                .Some(sb) => if(sb.index == nb.index, {
+                  dup0 = true;
+                }),
+                .None => ()
+              );
+              si0 = (si0 + usize(1));
+            });
+            if(!(dup0), {
+              sink.branches.push(nb);
+            });
+          },
+          .None => ()
+        );
+        bi0 = (bi0 + usize(1));
+      });
+      if(target_variable_id.is_some(), {
+        sink.target_variable_id = target_variable_id;
+      });
+      if(target_assignment_code.is_some(), {
+        sink.target_assignment_code = target_assignment_code;
+      });
+      return(());
+    },
+    .None => ()
+  );
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
   });
@@ -2523,7 +2713,8 @@ _store_cond_branch_info :: (
             target_variable_id : target_variable_id,
             target_assignment_code : target_assignment_code,
             cond_branch_field_index : existing.cond_branch_field_index,
-            chained_branches : existing.chained_branches
+            chained_branches : existing.chained_branches,
+            cond_field_name : Option(String).None
           )
         );
       },
@@ -2535,7 +2726,8 @@ _store_cond_branch_info :: (
             target_variable_id : target_variable_id,
             target_assignment_code : target_assignment_code,
             cond_branch_field_index : Option(usize).None,
-            chained_branches : Option(ArrayList(ChainedCondBranches)).None
+            chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+            cond_field_name : Option(String).None
           )
         );
       }
@@ -2552,7 +2744,8 @@ _store_cond_branch_info :: (
         target_variable_id : target_variable_id,
         target_assignment_code : target_assignment_code,
         cond_branch_field_index : Option(usize).None,
-        chained_branches : Option(ArrayList(ChainedCondBranches)).None
+        chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+        cond_field_name : Option(String).None
       )
     );
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(cmap);
@@ -2687,14 +2880,15 @@ generate_cond_with_await :: (
               // with the recorded branch index while that index happened to be
               // 0. Dispatch codes are per-function now (_alloc_cond_branch_codes),
               // so the assignment has to be real.
-              em.emit_string_line(`${indent}sm->cond_branch_${idx_s} = ${(cond_branch_base + fi).to_string()};`);
-              remaining := generate_cond_branch_with_await(value, await_point, indent, context);
+              em.emit_string_line(`${indent}sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + fi).to_string()};`);
+              emission := generate_cond_branch_with_await(value, await_point, indent, context);
+              remaining := emission.remaining;
               has_while := match(context.async_while_loop_info, .Some(m) => match(m.get(await_point.base.index), .Some(_) => true, .None => false), .None => false);
               if(has_while && (remaining.len() > usize(0)), {
                 _attach_cond_branch_post_while(cond_branch_base + fi, value, remaining, context, await_point.base.index);
-                branches_with_await.push(_make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).Some(ArrayList(AstExpr).new()), context));
+                branches_with_await.push(_make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).Some(ArrayList(AstExpr).new()), context, emission.nested));
               }, {
-                branches_with_await.push(_make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).Some(remaining), context));
+                branches_with_await.push(_make_cond_branch(cond_branch_base + fi, value, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested));
               });
             }, {
               if(_should_emit_async_branch_completion(cond_expr, value, context, target_variable_id, target_assignment_code), {
@@ -2753,8 +2947,9 @@ generate_cond_with_await :: (
             value_indent := current_indent.clone();
             value_indent.push_str("  ");
             if(branch_has_await(value), {
-              em.emit_string_line(`${value_indent}sm->cond_branch_${idx_s} = ${(cond_branch_base + ci).to_string()};`);
-              remaining := generate_cond_branch_with_await(value, await_point, value_indent, context);
+              em.emit_string_line(`${value_indent}sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + ci).to_string()};`);
+              emission := generate_cond_branch_with_await(value, await_point, value_indent, context);
+              remaining := emission.remaining;
               has_while := match(context.async_while_loop_info, .Some(m) => match(m.get(await_point.base.index), .Some(_) => true, .None => false), .None => false);
               if(has_while && (remaining.len() > usize(0)), {
                 // `cond_branch_base + ci`, NOT the raw `ci` — the guard emitted
@@ -2764,9 +2959,9 @@ generate_cond_with_await :: (
                 // `== 0` against a field holding `2`, so the buffer was never
                 // emptied and `BufWriter` reflushed the same bytes forever.
                 _attach_cond_branch_post_while(cond_branch_base + ci, value, remaining, context, await_point.base.index);
-                branches_with_await.push(_make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).Some(ArrayList(AstExpr).new()), context));
+                branches_with_await.push(_make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).Some(ArrayList(AstExpr).new()), context, emission.nested));
               }, {
-                branches_with_await.push(_make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).Some(remaining), context));
+                branches_with_await.push(_make_cond_branch(cond_branch_base + ci, value, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested));
               });
             }, {
               if(_should_emit_async_branch_completion(cond_expr, value, context, target_variable_id, target_assignment_code), {
@@ -2941,10 +3136,10 @@ generate_primitive_match_with_await :: (
             }
           );
         });
-        em.emit_string_line(`${indent}    sm->cond_branch_${idx_s} = ${(cond_branch_base + i).to_string()};`);
+        em.emit_string_line(`${indent}    sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + i).to_string()};`);
         if(branch_has_await(case_body), {
-          remaining := generate_cond_branch_with_await(case_body, await_point, `${indent}    `, context);
-          branches_with_await.push(_make_cond_branch(cond_branch_base + i, case_body, true, Option(ArrayList(AstExpr)).Some(remaining), context));
+          emission := generate_cond_branch_with_await(case_body, await_point, `${indent}    `, context);
+          branches_with_await.push(_make_cond_branch(cond_branch_base + i, case_body, true, Option(ArrayList(AstExpr)).Some(emission.remaining), context, emission.nested));
         }, {
           if(_should_emit_async_branch_completion(match_expr, case_body, context, target_variable_id, target_assignment_code), {
             _emit_non_await_branch_async_completion(case_body, `${indent}    `, context);
@@ -2977,7 +3172,8 @@ generate_primitive_match_with_await :: (
       target_variable_id : target_variable_id,
       target_assignment_code : _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()),
       cond_branch_field_index : Option(usize).None,
-      chained_branches : Option(ArrayList(ChainedCondBranches)).None
+      chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+      cond_field_name : Option(String).None
     )
   );
   context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(pmap);
@@ -2987,6 +3183,15 @@ generate_primitive_match_with_await :: (
 /// incrementally (vs cond's whole-entry store). Mirrors the
 /// `asyncCondBranchInfo.get(idx) || {branches:[]}; push; set` pattern.
 _push_cond_branch :: (fn(context : FunctionGenerationContext, idx : usize, branch : CondBranch) -> unit)({
+  // A NESTED instance registers into its own record (see _emit_nested_cond_or_match).
+  match(
+    context.nested_cond_sink,
+    .Some(sink) => {
+      sink.branches.push(branch);
+      return(());
+    },
+    .None => ()
+  );
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
   });
@@ -2999,7 +3204,8 @@ _push_cond_branch :: (fn(context : FunctionGenerationContext, idx : usize, branc
       target_variable_id : Option(String).None,
       target_assignment_code : Option(String).None,
       cond_branch_field_index : Option(usize).None,
-      chained_branches : Option(ArrayList(ChainedCondBranches)).None
+      chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+      cond_field_name : Option(String).None
     )
   );
   entry.branches.push(branch);
@@ -3169,7 +3375,8 @@ _push_chained_match_arm :: (
       target_variable_id : Option(String).None,
       target_assignment_code : Option(String).None,
       cond_branch_field_index : Option(usize).None,
-      chained_branches : Option(ArrayList(ChainedCondBranches)).None
+      chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+      cond_field_name : Option(String).None
     )
   );
   chained_awaits := ArrayList(AstExpr).new();
@@ -3181,7 +3388,8 @@ _push_chained_match_arm :: (
     remaining_exprs : Option(ArrayList(AstExpr)).Some(remaining),
     deferred_drop_expressions : match(context.base.get_expr_info(case_body), .Some(ei) => ei.deferred_drop_expressions, .None => Option(ArrayList(AstExpr)).None),
     await_target_variable_id : Option(String).None,
-    await_exprs : Option(ArrayList(AstExpr)).Some(chained_awaits)
+    await_exprs : Option(ArrayList(AstExpr)).Some(chained_awaits),
+    nested : Option(usize).None
   );
   chained := match(entry.chained_branches, .Some(c) => c, .None => ArrayList(ChainedCondBranches).new());
   bl := ArrayList(CondBranch).new();
@@ -3211,7 +3419,8 @@ _emit_match_case_await_or_value :: (
 )({
   if(branch_has_await(case_body), {
     branch_count_before := _cond_entry_branch_count(context, await_point.base.index);
-    remaining := generate_cond_branch_with_await(case_body, await_point, indent, context);
+    emission := generate_cond_branch_with_await(case_body, await_point, indent, context);
+    remaining := emission.remaining;
     if(remaining.len() == usize(0), {
       // Tail-await arm (the await IS the arm's value): record it anyway —
       // dispatch-mode registration/extraction and the uniform target handover
@@ -3220,7 +3429,7 @@ _emit_match_case_await_or_value :: (
       // dispatch slot during the recursion above (its arm records are the
       // live ones).
       if(!(_cond_entry_branch_count(context, await_point.base.index) > branch_count_before), {
-        _push_cond_branch(context, await_point.base.index, _make_cond_branch(case_index, case_body, true, Option(ArrayList(AstExpr)).Some(remaining), context));
+        _push_cond_branch(context, await_point.base.index, _make_cond_branch(case_index, case_body, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested));
       });
       _set_cond_branch_target(context, await_point.base.index, _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
     });
@@ -3274,7 +3483,7 @@ _emit_match_case_await_or_value :: (
           _push_chained_match_arm(context, await_point.base.index, case_index, case_body, remaining);
         });
       }, {
-        _push_cond_branch(context, await_point.base.index, _make_cond_branch(case_index, case_body, true, Option(ArrayList(AstExpr)).Some(remaining), context));
+        _push_cond_branch(context, await_point.base.index, _make_cond_branch(case_index, case_body, true, Option(ArrayList(AstExpr)).Some(remaining), context, emission.nested));
       });
     });
     _set_cond_branch_target(context, await_point.base.index, _registration_target_assignment(match_expr, context, target_variable_id.clone(), target_assignment_code.clone()));
@@ -3442,7 +3651,7 @@ generate_match_with_await :: (
                           },
                           .None => ()
                         );
-                        em.emit_string_line(`${indent}  sm->cond_branch_${idx_s} = ${(cond_branch_base + pci).to_string()};`);
+                        em.emit_string_line(`${indent}  sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + pci).to_string()};`);
                         _emit_match_case_await_or_value(match_expr, case_body, cond_branch_base + pci, await_point, `${indent}  `, context, target_variable_id, target_assignment_code);
                       },
                       .None => ()
@@ -3462,7 +3671,7 @@ generate_match_with_await :: (
                     match(
                       cb_body,
                       .Some(case_body) => {
-                        em.emit_string_line(`${indent}  sm->cond_branch_${idx_s} = ${(cond_branch_base + nci).to_string()};`);
+                        em.emit_string_line(`${indent}  sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + nci).to_string()};`);
                         _emit_match_case_await_or_value(match_expr, case_body, cond_branch_base + nci, await_point, `${indent}  `, context, target_variable_id, target_assignment_code);
                       },
                       .None => ()
@@ -3516,7 +3725,7 @@ generate_match_with_await :: (
                       }
                     ));
                     if(emit_case, {
-                      em.emit_string_line(`${indent}    sm->cond_branch_${idx_s} = ${(cond_branch_base + gi).to_string()};`);
+                      em.emit_string_line(`${indent}    sm->${_cond_field_name(context, idx_s)} = ${(cond_branch_base + gi).to_string()};`);
                       // Destructuring: bind variant fields.
                       if(ast_expr_is_fn_call(pattern), {
                         pf := match(pattern, .FnCall(_, fb, _, _, _) => fb, _ => pattern);
@@ -3584,6 +3793,7 @@ register_fsm_emitters_impl :: (fn() -> unit)({
   register_fsm_emitters(generate_cond_with_await, generate_match_with_await, generate_while_with_await);
 });
 export(
+  max_nested_cond_depth,
   hoist_non_splittable_awaits,
   await_is_while_condition,
   expr_is_bare_await,

--- a/src/codegen/async/state_machine.yo
+++ b/src/codegen/async/state_machine.yo
@@ -1979,6 +1979,151 @@ _await_target_has_struct_field :: (
 /// bound variable's field; else the cond's registered target when the branch
 /// VALUE is the await itself; else nothing (a discarded await result stays
 /// owned by the future and is released with it).
+/// One `case` of the dispatch-mode extraction switch. A branch whose await
+/// lives in a NESTED cond/match (`branch.nested`) switches on the nested
+/// instance's own field and extracts per nested arm, recursively — the
+/// destinations are the nested arms' own bindings, or the nested instance's
+/// registered target when the nested arm's value IS the await.
+_emit_dispatch_extraction_case :: (
+  fn(
+    branch : CondBranch,
+    level_target_assignment : Option(String),
+    async_block_id : String,
+    prev_await : AwaitPoint,
+    depth : usize,
+    slot : String,
+    context : FunctionGenerationContext,
+    cross_boundary_ids : Option(HashSet(String))
+  ) -> unit
+)({
+  em := context.base.emitter;
+  prev_idx_s := prev_await.base.index.to_string();
+  match(
+    branch.nested,
+    .Some(nk) => match(
+      context.nested_cond_records.get(nk),
+      .Some(ninfo) => {
+        field := match(ninfo.cond_field_name, .Some(f) => f, .None => `cond_branch_${prev_idx_s}`);
+        em.emit_string_line(`        case ${branch.index.to_string()}: {`);
+        em.emit_string_line(`          // Nested cond/match: extract per nested arm`);
+        em.emit_string_line(`          switch (sm->${field}) {`);
+        (ni : usize) = usize(0);
+        while(ni < ninfo.branches.len(), {
+          match(
+            ninfo.branches.get(ni),
+            .Some(inner) => if(inner.has_await, {
+              recur(inner, ninfo.target_assignment_code, async_block_id.clone(), prev_await, depth, slot.clone(), context, cross_boundary_ids);
+            }),
+            .None => ()
+          );
+          ni = (ni + usize(1));
+        });
+        em.emit_string_line(`          default: break;`);
+        em.emit_string_line(`          }`);
+        em.emit_string_line(`          break;`);
+        em.emit_string_line(`        }`);
+        return(());
+      },
+      .None => ()
+    ),
+    .None => ()
+  );
+  ae_opt := match(
+    branch.await_exprs,
+    .Some(aes) => aes.get(depth),
+    .None => Option(AstExpr).None
+  );
+  match(
+    ae_opt,
+    .None => (),
+    .Some(ae) => match(
+      cond_branch_future_access(ae, prev_await, context),
+      .None => {
+        bt2 := ast_expr_token(ae);
+        codegen_fatal(`internal: dispatch-mode await point ${prev_idx_s} branch ${branch.index.to_string()} future access unresolvable at extraction (${bt2.module_path}:${(bt2.row + usize(1)).to_string()}:${(bt2.column + usize(1)).to_string()})`);
+      },
+      .Some(acc_info) => {
+        acc := acc_info.access;
+        em.emit_string_line(`        case ${branch.index.to_string()}: {`);
+        if(!(acc_info.is_named), {
+          // NULL slot: this arm's own store never ran (nested plain arm
+          // kept the code / dead outer layer) — nothing to extract.
+          em.emit_string_line(`          if (${slot} != NULL) {`);
+        });
+        // Abort check. A named future stays owned by its binding (the
+        // dispose drops it); the anonymous slot ref is released here.
+        em.emit_string_line(`          // Check if the awaited Future was aborted`);
+        em.emit_string_line(`          if (${acc}->state == -2) {`);
+        if(!(acc_info.is_named), {
+          em.emit_string_line(`            __yo_decr_rc((void*)${slot});`);
+          em.emit_string_line(`            ${slot} = NULL;`);
+        });
+        emit_async_future_escape(em, `            `, Option(String).None, Option(String).Some(async_block_id.clone()));
+        em.emit_string_line(`          }`);
+        // This branch's result copy.
+        rt_opt := acc_info.result_type;
+        is_unit_result := match(
+          rt_opt,
+          .Some(rt) => (
+            is_unit_type(rt) || (
+              is_some_type(rt) && match(rt, .SomeT({ id }) => lookup_some_resolved_concrete(id).is_none(), _ => false)
+            )
+          ),
+          .None => true
+        );
+        (dest : Option(String)) = Option(String).None;
+        match(
+          branch.await_target_variable_id,
+          .Some(btvid) => if(_await_target_has_struct_field(btvid.clone(), cross_boundary_ids, context), {
+            fname := get_state_machine_field_name(btvid, Option(String).Some(String.from("local")), context.state_machine_field_aliases);
+            d := String.from("sm->");
+            d.push_string(fname);
+            dest = Option(String).Some(d);
+          }),
+          // The branch VALUE is the await itself (no binding, nothing
+          // after it) — its result IS the cond's value.
+          .None => if(match(branch.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true), {
+            match(
+              level_target_assignment,
+              .Some(tac) => {
+                dest = Option(String).Some(tac.clone());
+              },
+              .None => ()
+            );
+          })
+        );
+        if(!(is_unit_result), {
+          match(
+            dest,
+            .Some(d) => {
+              rt := match(rt_opt, .Some(t) => t, .None => TypeValue.Unit);
+              em.emit_string_line(`          // Extract result from await ${prev_idx_s} (branch ${branch.index.to_string()})`);
+              if(type_contains_rc_type(rt), {
+                match(
+                  get_dup_function_for_type(rt, context),
+                  .Some(dup) => em.emit_string_line(`          ${d} = ${dup}(${acc}->result);`),
+                  .None => {
+                    dup_code := generate_dup_code_for_value(`${acc}->result`, rt, context);
+                    em.emit_string_line(`          ${d} = ${dup_code};`);
+                  }
+                );
+              }, {
+                em.emit_string_line(`          ${d} = ${acc}->result;`);
+              });
+            },
+            .None => ()
+          );
+        });
+        if(!(acc_info.is_named), {
+          em.emit_string_line(`          if (${slot} != NULL) { __yo_decr_rc((void*)${slot}); ${slot} = NULL; }`);
+          em.emit_string_line(`          }`);
+        });
+        em.emit_string_line(`          break;`);
+        em.emit_string_line(`        }`);
+      }
+    )
+  );
+});
 _emit_prev_await_result_extraction_dispatch :: (
   fn(
     async_block_id : String,
@@ -2002,101 +2147,7 @@ _emit_prev_await_result_extraction_dispatch :: (
     match(
       dispatch_branches.get(bi),
       .Some(branch) => if(branch.has_await, {
-        ae_opt := match(
-          branch.await_exprs,
-          .Some(aes) => aes.get(depth),
-          .None => Option(AstExpr).None
-        );
-        match(
-          ae_opt,
-          .None => (),
-          .Some(ae) => match(
-            cond_branch_future_access(ae, prev_await, context),
-            .None => {
-              bt2 := ast_expr_token(ae);
-              codegen_fatal(`internal: dispatch-mode await point ${prev_idx_s} branch ${branch.index.to_string()} future access unresolvable at extraction (${bt2.module_path}:${(bt2.row + usize(1)).to_string()}:${(bt2.column + usize(1)).to_string()})`);
-            },
-            .Some(acc_info) => {
-              acc := acc_info.access;
-              em.emit_string_line(`        case ${branch.index.to_string()}: {`);
-              if(!(acc_info.is_named), {
-                // NULL slot: this arm's own store never ran (nested plain arm
-                // kept the code / dead outer layer) — nothing to extract.
-                em.emit_string_line(`          if (${slot} != NULL) {`);
-              });
-              // Abort check. A named future stays owned by its binding (the
-              // dispose drops it); the anonymous slot ref is released here.
-              em.emit_string_line(`          // Check if the awaited Future was aborted`);
-              em.emit_string_line(`          if (${acc}->state == -2) {`);
-              if(!(acc_info.is_named), {
-                em.emit_string_line(`            __yo_decr_rc((void*)${slot});`);
-                em.emit_string_line(`            ${slot} = NULL;`);
-              });
-              emit_async_future_escape(em, `            `, Option(String).None, Option(String).Some(async_block_id.clone()));
-              em.emit_string_line(`          }`);
-              // This branch's result copy.
-              rt_opt := acc_info.result_type;
-              is_unit_result := match(
-                rt_opt,
-                .Some(rt) => (
-                  is_unit_type(rt) || (
-                    is_some_type(rt) && match(rt, .SomeT({ id }) => lookup_some_resolved_concrete(id).is_none(), _ => false)
-                  )
-                ),
-                .None => true
-              );
-              (dest : Option(String)) = Option(String).None;
-              match(
-                branch.await_target_variable_id,
-                .Some(btvid) => if(_await_target_has_struct_field(btvid.clone(), cross_boundary_ids, context), {
-                  fname := get_state_machine_field_name(btvid, Option(String).Some(String.from("local")), context.state_machine_field_aliases);
-                  d := String.from("sm->");
-                  d.push_string(fname);
-                  dest = Option(String).Some(d);
-                }),
-                // The branch VALUE is the await itself (no binding, nothing
-                // after it) — its result IS the cond's value.
-                .None => if(match(branch.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true), {
-                  match(
-                    cbd.target_assignment_code,
-                    .Some(tac) => {
-                      dest = Option(String).Some(tac.clone());
-                    },
-                    .None => ()
-                  );
-                })
-              );
-              if(!(is_unit_result), {
-                match(
-                  dest,
-                  .Some(d) => {
-                    rt := match(rt_opt, .Some(t) => t, .None => TypeValue.Unit);
-                    em.emit_string_line(`          // Extract result from await ${prev_idx_s} (branch ${branch.index.to_string()})`);
-                    if(type_contains_rc_type(rt), {
-                      match(
-                        get_dup_function_for_type(rt, context),
-                        .Some(dup) => em.emit_string_line(`          ${d} = ${dup}(${acc}->result);`),
-                        .None => {
-                          dup_code := generate_dup_code_for_value(`${acc}->result`, rt, context);
-                          em.emit_string_line(`          ${d} = ${dup_code};`);
-                        }
-                      );
-                    }, {
-                      em.emit_string_line(`          ${d} = ${acc}->result;`);
-                    });
-                  },
-                  .None => ()
-                );
-              });
-              if(!(acc_info.is_named), {
-                em.emit_string_line(`          if (${slot} != NULL) { __yo_decr_rc((void*)${slot}); ${slot} = NULL; }`);
-                em.emit_string_line(`          }`);
-              });
-              em.emit_string_line(`          break;`);
-              em.emit_string_line(`        }`);
-            }
-          )
-        );
+        _emit_dispatch_extraction_case(branch, cbd.target_assignment_code, async_block_id.clone(), prev_await, depth, slot.clone(), context, cross_boundary_ids);
       }),
       .None => ()
     );
@@ -2291,7 +2342,8 @@ _chain_additional_remaining :: (
     await_exprs : cond(
       has_await => Option(ArrayList(AstExpr)).Some(chained_awaits),
       true => Option(ArrayList(AstExpr)).None
-    )
+    ),
+    nested : Option(usize).None
   );
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
@@ -2317,7 +2369,8 @@ _chain_additional_remaining :: (
           target_variable_id : Option(String).None,
           target_assignment_code : Option(String).None,
           cond_branch_field_index : Option(usize).Some(cond_branch_field_index),
-          chained_branches : Option(ArrayList(ChainedCondBranches)).None
+          chained_branches : Option(ArrayList(ChainedCondBranches)).None,
+          cond_field_name : Option(String).None
         )
       );
     }
@@ -2591,6 +2644,201 @@ _emit_cond_branch_remaining :: (
     .None => ()
   );
 });
+/// The resume-side switch for a cond/match NESTED inside an awaiting arm
+/// (`CondBranch.nested`): dispatch on the nested instance's own field, bind
+/// the taken arm's await result, recurse into deeper nesting, run that arm's
+/// remaining code. The caller then runs the ENCLOSING arm's remaining code —
+/// the two-level dispatch that replaced the dead `case` the enclosing arm's
+/// statements used to be keyed on
+/// (issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+_emit_nested_level_switch :: (
+  fn(
+    ninfo : AsyncCondBranchInfo,
+    async_block_id : String,
+    prev_await : AwaitPoint,
+    segment : StateSegment,
+    body_expr : AstExpr,
+    future_type : TypeValue,
+    capture_type : Option(TypeValue),
+    analysis : AwaitAnalysisResult,
+    cond_field : usize,
+    indent : String,
+    context : FunctionGenerationContext,
+    cross_boundary_ids : Option(HashSet(String)),
+    /// Dispatch-mode point: the per-branch extraction already wrote every
+    /// destination — bind nothing here.
+    dispatch_mode : bool,
+    /// A C condition that is true only when a future was stored and its
+    /// result extracted (`__yo_had_future_N`): the bindings run under it,
+    /// because this switch is emitted OUTSIDE the slot guard so that the
+    /// enclosing arm's remaining code also runs when the nested arm
+    /// completed synchronously.
+    c_guard : Option(String)
+  ) -> unit
+)({
+  em := context.base.emitter;
+  field := match(ninfo.cond_field_name, .Some(f) => f, .None => `cond_branch_${prev_await.base.index.to_string()}`);
+  idx_s := prev_await.base.index.to_string();
+  em.emit_string_line(`${indent}// Nested cond/match: dispatch on its own field, then fall through to the enclosing arm`);
+  em.emit_string_line(`${indent}switch (sm->${field}) {`);
+  (ni : usize) = usize(0);
+  while(ni < ninfo.branches.len(), {
+    match(
+      ninfo.branches.get(ni),
+      .Some(inner) => if(inner.has_await, {
+        em.emit_string_line(`${indent}  case ${inner.index.to_string()}: {`);
+        em.emit_string_line(`${indent}    ASYNC_DEBUG("${async_block_id}: Executing remaining code from nested branch ${inner.index.to_string()}\\n");`);
+        inner_indent := `${indent}    `;
+        if(inner.nested.is_none(), {
+          guard_open := match(c_guard, .Some(g) => `if (${g}) {`, .None => String.from("{"));
+          if(!(dispatch_mode), {
+            em.emit_string_line(`${inner_indent}${guard_open}`);
+          });
+          if(
+            !(dispatch_mode),
+            match(
+              inner.await_target_variable_id,
+              .Some(btvid) => if((
+                match(prev_await.base.target_variable_id, .Some(ptv) => !(ptv == btvid), .None => true)
+                && _await_target_has_struct_field(btvid.clone(), cross_boundary_ids, context)
+              )
+              && _branch_target_matches_await_type(btvid.clone(), prev_await.result_type, context), {
+                bfield := get_state_machine_field_name(btvid, Option(String).Some(String.from("local")), context.state_machine_field_aliases);
+                em.emit_string_line(`${inner_indent}sm->${bfield} = sm->await_result_${idx_s};`);
+              }),
+              // The arm's VALUE is the await itself: hand the result to the
+              // nested instance's binding (`x := match(...)`).
+              .None => if(match(inner.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true), {
+                match(
+                  ninfo.target_assignment_code,
+                  .Some(tac) => {
+                    em.emit_string_line(`${inner_indent}${tac} = sm->await_result_${idx_s};`);
+                  },
+                  .None => ()
+                );
+              })
+            )
+          );
+          if(!(dispatch_mode), {
+            em.emit_string_line(`${inner_indent}}`);
+          });
+        }, {
+          match(
+            inner.nested,
+            .Some(nk) => match(
+              context.nested_cond_records.get(nk),
+              .Some(nn) => recur(nn, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, inner_indent.clone(), context, cross_boundary_ids, dispatch_mode, c_guard),
+              .None => ()
+            ),
+            .None => ()
+          );
+        });
+        _emit_cond_branch_remaining(inner, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, ninfo.target_assignment_code, inner_indent, context);
+        em.emit_string_line(`${indent}    break;`);
+        em.emit_string_line(`${indent}  }`);
+      }),
+      .None => ()
+    );
+    ni = (ni + usize(1));
+  });
+  em.emit_string_line(`${indent}  default: break;`);
+  em.emit_string_line(`${indent}}`);
+});
+/// True when one of the await point's registered arms holds a NESTED
+/// cond/match instance (`CondBranch.nested`) — the arms
+/// `_emit_nested_branch_continuation` runs outside the slot guard, and the
+/// only reason to declare `__yo_had_future_N`.
+_cond_point_has_nested_arm :: (fn(prev_await : AwaitPoint, context : FunctionGenerationContext) -> bool)(
+  match(
+    context.async_cond_branch_info,
+    .Some(cbi_map) => match(
+      cbi_map.get(prev_await.base.index),
+      .Some(cbd) => {
+        (any_nested : bool) = false;
+        (ni : usize) = usize(0);
+        while(ni < cbd.branches.len(), {
+          match(
+            cbd.branches.get(ni),
+            .Some(b) => if(b.has_await && b.nested.is_some(), {
+              any_nested = true;
+            }),
+            .None => ()
+          );
+          ni = (ni + usize(1));
+        });
+        any_nested
+      },
+      .None => false
+    ),
+    .None => false
+  )
+);
+/// The continuation of a uniform (slot-guarded) cond point's arms that hold a
+/// NESTED cond/match instance. Emitted AFTER the guarded block, unconditionally:
+/// when the nested arm awaited, the guard extracted the result and
+/// `__yo_had_future_N` is true; when it completed synchronously no future was
+/// stored, the guard was skipped, and the enclosing arm's remaining
+/// statements must still run. The nested switch binds the await result only
+/// under `__yo_had_future_N`; the enclosing arm's remaining code is emitted
+/// ONCE here (emitting it twice would re-reference cached temporaries of its
+/// own next await).
+_emit_nested_branch_continuation :: (
+  fn(
+    async_block_id : String,
+    prev_await : AwaitPoint,
+    segment : StateSegment,
+    body_expr : AstExpr,
+    future_type : TypeValue,
+    capture_type : Option(TypeValue),
+    analysis : AwaitAnalysisResult,
+    context : FunctionGenerationContext,
+    cross_boundary_ids : Option(HashSet(String))
+  ) -> unit
+)({
+  em := context.base.emitter;
+  match(
+    context.async_cond_branch_info,
+    .Some(cbi_map) => match(
+      cbi_map.get(prev_await.base.index),
+      .Some(cbd) => {
+        if(_cond_point_has_nested_arm(prev_await, context), {
+          cond_field := match(cbd.cond_branch_field_index, .Some(x) => x, .None => prev_await.base.index);
+          idx_s := prev_await.base.index.to_string();
+          c_guard := Option(String).Some(`__yo_had_future_${idx_s}`);
+          em.emit_string_line(`      // Arms with a nested cond/match: run whether or not the nested arm awaited`);
+          em.emit_string_line(`      switch (sm->cond_branch_${cond_field.to_string()}) {`);
+          (bi : usize) = usize(0);
+          while(bi < cbd.branches.len(), {
+            match(
+              cbd.branches.get(bi),
+              .Some(branch) => match(
+                branch.nested,
+                .Some(nk) => if(branch.has_await, {
+                  em.emit_string_line(`        case ${branch.index.to_string()}: {`);
+                  match(
+                    context.nested_cond_records.get(nk),
+                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, false, c_guard),
+                    .None => ()
+                  );
+                  _emit_cond_branch_remaining(branch, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, cbd.target_assignment_code, `          `, context);
+                  em.emit_string_line(`          break;`);
+                  em.emit_string_line(`        }`);
+                }),
+                .None => ()
+              ),
+              .None => ()
+            );
+            bi = (bi + usize(1));
+          });
+          em.emit_string_line(`        default: break;`);
+          em.emit_string_line(`      }`);
+        });
+      },
+      .None => ()
+    ),
+    .None => ()
+  );
+});
 /// Emit the cond/match-branch continuation at the top of a resume state: a
 /// `switch (sm->cond_branch_N)` over the await-bearing branches (each runs its
 /// post-await remaining code), then any chained-branch layers, then the cond
@@ -2646,7 +2894,11 @@ _emit_cond_branch_continuation :: (
           while(mbi < cbd.branches.len(), {
             match(
               cbd.branches.get(mbi),
-              .Some(branch) => if(branch.has_await, {
+              // Uniform-mode arms with a NESTED instance are emitted after the
+              // slot guard by `_emit_nested_branch_continuation` — their
+              // remaining code must also run when the nested arm completed
+              // synchronously (no future, guard skipped).
+              .Some(branch) => if(branch.has_await && (dispatch_mode || branch.nested.is_none()), {
                 if(!(skip_switch), {
                   em.emit_string_line(`        case ${branch.index.to_string()}: {`);
                 });
@@ -2658,7 +2910,7 @@ _emit_cond_branch_continuation :: (
                 // binding — every other arm read a zero-initialised field and
                 // the program silently produced `false`/`0`. Skip the arm the
                 // pre-switch copy already covers, so it is not written twice.
-                if(!(dispatch_mode), {
+                if(!(dispatch_mode) && branch.nested.is_none(), {
                   match(
                     branch.await_target_variable_id,
                     // Emit only when this is NOT the arm the pre-switch copy
@@ -2693,6 +2945,15 @@ _emit_cond_branch_continuation :: (
                     })
                   );
                 });
+                match(
+                  branch.nested,
+                  .Some(nk) => match(
+                    context.nested_cond_records.get(nk),
+                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, dispatch_mode, Option(String).None),
+                    .None => ()
+                  ),
+                  .None => ()
+                );
                 _emit_cond_branch_remaining(branch, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, cbd.target_assignment_code, `          `, context);
                 if(!(skip_switch), {
                   em.emit_string_line(`          break;`);
@@ -3539,12 +3800,20 @@ generate_async_block_resume_function :: (
               // no awaiting arm ran.
               guard_slot := (in_cond && !(cond_await_point_needs_dispatch(prev_await, context)));
               if(guard_slot, {
+                // Remembered across the guarded block (which NULLs the slot
+                // after extracting) for the nested-arm continuation below;
+                // declared only when an arm needs it so that a program
+                // without nesting emits the same C as before.
+                if(_cond_point_has_nested_arm(prev_await, context), {
+                  em.emit_string_line(`      int __yo_had_future_${prev_await.base.index.to_string()} = (sm->${pffn} != NULL);`);
+                });
                 em.emit_string_line(`      if (sm->${pffn} != NULL) {`);
               });
               _emit_prev_await_result_extraction(async_block_id, segment.state_number, prev_await, analysis, context, cross_boundary_ids);
               _emit_cond_branch_continuation(async_block_id, prev_await, segment, body_expr, future_type, capture_type, analysis, context, cross_boundary_ids);
               if(guard_slot, {
                 em.emit_string_line(`      }`);
+                _emit_nested_branch_continuation(async_block_id, prev_await, segment, body_expr, future_type, capture_type, analysis, context, cross_boundary_ids);
               });
               _emit_outer_chained_branch_layers(prev_await, segment, body_expr, future_type, capture_type, analysis, context);
               _emit_while_continuation(prev_await, segment, body_expr, async_block_id, future_type, capture_type, analysis, context);

--- a/src/codegen/async/state_machine.yo
+++ b/src/codegen/async/state_machine.yo
@@ -15,7 +15,7 @@
 { lookup_macro_expansion, lookup_some_resolved_concrete } :: import("../../expr_info.yo");
 { AwaitAnalysisResult, AwaitPoint, CapturedVariable, CapturedVariableKind } :: import("../../evaluator/async/await_analysis_types.yo");
 { SuspensionCapturedVariable } :: import("../../evaluator/shared/suspension_analysis_types.yo");
-{ StateSegment, split_into_state_segments, generate_await_expression, generate_state_segment_code, hoist_non_splittable_awaits, await_is_while_condition, is_io_future_type, cond_await_point_needs_dispatch, cond_branch_future_access, CondBranchFutureAccess, collect_branch_await_exprs, _find_branch_await_target_variable_id, cond_branch_expr_in_while } :: import("./state_code_gen.yo");
+{ StateSegment, split_into_state_segments, generate_await_expression, generate_state_segment_code, hoist_non_splittable_awaits, await_is_while_condition, is_io_future_type, cond_await_point_needs_dispatch, cond_branch_future_access, CondBranchFutureAccess, collect_branch_await_exprs, _find_branch_await_target_variable_id, cond_branch_expr_in_while, _single_part_codes, _single_part_len } :: import("./state_code_gen.yo");
 { is_io_async_call, is_io_await_call } :: import("../../evaluator/async/await_analysis.yo");
 { AstExpr, ast_expr_id, ast_expr_is_atom, ast_expr_is_atom_of, ast_expr_is_fn_call, ast_expr_is_fn_call_of, ast_expr_token, BK_COND, BK_MATCH, BK_WHILE, BK_BEGIN } :: import("../../expr.yo");
 { _call_generate_expr } :: import("../exprs/_expr.yo");
@@ -1667,6 +1667,81 @@ _dispatch_branches :: (fn(cbd : AsyncCondBranchInfo, cond_field : usize, ap_inde
   );
   all
 });
+/// One `case` of the dispatch-mode suspension switch, suspending through the
+/// arm's OWN future access (shape and named-ness). Nested cond/match arms are
+/// entry arms with their own codes, so each gets its own exact case here;
+/// the enclosing arm gets none (see below).
+_emit_dispatch_suspension_case :: (
+  fn(
+    branch : CondBranch,
+    ap : AwaitPoint,
+    next_s : String,
+    resume_function_name : String,
+    depth : usize,
+    outer_loop_info : Option(WhileLoopInfo),
+    indent : String,
+    context : FunctionGenerationContext
+  ) -> unit
+)({
+  em := context.base.emitter;
+  // An arm whose await lives in a NESTED cond/match never holds the field
+  // at this point — the nested arm's write comes after its own — so it has
+  // no case of its own: the nested arms are entry arms and get theirs.
+  if(branch.nested.is_some(), return(()));
+  ae_opt := match(
+    branch.await_exprs,
+    .Some(aes) => aes.get(depth),
+    .None => Option(AstExpr).None
+  );
+  match(
+    ae_opt,
+    // A branch with fewer awaits than this depth never reaches this
+    // state — no case; the default skips.
+    .None => (),
+    .Some(ae) => match(
+      cond_branch_future_access(ae, ap, context),
+      .None => {
+        bt := ast_expr_token(ae);
+        codegen_fatal(`internal: dispatch-mode await point ${ap.base.index.to_string()} branch ${branch.index.to_string()} future access unresolvable (${bt.module_path}:${(bt.row + usize(1)).to_string()}:${(bt.column + usize(1)).to_string()})`);
+      },
+      .Some(acc_info) => {
+        em.emit_string_line(`${indent}case ${branch.index.to_string()}: {`);
+        if(!(acc_info.is_named), {
+          // A live code with a NULL slot means this arm's own store
+          // never ran (e.g. a nested plain arm kept the code, or this
+          // record is a dead outer layer) — nothing to await.
+          em.emit_string_line(`${indent}  if (sm->await_future_${ap.base.index.to_string()} == NULL) {`);
+          em.emit_string_line(`${indent}    sm->state = ${next_s};`);
+          em.emit_string_line(`${indent}    goto state_${next_s};`);
+          em.emit_string_line(`${indent}  }`);
+        });
+        branch_while_info := cond(
+          cond_branch_expr_in_while(ap.base, ae) =>
+            match(context.async_while_loop_info, .Some(m) => m.get(ap.base.index), .None => Option(WhileLoopInfo).None),
+          true => outer_loop_info
+        );
+        match(
+          branch_while_info,
+          .Some(wi) => {
+            wli := match(wi.while_loop_origin_index, .Some(o) => o, .None => ap.base.index);
+            em.emit_string_line(`${indent}  // Only await if while loop is still active (not broken)`);
+            em.emit_string_line(`${indent}  if (sm->while_loop_${wli.to_string()}_active) {`);
+            _emit_await_suspension_core(acc_info.access.clone(), acc_info.is_io_future, next_s.clone(), resume_function_name.clone(), ae, `${indent}    `, context);
+            em.emit_string_line(`${indent}  } else {`);
+            em.emit_string_line(`${indent}    // While loop was broken, jump to code after loop`);
+            em.emit_string_line(`${indent}    goto after_while_loop_${wli.to_string()};`);
+            em.emit_string_line(`${indent}  }`);
+          },
+          .None => {
+            _emit_await_suspension_core(acc_info.access.clone(), acc_info.is_io_future, next_s.clone(), resume_function_name.clone(), ae, `${indent}  `, context);
+          }
+        );
+        em.emit_string_line(`${indent}  break;`);
+        em.emit_string_line(`${indent}}`);
+      }
+    )
+  );
+});
 _emit_await_suspension_dispatch :: (
   fn(
     ap : AwaitPoint,
@@ -1712,59 +1787,7 @@ _emit_await_suspension_dispatch :: (
     match(
       dispatch_branches.get(bi),
       .Some(branch) => if(branch.has_await, {
-        ae_opt := match(
-          branch.await_exprs,
-          .Some(aes) => aes.get(depth),
-          .None => Option(AstExpr).None
-        );
-        match(
-          ae_opt,
-          // A branch with fewer awaits than this depth never reaches this
-          // state — no case; the default skips.
-          .None => (),
-          .Some(ae) => match(
-            cond_branch_future_access(ae, ap, context),
-            .None => {
-              bt := ast_expr_token(ae);
-              codegen_fatal(`internal: dispatch-mode await point ${ap.base.index.to_string()} branch ${branch.index.to_string()} future access unresolvable (${bt.module_path}:${(bt.row + usize(1)).to_string()}:${(bt.column + usize(1)).to_string()})`);
-            },
-            .Some(acc_info) => {
-              em.emit_string_line(`        case ${branch.index.to_string()}: {`);
-              if(!(acc_info.is_named), {
-                // A live code with a NULL slot means this arm's own store
-                // never ran (e.g. a nested plain arm kept the code, or this
-                // record is a dead outer layer) — nothing to await.
-                em.emit_string_line(`          if (sm->await_future_${ap.base.index.to_string()} == NULL) {`);
-                em.emit_string_line(`            sm->state = ${next_s};`);
-                em.emit_string_line(`            goto state_${next_s};`);
-                em.emit_string_line(`          }`);
-              });
-              branch_while_info := cond(
-                cond_branch_expr_in_while(ap.base, ae) =>
-                  match(context.async_while_loop_info, .Some(m) => m.get(ap.base.index), .None => Option(WhileLoopInfo).None),
-                true => outer_loop_info
-              );
-              match(
-                branch_while_info,
-                .Some(wi) => {
-                  wli := match(wi.while_loop_origin_index, .Some(o) => o, .None => ap.base.index);
-                  em.emit_string_line(`          // Only await if while loop is still active (not broken)`);
-                  em.emit_string_line(`          if (sm->while_loop_${wli.to_string()}_active) {`);
-                  _emit_await_suspension_core(acc_info.access.clone(), acc_info.is_io_future, next_s.clone(), resume_function_name.clone(), ae, String.from("            "), context);
-                  em.emit_string_line(`          } else {`);
-                  em.emit_string_line(`            // While loop was broken, jump to code after loop`);
-                  em.emit_string_line(`            goto after_while_loop_${wli.to_string()};`);
-                  em.emit_string_line(`          }`);
-                },
-                .None => {
-                  _emit_await_suspension_core(acc_info.access.clone(), acc_info.is_io_future, next_s.clone(), resume_function_name.clone(), ae, String.from("          "), context);
-                }
-              );
-              em.emit_string_line(`          break;`);
-              em.emit_string_line(`        }`);
-            }
-          )
-        );
+        _emit_dispatch_suspension_case(branch, ap, next_s.clone(), resume_function_name.clone(), depth, outer_loop_info, String.from("        "), context);
       }),
       .None => ()
     );
@@ -2008,26 +2031,173 @@ _cond_layer_target :: (
   )
 );
 /// The destination of a NESTED instance's value: its own `x :=` target, else —
-/// when it is the enclosing arm's TAIL (no remaining statements), so its value
-/// IS the enclosing arm's value — the enclosing level's target.
+/// when it is the enclosing arm's TAIL expression, so its value IS the
+/// enclosing arm's value — the enclosing level's target.
 _nested_level_target :: (
-  fn(branch : CondBranch, ninfo : AsyncCondBranchInfo, enclosing_target : Option(String)) -> Option(String)
+  fn(ninfo : AsyncCondBranchInfo, enclosing_target : Option(String)) -> Option(String)
 )(
   match(
     ninfo.target_assignment_code,
     .Some(t) => Option(String).Some(t),
-    .None => if(
-      match(branch.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true),
-      enclosing_target,
-      Option(String).None
-    )
+    .None => if(ninfo.tail_of_enclosing_arm, enclosing_target, Option(String).None)
   )
 );
-/// One `case` of the dispatch-mode extraction switch. A branch whose await
-/// lives in a NESTED cond/match (`branch.nested`) switches on the nested
-/// instance's own field and extracts per nested arm, recursively — the
-/// destinations are the nested arms' own bindings, or the nested instance's
-/// registered target when the nested arm's value IS the await.
+/// `_nested_level_target` resolved up the owner chain: the target of the
+/// nested record `k`, given the top-level entry's target `layer_target`.
+_instance_target :: (
+  fn(k : usize, layer_target : Option(String), context : FunctionGenerationContext) -> Option(String)
+)(
+  match(
+    context.nested_cond_records.get(k),
+    .Some(rec) => _nested_level_target(
+      rec,
+      match(rec.nested_owner, .Some(o) => recur(o, layer_target, context), .None => layer_target)
+    ),
+    .None => Option(String).None
+  )
+);
+/// Where an arm's value goes when its value IS the await: an owned (nested)
+/// arm's instance target, a top-level arm's layer target.
+_branch_value_target :: (
+  fn(branch : CondBranch, layer_target : Option(String), context : FunctionGenerationContext) -> Option(String)
+)(
+  match(branch.owner, .Some(k) => _instance_target(k, layer_target, context), .None => layer_target)
+);
+/// Which arm of one `switch (sm->cond_branch_N)` owns each dispatch code. An
+/// arm's `codes` is the window of codes allocated while its body was emitted,
+/// so windows are nested or disjoint: a code inside several windows belongs
+/// to the arm with the SMALLEST one (the arm actually written last — a cond in
+/// a while body over the arm enclosing the loop, a nested arm over the arm
+/// enclosing it when the nested arm has a case of its own). Codes nobody more
+/// specific claims — a synchronous nested arm's, which never registers — go
+/// to the enclosing arm, so its continuation still runs. Returns
+/// branch index → the codes to label its case with.
+_assign_case_labels :: (
+  fn(branches : ArrayList(CondBranch), context : FunctionGenerationContext) -> HashMap(usize, ArrayList(usize))
+)({
+  // Order by window size, ascending; stable within a size.
+  order := ArrayList(usize).new();
+  (i : usize) = usize(0);
+  while(i < branches.len(), {
+    order.push(i);
+    i = (i + usize(1));
+  });
+  (a : usize) = usize(1);
+  while(a < order.len(), {
+    (b : usize) = a;
+    (moving : bool) = true;
+    while((b > usize(0)) && moving, {
+      cur := match(order.get(b), .Some(x) => x, .None => usize(0));
+      prev := match(order.get(b - usize(1)), .Some(x) => x, .None => usize(0));
+      cur_len := match(branches.get(cur), .Some(br) => br.codes.len(), .None => usize(0));
+      prev_len := match(branches.get(prev), .Some(br) => br.codes.len(), .None => usize(0));
+      if(cur_len < prev_len, {
+        order.swap(b, b - usize(1));
+        b = (b - usize(1));
+      }, {
+        moving = false;
+      });
+    });
+    a = (a + usize(1));
+  });
+  claimed := HashSet(usize).new();
+  out := HashMap(usize, ArrayList(usize)).new();
+  (oi : usize) = usize(0);
+  while(oi < order.len(), {
+    bi := match(order.get(oi), .Some(x) => x, .None => usize(0));
+    match(
+      branches.get(bi),
+      .Some(br) => {
+        mine := ArrayList(usize).new();
+        (ci : usize) = usize(0);
+        while(ci < br.codes.len(), {
+          match(
+            br.codes.get(ci),
+            .Some(c) => if(!(claimed.contains(c)), {
+              claimed.insert(c);
+              mine.push(c);
+            }),
+            .None => ()
+          );
+          ci = (ci + usize(1));
+        });
+        out.insert(br.index, mine);
+      },
+      .None => ()
+    );
+    oi = (oi + usize(1));
+  });
+  out
+});
+/// The arms that get a case of their own in an entry's continuation switch:
+/// every arm not OWNED by a nested record (owned arms run inside their owner
+/// arm's case, so they must not claim codes in the owner's switch).
+_unowned_branches :: (fn(branches : ArrayList(CondBranch)) -> ArrayList(CondBranch))({
+  out := ArrayList(CondBranch).new();
+  (i : usize) = usize(0);
+  while(i < branches.len(), {
+    match(
+      branches.get(i),
+      .Some(b) => if(b.owner.is_none(), {
+        out.push(b);
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  out
+});
+/// `case a: case b: …` for the codes `_assign_case_labels` gave `branch`.
+_case_labels :: (fn(labels : HashMap(usize, ArrayList(usize)), branch : CondBranch) -> String)({
+  codes := match(
+    labels.get(branch.index),
+    .Some(l) => l,
+    .None => {
+      own := ArrayList(usize).new();
+      own.push(branch.index);
+      own
+    }
+  );
+  out := String.new();
+  (i : usize) = usize(0);
+  while(i < codes.len(), {
+    match(
+      codes.get(i),
+      .Some(c) => {
+        if(i > usize(0), {
+          out.push_str(" ");
+        });
+        out.push_string(`case ${c.to_string()}:`);
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  out
+});
+/// `(f == a || f == b …)` over `codes` — the arm identity test for `if` guards.
+_codes_guard :: (fn(field : String, codes : ArrayList(usize)) -> String)({
+  out := String.from("(");
+  (i : usize) = usize(0);
+  while(i < codes.len(), {
+    match(
+      codes.get(i),
+      .Some(c) => {
+        if(i > usize(0), {
+          out.push_str(" || ");
+        });
+        out.push_string(`${field} == ${c.to_string()}`);
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  out.push_str(")");
+  out
+});
+/// One `case` of the dispatch-mode extraction switch. A nested cond/match
+/// arm's destination is its own binding, or — when its value IS the await —
+/// its instance's target (`_branch_value_target`), never the entry's.
 _emit_dispatch_extraction_case :: (
   fn(
     branch : CondBranch,
@@ -2042,37 +2212,8 @@ _emit_dispatch_extraction_case :: (
 )({
   em := context.base.emitter;
   prev_idx_s := prev_await.base.index.to_string();
-  match(
-    branch.nested,
-    .Some(nk) => match(
-      context.nested_cond_records.get(nk),
-      .Some(ninfo) => {
-        field := match(ninfo.cond_field_name, .Some(f) => f, .None => `cond_branch_${prev_idx_s}`);
-        em.emit_string_line(`        case ${branch.index.to_string()}: {`);
-        em.emit_string_line(`          // Nested cond/match: extract per nested arm`);
-        em.emit_string_line(`          switch (sm->${field}) {`);
-        level_target := _nested_level_target(branch, ninfo, level_target_assignment);
-        (ni : usize) = usize(0);
-        while(ni < ninfo.branches.len(), {
-          match(
-            ninfo.branches.get(ni),
-            .Some(inner) => if(inner.has_await, {
-              recur(inner, level_target, async_block_id.clone(), prev_await, depth, slot.clone(), context, cross_boundary_ids);
-            }),
-            .None => ()
-          );
-          ni = (ni + usize(1));
-        });
-        em.emit_string_line(`          default: break;`);
-        em.emit_string_line(`          }`);
-        em.emit_string_line(`          break;`);
-        em.emit_string_line(`        }`);
-        return(());
-      },
-      .None => ()
-    ),
-    .None => ()
-  );
+  // See _emit_dispatch_suspension_case: the nested arms carry the live codes.
+  if(branch.nested.is_some(), return(()));
   ae_opt := match(
     branch.await_exprs,
     .Some(aes) => aes.get(depth),
@@ -2129,7 +2270,7 @@ _emit_dispatch_extraction_case :: (
           // after it) — its result IS the cond's value.
           .None => if(match(branch.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true), {
             match(
-              level_target_assignment,
+              _branch_value_target(branch, level_target_assignment, context),
               .Some(tac) => {
                 dest = Option(String).Some(tac.clone());
               },
@@ -2361,6 +2502,8 @@ _chain_additional_remaining :: (
     context : FunctionGenerationContext,
     next_index : usize,
     branch_index : usize,
+    /// The arm's identity set (`CondBranch.codes`), carried onto the chained record.
+    codes : ArrayList(usize),
     branch_value : AstExpr,
     additional_remaining : ArrayList(AstExpr),
     deferred_drops : Option(ArrayList(AstExpr)),
@@ -2388,7 +2531,9 @@ _chain_additional_remaining :: (
       has_await => Option(ArrayList(AstExpr)).Some(chained_awaits),
       true => Option(ArrayList(AstExpr)).None
     ),
-    nested : Option(usize).None
+    nested : Option(usize).None,
+    owner : Option(usize).None,
+    codes : codes
   );
   if(context.async_cond_branch_info.is_none(), {
     context.async_cond_branch_info = Option(HashMap(usize, AsyncCondBranchInfo)).Some(HashMap(usize, AsyncCondBranchInfo).new());
@@ -2415,7 +2560,8 @@ _chain_additional_remaining :: (
           target_assignment_code : Option(String).None,
           cond_branch_field_index : Option(usize).Some(cond_branch_field_index),
           chained_branches : Option(ArrayList(ChainedCondBranches)).None,
-          cond_field_name : Option(String).None
+          nested_owner : Option(usize).None,
+          tail_of_enclosing_arm : false
         )
       );
     }
@@ -2623,8 +2769,11 @@ _emit_cond_branch_remaining :: (
                         nested_while.cond_branch_post_while_exprs,
                         CondBranchPostWhileExprs(
                           branch_index : branch.index,
+                          codes : branch.codes,
                           cond_branch_field_index : cond_field,
                           exprs : additional_remaining,
+                          part_codes : _single_part_codes(branch.codes),
+                          part_lens : _single_part_len(additional_remaining.len()),
                           deferred_drop_expressions : branch.deferred_drop_expressions,
                           skip_cond_branch_check : Option(bool).None
                         )
@@ -2653,7 +2802,7 @@ _emit_cond_branch_remaining :: (
               .Some(ae) => _find_branch_await_target_variable_id(ae, context),
               .None => Option(String).None
             );
-            _chain_additional_remaining(context, ap.base.index, branch.index, branch.value, additional_remaining, branch.deferred_drop_expressions, cond_field, additional_target);
+            _chain_additional_remaining(context, ap.base.index, branch.index, branch.codes, branch.value, additional_remaining, branch.deferred_drop_expressions, cond_field, additional_target);
           });
           true
         }, false),
@@ -2690,11 +2839,11 @@ _emit_cond_branch_remaining :: (
   );
 });
 /// The resume-side switch for a cond/match NESTED inside an awaiting arm
-/// (`CondBranch.nested`): dispatch on the nested instance's own field, bind
-/// the taken arm's await result, recurse into deeper nesting, run that arm's
-/// remaining code. The caller then runs the ENCLOSING arm's remaining code —
-/// the two-level dispatch that replaced the dead `case` the enclosing arm's
-/// statements used to be keyed on
+/// (`CondBranch.nested`): dispatch on the shared field over the nested arms'
+/// codes, bind the taken arm's await result, recurse into deeper nesting, run
+/// that arm's remaining code. The caller then runs the ENCLOSING arm's
+/// remaining code — the two-level dispatch that replaced the dead `case` the
+/// enclosing arm's statements used to be keyed on
 /// (issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
 _emit_nested_level_switch :: (
   fn(
@@ -2724,16 +2873,16 @@ _emit_nested_level_switch :: (
   ) -> unit
 )({
   em := context.base.emitter;
-  field := match(ninfo.cond_field_name, .Some(f) => f, .None => `cond_branch_${prev_await.base.index.to_string()}`);
   idx_s := prev_await.base.index.to_string();
-  em.emit_string_line(`${indent}// Nested cond/match: dispatch on its own field, then fall through to the enclosing arm`);
-  em.emit_string_line(`${indent}switch (sm->${field}) {`);
+  labels := _assign_case_labels(ninfo.branches, context);
+  em.emit_string_line(`${indent}// Nested cond/match: dispatch on the nested arm's code, then fall through to the enclosing arm`);
+  em.emit_string_line(`${indent}switch (sm->cond_branch_${cond_field.to_string()}) {`);
   (ni : usize) = usize(0);
   while(ni < ninfo.branches.len(), {
     match(
       ninfo.branches.get(ni),
       .Some(inner) => if(inner.has_await, {
-        em.emit_string_line(`${indent}  case ${inner.index.to_string()}: {`);
+        em.emit_string_line(`${indent}  ${_case_labels(labels, inner)} {`);
         em.emit_string_line(`${indent}    ASYNC_DEBUG("${async_block_id}: Executing remaining code from nested branch ${inner.index.to_string()}\\n");`);
         inner_indent := `${indent}    `;
         if(inner.nested.is_none(), {
@@ -2774,7 +2923,7 @@ _emit_nested_level_switch :: (
             inner.nested,
             .Some(nk) => match(
               context.nested_cond_records.get(nk),
-              .Some(nn) => recur(nn, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, inner_indent.clone(), context, cross_boundary_ids, dispatch_mode, _nested_level_target(inner, nn, level_target), c_guard),
+              .Some(nn) => recur(nn, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, inner_indent.clone(), context, cross_boundary_ids, dispatch_mode, _nested_level_target(nn, level_target), c_guard),
               .None => ()
             ),
             .None => ()
@@ -2851,6 +3000,7 @@ _emit_nested_branch_continuation :: (
         if(_cond_point_has_nested_arm(prev_await, context), {
           cond_field := match(cbd.cond_branch_field_index, .Some(x) => x, .None => prev_await.base.index);
           layer_target := _cond_layer_target(cbd, cond_field, context);
+          labels := _assign_case_labels(_unowned_branches(cbd.branches), context);
           idx_s := prev_await.base.index.to_string();
           c_guard := Option(String).Some(`__yo_had_future_${idx_s}`);
           em.emit_string_line(`      // Arms with a nested cond/match: run whether or not the nested arm awaited`);
@@ -2862,10 +3012,10 @@ _emit_nested_branch_continuation :: (
               .Some(branch) => match(
                 branch.nested,
                 .Some(nk) => if(branch.has_await, {
-                  em.emit_string_line(`        case ${branch.index.to_string()}: {`);
+                  em.emit_string_line(`        ${_case_labels(labels, branch)} {`);
                   match(
                     context.nested_cond_records.get(nk),
-                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, false, _nested_level_target(branch, ninfo, layer_target), c_guard),
+                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, false, _nested_level_target(ninfo, layer_target), c_guard),
                     .None => ()
                   );
                   _emit_cond_branch_remaining(branch, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, layer_target, `          `, context);
@@ -2934,6 +3084,7 @@ _emit_cond_branch_continuation :: (
         if(any_await, {
           cond_field := match(cbd.cond_branch_field_index, .Some(x) => x, .None => prev_await.base.index);
           layer_target := _cond_layer_target(cbd, cond_field, context);
+          labels := _assign_case_labels(_unowned_branches(cbd.branches), context);
           skip_switch := (cond_field == usize.MAX);
           em.emit_string_line(`      // Execute remaining code from chosen cond branch`);
           if(!(skip_switch), {
@@ -2947,9 +3098,11 @@ _emit_cond_branch_continuation :: (
               // slot guard by `_emit_nested_branch_continuation` — their
               // remaining code must also run when the nested arm completed
               // synchronously (no future, guard skipped).
-              .Some(branch) => if(branch.has_await && (dispatch_mode || branch.nested.is_none()), {
+              // An OWNED arm (one of a nested instance's) runs inside its
+              // owner arm's case — never as a case of its own here.
+              .Some(branch) => if((branch.has_await && branch.owner.is_none()) && (dispatch_mode || branch.nested.is_none()), {
                 if(!(skip_switch), {
-                  em.emit_string_line(`        case ${branch.index.to_string()}: {`);
+                  em.emit_string_line(`        ${_case_labels(labels, branch)} {`);
                 });
                 em.emit_string_line(`          ASYNC_DEBUG("${async_block_id}: Executing remaining code from branch ${branch.index.to_string()}\\n");`);
                 // Bind THIS branch's own await result. Several arms share one
@@ -2998,7 +3151,7 @@ _emit_cond_branch_continuation :: (
                   branch.nested,
                   .Some(nk) => match(
                     context.nested_cond_records.get(nk),
-                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, dispatch_mode, _nested_level_target(branch, ninfo, layer_target), Option(String).None),
+                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, dispatch_mode, _nested_level_target(ninfo, layer_target), Option(String).None),
                     .None => ()
                   ),
                   .None => ()
@@ -3111,7 +3264,8 @@ _emit_outer_chained_branch_layers :: (
                     layer.branches.get(ci),
                     .Some(cb) => if(cb.has_await && match(cb.remaining_exprs, .Some(r) => (r.len() > usize(0)), .None => false), {
                       em.emit_string_line(`      // Outer cond branch ${cb.index.to_string()} remaining code (chained)`);
-                      em.emit_string_line(`      if (sm->cond_branch_${layer.cond_branch_field_index.to_string()} == ${cb.index.to_string()}) {`);
+                      layer_guard := _codes_guard(`sm->cond_branch_${layer.cond_branch_field_index.to_string()}`, cb.codes);
+                      em.emit_string_line(`      if ${layer_guard} {`);
                       // The layer's tail value is the OUTER arm's value — it goes
                       // to the outer cond's target (`_cond_layer_target`).
                       outer_target := match(
@@ -3165,7 +3319,8 @@ _emit_post_while_cond_branch :: (
         em.emit_string_line(`      {`);
       }, {
         em.emit_string_line(`      // Execute post-while-loop code from cond branch`);
-        em.emit_string_line(`      if (sm->cond_branch_${pw.cond_branch_field_index.to_string()} == ${pw.branch_index.to_string()}) {`);
+        pw_guard := _codes_guard(`sm->cond_branch_${pw.cond_branch_field_index.to_string()}`, pw.codes);
+        em.emit_string_line(`      if ${pw_guard} {`);
       });
       prev_in_sm := context.in_async_state_machine;
       prev_smv := context.state_machine_variables;
@@ -3180,12 +3335,35 @@ _emit_post_while_cond_branch :: (
       has_next := match(segment.await_point, .Some(_) => true, .None => false);
       (found : bool) = false;
       additional := ArrayList(AstExpr).new();
+      // Several clients merged into this slot (inner arm first): each one's
+      // statements run under ITS OWN codes guard. A single client's guard is
+      // the slot's, already emitted above.
+      multi_part := (pw.part_codes.len() > usize(1));
+      (part : usize) = usize(0);
+      (part_end : usize) = match(pw.part_lens.get(usize(0)), .Some(l) => l, .None => pw.exprs.len());
+      (part_open : bool) = false;
       (i : usize) = usize(0);
       while(i < pw.exprs.len(), {
         expr := match(pw.exprs.get(i), .Some(e) => e, .None => body_expr);
+        while((i >= part_end) && ((part + usize(1)) < pw.part_lens.len()), {
+          if(part_open, {
+            em.emit_string_line(`        }`);
+            part_open = false;
+          });
+          part = (part + usize(1));
+          part_end = (part_end + match(pw.part_lens.get(part), .Some(l) => l, .None => usize(0)));
+        });
         if(found, {
           additional.push(expr);
         }, {
+          if(multi_part && !(part_open), {
+            part_guard := _codes_guard(
+              `sm->cond_branch_${pw.cond_branch_field_index.to_string()}`,
+              match(pw.part_codes.get(part), .Some(pc) => pc, .None => pw.codes)
+            );
+            em.emit_string_line(`        if ${part_guard} {`);
+            part_open = true;
+          });
           if(has_next && expr_contains_await(expr), {
             found = true;
             match(segment.await_point, .Some(ap) => generate_remaining_expr_future(expr, ap, analysis, `        `, context), .None => ());
@@ -3203,12 +3381,15 @@ _emit_post_while_cond_branch :: (
         });
         i = (i + usize(1));
       });
+      if(part_open, {
+        em.emit_string_line(`        }`);
+      });
       chained := match(
         segment.await_point,
         .Some(ap) => if(found, {
           ccf := if(skip_check, usize.MAX, pw.cond_branch_field_index);
           bv := match(pw.exprs.get(usize(0)), .Some(e) => e, .None => body_expr);
-          _chain_additional_remaining(context, ap.base.index, pw.branch_index, bv, additional, pw.deferred_drop_expressions, ccf, Option(String).None);
+          _chain_additional_remaining(context, ap.base.index, pw.branch_index, pw.codes, bv, additional, pw.deferred_drop_expressions, ccf, Option(String).None);
           true
         }, false),
         .None => false

--- a/src/codegen/async/state_machine.yo
+++ b/src/codegen/async/state_machine.yo
@@ -3011,7 +3011,9 @@ _emit_nested_branch_continuation :: (
               cbd.branches.get(bi),
               .Some(branch) => match(
                 branch.nested,
-                .Some(nk) => if(branch.has_await, {
+                // An OWNED arm's nested instance runs inside its owner's case
+                // (`_emit_nested_level_switch` recurses), never as a case here.
+                .Some(nk) => if(branch.has_await && branch.owner.is_none(), {
                   em.emit_string_line(`        ${_case_labels(labels, branch)} {`);
                   match(
                     context.nested_cond_records.get(nk),
@@ -3189,6 +3191,7 @@ _emit_cond_branch_continuation :: (
                       match(
                         layer.branches.get(ci),
                         .Some(cb) => if(cb.has_await && match(cb.remaining_exprs, .Some(r) => (r.len() > usize(0)), .None => false), {
+                          _emit_chained_arm_binding(cb, prev_await, `      `, context, cross_boundary_ids);
                           _emit_cond_branch_remaining(cb, prev_await, segment, body_expr, future_type, capture_type, analysis, layer.cond_branch_field_index, Option(String).None, `      `, context);
                         }),
                         .None => ()
@@ -3226,6 +3229,38 @@ _emit_cond_branch_continuation :: (
     .None => ()
   );
 });
+/// A chained arm's own await binding at a uniform point: `sm->var_<b> =
+/// sm->await_result_N` for the `b` in `b := io.await(...)` that carried the
+/// arm's additional await, under the same three conditions the main
+/// continuation switch applies to its arms (not the arm the pre-switch copy
+/// already covers; the binding lives in the state struct; it has this point's
+/// result type). Chained layers used to run their remaining code without ever
+/// assigning it, so a sibling arm's second-await binding read calloc zero
+/// (issues/fixed/async-chained-sibling-arm-second-await-binding-never-assigned.md).
+_emit_chained_arm_binding :: (
+  fn(
+    cb : CondBranch,
+    prev_await : AwaitPoint,
+    indent : String,
+    context : FunctionGenerationContext,
+    cross_boundary_ids : Option(HashSet(String))
+  ) -> unit
+)({
+  em := context.base.emitter;
+  if(cond_await_point_needs_dispatch(prev_await, context), return(()));
+  match(
+    cb.await_target_variable_id,
+    .Some(btvid) => if((
+      match(prev_await.base.target_variable_id, .Some(ptv) => !(ptv == btvid), .None => true)
+      && _await_target_has_struct_field(btvid.clone(), cross_boundary_ids, context)
+    )
+    && _branch_target_matches_await_type(btvid.clone(), prev_await.result_type, context), {
+      bfield := get_state_machine_field_name(btvid, Option(String).Some(String.from("local")), context.state_machine_field_aliases);
+      em.emit_string_line(`${indent}sm->${bfield} = sm->await_result_${prev_await.base.index.to_string()};`);
+    }),
+    .None => ()
+  );
+});
 /// Chained layers from an OUTER cond (field != prev_await.index): the outer
 /// branch's remaining code must run even when THIS state's await was never
 /// submitted (the nested branch was not taken), so it lives OUTSIDE the
@@ -3242,7 +3277,8 @@ _emit_outer_chained_branch_layers :: (
     future_type : TypeValue,
     capture_type : Option(TypeValue),
     analysis : AwaitAnalysisResult,
-    context : FunctionGenerationContext
+    context : FunctionGenerationContext,
+    cross_boundary_ids : Option(HashSet(String))
   ) -> unit
 )({
   em := context.base.emitter;
@@ -3273,6 +3309,7 @@ _emit_outer_chained_branch_layers :: (
                         .Some(outer) => outer.target_assignment_code,
                         .None => Option(String).None
                       );
+                      _emit_chained_arm_binding(cb, prev_await, `        `, context, cross_boundary_ids);
                       _emit_cond_branch_remaining(cb, prev_await, segment, body_expr, future_type, capture_type, analysis, layer.cond_branch_field_index, outer_target, `      `, context);
                       em.emit_string_line(`      }`);
                     }),
@@ -4052,7 +4089,7 @@ generate_async_block_resume_function :: (
                 em.emit_string_line(`      }`);
                 _emit_nested_branch_continuation(async_block_id, prev_await, segment, body_expr, future_type, capture_type, analysis, context, cross_boundary_ids);
               });
-              _emit_outer_chained_branch_layers(prev_await, segment, body_expr, future_type, capture_type, analysis, context);
+              _emit_outer_chained_branch_layers(prev_await, segment, body_expr, future_type, capture_type, analysis, context, cross_boundary_ids);
               _emit_while_continuation(prev_await, segment, body_expr, async_block_id, future_type, capture_type, analysis, context);
             },
             .None => ()

--- a/src/codegen/async/state_machine.yo
+++ b/src/codegen/async/state_machine.yo
@@ -1458,6 +1458,13 @@ generate_remaining_expr_future :: (
           }),
           .None => ()
         );
+      }, {
+        // `x := cond/match(… await …)` as an arm's additional await: the
+        // await lives in a nested instance whose value is bound. This used to
+        // return here having emitted NOTHING — the binding, the instance and
+        // the arm's statements after it all vanished
+        // (issues/fixed/async-cond-arm-tail-value-lost-after-second-await.md).
+        generate_await_expression(expr, await_point, usize(0), indent, context);
       }),
       .None => ()
     );
@@ -1979,6 +1986,43 @@ _await_target_has_struct_field :: (
 /// bound variable's field; else the cond's registered target when the branch
 /// VALUE is the await itself; else nothing (a discarded await result stays
 /// owned by the future and is released with it).
+/// The destination a cond/match layer's arm values go to at a resume state:
+/// the entry's own registered target, else — for an entry whose branches
+/// CONTINUE an outer cond's arms past an additional await (created by
+/// `_chain_additional_remaining`; `cond_field` names the outer field) — the
+/// outer cond's target. Before this the continuation of a value-producing
+/// cond whose arm awaited TWICE computed the arm's tail value after the second
+/// await and discarded it, so the bound result stayed zeroed
+/// (issues/fixed/async-cond-arm-tail-value-lost-after-second-await.md).
+_cond_layer_target :: (
+  fn(cbd : AsyncCondBranchInfo, cond_field : usize, context : FunctionGenerationContext) -> Option(String)
+)(
+  match(
+    cbd.target_assignment_code,
+    .Some(t) => Option(String).Some(t),
+    .None => match(
+      context.async_cond_branch_info,
+      .Some(m) => match(m.get(cond_field), .Some(outer) => outer.target_assignment_code, .None => Option(String).None),
+      .None => Option(String).None
+    )
+  )
+);
+/// The destination of a NESTED instance's value: its own `x :=` target, else —
+/// when it is the enclosing arm's TAIL (no remaining statements), so its value
+/// IS the enclosing arm's value — the enclosing level's target.
+_nested_level_target :: (
+  fn(branch : CondBranch, ninfo : AsyncCondBranchInfo, enclosing_target : Option(String)) -> Option(String)
+)(
+  match(
+    ninfo.target_assignment_code,
+    .Some(t) => Option(String).Some(t),
+    .None => if(
+      match(branch.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true),
+      enclosing_target,
+      Option(String).None
+    )
+  )
+);
 /// One `case` of the dispatch-mode extraction switch. A branch whose await
 /// lives in a NESTED cond/match (`branch.nested`) switches on the nested
 /// instance's own field and extracts per nested arm, recursively — the
@@ -2007,12 +2051,13 @@ _emit_dispatch_extraction_case :: (
         em.emit_string_line(`        case ${branch.index.to_string()}: {`);
         em.emit_string_line(`          // Nested cond/match: extract per nested arm`);
         em.emit_string_line(`          switch (sm->${field}) {`);
+        level_target := _nested_level_target(branch, ninfo, level_target_assignment);
         (ni : usize) = usize(0);
         while(ni < ninfo.branches.len(), {
           match(
             ninfo.branches.get(ni),
             .Some(inner) => if(inner.has_await, {
-              recur(inner, ninfo.target_assignment_code, async_block_id.clone(), prev_await, depth, slot.clone(), context, cross_boundary_ids);
+              recur(inner, level_target, async_block_id.clone(), prev_await, depth, slot.clone(), context, cross_boundary_ids);
             }),
             .None => ()
           );
@@ -2147,7 +2192,7 @@ _emit_prev_await_result_extraction_dispatch :: (
     match(
       dispatch_branches.get(bi),
       .Some(branch) => if(branch.has_await, {
-        _emit_dispatch_extraction_case(branch, cbd.target_assignment_code, async_block_id.clone(), prev_await, depth, slot.clone(), context, cross_boundary_ids);
+        _emit_dispatch_extraction_case(branch, _cond_layer_target(cbd, cond_field, context), async_block_id.clone(), prev_await, depth, slot.clone(), context, cross_boundary_ids);
       }),
       .None => ()
     );
@@ -2650,7 +2695,7 @@ _emit_cond_branch_remaining :: (
 /// remaining code. The caller then runs the ENCLOSING arm's remaining code —
 /// the two-level dispatch that replaced the dead `case` the enclosing arm's
 /// statements used to be keyed on
-/// (issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+/// (issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
 _emit_nested_level_switch :: (
   fn(
     ninfo : AsyncCondBranchInfo,
@@ -2668,6 +2713,8 @@ _emit_nested_level_switch :: (
     /// Dispatch-mode point: the per-branch extraction already wrote every
     /// destination — bind nothing here.
     dispatch_mode : bool,
+    /// Where this nested instance's value goes (`_nested_level_target`).
+    level_target : Option(String),
     /// A C condition that is true only when a future was stored and its
     /// result extracted (`__yo_had_future_N`): the bindings run under it,
     /// because this switch is emitted OUTSIDE the slot guard so that the
@@ -2710,7 +2757,7 @@ _emit_nested_level_switch :: (
               // nested instance's binding (`x := match(...)`).
               .None => if(match(inner.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true), {
                 match(
-                  ninfo.target_assignment_code,
+                  level_target,
                   .Some(tac) => {
                     em.emit_string_line(`${inner_indent}${tac} = sm->await_result_${idx_s};`);
                   },
@@ -2727,13 +2774,13 @@ _emit_nested_level_switch :: (
             inner.nested,
             .Some(nk) => match(
               context.nested_cond_records.get(nk),
-              .Some(nn) => recur(nn, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, inner_indent.clone(), context, cross_boundary_ids, dispatch_mode, c_guard),
+              .Some(nn) => recur(nn, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, inner_indent.clone(), context, cross_boundary_ids, dispatch_mode, _nested_level_target(inner, nn, level_target), c_guard),
               .None => ()
             ),
             .None => ()
           );
         });
-        _emit_cond_branch_remaining(inner, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, ninfo.target_assignment_code, inner_indent, context);
+        _emit_cond_branch_remaining(inner, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, level_target, inner_indent, context);
         em.emit_string_line(`${indent}    break;`);
         em.emit_string_line(`${indent}  }`);
       }),
@@ -2803,6 +2850,7 @@ _emit_nested_branch_continuation :: (
       .Some(cbd) => {
         if(_cond_point_has_nested_arm(prev_await, context), {
           cond_field := match(cbd.cond_branch_field_index, .Some(x) => x, .None => prev_await.base.index);
+          layer_target := _cond_layer_target(cbd, cond_field, context);
           idx_s := prev_await.base.index.to_string();
           c_guard := Option(String).Some(`__yo_had_future_${idx_s}`);
           em.emit_string_line(`      // Arms with a nested cond/match: run whether or not the nested arm awaited`);
@@ -2817,10 +2865,10 @@ _emit_nested_branch_continuation :: (
                   em.emit_string_line(`        case ${branch.index.to_string()}: {`);
                   match(
                     context.nested_cond_records.get(nk),
-                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, false, c_guard),
+                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, false, _nested_level_target(branch, ninfo, layer_target), c_guard),
                     .None => ()
                   );
-                  _emit_cond_branch_remaining(branch, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, cbd.target_assignment_code, `          `, context);
+                  _emit_cond_branch_remaining(branch, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, layer_target, `          `, context);
                   em.emit_string_line(`          break;`);
                   em.emit_string_line(`        }`);
                 }),
@@ -2885,6 +2933,7 @@ _emit_cond_branch_continuation :: (
         });
         if(any_await, {
           cond_field := match(cbd.cond_branch_field_index, .Some(x) => x, .None => prev_await.base.index);
+          layer_target := _cond_layer_target(cbd, cond_field, context);
           skip_switch := (cond_field == usize.MAX);
           em.emit_string_line(`      // Execute remaining code from chosen cond branch`);
           if(!(skip_switch), {
@@ -2936,7 +2985,7 @@ _emit_cond_branch_continuation :: (
                     // no-target-assignment fallback below.
                     .None => if(match(branch.remaining_exprs, .Some(r) => (r.len() == usize(0)), .None => true), {
                       match(
-                        cbd.target_assignment_code,
+                        layer_target,
                         .Some(tac) => {
                           em.emit_string_line(`          ${tac} = sm->await_result_${prev_await.base.index.to_string()};`);
                         },
@@ -2949,12 +2998,12 @@ _emit_cond_branch_continuation :: (
                   branch.nested,
                   .Some(nk) => match(
                     context.nested_cond_records.get(nk),
-                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, dispatch_mode, Option(String).None),
+                    .Some(ninfo) => _emit_nested_level_switch(ninfo, async_block_id.clone(), prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, `          `, context, cross_boundary_ids, dispatch_mode, _nested_level_target(branch, ninfo, layer_target), Option(String).None),
                     .None => ()
                   ),
                   .None => ()
                 );
-                _emit_cond_branch_remaining(branch, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, cbd.target_assignment_code, `          `, context);
+                _emit_cond_branch_remaining(branch, prev_await, segment, body_expr, future_type, capture_type, analysis, cond_field, layer_target, `          `, context);
                 if(!(skip_switch), {
                   em.emit_string_line(`          break;`);
                   em.emit_string_line(`        }`);
@@ -3063,7 +3112,14 @@ _emit_outer_chained_branch_layers :: (
                     .Some(cb) => if(cb.has_await && match(cb.remaining_exprs, .Some(r) => (r.len() > usize(0)), .None => false), {
                       em.emit_string_line(`      // Outer cond branch ${cb.index.to_string()} remaining code (chained)`);
                       em.emit_string_line(`      if (sm->cond_branch_${layer.cond_branch_field_index.to_string()} == ${cb.index.to_string()}) {`);
-                      _emit_cond_branch_remaining(cb, prev_await, segment, body_expr, future_type, capture_type, analysis, layer.cond_branch_field_index, Option(String).None, `      `, context);
+                      // The layer's tail value is the OUTER arm's value — it goes
+                      // to the outer cond's target (`_cond_layer_target`).
+                      outer_target := match(
+                        cbi_map.get(layer.cond_branch_field_index),
+                        .Some(outer) => outer.target_assignment_code,
+                        .None => Option(String).None
+                      );
+                      _emit_cond_branch_remaining(cb, prev_await, segment, body_expr, future_type, capture_type, analysis, layer.cond_branch_field_index, outer_target, `      `, context);
                       em.emit_string_line(`      }`);
                     }),
                     .None => ()

--- a/src/codegen/exprs/async.yo
+++ b/src/codegen/exprs/async.yo
@@ -15,7 +15,7 @@
 //! key — yo-self `Func` types carry no `.id`).
 { String } :: import("std/string");
 { ArrayList } :: import("std/collections/array_list");
-{ await_is_while_condition, cond_await_point_needs_dispatch, cond_await_point_any_branch_in_while } :: import("../async/state_code_gen.yo");
+{ await_is_while_condition, cond_await_point_needs_dispatch, cond_await_point_any_branch_in_while, max_nested_cond_depth } :: import("../async/state_code_gen.yo");
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
 {
@@ -513,7 +513,11 @@ AsyncBlockStructInfo :: ref(
     await_future_temp_var_aliases : Option(HashMap(String, String)),
     overlapping_slot_aliases : Option(HashMap(String, String)),
     overlapping_slots : Option(ArrayList(OverlappingSlot)),
-    closure_param_slots : Option(ArrayList(ClosureParamSlot))
+    closure_param_slots : Option(ArrayList(ClosureParamSlot)),
+    /// `max_nested_cond_depth(body)`: how many levels of cond/match-with-await
+    /// nest inside awaiting arms; the struct declares `cond_branch_N_n<d>` for
+    /// d in 1..depth-1 (state_code_gen.yo `_cond_field_name`).
+    nested_cond_depth : usize
   )
 );
 /// True if an await point's result type is effectively unit (real unit, or an
@@ -849,6 +853,13 @@ emit_async_block_struct_definition :: (
           cond_emitted = true;
         });
         em.emit_declaration_string_line(`  int cond_branch_${ap.base.index.to_string()};  // Which branch was taken in cond with await ${ap.base.index.to_string()}`);
+        // One extra field per nesting level for cond/match instances NESTED
+        // inside this point's awaiting arms (the top level is depth 1).
+        (nd : usize) = usize(1);
+        while(nd < info.nested_cond_depth, {
+          em.emit_declaration_string_line(`  int cond_branch_${ap.base.index.to_string()}_n${nd.to_string()};  // nested level ${nd.to_string()}`);
+          nd = (nd + usize(1));
+        });
       }),
       .None => ()
     );
@@ -1148,7 +1159,8 @@ emit_deferred_async_block_struct_definitions :: (fn(context : FunctionGeneration
             await_future_temp_var_aliases : Option(HashMap(String, String)).Some(cbr.await_future_temp_var_aliases),
             overlapping_slot_aliases : Option(HashMap(String, String)).Some(osr.slot_aliases),
             overlapping_slots : Option(ArrayList(OverlappingSlot)).Some(osr.slots),
-            closure_param_slots : b.closure_param_slots
+            closure_param_slots : b.closure_param_slots,
+            nested_cond_depth : max_nested_cond_depth(b.body_expr)
           ),
           context
         );
@@ -2272,7 +2284,8 @@ generate_deferred_async_blocks :: (fn(context : FunctionGenerationContext) -> un
                 await_future_temp_var_aliases : Option(HashMap(String, String)).Some(ncbr.await_future_temp_var_aliases),
                 overlapping_slot_aliases : Option(HashMap(String, String)).Some(nosr.slot_aliases),
                 overlapping_slots : Option(ArrayList(OverlappingSlot)).Some(nosr.slots),
-                closure_param_slots : nb.closure_param_slots
+                closure_param_slots : nb.closure_param_slots,
+                nested_cond_depth : max_nested_cond_depth(nb.body_expr)
               ),
               context
             );

--- a/src/codegen/exprs/async.yo
+++ b/src/codegen/exprs/async.yo
@@ -15,7 +15,7 @@
 //! key — yo-self `Func` types carry no `.id`).
 { String } :: import("std/string");
 { ArrayList } :: import("std/collections/array_list");
-{ await_is_while_condition, cond_await_point_needs_dispatch, cond_await_point_any_branch_in_while, max_nested_cond_depth } :: import("../async/state_code_gen.yo");
+{ await_is_while_condition, cond_await_point_needs_dispatch, cond_await_point_any_branch_in_while } :: import("../async/state_code_gen.yo");
 { HashMap } :: import("std/collections/hash_map");
 { HashSet } :: import("std/collections/hash_set");
 {
@@ -513,11 +513,7 @@ AsyncBlockStructInfo :: ref(
     await_future_temp_var_aliases : Option(HashMap(String, String)),
     overlapping_slot_aliases : Option(HashMap(String, String)),
     overlapping_slots : Option(ArrayList(OverlappingSlot)),
-    closure_param_slots : Option(ArrayList(ClosureParamSlot)),
-    /// `max_nested_cond_depth(body)`: how many levels of cond/match-with-await
-    /// nest inside awaiting arms; the struct declares `cond_branch_N_n<d>` for
-    /// d in 1..depth-1 (state_code_gen.yo `_cond_field_name`).
-    nested_cond_depth : usize
+    closure_param_slots : Option(ArrayList(ClosureParamSlot))
   )
 );
 /// True if an await point's result type is effectively unit (real unit, or an
@@ -853,13 +849,6 @@ emit_async_block_struct_definition :: (
           cond_emitted = true;
         });
         em.emit_declaration_string_line(`  int cond_branch_${ap.base.index.to_string()};  // Which branch was taken in cond with await ${ap.base.index.to_string()}`);
-        // One extra field per nesting level for cond/match instances NESTED
-        // inside this point's awaiting arms (the top level is depth 1).
-        (nd : usize) = usize(1);
-        while(nd < info.nested_cond_depth, {
-          em.emit_declaration_string_line(`  int cond_branch_${ap.base.index.to_string()}_n${nd.to_string()};  // nested level ${nd.to_string()}`);
-          nd = (nd + usize(1));
-        });
       }),
       .None => ()
     );
@@ -1159,8 +1148,7 @@ emit_deferred_async_block_struct_definitions :: (fn(context : FunctionGeneration
             await_future_temp_var_aliases : Option(HashMap(String, String)).Some(cbr.await_future_temp_var_aliases),
             overlapping_slot_aliases : Option(HashMap(String, String)).Some(osr.slot_aliases),
             overlapping_slots : Option(ArrayList(OverlappingSlot)).Some(osr.slots),
-            closure_param_slots : b.closure_param_slots,
-            nested_cond_depth : max_nested_cond_depth(b.body_expr)
+            closure_param_slots : b.closure_param_slots
           ),
           context
         );
@@ -2284,8 +2272,7 @@ generate_deferred_async_blocks :: (fn(context : FunctionGenerationContext) -> un
                 await_future_temp_var_aliases : Option(HashMap(String, String)).Some(ncbr.await_future_temp_var_aliases),
                 overlapping_slot_aliases : Option(HashMap(String, String)).Some(nosr.slot_aliases),
                 overlapping_slots : Option(ArrayList(OverlappingSlot)).Some(nosr.slots),
-                closure_param_slots : nb.closure_param_slots,
-                nested_cond_depth : max_nested_cond_depth(nb.body_expr)
+                closure_param_slots : nb.closure_param_slots
               ),
               context
             );

--- a/src/codegen/functions/context.yo
+++ b/src/codegen/functions/context.yo
@@ -238,7 +238,7 @@ CondBranch :: ref(
     /// and the resume runs a two-level switch — the nested arm's remaining
     /// code, then this arm's. Before this the nested instance overwrote the
     /// shared `cond_branch_N` and this arm's remaining statements were a dead
-    /// `case` (issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+    /// `case` (issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
     /// An INDEX into `FunctionGenerationContext.nested_cond_records` — the
     /// record type names `CondBranch`, and two type definitions may not name
     /// each other.

--- a/src/codegen/functions/context.yo
+++ b/src/codegen/functions/context.yo
@@ -90,8 +90,18 @@ EvidenceParameter :: ref(
 CondBranchPostWhileExprs :: ref(
   struct(
     branch_index : usize,
+    /// The arm's identity on `sm->cond_branch_<field>`: its own code plus
+    /// every code written while its body ran (`CondBranch.codes`). For a
+    /// MERGED slot, the union over its clients.
+    codes : ArrayList(usize),
     cond_branch_field_index : usize,
     exprs : ArrayList(AstExpr),
+    /// The slot's clients in order (inner arm first): each client's own
+    /// `codes` and how many leading `exprs` are its. A client's code runs only
+    /// under ITS guard — the loop arm's post-loop statements must not run
+    /// when a sibling nested arm was taken and the loop never started.
+    part_codes : ArrayList(ArrayList(usize)),
+    part_lens : ArrayList(usize),
     deferred_drop_expressions : Option(ArrayList(AstExpr)),
     /// When true, skip the `sm->cond_branch_N` guard (nested conds share the field).
     skip_cond_branch_check : Option(bool)
@@ -120,7 +130,45 @@ merge_cond_branch_post_while_exprs :: (
     existing,
     .None => incoming,
     .Some(ex) => {
-      guards_disagree := (!(ex.branch_index == incoming.branch_index) || !(ex.cond_branch_field_index == incoming.cond_branch_field_index));
+      // Two clients with different arms: the merged code runs for EITHER
+      // arm's codes (a union), no longer unconditionally.
+      merged_codes := ArrayList(usize).new();
+      (ci : usize) = usize(0);
+      while(ci < ex.codes.len(), {
+        match(
+          ex.codes.get(ci),
+          .Some(c) => {
+            merged_codes.push(c);
+          },
+          .None => ()
+        );
+        ci = (ci + usize(1));
+      });
+      ci = usize(0);
+      while(ci < incoming.codes.len(), {
+        match(
+          incoming.codes.get(ci),
+          .Some(c) => {
+            (dup : bool) = false;
+            (di : usize) = usize(0);
+            while((di < merged_codes.len()) && !dup, {
+              match(
+                merged_codes.get(di),
+                .Some(m) => if(m == c, {
+                  dup = true;
+                }),
+                .None => ()
+              );
+              di = (di + usize(1));
+            });
+            if(!dup, {
+              merged_codes.push(c);
+            });
+          },
+          .None => ()
+        );
+        ci = (ci + usize(1));
+      });
       merged_exprs := ArrayList(AstExpr).new();
       (i : usize) = usize(0);
       while(i < ex.exprs.len(), {
@@ -181,15 +229,56 @@ merge_cond_branch_post_while_exprs :: (
       );
       ex_skip := match(ex.skip_cond_branch_check, .Some(b) => b, .None => false);
       in_skip := match(incoming.skip_cond_branch_check, .Some(b) => b, .None => false);
+      merged_part_codes := ArrayList(ArrayList(usize)).new();
+      merged_part_lens := ArrayList(usize).new();
+      (pi : usize) = usize(0);
+      while(pi < ex.part_codes.len(), {
+        match(
+          ex.part_codes.get(pi),
+          .Some(pc) => {
+            merged_part_codes.push(pc);
+          },
+          .None => ()
+        );
+        match(
+          ex.part_lens.get(pi),
+          .Some(pl) => {
+            merged_part_lens.push(pl);
+          },
+          .None => ()
+        );
+        pi = (pi + usize(1));
+      });
+      pi = usize(0);
+      while(pi < incoming.part_codes.len(), {
+        match(
+          incoming.part_codes.get(pi),
+          .Some(pc) => {
+            merged_part_codes.push(pc);
+          },
+          .None => ()
+        );
+        match(
+          incoming.part_lens.get(pi),
+          .Some(pl) => {
+            merged_part_lens.push(pl);
+          },
+          .None => ()
+        );
+        pi = (pi + usize(1));
+      });
       CondBranchPostWhileExprs(
         branch_index : ex.branch_index,
+        codes : merged_codes,
         cond_branch_field_index : ex.cond_branch_field_index,
         exprs : merged_exprs,
+        part_codes : merged_part_codes,
+        part_lens : merged_part_lens,
         deferred_drop_expressions : cond(
           (merged_drops.len() > usize(0)) => Option(ArrayList(AstExpr)).Some(merged_drops),
           true => Option(ArrayList(AstExpr)).None
         ),
-        skip_cond_branch_check : Option(bool).Some(ex_skip || in_skip || guards_disagree)
+        skip_cond_branch_check : Option(bool).Some(ex_skip || in_skip)
       )
     }
   )
@@ -233,16 +322,27 @@ CondBranch :: ref(
     await_exprs : Option(ArrayList(AstExpr)),
     /// When this arm's await lives inside a cond/match NESTED in the arm body
     /// (`.Git(..) => { x := match(o, .Some(v) => v, .None => io.await(...)); … }`),
-    /// the nested instance's own dispatch record: it writes its own
-    /// `cond_branch_N_n<depth>` field, so this arm's dispatch code survives
-    /// and the resume runs a two-level switch — the nested arm's remaining
-    /// code, then this arm's. Before this the nested instance overwrote the
-    /// shared `cond_branch_N` and this arm's remaining statements were a dead
-    /// `case` (issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
-    /// An INDEX into `FunctionGenerationContext.nested_cond_records` — the
-    /// record type names `CondBranch`, and two type definitions may not name
-    /// each other.
-    nested : Option(usize)
+    /// the nested instance's record (an INDEX into
+    /// `FunctionGenerationContext.nested_cond_records` — the record type names
+    /// `CondBranch`, and two type definitions may not name each other). The
+    /// nested instance shares this arm's `sm->cond_branch_N` field, and its
+    /// arms register in the same await-point entry (their codes are unique
+    /// within the function, so every consumer keyed on the field still
+    /// identifies them). This arm's continuation is emitted as ONE case
+    /// covering `codes` — a switch over the nested arms' remaining code, then
+    /// this arm's. Before this the nested write left this arm's statements a
+    /// dead `case` (issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+    nested : Option(usize),
+    /// The nested record this arm belongs to (`.None` for a top-level arm).
+    /// An owned arm's remaining code is emitted inside its owner arm's case,
+    /// and its await value goes to the nested instance's own target.
+    owner : Option(usize),
+    /// This arm's identity on `sm->cond_branch_N`: its own dispatch code plus
+    /// every code allocated while its body was emitted (nested cond/match
+    /// arms, conds inside while loops, …) — any of them in the field means
+    /// this arm ran. `[index]` for an arm with nothing nested, so emission is
+    /// unchanged there.
+    codes : ArrayList(usize)
   )
 );
 /// A chained cond/match continuation: an outer cond's remaining code that shares
@@ -266,10 +366,13 @@ AsyncCondBranchInfo :: ref(
     /// The `cond_branch_X` index to use in the switch (continuation states).
     cond_branch_field_index : Option(usize),
     chained_branches : Option(ArrayList(ChainedCondBranches)),
-    /// A NESTED instance's own state-machine field (`cond_branch_N_n<depth>`);
-    /// `.None` for a top-level instance, which dispatches on
-    /// `cond_branch_<cond_branch_field_index | await index>`.
-    cond_field_name : Option(String)
+    /// A NESTED instance's record only: the record of the instance IT is
+    /// nested in (`.None` when the enclosing arm belongs to the top-level
+    /// entry), and whether it is the enclosing arm's TAIL expression — then a
+    /// nested arm whose value IS the await hands it to the enclosing level's
+    /// target. Both `.None`/`false` for a top-level entry.
+    nested_owner : Option(usize),
+    tail_of_enclosing_arm : bool
   )
 );
 /// Per-await-point info about a while loop containing an await. Mirrors the
@@ -418,14 +521,22 @@ FunctionGenerationContext :: ref(
     /// return value — its non-await branches must emit Future completion. Mirrors
     /// `asyncBodyReturnExpr`.
     async_body_return_expr : Option(AstExpr),
-    /// Nested cond/match emission (see `CondBranch.nested`). While a cond/match
-    /// NESTED inside an awaiting arm is being emitted, its branch records go to
-    /// this sink instead of the await point's entry and its dispatch writes go
-    /// to `cond_branch_N_n<nested_cond_depth>`.
-    nested_cond_sink : Option(AsyncCondBranchInfo),
-    /// The nested instances' dispatch records, addressed by `CondBranch.nested`.
+    /// Nested cond/match emission (see `CondBranch.nested`). Set by
+    /// `_emit_nested_cond_or_match` right before it calls the cond/match
+    /// emitter for a NESTED instance: the record (an index into
+    /// `nested_cond_records`) that instance's arms belong to. The emitter
+    /// CLAIMS it at entry (`generate_cond_with_await` / `generate_match_with_await`
+    /// move it into `nested_cond_owner` and clear it), so an instance emitted
+    /// inside one of its arm bodies some other way — a cond in a while body —
+    /// finds nothing here and registers as an ordinary entry arm.
+    nested_cond_sink : Option(usize),
+    /// The record the instance CURRENTLY being emitted registers its arms
+    /// under (`CondBranch.owner`; targets go there instead of the entry):
+    /// `.None` for a top-level instance. Saved/restored around each instance.
+    nested_cond_owner : Option(usize),
+    /// The nested instances' records, addressed by `CondBranch.nested` /
+    /// `CondBranch.owner` / `AsyncCondBranchInfo.nested_owner`.
     nested_cond_records : ArrayList(AsyncCondBranchInfo),
-    nested_cond_depth : usize,
     /// Effect-evidence parameters in scope (implicit label → evidence param), for
     /// explicit-effects dispatch / effect injection. Mirrors `currentEvidenceParams`.
     current_evidence_params : Option(HashMap(String, EvidenceParameter)),
@@ -498,9 +609,9 @@ impl(
       async_cond_branch_info : Option(HashMap(usize, AsyncCondBranchInfo)).None,
       cond_branch_case_seq : usize(0),
       async_body_return_expr : Option(AstExpr).None,
-      nested_cond_sink : Option(AsyncCondBranchInfo).None,
+      nested_cond_sink : Option(usize).None,
+      nested_cond_owner : Option(usize).None,
       nested_cond_records : ArrayList(AsyncCondBranchInfo).new(),
-      nested_cond_depth : usize(0),
       current_evidence_params : Option(HashMap(String, EvidenceParameter)).None,
       deferred_async_blocks : Option(ArrayList(DeferredAsyncBlock)).None,
       current_assignment_save_temp : Option(String).None,

--- a/src/codegen/functions/context.yo
+++ b/src/codegen/functions/context.yo
@@ -230,7 +230,19 @@ CondBranch :: ref(
     /// dispatch-mode emitters access each branch's future through its own
     /// exact shape instead of the representative's. See
     /// issues/fixed/async-cond-shared-await-point-only-models-representative-branch.md.
-    await_exprs : Option(ArrayList(AstExpr))
+    await_exprs : Option(ArrayList(AstExpr)),
+    /// When this arm's await lives inside a cond/match NESTED in the arm body
+    /// (`.Git(..) => { x := match(o, .Some(v) => v, .None => io.await(...)); … }`),
+    /// the nested instance's own dispatch record: it writes its own
+    /// `cond_branch_N_n<depth>` field, so this arm's dispatch code survives
+    /// and the resume runs a two-level switch — the nested arm's remaining
+    /// code, then this arm's. Before this the nested instance overwrote the
+    /// shared `cond_branch_N` and this arm's remaining statements were a dead
+    /// `case` (issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+    /// An INDEX into `FunctionGenerationContext.nested_cond_records` — the
+    /// record type names `CondBranch`, and two type definitions may not name
+    /// each other.
+    nested : Option(usize)
   )
 );
 /// A chained cond/match continuation: an outer cond's remaining code that shares
@@ -253,7 +265,11 @@ AsyncCondBranchInfo :: ref(
     target_assignment_code : Option(String),
     /// The `cond_branch_X` index to use in the switch (continuation states).
     cond_branch_field_index : Option(usize),
-    chained_branches : Option(ArrayList(ChainedCondBranches))
+    chained_branches : Option(ArrayList(ChainedCondBranches)),
+    /// A NESTED instance's own state-machine field (`cond_branch_N_n<depth>`);
+    /// `.None` for a top-level instance, which dispatches on
+    /// `cond_branch_<cond_branch_field_index | await index>`.
+    cond_field_name : Option(String)
   )
 );
 /// Per-await-point info about a while loop containing an await. Mirrors the
@@ -402,6 +418,14 @@ FunctionGenerationContext :: ref(
     /// return value — its non-await branches must emit Future completion. Mirrors
     /// `asyncBodyReturnExpr`.
     async_body_return_expr : Option(AstExpr),
+    /// Nested cond/match emission (see `CondBranch.nested`). While a cond/match
+    /// NESTED inside an awaiting arm is being emitted, its branch records go to
+    /// this sink instead of the await point's entry and its dispatch writes go
+    /// to `cond_branch_N_n<nested_cond_depth>`.
+    nested_cond_sink : Option(AsyncCondBranchInfo),
+    /// The nested instances' dispatch records, addressed by `CondBranch.nested`.
+    nested_cond_records : ArrayList(AsyncCondBranchInfo),
+    nested_cond_depth : usize,
     /// Effect-evidence parameters in scope (implicit label → evidence param), for
     /// explicit-effects dispatch / effect injection. Mirrors `currentEvidenceParams`.
     current_evidence_params : Option(HashMap(String, EvidenceParameter)),
@@ -474,6 +498,9 @@ impl(
       async_cond_branch_info : Option(HashMap(usize, AsyncCondBranchInfo)).None,
       cond_branch_case_seq : usize(0),
       async_body_return_expr : Option(AstExpr).None,
+      nested_cond_sink : Option(AsyncCondBranchInfo).None,
+      nested_cond_records : ArrayList(AsyncCondBranchInfo).new(),
+      nested_cond_depth : usize(0),
       current_evidence_params : Option(HashMap(String, EvidenceParameter)).None,
       deferred_async_blocks : Option(ArrayList(DeferredAsyncBlock)).None,
       current_assignment_save_temp : Option(String).None,

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -5104,8 +5104,8 @@ _sibling_second_awaits :: (fn(k : _SibKind, io : Io) -> Impl(Future(String, IoEx
     match(
       k,
       .A => {
-        exists := e.io.await(_sib_flag(e.io), e);
-        log.push_string(`A:exists=${exists.to_string()};`);
+        present := e.io.await(_sib_flag(e.io), e);
+        log.push_string(`A:present=${present.to_string()};`);
         added := e.io.await(_sib_flag(e.io), e);
         if(added, {
           log.push_str("A:added;");
@@ -5209,7 +5209,7 @@ test("a sibling arm's second-await binding is assigned when its continuation is 
   exn := Exception(throw : (_err -> unwind(())));
   bundle := IoExn(io : io, exn : exn);
   a := io.await(_sibling_second_awaits(_SibKind.A, io), bundle);
-  assert(a == "A:exists=true;A:added;", `the first arm binds both awaits (got ${a})`);
+  assert(a == "A:present=true;A:added;", `the first arm binds both awaits (got ${a})`);
   b := io.await(_sibling_second_awaits(_SibKind.B, io), bundle);
   assert(b == "B:nm=nm;B:added;", `the second arm's second-await binding is assigned (got ${b})`);
 });

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -4824,3 +4824,158 @@ test("Test a module global survives a suspension point", {
   assert(d == usize(2), "a spawned suspending body saw its own increments");
   assert(_g_async_counter == usize(2), "and they landed on the real global");
 });
+// ---------------------------------------------------------------------------
+// A cond/match with an awaiting arm NESTED inside an awaiting match arm
+// (issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+// The enclosing arm's statements after the nested instance used to be a dead
+// dispatch case — the whole arm vanished, exit 0, `check` clean. The resume
+// now dispatches on a per-nesting-level field (`cond_branch_N_n<d>`) and a
+// nested arm that completes synchronously runs the enclosing statements inline.
+// ---------------------------------------------------------------------------
+_NestedParsed :: enum(
+  Git(name : String, pinned_ref : Option(String)),
+  Path(name : String, rel : String),
+  Other
+);
+_nested_resolve :: (fn(io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    s := String.from("resolved");
+    s
+  })
+);
+_nested_append :: (fn(line : String, io : Io) -> Impl(Future(bool, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    line.len() > usize(0)
+  })
+);
+/// Shape A — the reproducer: a value-producing inner match whose `.None` arm
+/// awaits (tail await) and whose `.Some` arm is synchronous, followed by
+/// statements that use the bound value and an outer pattern binding.
+_nested_shape_a :: (fn(parsed : _NestedParsed, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    out := match(
+      parsed,
+      .Other => String.from("other"),
+      .Path(
+        p_name,
+        p_rel
+      ) => `${p_name}@${p_rel}`,
+      .Git(
+        g_name,
+        g_pinned_ref
+      ) => {
+        ref_str := match(
+          g_pinned_ref,
+          .Some(r) => r,
+          .None => e.io.await(_nested_resolve(e.io), e)
+        );
+        tail := `${ref_str};${g_name}`;
+        tail
+      }
+    );
+    out
+  })
+);
+/// Shape B — the `yo install` shape: the inner match, then a SECOND await
+/// bound to a local, then an `if` whose body awaits; a sibling arm binds the
+/// same local name from its own await.
+_nested_shape_b :: (fn(parsed : _NestedParsed, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    out := match(
+      parsed,
+      .Other => String.from("other"),
+      .Path(
+        p_name,
+        p_rel
+      ) => {
+        added := e.io.await(_nested_append(`${p_name} path ${p_rel}`, e.io), e);
+        if(added, `path-added:${p_name}`, `path-skipped:${p_name}`)
+      },
+      .Git(
+        g_name,
+        g_pinned_ref
+      ) => {
+        ref_str := match(
+          g_pinned_ref,
+          .Some(r) => r,
+          .None => e.io.await(_nested_resolve(e.io), e)
+        );
+        added := e.io.await(_nested_append(`${g_name}@${ref_str}`, e.io), e);
+        fetched := if(added, {
+          second := e.io.await(_nested_resolve(e.io), e);
+          `fetched:${second}`
+        }, String.from("not-fetched"));
+        `${ref_str};${fetched};${g_name}`
+      }
+    );
+    out
+  })
+);
+/// Shape C — two nesting levels: match → match → cond with an awaiting arm.
+_nested_shape_c :: (fn(parsed : _NestedParsed, deep : bool, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    out := match(
+      parsed,
+      .Other => String.from("other"),
+      .Path(
+        p_name,
+        _
+      ) => p_name,
+      .Git(
+        g_name,
+        g_pinned_ref
+      ) => {
+        inner := match(
+          g_pinned_ref,
+          .Some(r) => r,
+          .None => {
+            picked := cond(
+              deep => e.io.await(_nested_resolve(e.io), e),
+              true => String.from("shallow")
+            );
+            `${picked}!`
+          }
+        );
+        `${inner};${g_name}`
+      }
+    );
+    out
+  })
+);
+test("an awaiting inner match inside a match arm keeps the arm's trailing statements", {
+  if(arch == Arch.Wasm32, return(()));
+  exn := Exception(throw : (_err -> unwind(())));
+  bundle := IoExn(io : io, exn : exn);
+  pinned := io.await(_nested_shape_a(_NestedParsed.Git(String.from("raylib"), Option(String).Some(String.from("v6"))), io), bundle);
+  assert(pinned == "v6;raylib", `synchronous inner arm: the trailing statements ran with the bound value (got ${pinned})`);
+  resolved := io.await(_nested_shape_a(_NestedParsed.Git(String.from("raylib"), Option(String).None), io), bundle);
+  assert(resolved == "resolved;raylib", `awaiting inner arm: the trailing statements ran after the resume (got ${resolved})`);
+  other := io.await(_nested_shape_a(_NestedParsed.Other, io), bundle);
+  assert(other == "other", "an unrelated arm is unaffected");
+  path := io.await(_nested_shape_a(_NestedParsed.Path(String.from("mylib"), String.from("../mylib")), io), bundle);
+  assert(path == "mylib@../mylib", "a synchronous sibling arm is unaffected");
+});
+test("the yo install shape: inner match, a second bound await, an awaiting if, and a sibling arm binding the same name", {
+  if(arch == Arch.Wasm32, return(()));
+  exn := Exception(throw : (_err -> unwind(())));
+  bundle := IoExn(io : io, exn : exn);
+  pinned := io.await(_nested_shape_b(_NestedParsed.Git(String.from("raylib"), Option(String).Some(String.from("v6"))), io), bundle);
+  assert(pinned == "v6;fetched:resolved;raylib", `pinned ref: every statement of the arm ran (got ${pinned})`);
+  latest := io.await(_nested_shape_b(_NestedParsed.Git(String.from("raylib"), Option(String).None), io), bundle);
+  assert(latest == "resolved;fetched:resolved;raylib", `resolved ref: every statement of the arm ran (got ${latest})`);
+  path := io.await(_nested_shape_b(_NestedParsed.Path(String.from("mylib"), String.from("../mylib")), io), bundle);
+  assert(path == "path-added:mylib", `the sibling arm's own await binding is intact (got ${path})`);
+});
+test("two nesting levels: an awaiting cond inside a match inside a match arm", {
+  if(arch == Arch.Wasm32, return(()));
+  exn := Exception(throw : (_err -> unwind(())));
+  bundle := IoExn(io : io, exn : exn);
+  deep := io.await(_nested_shape_c(_NestedParsed.Git(String.from("n"), Option(String).None), true, io), bundle);
+  assert(deep == "resolved!;n", `innermost await: both enclosing levels' trailing statements ran (got ${deep})`);
+  shallow := io.await(_nested_shape_c(_NestedParsed.Git(String.from("n"), Option(String).None), false, io), bundle);
+  assert(shallow == "shallow!;n", `innermost synchronous arm: both enclosing levels completed inline (got ${shallow})`);
+  pinned := io.await(_nested_shape_c(_NestedParsed.Git(String.from("n"), Option(String).Some(String.from("v1"))), true, io), bundle);
+  assert(pinned == "v1;n", `middle synchronous arm (got ${pinned})`);
+});

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -4828,9 +4828,11 @@ test("Test a module global survives a suspension point", {
 // A cond/match with an awaiting arm NESTED inside an awaiting match arm
 // (issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
 // The enclosing arm's statements after the nested instance used to be a dead
-// dispatch case — the whole arm vanished, exit 0, `check` clean. The resume
-// now dispatches on a per-nesting-level field (`cond_branch_N_n<d>`) and a
-// nested arm that completes synchronously runs the enclosing statements inline.
+// dispatch case — the whole arm vanished, exit 0, `check` clean. The enclosing
+// arm's case now covers its nested arms' dispatch codes (unique per function
+// on the shared `cond_branch_N`), runs the taken nested arm's remaining code
+// and then its own, and a nested arm that completes synchronously still runs
+// the enclosing statements.
 // ---------------------------------------------------------------------------
 _NestedParsed :: enum(
   Git(name : String, pinned_ref : Option(String)),
@@ -4992,6 +4994,94 @@ _nested_if_statement :: (fn(parsed : _NestedParsed, io : Io) -> Impl(Future(Stri
     out
   })
 );
+/// Shape F — dispatch-mode nested arms mixing a NAMED future with an
+/// anonymous one of a different shape: the suspension must go through each
+/// nested arm's own access (a representative would read the named future's
+/// slot as NULL and skip the await, or cast the slot to the wrong struct).
+_nested_named_mix :: (fn(n : usize, rio : Io) -> Impl(Future(i32, Io)))(
+  rio.async((aio : Io) => {
+    fut := shape_ten(aio);
+    r := cond(
+      (n == usize(0)) => i32(1),
+      true => cond(
+        (n == usize(1)) => aio.await(fut, aio),
+        true => aio.await(shape_twenty(aio), aio)
+      )
+    );
+    return(r)
+  })
+);
+/// Shape G — the same mix bound inside a match arm, with a statement after it.
+_nested_named_mix_bound :: (fn(n : usize, rio : Io) -> Impl(Future(i32, Io)))(
+  rio.async((aio : Io) => {
+    fut := shape_twenty(aio);
+    (acc : i32) = i32(0);
+    match(
+      n,
+      0 => {
+        acc = i32(1);
+      },
+      _ => {
+        v := cond(
+          (n == usize(1)) => aio.await(shape_ten(aio), aio),
+          true => aio.await(fut, aio)
+        );
+        acc = (v + i32(100));
+      }
+    );
+    return(acc)
+  })
+);
+/// Shape H — a nested cond whose arm LOOPS with an await, then statements of
+/// the enclosing arm: the loop arm's post-loop code must run for that arm
+/// only, and the enclosing statements for both nested arms.
+_nested_loop_step :: (fn(n : usize, io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    n + usize(1)
+  })
+);
+_nested_loop_arm :: (fn(mode : usize, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    (log : String) = String.new();
+    first := e.io.await(_nested_loop_step(usize(0), e.io), e);
+    cond(
+      (mode == usize(0)) => {
+        log.push_str("plain;");
+      },
+      true => {
+        cond(
+          (mode == usize(1)) => {
+            log.push_str("no-loop;");
+          },
+          true => {
+            (i : usize) = first;
+            while(runtime(i < usize(3)), {
+              r := e.io.await(_nested_loop_step(i, e.io), e);
+              i = r;
+              log.push_string(`i=${i.to_string()};`);
+            });
+            log.push_str("loop-done;");
+          }
+        );
+        log.push_str("outer-tail;");
+      }
+    );
+    log.push_str("end");
+    log
+  })
+);
+/// Shape I — a while body that RE-ASSIGNS an outer local from an await
+/// (`i = e.io.await(...)`, not `:=`).
+_while_reassign_await :: (fn(io : Io) -> Impl(Future(usize, IoExn)))(
+  io.async((e : IoExn) => {
+    (i : usize) = usize(0);
+    while(runtime(i < usize(3)), {
+      i = e.io.await(_nested_loop_step(i, e.io), e);
+    });
+    i
+  })
+);
 test("an awaiting inner match inside a match arm keeps the arm's trailing statements", {
   if(arch == Arch.Wasm32, return(()));
   exn := Exception(throw : (_err -> unwind(())));
@@ -5046,4 +5136,30 @@ test("an awaiting if statement after a bound await, then the arm's tail value", 
   assert(latest == "fetched:resolved;resolved;raylib", `resolved: the if body ran and the tail value reached the result (got ${latest})`);
   path := io.await(_nested_if_statement(_NestedParsed.Path(String.from("mylib"), String.from("../mylib")), io), bundle);
   assert(path == "mylib", "a synchronous sibling arm is unaffected");
+});
+test("nested cond arms mixing a named and an anonymous future await through their own access", {
+  if(arch == Arch.Wasm32, return(()));
+  assert(io.await(_nested_named_mix(usize(0), io), io) == i32(1), "plain outer arm");
+  assert(io.await(_nested_named_mix(usize(1), io), io) == i32(10), "named nested arm");
+  assert(io.await(_nested_named_mix(usize(2), io), io) == i32(20), "anonymous nested arm of another shape");
+  assert(io.await(_nested_named_mix_bound(usize(0), io), io) == i32(1), "plain outer arm (bound form)");
+  assert(io.await(_nested_named_mix_bound(usize(1), io), io) == i32(110), "anonymous nested arm, then the arm's statement");
+  assert(io.await(_nested_named_mix_bound(usize(2), io), io) == i32(120), "named nested arm, then the arm's statement");
+});
+test("a nested arm that loops with an await runs its post-loop code for that arm only", {
+  if(arch == Arch.Wasm32, return(()));
+  exn := Exception(throw : (_err -> unwind(())));
+  bundle := IoExn(io : io, exn : exn);
+  plain := io.await(_nested_loop_arm(usize(0), io), bundle);
+  assert(plain == "plain;end", `the plain outer arm runs nothing of the other arm (got ${plain})`);
+  no_loop := io.await(_nested_loop_arm(usize(1), io), bundle);
+  assert(no_loop == "no-loop;outer-tail;end", `the synchronous nested arm: enclosing tail, no post-loop code (got ${no_loop})`);
+  looped := io.await(_nested_loop_arm(usize(2), io), bundle);
+  assert(looped == "i=2;i=3;loop-done;outer-tail;end", `the looping nested arm: iterations, post-loop code, enclosing tail (got ${looped})`);
+});
+test("a while body that re-assigns an outer local from an await stores the future", {
+  if(arch == Arch.Wasm32, return(()));
+  exn := Exception(throw : (_err -> unwind(())));
+  got := io.await(_while_reassign_await(io), IoExn(io : io, exn : exn));
+  assert(got == usize(3), `the loop advanced through the awaited values (got ${got.to_string()})`);
 });

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -4826,7 +4826,7 @@ test("Test a module global survives a suspension point", {
 });
 // ---------------------------------------------------------------------------
 // A cond/match with an awaiting arm NESTED inside an awaiting match arm
-// (issues/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
+// (issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md).
 // The enclosing arm's statements after the nested instance used to be a dead
 // dispatch case — the whole arm vanished, exit 0, `check` clean. The resume
 // now dispatches on a per-nesting-level field (`cond_branch_N_n<d>`) and a
@@ -4944,6 +4944,54 @@ _nested_shape_c :: (fn(parsed : _NestedParsed, deep : bool, io : Io) -> Impl(Fut
     out
   })
 );
+/// Shape D — a value-producing cond whose arm awaits TWICE (two plain bound
+/// awaits): the arm's tail value after the second await must reach the bound
+/// result (issues/fixed/async-cond-arm-tail-value-lost-after-second-await.md).
+_nested_two_awaits :: (fn(flag : bool, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    out := cond(
+      flag => {
+        a := e.io.await(_nested_resolve(e.io), e);
+        b := e.io.await(_nested_append(a.clone(), e.io), e);
+        `${a}|${b.to_string()}`
+      },
+      true => String.from("no")
+    );
+    out
+  })
+);
+/// Shape E — an awaiting `if` STATEMENT after a bound await, then the arm's
+/// tail value (the `yo install` `.Git` arm with `if(added, { … await fetch … })`).
+_nested_if_statement :: (fn(parsed : _NestedParsed, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    (log : String) = String.new();
+    out := match(
+      parsed,
+      .Other => String.from("other"),
+      .Path(
+        p_name,
+        _
+      ) => p_name,
+      .Git(
+        g_name,
+        g_pinned_ref
+      ) => {
+        ref_str := match(
+          g_pinned_ref,
+          .Some(r) => r,
+          .None => e.io.await(_nested_resolve(e.io), e)
+        );
+        added := e.io.await(_nested_append(g_name.clone(), e.io), e);
+        if(added, {
+          second := e.io.await(_nested_resolve(e.io), e);
+          log.push_string(`fetched:${second};`);
+        });
+        `${log}${ref_str};${g_name}`
+      }
+    );
+    out
+  })
+);
 test("an awaiting inner match inside a match arm keeps the arm's trailing statements", {
   if(arch == Arch.Wasm32, return(()));
   exn := Exception(throw : (_err -> unwind(())));
@@ -4978,4 +5026,24 @@ test("two nesting levels: an awaiting cond inside a match inside a match arm", {
   assert(shallow == "shallow!;n", `innermost synchronous arm: both enclosing levels completed inline (got ${shallow})`);
   pinned := io.await(_nested_shape_c(_NestedParsed.Git(String.from("n"), Option(String).Some(String.from("v1"))), true, io), bundle);
   assert(pinned == "v1;n", `middle synchronous arm (got ${pinned})`);
+});
+test("a value-producing cond arm that awaits twice keeps its tail value", {
+  if(arch == Arch.Wasm32, return(()));
+  exn := Exception(throw : (_err -> unwind(())));
+  bundle := IoExn(io : io, exn : exn);
+  got := io.await(_nested_two_awaits(true, io), bundle);
+  assert(got == "resolved|true", `the tail value after the second await reached the bound result (got ${got})`);
+  other := io.await(_nested_two_awaits(false, io), bundle);
+  assert(other == "no", "the synchronous arm is unaffected");
+});
+test("an awaiting if statement after a bound await, then the arm's tail value", {
+  if(arch == Arch.Wasm32, return(()));
+  exn := Exception(throw : (_err -> unwind(())));
+  bundle := IoExn(io : io, exn : exn);
+  pinned := io.await(_nested_if_statement(_NestedParsed.Git(String.from("raylib"), Option(String).Some(String.from("v6"))), io), bundle);
+  assert(pinned == "fetched:resolved;v6;raylib", `pinned: the if body ran and the tail value reached the result (got ${pinned})`);
+  latest := io.await(_nested_if_statement(_NestedParsed.Git(String.from("raylib"), Option(String).None), io), bundle);
+  assert(latest == "fetched:resolved;resolved;raylib", `resolved: the if body ran and the tail value reached the result (got ${latest})`);
+  path := io.await(_nested_if_statement(_NestedParsed.Path(String.from("mylib"), String.from("../mylib")), io), bundle);
+  assert(path == "mylib", "a synchronous sibling arm is unaffected");
 });

--- a/tests/async_await.test.yo
+++ b/tests/async_await.test.yo
@@ -5082,6 +5082,47 @@ _while_reassign_await :: (fn(io : Io) -> Impl(Future(usize, IoExn)))(
     i
   })
 );
+/// Shape J — two sibling arms whose SECOND awaits bind same-typed locals:
+/// the arm registered second lands in a chained layer of the sibling's
+/// entry, and its binding must still be assigned there.
+_sib_flag :: (fn(io : Io) -> Impl(Future(bool, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    true
+  })
+);
+_sib_name :: (fn(io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    e.io.await(yield(e.io), e.io);
+    String.from("nm")
+  })
+);
+_SibKind :: enum(A, B);
+_sibling_second_awaits :: (fn(k : _SibKind, io : Io) -> Impl(Future(String, IoExn)))(
+  io.async((e : IoExn) => {
+    (log : String) = String.new();
+    match(
+      k,
+      .A => {
+        exists := e.io.await(_sib_flag(e.io), e);
+        log.push_string(`A:exists=${exists.to_string()};`);
+        added := e.io.await(_sib_flag(e.io), e);
+        if(added, {
+          log.push_str("A:added;");
+        });
+      },
+      .B => {
+        nm := e.io.await(_sib_name(e.io), e);
+        log.push_string(`B:nm=${nm};`);
+        added := e.io.await(_sib_flag(e.io), e);
+        if(added, {
+          log.push_str("B:added;");
+        });
+      }
+    );
+    log
+  })
+);
 test("an awaiting inner match inside a match arm keeps the arm's trailing statements", {
   if(arch == Arch.Wasm32, return(()));
   exn := Exception(throw : (_err -> unwind(())));
@@ -5162,4 +5203,13 @@ test("a while body that re-assigns an outer local from an await stores the futur
   exn := Exception(throw : (_err -> unwind(())));
   got := io.await(_while_reassign_await(io), IoExn(io : io, exn : exn));
   assert(got == usize(3), `the loop advanced through the awaited values (got ${got.to_string()})`);
+});
+test("a sibling arm's second-await binding is assigned when its continuation is a chained layer", {
+  if(arch == Arch.Wasm32, return(()));
+  exn := Exception(throw : (_err -> unwind(())));
+  bundle := IoExn(io : io, exn : exn);
+  a := io.await(_sibling_second_awaits(_SibKind.A, io), bundle);
+  assert(a == "A:exists=true;A:added;", `the first arm binds both awaits (got ${a})`);
+  b := io.await(_sibling_second_awaits(_SibKind.B, io), bundle);
+  assert(b == "B:nm=nm;B:added;", `the second arm's second-await binding is assigned (got ${b})`);
 });

--- a/tests/cli-cases/init-build-test/expected_tree
+++ b/tests/cli-cases/init-build-test/expected_tree
@@ -5,7 +5,7 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	69cbd8a9e69207630f924e980ef7afe517b9b5d03092b31978d666f398a01baf
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7
 ./.gitignore	0731902a4953e85ff1820a81630bbb367bd7ddac37a04dd65f1fa7987c6c702e

--- a/tests/cli-cases/init-cwd/expected_tree
+++ b/tests/cli-cases/init-cwd/expected_tree
@@ -5,7 +5,7 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	69cbd8a9e69207630f924e980ef7afe517b9b5d03092b31978d666f398a01baf
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7
 ./.gitignore	0731902a4953e85ff1820a81630bbb367bd7ddac37a04dd65f1fa7987c6c702e

--- a/tests/cli-cases/init-existing/expected_tree
+++ b/tests/cli-cases/init-existing/expected_tree
@@ -5,7 +5,7 @@
 ./probe/.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./probe/.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./probe/.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./probe/.agents/skills/yo-syntax/syntax-cheatsheet.md	69cbd8a9e69207630f924e980ef7afe517b9b5d03092b31978d666f398a01baf
+./probe/.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
 ./probe/.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./probe/.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7
 ./probe/.gitignore	0731902a4953e85ff1820a81630bbb367bd7ddac37a04dd65f1fa7987c6c702e

--- a/tests/cli-cases/init/expected_tree
+++ b/tests/cli-cases/init/expected_tree
@@ -5,7 +5,7 @@
 ./probe/.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./probe/.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./probe/.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./probe/.agents/skills/yo-syntax/syntax-cheatsheet.md	69cbd8a9e69207630f924e980ef7afe517b9b5d03092b31978d666f398a01baf
+./probe/.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
 ./probe/.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./probe/.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7
 ./probe/.gitignore	0731902a4953e85ff1820a81630bbb367bd7ddac37a04dd65f1fa7987c6c702e

--- a/tests/cli-cases/skills-install-zh/expected_tree
+++ b/tests/cli-cases/skills-install-zh/expected_tree
@@ -5,6 +5,6 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	69cbd8a9e69207630f924e980ef7afe517b9b5d03092b31978d666f398a01baf
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7

--- a/tests/cli-cases/skills-install/expected_tree
+++ b/tests/cli-cases/skills-install/expected_tree
@@ -5,6 +5,6 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	69cbd8a9e69207630f924e980ef7afe517b9b5d03092b31978d666f398a01baf
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7


### PR DESCRIPTION
Fixes the async state-machine emitter bug that made `yo install user/repo@tag` write `ref: ""` — the real fix in `src/codegen/async/`, not a workaround in `install_command.yo` — plus five more pre-existing emitter bugs found while gating it, each with a red-first reproducer and a test.

## The original bug

In an `io.async` body, a match/cond arm whose body holds a value-producing INNER match/cond with an awaiting arm was emitted as nothing (`issues/fixed/nested-value-match-with-await-drops-the-enclosing-match-arm.md`):

```rust
.Git(g_name, g_pinned_ref) => {
  ref_str := match(g_pinned_ref, .Some(r) => r, .None => e.io.await(resolve(...), e));
  println(`ref_str = "${ref_str}"`);   // never ran
  added := e.io.await(append(...), e); // never ran
}
```

The nested instance wrote the SAME `sm->cond_branch_N` as the enclosing match, so the enclosing arm's statements were keyed on a dispatch code that had already been overwritten — a dead `case` (`_emit_match_case_await_or_value` documented the gap as "pre-existing"). The bound form `x := match(… await …)` inside an awaiting arm additionally fell through every emitter case and emitted nothing at all. `check` was clean; the program exited 0.

## The fix: one shared field, codes as identity

Dispatch codes (`_alloc_cond_branch_codes`) are unique within a function, so a nested arm's code in the shared field identifies both itself AND its enclosing arm. The fix keeps the single `cond_branch_N` per await point (every legacy consumer — chained layers, post-while continuations, dispatch-mode switches, chained entries — keeps identifying arms by code on that field) and adds the structure the resume side lacked:

- **Registration** (`state_code_gen.yo`): `generate_cond_branch_with_await` returns `BranchEmission(remaining, nested, codes)`. A nested cond/match in an awaiting arm — bare, or the RHS of `x := …` / `x = …` — goes through `_emit_nested_cond_or_match`, which pushes a record to `context.nested_cond_records` and hands it to the emitter via `context.nested_cond_sink`; the emitter CLAIMS it into `nested_cond_owner` at entry (restored at exit), so exactly the instance's own arms register in the entry as usual AND in the record (`CondBranch.owner`), with the instance's targets on the record only. `CondBranch.codes` is the arm's code plus every code allocated while its body was emitted. The legacy "nested claimed the slot" special cases (`_push_chained_match_arm`, trivial-remaining post-while routing, inner-wins store skip) are gone; `_store_cond_branch_info` always unions by code.
- **Resume** (`state_machine.yo`): an arm holding a nested instance is ONE case labelled by `_assign_case_labels` — within a switch each code goes to the arm with the smallest code window containing it, and unclaimed codes (a synchronous nested arm's) go to the enclosing arm — whose body is `_emit_nested_level_switch` (bind the taken nested arm's result or hand it to the instance's target, recurse, run its remaining) followed by the enclosing arm's remaining. Uniform points emit these cases after the slot guard (`_emit_nested_branch_continuation`) with bindings under a `__yo_had_future_N` local, so a synchronously completed nested arm still runs the enclosing statements. Chained layers and post-while continuations test `_codes_guard`. Dispatch-mode suspension/extraction switch over the nested arms' own exact cases; a nested arm whose value IS the await hands it to its instance's target (`_branch_value_target`).

Non-nested programs emit byte-identical C.

## Also fixed (pre-existing, found while gating; each red on the pre-fix compiler)

- `issues/fixed/async-cond-arm-tail-value-lost-after-second-await.md` — a value-producing arm that awaits twice lost its tail value (`out` stayed zeroed): chained entries carried no target (`_cond_layer_target`); `fetched := if(added, { … await … }, …)` after an arm's first await emitted nothing (`generate_remaining_expr_future` returned early).
- `issues/fixed/async-post-while-code-runs-for-a-sibling-nested-arm.md` — the merged post-while slot ran every client's statements under one guard; now per-client guards (`part_codes`/`part_lens`).
- `issues/fixed/async-while-body-reassigning-an-await-result-never-stores-the-future.md` — `i = e.io.await(...)` in a while body stored no future; SIGSEGV.
- `issues/fixed/async-chained-sibling-arm-second-await-binding-never-assigned.md` — a sibling arm's second-await binding was never assigned when its continuation was a chained layer (`_emit_chained_arm_binding`); this is what still kept `run_install`'s fetch step dead after the first fix.

## Gates (final build, gen-1 = seed-built from this tree; gen-2 = built by gen-1)

| gate | result |
| --- | --- |
| `tests/async_await.test.yo` (9 new tests: reproducer, `yo install` shape, two nesting levels, named+anonymous nested arms, two-await value arm, awaiting `if` statement, looping nested arm, while re-assignment, sibling second-await binding) | 199 / 199 |
| `tests/fs/{dir,fs_convenience,walker}.test.yo` (the `create_dir_all` canary caught two intermediate designs) | 18 / 18, 16 / 16, 8 / 8 |
| fast suite `yo test ./tests --exclude tests/internal --exclude tests/cli-cases` | 4147 / 4147 |
| `tests/internal/{match_binding_shadow,gc_runtime_atomics,build_runner}.test.yo` | 3 / 3, 4 / 4, 11 / 11 |
| full CLI corpus | PASS 103, GOLDEN-DIFF 0 (six skills-hashing goldens re-recorded for the cheatsheet update) |
| `check ./src` (gen-2) | 270 / 270 |
| emit A/B, same tree, `#583` compiler vs this one, per-function with type ids normalized | identical function set; 45 `_resume` state machines differ (the nested shapes), nothing else |
| gen-1 / gen-2 fixpoint (`src/main.yo` emission) | byte-identical |
| `yo install shd101wyy/raylib_yo@v0.0.6` with the gen-2 binary | `ref: "v0.0.6"`, `Fetching dependency...`, `yo.lock` written with commit + hash |

## Docs

- `issues/nested-value-match-…` → `issues/fixed/` with the fix record; four new `issues/fixed/` docs with reproducers in `issues/repros/`; `issues/yo-install-git-dependency-writes-an-empty-ref.md` now records that the install flow works at gen-2 (its data-path hardening item stays open).
- `.github/skills/yo-syntax/syntax-cheatsheet.md`: the "await only at statement level" rule is replaced by the list of fixed shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
