### PR TITLE
cleanup: write discarded calls as bare statements instead of _ := / ___ := bindings

### DIFF
--- a/.github/instructions/yo-syntax.instructions.md
+++ b/.github/instructions/yo-syntax.instructions.md
@@ -997,6 +997,8 @@ foo();
 bar();
 ```
 
+**Prefer the bare call over `_ := foo();` / `___ := foo();` when the result is unused** (a 2026-09-11 tree sweep removed 45 such discard bindings). Two cases where the binding is load-bearing — leave it: drop/borrow fixtures that count `rc(...)` or test the discard's own scope-end drop, and compile-error fixtures whose diagnostic fires only on the value-evaluation path a binding forces (a bare statement can skip it — e.g. the `list(i).*` clear-error fixture in `tests/collections/array_list.test.yo` errors under `_ := bad_list(usize(0)).*;` but passes as a bare `bad_list(usize(0)).*;` statement).
+
 ## ArrayList indexing via `arr(index)`
 
 `ArrayList(T)` implements the `Index` trait, so elements can be accessed with call syntax:

--- a/.github/skills/yo-syntax/syntax-cheatsheet.md
+++ b/.github/skills/yo-syntax/syntax-cheatsheet.md
@@ -694,6 +694,25 @@ foo();
 bar();
 ```
 
+**Prefer the bare call** when the result is unused — `_ := foo();` and
+`___ := foo();` around a discarded call result are noise (the tree-wide
+sweep of 2026-09-11 removed 45 of them). Two cases where the binding IS
+load-bearing, so leave it alone:
+
+- Drop/borrow fixtures that count references (`rc(h)`) or test the
+  discard binding's own scope-end drop (`tests/rc.test.yo`,
+  `tests/ref_field_borrow.test.yo`,
+  `tests/shadowed_binding_early_return_drop.test.yo`).
+- Compile-error fixtures whose diagnostic fires on the VALUE-evaluation
+  path only: a binding forces the value to be evaluated and checked,
+  while the same expression as a bare statement can evaluate through a
+  statement path that skips it. Measured: in
+  `tests/collections/array_list.test.yo`, `_ := bad_list(usize(0)).*;`
+  is the `comptime_expect_error` fixture for the clear "index `.*` on
+  non-pointer Output" error, but the bare `bad_list(usize(0)).*;`
+  statement evaluates successfully — the `_ :=` is what makes the
+  error fire.
+
 ### Enum pattern matching does NOT support literal values
 
 Match patterns on enum variants only support **variable binding**, not literal comparison.

--- a/docs/en-US/MEMORY_SAFETY.md
+++ b/docs/en-US/MEMORY_SAFETY.md
@@ -130,7 +130,7 @@ pragma(Pragma.AllowUnsafe);
 copy_bytes :: (fn(dst : *(u8), src : *(u8), n : usize) -> unit)({
   // The extern call MUST be wrapped in unsafe(...) — see "Per-Call
   // Audit Marker" below.
-  _ := unsafe(memcpy((*void)(dst), (*void)(src), n));
+  unsafe(memcpy((*void)(dst), (*void)(src), n));
 });
 ```
 

--- a/docs/zh-CN/MEMORY_SAFETY.md
+++ b/docs/zh-CN/MEMORY_SAFETY.md
@@ -129,7 +129,7 @@ pragma(Pragma.AllowUnsafe);
 
 copy_bytes :: (fn(dst : *(u8), src : *(u8), n : usize) -> unit)({
   // extern 调用必须包在 unsafe(...) 里 —— 见下面的"逐调用审计标记"。
-  _ := unsafe(memcpy((*void)(dst), (*void)(src), n));
+  unsafe(memcpy((*void)(dst), (*void)(src), n));
 });
 ```
 

