### PR TITLE
tests/cli-cases: re-record the six goldens #594 moved

### DIFF
--- a/tests/cli-cases/init-build-test/expected_tree
+++ b/tests/cli-cases/init-build-test/expected_tree
@@ -5,7 +5,7 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	24543a39dff1ebb26524e17eeb8e249b14cadc62ed8b69a638f95dd200801b19
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7
 ./.gitignore	0731902a4953e85ff1820a81630bbb367bd7ddac37a04dd65f1fa7987c6c702e

--- a/tests/cli-cases/init-cwd/expected_tree
+++ b/tests/cli-cases/init-cwd/expected_tree
@@ -5,7 +5,7 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	24543a39dff1ebb26524e17eeb8e249b14cadc62ed8b69a638f95dd200801b19
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7
 ./.gitignore	0731902a4953e85ff1820a81630bbb367bd7ddac37a04dd65f1fa7987c6c702e

--- a/tests/cli-cases/init-existing/expected_tree
+++ b/tests/cli-cases/init-existing/expected_tree
@@ -5,7 +5,7 @@
 ./probe/.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./probe/.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./probe/.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./probe/.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
+./probe/.agents/skills/yo-syntax/syntax-cheatsheet.md	24543a39dff1ebb26524e17eeb8e249b14cadc62ed8b69a638f95dd200801b19
 ./probe/.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./probe/.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7
 ./probe/.gitignore	0731902a4953e85ff1820a81630bbb367bd7ddac37a04dd65f1fa7987c6c702e

--- a/tests/cli-cases/init/expected_tree
+++ b/tests/cli-cases/init/expected_tree
@@ -5,7 +5,7 @@
 ./probe/.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./probe/.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./probe/.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./probe/.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
+./probe/.agents/skills/yo-syntax/syntax-cheatsheet.md	24543a39dff1ebb26524e17eeb8e249b14cadc62ed8b69a638f95dd200801b19
 ./probe/.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./probe/.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7
 ./probe/.gitignore	0731902a4953e85ff1820a81630bbb367bd7ddac37a04dd65f1fa7987c6c702e

--- a/tests/cli-cases/skills-install-zh/expected_tree
+++ b/tests/cli-cases/skills-install-zh/expected_tree
@@ -5,6 +5,6 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	24543a39dff1ebb26524e17eeb8e249b14cadc62ed8b69a638f95dd200801b19
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7

--- a/tests/cli-cases/skills-install/expected_tree
+++ b/tests/cli-cases/skills-install/expected_tree
@@ -5,6 +5,6 @@
 ./.agents/skills/yo-project-workflow/SKILL.md	b0afd699d2ba39aa58f9d613f19c8bacda021d2be2089be3f2dd0fa6a9a2f3ad
 ./.agents/skills/yo-project-workflow/workflow-cheatsheet.md	93b06177a4e220bed1c0f0a1abffc83ea2a2d16261f21f3c3df5106bc6cc0032
 ./.agents/skills/yo-syntax/SKILL.md	68190a784d52197276cede6f5d3bb11cfa6ad39559630aaf1860ecef7637ef54
-./.agents/skills/yo-syntax/syntax-cheatsheet.md	fddc41ccb5f42414285b8f0b00384b2c07049a4a5ad1f64b5e2befd64fda074b
+./.agents/skills/yo-syntax/syntax-cheatsheet.md	24543a39dff1ebb26524e17eeb8e249b14cadc62ed8b69a638f95dd200801b19
 ./.agents/skills/yo-wasm-integration/SKILL.md	369391eb88bd142bc44020fc1a9b77c8823464802777435c97628f56aeba3f54
 ./.agents/skills/yo-wasm-integration/wasm-integration-cheatsheet.md	fc9c89187826f4fc7c1088a60e4bbed49915b9682c4fe830bb9b47bcd20191e7


### PR DESCRIPTION
develop's first full battery since #590 (run 34627500774) is red on the tier-1
gate, and the whole of it is one stale hash.

#594 edited `.github/skills/yo-syntax/syntax-cheatsheet.md` without re-recording
the CLI corpus. `yo skills install` hashes every installed file into its
`expected_tree`, and `yo init` scaffolds the same skills directory, so one
cheatsheet edit moves **six** goldens: `skills-install`, `skills-install-zh`,
`init`, `init-cwd`, `init-existing`, `init-build-test`.

Each diff is exactly one line — the cheatsheet's sha256, `fddc41cc` → `24543a39`.

Nothing else in that job failed: `T1_DONE (ci) failures=2` counts gate 7's two
checks (the scoring exit code and the scorecard assertion), and gates 0–6 and 8
all passed. #594 landed with 18 of its 22 checks cancelled, which is why this
was not caught on the PR.

Re-recorded with `scripts/cli-diff-test.sh --record` and re-scored:
`PASS 6  GOLDEN-DIFF 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)