--- a/src/build_runner.yo
+++ b/src/build_runner.yo
@@ -1091,7 +1091,7 @@ compile_artifact :: (
     imports_path := `${output_path.to_string()}.imports`;
     nl := String.from("\n");
     imports_text := if(import_lines.len() > usize(0), `${nl.join(import_lines)}\n`, String.new());
-    _ := e.io.await(_write_stamp(imports_path.clone(), imports_text.clone(), e.io), e);
+    e.io.await(_write_stamp(imports_path.clone(), imports_text.clone(), e.io), e);
     cmd := Command.new(_self_exe());
     cmd.arg(String.from("compile"));
     if(import_lines.len() > usize(0), {
@@ -1350,7 +1350,7 @@ compile_artifact :: (
       ((st.success() && cache_enabled) && (stamp.len() > usize(0))) => stamp.clone(),
       true => String.new()
     );
-    _ := e.io.await(_write_stamp(stamp_path.clone(), stamp_to_write, e.io), e);
+    e.io.await(_write_stamp(stamp_path.clone(), stamp_to_write, e.io), e);
     cond(
       st.success() => Result(unit, String).Ok(()),
       true => {

--- a/src/evaluator/calls/function_type.yo
+++ b/src/evaluator/calls/function_type.yo
@@ -1195,13 +1195,13 @@ Result type: ${type_to_string(result_box)}`
         // the return label as unknown values — exactly the names a
         // predicate may mention.
         pred_env := _share_def_time_frames(caller_env, false);
-        _ := pred_env.push_frame(false);
+        pred_env.push_frame(false);
         (pv_i : usize) = usize(0);
         while(pv_i < param_labels.len(), {
           pv_name := match(param_labels.get(pv_i), .Some(l) => l, .None => String.new());
           pv_ty := match(param_types.get(pv_i), .Some(t) => t, .None => t_unit());
           if(pv_name.len() > usize(0), {
-            _ := add_variable_to_env(
+            add_variable_to_env(
               pred_env,
               pv_name.clone(),
               pv_ty.clone(),
@@ -1219,7 +1219,7 @@ Result type: ${type_to_string(result_box)}`
         match(
           raw_label,
           .Some(rl) => {
-            _ := add_variable_to_env(
+            add_variable_to_env(
               pred_env,
               rl.clone(),
               result_box.clone(),

--- a/src/evaluator/effects/mutation_summary.yo
+++ b/src/evaluator/effects/mutation_summary.yo
@@ -223,7 +223,7 @@ impl(
     g_ms_in_progress.insert(fid.clone(), true);
     local_touched := ArrayList(String).new();
     mutates := _MsW.walk(body, table, local_touched);
-    ___ := g_ms_in_progress.remove(fid.clone());
+    g_ms_in_progress.remove(fid.clone());
     // Remove the self edge (pure self-recursion does not poison memoization).
     (li : usize) = usize(0);
     filtered_touched := ArrayList(String).new();
@@ -1368,7 +1368,7 @@ impl(
       );
       ri = (ri + usize(1));
     });
-    ___ := g_msp_in_progress.remove(fid.clone());
+    g_msp_in_progress.remove(fid.clone());
     filtered := ArrayList(String).new();
     (li : usize) = usize(0);
     while(li < local_touched.len(), {

--- a/src/module_manager.yo
+++ b/src/module_manager.yo
@@ -183,7 +183,7 @@ _read_file_sync :: (fn(path : String, exn : Exception) -> ArrayList(u8))({
     cond(
       (n < i64(0)) => {
         free(.Some((*void)(buf)));
-        _ := unsafe(unistd.close(fd));
+        unsafe(unistd.close(fd));
         exn.throw(dyn(IoError.from_errno(__yo_errno())));
       },
       (n == i64(0)) => break,
@@ -197,7 +197,7 @@ _read_file_sync :: (fn(path : String, exn : Exception) -> ArrayList(u8))({
     );
   });
   free(.Some((*void)(buf)));
-  _ := unsafe(unistd.close(fd));
+  unsafe(unistd.close(fd));
   result
 });
 /// Resolve the standard-library root. The proper evaluator needs this so

--- a/src/types/utils.yo
+++ b/src/types/utils.yo
@@ -1737,7 +1737,7 @@ get_size_of_type :: (fn(ty_in : TypeValue) -> Option(usize))({
             (s_nt && (sfts.len() > usize(0))) => match(sfts.get(usize(0)), .Some(f0) => recur(f0), .None => Option(usize).None),
             true => _c_aggregate_size(sfts)
           );
-          _ := g_size_walk_stack.pop();
+          g_size_walk_stack.pop();
           out
         }
       ),
@@ -1781,7 +1781,7 @@ get_size_of_type :: (fn(ty_in : TypeValue) -> Option(usize))({
       true => {
         g_size_walk_stack.push(e_sz_id.clone());
         out := _enum_value_size(evf);
-        _ := g_size_walk_stack.pop();
+        g_size_walk_stack.pop();
         out
       }
     ),

--- a/src/verifier/driver.yo
+++ b/src/verifier/driver.yo
@@ -321,7 +321,7 @@ _cache_store :: (fn(q : VcQuery, verdict : VerifyVerdict) -> unit)({
     String.from("verdict"),
     _verdict_to_json(verdict)
   );
-  _ := _z3_write_file_sync(cache_path.clone(), json.stringify(payload));
+  _z3_write_file_sync(cache_path.clone(), json.stringify(payload));
   ()
 });
 /// Run one obligation end-to-end: cache lookup → solver → parse → cache
@@ -618,7 +618,7 @@ verify_and_strip_tasks :: (
             // REFUTED function never reaches here (it is a compile error at
             // the caller); unproven ones keep their asserts (the fallback).
             if(t.mode == "verify+", {
-              _ := strip_proved_ensures_asserts(t.func_val, _proved_ensures(obligations));
+              strip_proved_ensures_asserts(t.func_val, _proved_ensures(obligations));
               ()
             });
             reports.push(

--- a/src/verifier/vc.yo
+++ b/src/verifier/vc.yo
@@ -305,7 +305,7 @@ _emit :: (
         match(
           declared.get(k.clone()),
           .Some(srt) => {
-            _ := q.declare(mangle_vc_name(ctx.fn_name.clone(), k.clone()), srt);
+            q.declare(mangle_vc_name(ctx.fn_name.clone(), k.clone()), srt);
             ();
           },
           .None => ()
@@ -353,7 +353,7 @@ _emit :: (
   });
   (ai : usize) = usize(0);
   while(ai < all.len(), {
-    _ := q.assume(all.get(ai).unwrap());
+    q.assume(all.get(ai).unwrap());
     ai = (ai + usize(1));
   });
   q.goal = _rename_vars(goal, rename_map);
@@ -1161,7 +1161,7 @@ _arm_under_pattern :: (
             ctx.vars.insert(sn.clone(), old);
           },
           .None => {
-            _ := ctx.vars.remove(sn.clone());
+            ctx.vars.remove(sn.clone());
             ()
           }
         );
@@ -1561,7 +1561,7 @@ _while_term :: (fn(inout(ctx) : VcCtx, e : AstExpr, args : ArrayList(AstExpr)) -
   //    Inv ∧ ¬Cond over unconstrained constants, the standard modular
   //    rule (issues/fixed/verifier-loop-exit-pins-post-body-bindings.md).
   while(ctx.path.len() > path_mark, {
-    _ := ctx.path.pop();
+    ctx.path.pop();
   });
   _havoc_assigned(ctx, assigned);
   inv_exit := ArrayList(VcTerm).new();
@@ -1949,12 +1949,12 @@ _unwind_path_guards :: (fn(inout(ctx) : VcCtx, base : usize, guard_count : usize
       .Some(top) => keep.push(top),
       .None => ()
     );
-    _ := ctx.path.pop();
+    ctx.path.pop();
     k = (k - usize(1));
   });
   (g : usize) = guard_count;
   while(g > usize(0), {
-    _ := ctx.path.pop();
+    ctx.path.pop();
     g = (g - usize(1));
   });
   (r : usize) = keep.len();
@@ -2053,7 +2053,7 @@ _cond_ite :: (fn(inout(ctx) : VcCtx, at : AstExpr, args : ArrayList(AstExpr)) ->
                 ctx.vars.insert(nm.clone(), old);
               },
               .None => {
-                _ := ctx.vars.remove(nm.clone());
+                ctx.vars.remove(nm.clone());
                 ()
               }
             );
@@ -2531,7 +2531,7 @@ _callee_call_term :: (
                 ctx.vars.insert(sn.clone(), old);
               },
               .None => {
-                _ := ctx.vars.remove(sn.clone());
+                ctx.vars.remove(sn.clone());
                 ()
               }
             );

--- a/src/verifier/z3.yo
+++ b/src/verifier/z3.yo
@@ -137,7 +137,7 @@ _z3_read_file_sync :: (fn(path : String) -> Option(String))({
     cond(
       (n < i64(0)) => {
         free(.Some((*void)(buf)));
-        _ := unsafe(unistd.close(fd));
+        unsafe(unistd.close(fd));
         return(Option(String).None);
       },
       (n == i64(0)) => break,
@@ -151,7 +151,7 @@ _z3_read_file_sync :: (fn(path : String) -> Option(String))({
     );
   });
   free(.Some((*void)(buf)));
-  _ := unsafe(unistd.close(fd));
+  unsafe(unistd.close(fd));
   match(
     String.from_utf8(result),
     .Ok(s) => Option(String).Some(s),
@@ -174,7 +174,7 @@ _z3_write_file_sync :: (fn(path : String, contents : String) -> bool)({
         .None => (*u8)(malloc(usize(1)).unwrap())
       );
       wrote := unsafe(stdio.fwrite((*void)(bptr), usize(1), b.len(), fh));
-      _ := unsafe(stdio.fclose(fh));
+      unsafe(stdio.fclose(fh));
       wrote == b.len()
     },
     .None => false
@@ -183,7 +183,7 @@ _z3_write_file_sync :: (fn(path : String, contents : String) -> bool)({
 /// Unlink a file (best effort — failures ignored; the temp dir recovers).
 _z3_unlink_sync :: (fn(path : String) -> unit)({
   cstr := path.to_cstr().ptr().unwrap();
-  _ := unsafe(unistd.unlink((*char)(cstr)));
+  unsafe(unistd.unlink((*char)(cstr)));
   ()
 });
 /// Ensure a directory (and its parents) exist — portable BECAUSE it shells
@@ -201,7 +201,7 @@ _z3_ensure_dir_sync :: (fn(path : String) -> unit)({
   );
   cmd_buf := cmd.to_cstr();
   cmd_cstr := cmd_buf.ptr().unwrap();
-  _ := unsafe(stdlib.system(Option(*char).Some((*char)(cmd_cstr))));
+  unsafe(stdlib.system(Option(*char).Some((*char)(cmd_cstr))));
   ()
 });
 /// Monotonic counter for temp-file names — unique within one process run,

--- a/src/version_cache.yo
+++ b/src/version_cache.yo
@@ -253,7 +253,7 @@ host_bundle_triple_name :: (fn(version : String, exn : Exception) -> String)({
     // Reuse the short-name builder's diagnostics: it throws naming the
     // supported platforms and architectures. If it ever stops throwing for a
     // host this table has no triple for, refuse rather than build a bogus name.
-    ___ := _host_bundle_name_base(version, exn);
+    _host_bundle_name_base(version, exn);
     exn.throw(dyn(`No release-bundle target triple for this host.`));
   });
   `yo-v${version}-${triple}`

--- a/std/collections/array_list.yo
+++ b/std/collections/array_list.yo
@@ -743,7 +743,7 @@ impl(
           self._ptr,
           .Some(dst_base) => {
             dst := (*(void))(dst_base.add(self._length));
-            _ := unsafe(memcpy(dst, (*(void))(src), count * sizeof(T)));
+            unsafe(memcpy(dst, (*(void))(src), count * sizeof(T)));
             self._length = (self._length + count);
           },
           .None => __yo_panic("ArrayList.extend_from_ptr: no ptr after ensure_total_capacity")
@@ -769,7 +769,7 @@ impl(
       self._ptr,
       .None => (),
       .Some(_ptr) => {
-        _ := unsafe(memset((*(void))(_ptr), byte_val, self._length * sizeof(T)));
+        unsafe(memset((*(void))(_ptr), byte_val, self._length * sizeof(T)));
       }
     )
   ),
@@ -792,7 +792,7 @@ impl(
           .Some(_ptr) => {
             start := (*(void))(_ptr.add(self._length));
             fill_count := ((new_len - self._length) * sizeof(T));
-            _ := unsafe(memset(start, byte_val, fill_count));
+            unsafe(memset(start, byte_val, fill_count));
             self._length = new_len;
           },
           .None => __yo_panic("ArrayList.resize_with_byte: no ptr after ensure")

--- a/std/collections/linked_list.yo
+++ b/std/collections/linked_list.yo
@@ -344,7 +344,7 @@ impl(
   /// chain as it goes.
   clear : (fn(self : Self) -> unit)({
     while(self.length > usize(0), {
-      _ := self.pop_front();
+      self.pop_front();
     });
   }),
   /// Whether any element equals `value` — a walk from the head, O(n),

--- a/std/imm/vec.yo
+++ b/std/imm/vec.yo
@@ -172,7 +172,7 @@ impl(
   /// (issues/fixed/imm-vec-leaks-on-grow-and-drops-uninitialized-memory.md).
   _move_elems : (fn(dst : *T, src : *T, count : usize) -> unit)({
     if(count > usize(0), {
-      _ := unsafe(memcpy((*void)(dst), (*void)(src), count * sizeof(T)));
+      unsafe(memcpy((*void)(dst), (*void)(src), count * sizeof(T)));
     });
   }),
   /// Create a new empty vector.

--- a/tests/async_value_struct_param.test.yo
+++ b/tests/async_value_struct_param.test.yo
@@ -20,7 +20,7 @@ use_cfg :: (fn(c : CFG) -> i32)(c.n);
 echo_cfg :: (fn(c : CFG, io : Io) -> Impl(Future(i32, IoExn)))(
   io.async((e : IoExn) => {
     before := use_cfg(c);
-    _ := e.io.await(yield(e.io), e);
+    e.io.await(yield(e.io), e);
     after := use_cfg(c);
     after - before
   })

--- a/tests/internal/verifier_loops.test.yo
+++ b/tests/internal/verifier_loops.test.yo
@@ -56,7 +56,7 @@ _load_reports :: (fn(rel_path : String, io : Io) -> ArrayList(VerifyFnReport))({
   targets := ArrayList(String).new();
   targets.push(rel_path.clone());
   targets.push(mm_resolve_entry_abs(rel_path.clone(), std_path.clone()));
-  _ := take_verify_tasks();
+  take_verify_tasks();
   set_verify_mode_override(Option(String).None);
   set_verify_target_paths(targets);
   clear_module_cache();
@@ -237,7 +237,7 @@ test("the SMT encoding of a loop query havocs the assigned names (solver-free)",
   targets := ArrayList(String).new();
   targets.push(rel.clone());
   targets.push(mm_resolve_entry_abs(rel.clone(), std_path.clone()));
-  _ := take_verify_tasks();
+  take_verify_tasks();
   set_verify_mode_override(Option(String).None);
   set_verify_target_paths(targets);
   clear_module_cache();
@@ -354,7 +354,7 @@ test("the exit encoding re-havocs and selects break states (solver-free)", {
   targets := ArrayList(String).new();
   targets.push(rel.clone());
   targets.push(mm_resolve_entry_abs(rel.clone(), std_path.clone()));
-  _ := take_verify_tasks();
+  take_verify_tasks();
   set_verify_mode_override(Option(String).None);
   set_verify_target_paths(targets);
   clear_module_cache();

--- a/tests/internal/verifier_match.test.yo
+++ b/tests/internal/verifier_match.test.yo
@@ -54,7 +54,7 @@ _load_reports :: (fn(rel_path : String, io : Io) -> ArrayList(VerifyFnReport))({
   targets := ArrayList(String).new();
   targets.push(rel_path.clone());
   targets.push(mm_resolve_entry_abs(rel_path.clone(), std_path.clone()));
-  _ := take_verify_tasks();
+  take_verify_tasks();
   set_verify_mode_override(Option(String).None);
   set_verify_target_paths(targets);
   clear_module_cache();
@@ -137,7 +137,7 @@ test("the SMT encoding of a match query declares the datatype (solver-free)", {
   targets := ArrayList(String).new();
   targets.push(rel.clone());
   targets.push(mm_resolve_entry_abs(rel.clone(), std_path.clone()));
-  _ := take_verify_tasks();
+  take_verify_tasks();
   set_verify_mode_override(Option(String).None);
   set_verify_target_paths(targets);
   clear_module_cache();

--- a/tests/internal/verifier_negative.test.yo
+++ b/tests/internal/verifier_negative.test.yo
@@ -69,7 +69,7 @@ _verify_fixture :: (fn(rel_path : String, io : Io) -> ArrayList(VerifyFnReport))
   targets.push(mm_resolve_entry_abs(rel_path.clone(), std_path.clone()));
   // Drop anything a previous test left in the registry, arm the mode and
   // the target set, evaluate, drain.
-  _ := take_verify_tasks();
+  take_verify_tasks();
   set_verify_mode_override(Option(String).Some(String.from("verify")));
   set_verify_target_paths(targets);
   clear_module_cache();

--- a/tests/internal/verifier_strip.test.yo
+++ b/tests/internal/verifier_strip.test.yo
@@ -58,7 +58,7 @@ _load_strip_tasks :: (fn(io : Io) -> ArrayList(VerifyTask))({
   targets := ArrayList(String).new();
   targets.push(rel.clone());
   targets.push(mm_resolve_entry_abs(rel.clone(), std_path.clone()));
-  _ := take_verify_tasks();
+  take_verify_tasks();
   set_verify_mode_override(Option(String).None);
   set_verify_target_paths(targets);
   clear_module_cache();

--- a/tests/internal/verifier_twostate.test.yo
+++ b/tests/internal/verifier_twostate.test.yo
@@ -57,7 +57,7 @@ _load_reports :: (
   targets := ArrayList(String).new();
   targets.push(rel_path.clone());
   targets.push(mm_resolve_entry_abs(rel_path.clone(), std_path.clone()));
-  _ := take_verify_tasks();
+  take_verify_tasks();
   set_verify_mode_override(Option(String).None);
   set_verify_target_paths(targets);
   clear_module_cache();

--- a/tests/ref_enum.test.yo
+++ b/tests/ref_enum.test.yo
@@ -145,8 +145,7 @@ test("value-enum holding a recursive ref(enum) field (RC-cycle analysis)", {
   h := Holder.Boxed(b : box(Holder.Plain(n : i32(1))), t : Nest.Tip(n : i32(9)));
   match(
     h,
-    .Boxed(b, t) => {
-      _ := b;
+    .Boxed(_, t) => {
       assert(nest_sum(t) == i32(9), "ref-enum field inside a value-enum");
     },
     .Plain(_) => ()

--- a/tests/string/string_builder.test.yo
+++ b/tests/string/string_builder.test.yo
@@ -106,7 +106,7 @@ test("StringBuilder write_line", {
 test("StringBuilder to_string empties buffer", {
   sb := StringBuilder.new();
   sb.write_str("data");
-  _ := sb.to_string();
+  sb.to_string();
   assert(sb.is_empty(), "empty after to_string");
   result2 := sb.to_string();
   assert(result2.is_empty(), "empty string after clear");

--- a/tests/sys/signal.test.yo
+++ b/tests/sys/signal.test.yo
@@ -31,7 +31,7 @@ test("signal handler installs and handles SIGUSR1", {
       r2 := Sig.kill(pid, SIGUSR1);
       unsafe(printf("  kill = %d\n", r2));
       assert(r2 == i32(0));
-      _ := unsafe(usleep(u32(100000)));
+      unsafe(usleep(u32(100000)));
       r3 := Sig.off_signal(SIGUSR1);
       unsafe(printf("  off_signal = %d\n", r3));
       assert(r3 == i32(0));


### PR DESCRIPTION
## Summary

45 sites across `src/`, `std/` and `tests/` bound a call result to a discard name only to throw it away:

```rust
_ := unsafe(unistd.close(fd));
```

becomes

```rust
unsafe(unistd.close(fd));
```

Covers `_\ :=`, `___ :=` (no `__ :=` or `_ ::` existed). `tests/ref_enum.test.yo`'s arm now pattern-ignores with `.Boxed(_, t)` instead of a `_ := b;` filler statement. `docs/` and the syntax cheatsheet no longer teach the discard spelling.

## Deliberately untouched

- **Drop/borrow fixtures that test the discard binding itself** — `tests/rc.test.yo` (whole-body discard), `tests/ref_field_borrow.test.yo`, `tests/shadowed_binding_early_return_drop.test.yo` (they count `rc(...)`).
- **The `array_list` comptime_expect_error fixture** — its `_ := bad_list(usize(0)).*;` binding is what forces the value-evaluation path where the "index `.*` on non-pointer Output" error fires; the bare statement evaluates successfully (verified: the bare form made the test fail, the binding form is required). Documented in the cheatsheet + `yo-syntax.instructions.md`.

## Verification

- `yo check ./src` — 270/270 files passed
- `yo check ./std` — 175/175 files passed
- `yo build` (seed v0.2.30, full self-compile incl. codegen of every changed file) — success
- Fast targeted suite on the freshly built binary: ref_enum 12, array_list 120, linked_list 70, async_value_struct_param 1, string_builder 22, signal 1 — all pass
- Internal battery on the fresh binary: verifier 17, verifier_loops 12, verifier_match 2, verifier_negative 5, verifier_strip 2, verifier_twostate 3, build_runner 11, algebraic_effects 75 — all pass