### PR TITLE
codegen: a static-dispatch call takes its C return type from the CALLEE, not the call site

### DIFF
--- a/issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md
+++ b/issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md
@@ -1,0 +1,158 @@
+# A call to a captured generic closure binds a `void` result to a `void*` temp
+
+**Found**: 2026-09-12, working D18b (`Thread(T).spawn` carrying its result,
+`plans/STD_API_STABILIZATION.md` §2 D18). **Class**: a codegen call site and
+the callee's own prototype disagreeing about the C return type. **Status**:
+FIXED 2026-09-12 — red-first regression test
+`tests/closure_param_forwarding.test.yo`, "Test a captured generic callback at
+T = unit".
+
+## The error
+
+```
+error: initializing 'void *' with an expression of incompatible type 'void'
+```
+
+## Minimal reproducer
+
+`issues/repros/closure-call-void-result.yo`:
+
+```rust
+_call1 :: (fn(f : Impl(Fn(n : i32) -> unit)) -> unit)({
+  f(i32(1));
+});
+_run :: (fn(generic(T : Type), cb : Impl(Fn(n : i32) -> T)) -> unit)({
+  _call1(((k : i32) => {
+    _v := cb(k);
+    ()
+  }));
+});
+main :: (fn() -> unit)({
+  _run(((n : i32) => ()));
+  println(`ok`);
+});
+```
+
+`yo compile … --optimize 2` emits one C error. The two lines that disagree:
+
+```c
+static inline void closure_yo_id_10905(void* closure_context, int32_t k);
+…
+void* _file____priv_temp_16750 = closure_yo_id_10905(&(((__yo_t8*)closure_context)->cb), k);
+```
+
+The prototype says `void`. The call site says `void*`.
+
+## Why they disagree
+
+Both spellings are computed, from different inputs, by code that never
+compares them.
+
+The **prototype** is written by `generate_function_declaration`
+(`src/codegen/functions/declarations.yo`): the return type is an
+`override ?? get_type_string(result)` choice, and for a closure whose
+signature result is a `SomeT` the override is the BODY's concrete type. The
+closure `(n : i32) => ()` has body type `unit`, so the prototype is `void`.
+
+The **call site** is the `cc_` static-dispatch path in
+`src/codegen/exprs/other_fn_call.yo` — a call whose callee resolves through
+`impl_closure_call_map` is emitted as `closure_<fid>(&<capture>, args…)`. Its
+void decision reads `result_type`, which comes from the CALLER's view of the
+callee's Func type: the still-unresolved generic `T`. Two lines conspire:
+
+```rust
+// ~:2022 — prefer the call's own resolution, EXCEPT when the expression's
+// own type is unit (which also means "value discarded", so it is not
+// evidence about the callee).
+if(is_some_type(result_type) && !(is_unit_type(ei.ty)), {
+  result_type = ei.ty;
+});
+```
+
+so at `T = unit` `result_type` stays the `SomeT`, and `get_type_string` of an
+unresolved `SomeT` is the erasure `void*` — which is neither `void` (so the
+statement form is not taken) nor wrong-looking (so nothing complains). The
+temp is declared `void*` and initialized from a `void` expression.
+
+Every other instantiation is fine: at `T = i32` the guard's `!is_unit_type`
+holds, `result_type` becomes the concrete type, and both sides say `int32_t`.
+It is exactly the ZST that falls between the two channels.
+
+## THREE emitters ask the expression, and all three are wrong the same way
+
+Fixing only the call site turns the error into the next one in the stack — the
+binding emitter declares the same temp from the same erased type:
+
+```c
+closure_yo_id_10905(&(((__yo_t8*)closure_context)->cb), k);   /* fixed */
+void* _file____priv_temp_16750 = ;                            /* next error */
+void* _v = _file____priv_temp_16750;
+```
+
+`src/codegen/exprs/init_assignment.yo`'s scalar path already carries the guard
+for this shape —
+
+```rust
+rhs_is_unit := is_unit_type(resolve_some_type_to_concrete(effective_type));
+```
+
+(issues/fixed/binding-a-unit-returning-call-emits-invalid-c.md) — and it
+misses for the same reason the call site did: the RHS's `rei.ty` and the
+binding's own `lhs_type` are both the unresolved `T`, and
+`resolve_some_type_to_concrete` finds no resolution to walk to. The registry
+that would hold one is deliberately not durable for a `generic(T : Type)`
+binder (`unregister_some_resolved_concrete`, `src/expr_info.yo`), so by the
+time codegen runs there is nothing to read.
+
+## The fix
+
+A `cc_` hit is a STATIC dispatch to a known callee, so the callee's own
+emitted signature is the ground truth, and all three emitters ask it.
+
+`declarations.yo` gains two exported helpers:
+
+- `emitted_return_type_string(func_id, context)` reproduces the prototype's
+  `override ?? signature` choice from the same three inputs —
+  the registered func type, the entry's body, the effect-record-member body
+  suppression. `generate_function_declaration` now goes through the same
+  extracted `_return_type_override`, so the two cannot drift.
+- `static_dispatch_callee_return_type(func_expr, context)` resolves a call's
+  callee through `impl_closure_call_map` and answers with the above.
+
+`other_fn_call.yo`'s shared void decision and `init_assignment.yo`'s
+`rhs_is_unit` / LHS-declaration guards all consult it.
+
+**Why this cannot regress a working program**: the helper answers `Some("void")`
+only where the old code emitted `<erasure> t = <void-returning call>` — C that
+never compiled. Every program that reached this path was already broken.
+
+The mirror case (callee says non-void, site says void) is not reachable
+today: the site only keeps the erasure when `ei.ty` is unit, which is the
+`void` direction.
+
+## Where it was found
+
+This is the first of the two walls `plans/STD_API_STABILIZATION.md` records
+against D18b. The other — `_capture_judgement_type` resolving a captured
+closure to its capture STRUCT and then rejecting it as not `Send` — is
+untouched by this, and D18b needs both.
+
+## Resolution
+
+Measured on the reproducer, `yo compile … --optimize 2`:
+
+| | errors |
+| --- | --- |
+| before | `void* t = <void call>` |
+| after call-site fix only | `void* t = ;` (the binding's spill, one level up) |
+| after | **compiles, runs, prints `ok`** |
+
+And on the full D18b repro (`issues/repros/d18b-thread-zst-channel.yo`), which
+carries a second independent defect: two C errors → one. The unit argument now
+renders as the dead byte `0` the callee's signature expects. What is left is
+`issues/generic-channel-send-specialisation-is-called-but-never-emitted.md`.
+
+The regression test asserts more than "it compiles": the callback must still
+have RUN exactly once with the forwarded argument, because the fix turns a
+declaration into a statement and a statement that was dropped rather than
+emitted would be a silent miscompile.

--- a/issues/generic-channel-send-specialisation-is-called-but-never-emitted.md
+++ b/issues/generic-channel-send-specialisation-is-called-but-never-emitted.md
@@ -1,0 +1,86 @@
+# `Channel(T).send` at `T = unit` is CALLED from a spawn closure and never emitted
+
+**Found**: 2026-09-12, working D18b (`Thread(T).spawn` carrying its result,
+`plans/STD_API_STABILIZATION.md` §2 D18). **Class**: a specialization that the
+call site emits a call to and the collector never registers, so the C has a
+call with no declaration. **Status**: OPEN.
+
+## The error
+
+```
+error: initializing '__yo_t18' (aka 'struct __yo_t18_struct') with an
+       expression of incompatible type 'int'
+```
+
+That is clang reporting an IMPLICIT-INT call: the callee has no declaration
+anywhere in the translation unit, so C assumes `int`.
+
+## Reproducer
+
+`issues/repros/d18b-thread-zst-channel.yo` — the D18b shape: a generic helper
+that spawns a thread whose body sends the callback's result down a
+`Channel(T)`, instantiated at `T = unit`.
+
+```rust
+_spawn_zst :: (
+  fn(generic(T : Type), cb : Impl(Fn(io : Io) -> T), where(T <: (Send, Acyclic))) -> Channel(T)
+)({
+  chan := Channel(T).new(usize(1));
+  sink := chan;
+  t := Thread.spawn((io : Io) => {
+    sink.send(cb(io));
+    ()
+  });
+  t.join();
+  chan
+});
+```
+
+## What the emitted C shows
+
+```c
+static inline void closure_yo_id_15580(void* closure_context, __yo_t21 io) {
+  __yo_effect_escaped = 0;
+  closure_yo_id_15554(&(((__yo_t28*)closure_context)->cb), io);
+  …
+  __yo_t18 _file____priv_temp_21781 =
+      yo_id_14942_…_rtparam1_2193_ret_enum_yo_id_14941_value_unit_error_unit(
+          ((__yo_t28*)closure_context)->sink, 0);
+}
+```
+
+The call is well-formed — the unit argument is correctly the dead byte `0` —
+and the mangled name appears **exactly once in the whole file**: no prototype,
+no definition. `grep -c yo_id_14942` is 1. So the specialization was resolved
+by the evaluator (the call site knows its mangled name and its return type,
+`enum … value_unit error_unit`) and never reached
+`CodeGenContext.functions`.
+
+Note the `rtparam1_2193` segment: the second runtime parameter is mangled with
+type id `2193`, the generic `T`'s own id, not `unit`. The same id appears in
+`_spawn_zst`'s own specialization name. Whether that is the cause (a
+registration keyed on a different mangling than the call site emits) or merely
+another symptom of the same unresolved-`T` channel is the first thing to
+check.
+
+## Relationship to the other half
+
+This is the SECOND of the two errors the D18b repro produced. The first — a
+call site binding a `void`-returning closure call to a `void*` temp — is fixed
+(`issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md`),
+and fixing it is what made this one legible: before, the argument was a
+`void*` temp of a broken declaration, and the call's shape said nothing.
+
+`plans/STD_API_STABILIZATION.md` D18b names a THIRD blocker, independent of
+both: `_capture_judgement_type` resolves a captured closure to its capture
+STRUCT and then rejects it as not `Send`. D18b needs all three.
+
+## Where to look
+
+`should_skip_function_codegen` (`src/codegen/functions/declarations.yo`) drops
+a spec "whose registered return still carries an unresolved SomeT", and the
+NAMED-callee path in `other_fn_call.yo` degrades such a call to an FTT
+comment. Neither happened here: the call was emitted as a real call. So either
+the spec was never registered at all, or it was registered under a key the
+emission loop does not iterate. Start by dumping `function_order` for a name
+containing `yo_id_14942`.

--- a/issues/generic-channel-send-specialisation-is-called-but-never-emitted.md
+++ b/issues/generic-channel-send-specialisation-is-called-but-never-emitted.md
@@ -129,6 +129,17 @@ signature every specialisation in the compiler is keyed by, so it moves
 `yo_id_*` names tree-wide and has to clear the bootstrap FIXPOINT gate — it
 belongs in its own PR with the full battery, not bolted onto another fix.
 
+Resolving at READ may not even be possible here. The sibling defect's
+investigation established that the CALL's result `SomeT` has no recorded
+resolution at codegen time at all —
+`resolve_some_type_to_concrete` consults both the per-object `resolved_concrete`
+cell and the global registry and finds neither, which is why
+`init_assignment.yo`'s existing `rhs_is_unit` guard missed. If the `T` in
+`rtparam1_2193` is in the same state, the resolution has to be RECORDED at
+specialisation time rather than looked up later, and that is evaluator work on
+how a generic body's ExprInfos are stamped for a specialisation. (Not measured
+for this particular `SomeT` — measure it before choosing a direction.)
+
 It is also probably not sufficient on its own. With the segment omitted, the
 closure's call mints the spec with a param type that is still the raw SomeT,
 and `should_skip_function_codegen` drops a spec whose signature carries one

--- a/issues/generic-channel-send-specialisation-is-called-but-never-emitted.md
+++ b/issues/generic-channel-send-specialisation-is-called-but-never-emitted.md
@@ -75,12 +75,70 @@ and fixing it is what made this one legible: before, the argument was a
 both: `_capture_judgement_type` resolves a captured closure to its capture
 STRUCT and then rejects it as not `Send`. D18b needs all three.
 
+## ROOT CAUSE (measured 2026-09-12): two manglings of the same specialisation
+
+Add a direct `Channel(unit).send(())` in `main` — which forces the
+specialisation to be collected from a call whose argument type is plainly
+`unit` — and the C gains a prototype AND a definition, while the closure's
+call STILL does not link:
+
+```
+warning: call to undeclared function 'yo_id_14942_…_rtparam1_2193_ret_enum_…'
+```
+
+Diffing the declared name against the called one, they agree for 509
+characters and then:
+
+```
+decl: …_std_sync_atomic_yo_ret_enum_yo_id_14941_value_unit_error_unit
+call: …_std_sync_atomic_yo_rtparam1_2193_ret_enum_yo_id_14941_value_unit_error_unit
+```
+
+The declaration omits the second runtime parameter from the mangled signature;
+the call includes it, as type id `2193` — the generic `T` itself.
+
+`_compute_compile_time_signature` (`src/evaluator/calls/helper.yo:1412`) is
+where they part:
+
+```rust
+ptype := match(runtime_param_tys.get(rti), .Some(t) => t, .None => t_unit());
+if(!(is_unit_type(ptype)), {
+  seg := `rtparam${rti.to_string()}_${sanitize_for_sig(type_key(ptype))}`;
+  parts.push(seg);
+});
+```
+
+`is_unit_type` is the SHALLOW test — it does not walk the SomeT resolution
+chain — and `type_key`'s SomeT arm deliberately keys by the SomeT's OWN id
+rather than hopping through its resolution cell (the comment there records why:
+a blanket hop over-merged the dyn/box closure-wrapper family). So the same
+parameter contributes NO segment when the caller sees `unit` and the segment
+`rtparam1_2193` when it sees the still-unresolved `T`. Two signatures, two
+specialised func ids, one runtime function: the callee is emitted under one
+name and called under the other.
+
+Without the warm-up call there is no second caller, so the only specialisation
+is the `rtparam1_2193` one — and that one is never emitted at all, which is the
+form the D18b repro shows.
+
+## Why this is NOT a one-line fix
+
+Resolving `ptype` through its SomeT chain before the unit test makes the two
+manglings agree, and that is the right shape. But it is a change to the
+signature every specialisation in the compiler is keyed by, so it moves
+`yo_id_*` names tree-wide and has to clear the bootstrap FIXPOINT gate — it
+belongs in its own PR with the full battery, not bolted onto another fix.
+
+It is also probably not sufficient on its own. With the segment omitted, the
+closure's call mints the spec with a param type that is still the raw SomeT,
+and `should_skip_function_codegen` drops a spec whose signature carries one
+(`func_params_have_raw_some_type`) — which would put us back at an emitted call
+to an unemitted callee, just under a different name. The spec's PARAM TYPES
+need the resolution too, not only its name.
+
 ## Where to look
 
-`should_skip_function_codegen` (`src/codegen/functions/declarations.yo`) drops
-a spec "whose registered return still carries an unresolved SomeT", and the
-NAMED-callee path in `other_fn_call.yo` degrades such a call to an FTT
-comment. Neither happened here: the call was emitted as a real call. So either
-the spec was never registered at all, or it was registered under a key the
-emission loop does not iterate. Start by dumping `function_order` for a name
-containing `yo_id_14942`.
+`_compute_compile_time_signature` (`src/evaluator/calls/helper.yo`, the
+`rtparam` loop), `type_key`'s `SomeT` arm and `_tk_resolve_arg_slot`
+(`src/types/type_key.yo`), and `should_skip_function_codegen` /
+`func_params_have_raw_some_type` (`src/codegen/functions/declarations.yo`).

--- a/issues/repros/closure-call-void-result.yo
+++ b/issues/repros/closure-call-void-result.yo
@@ -1,0 +1,18 @@
+//! Narrow repro for symptom 1 of D18b: a closure that CAPTURES a generic
+//! callback and calls it. At `T = unit` the callee's emitted prototype says
+//! `void` while the call site still spells the erasure `void*`.
+{ println } :: import("std/fmt");
+_call1 :: (fn(f : Impl(Fn(n : i32) -> unit)) -> unit)({
+  f(i32(1));
+});
+_run :: (fn(generic(T : Type), cb : Impl(Fn(n : i32) -> T)) -> unit)({
+  _call1((k : i32) => {
+    _v := cb(k);
+    ()
+  });
+});
+main :: (fn() -> unit)({
+  _run((n : i32) => ());
+  println(`ok`);
+});
+export(main);

--- a/issues/repros/d18b-thread-zst-channel.yo
+++ b/issues/repros/d18b-thread-zst-channel.yo
@@ -1,0 +1,26 @@
+//! D18b repro: a Thread(T)-shaped spawn whose callback returns a ZST.
+//! `Thread(T).spawn` takes `cb : Impl(Fn(io : Io) -> T)` and the thread body
+//! sends `cb(io)` down a Channel(T). At T = unit the spawn lowering binds the
+//! callback's unit result to a `void*` temp and the C does not compile:
+//!   error: initializing 'void *' with an expression of incompatible type 'void'
+pragma(Pragma.AllowUnsafe);
+{ println } :: import("std/fmt");
+{ Channel } :: import("std/sync/channel");
+{ Thread } :: import("std/thread");
+_spawn_zst :: (
+  fn(generic(T : Type), cb : Impl(Fn(io : Io) -> T), where(T <: (Send, Acyclic))) -> Channel(T)
+)({
+  chan := Channel(T).new(usize(1));
+  sink := chan;
+  t := Thread.spawn((io : Io) => {
+    sink.send(cb(io));
+    ()
+  });
+  t.join();
+  chan
+});
+main :: (fn(io : Io) -> unit)({
+  c := _spawn_zst((io : Io) => ());
+  match(c.try_recv(), .Ok(_) => println(`unit value delivered`), .Err(_) => println(`no value`));
+});
+export(main);

--- a/issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md
+++ b/issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md
@@ -1,8 +1,33 @@
 # `Thread(T).spawn` cannot take a callback returning a ZST — the spawn path emits `void* tmp = <void expr>`
 
-**Status:** OPEN, and D18 part 2 is **BLOCKED**. The workaround recorded below
-dodges this bug and then hits a SECOND wall — see "Why the workaround does not
-land either".
+**Status:** the FIRST symptom is **FIXED** (2026-09-12); D18 part 2 is still
+**BLOCKED** on the second and on the `Send` capture judgement. The workaround
+recorded below dodges this bug and then hits that wall — see "Why the
+workaround does not land either".
+
+> **CORRECTION 2026-09-12 — "specific to the thread-spawn lowering" was
+> wrong.** The three controls below are not enough to narrow it there.
+> `issues/repros/closure-call-void-result.yo` reproduces symptom 1 with **no
+> thread, no spawn, no channel**: a plain closure that captures an
+> `Impl(Fn(n : i32) -> T)` parameter and binds its call at `T = unit`. The
+> lowering in `src/codegen/exprs/parallelism.yo` is NOT involved.
+>
+> The real cause was the `cc_` static-dispatch call site in
+> `other_fn_call.yo` (and the binding emitter one level up in
+> `init_assignment.yo`) reading the CALL EXPRESSION's type — still the
+> unresolved `T`, spelled as the erasure `void*` — instead of the callee's own
+> emitted prototype, which says `void`. All three emitters ask the callee now.
+> See `issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md`
+> for the mechanism, the measurements, and the red-first test.
+>
+> Symptom 2 — the `Channel(unit).send` specialisation called and never emitted
+> — is also NOT the spawn lowering. It is two manglings of one specialisation:
+> `_compute_compile_time_signature` gates its `rtparam<i>` segment on the
+> SHALLOW `is_unit_type`, so a parameter that RESOLVES to unit contributes no
+> segment from one caller and `rtparam1_<T's id>` from another. Filed as
+> `issues/generic-channel-send-specialisation-is-called-but-never-emitted.md`.
+>
+> The D18b repro is accordingly down from two C errors to one.
 
 Found 2026-09-07 attempting **D18 part 2**
 (`plans/STD_API_STABILIZATION.md` §2: *"`Thread(T).spawn` carries its result and

--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -215,11 +215,18 @@ the work in §4 does not re-open them.
   `Dispose` before `try_recv`; `Thread(i32).join()` returning the body's
   value), but it cannot be landed:
   * writing the call-and-send INLINE in the spawn closure does not compile at
-    `T = unit` — the emitted C is `void* tmp = <void expr>` for the captured
-    callback's ZST result and the `Channel(unit).send` specialisation is never
-    emitted. Narrowed to `src/codegen/exprs/parallelism.yo`, which gives spawn
-    callbacks their own capture-struct lowering ("selects the primitive +
-    (unit) return convention"), with three controls that all work.
+    `T = unit`. This was TWO defects, not one, and the first is now FIXED. The
+    `void* tmp = <void expr>` half was not `parallelism.yo` at all: it was the
+    `cc_` static-dispatch call site in `other_fn_call.yo` (plus the binding
+    emitter one level up) reading the CALL EXPRESSION's type — still the
+    unresolved `T`, spelled as the erasure `void*` — instead of the callee's
+    own emitted prototype, which says `void`
+    (`issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md`,
+    red-first test in `tests/closure_param_forwarding.test.yo`). The repro is
+    down from two C errors to one. The remaining half — the
+    `Channel(unit).send` specialisation being CALLED and never emitted, its
+    mangled name appearing exactly once in the whole translation unit — is
+    `issues/generic-channel-send-specialisation-is-called-but-never-emitted.md`.
   * routing it through a top-level generic helper dodges that, and then hits
     the OTHER wall: the spawn closure now CAPTURES `cb`, and #451's Send
     enforcement rejects it —

--- a/src/codegen/exprs/init_assignment.yo
+++ b/src/codegen/exprs/init_assignment.yo
@@ -28,6 +28,7 @@
 { type_contains_rc_type } :: import("../../types/utils.yo");
 { get_type_string, get_variable_type_string, get_variable_name_for_codegen, sanitize_for_c_identifier } :: import("../utils/index.yo");
 { codegen_fatal_expr } :: import("../constants.yo");
+{ static_dispatch_callee_return_type } :: import("../functions/declarations.yo");
 /// True if `s` is all ASCII digits (non-empty).
 _all_digits :: (fn(s : String) -> bool)({
   // BYTE count — the loop reads byte_at; String.len() counts RUNES
@@ -451,6 +452,24 @@ generate_initialization_assignment :: (fn(expr : AstExpr, indent : String, conte
     }, {
       // Non-array scalar initialization.
       sanitized_var_name := get_variable_name_for_codegen(var_name.clone(), Option(Environment).Some(lhs_ei.env));
+      // A STATIC-dispatch call whose callee's prototype returns `void` has no
+      // value, whatever this binding's own types say. They can disagree: a
+      // generic `Impl(Fn(...) -> T)` callee specialised at `T = unit` emits a
+      // `void` prototype while both `rei.ty` and `lhs_type` still carry the
+      // unresolved `T`, whose spelling is the erasure `void*` — so neither the
+      // `rhs_is_unit` guard below nor the `!is_unit_type(lhs_type)` guard fires
+      // and the C came out `void* t = <void call>; void* v = t;`. Ask the
+      // callee.
+      // See issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md.
+      rhs_is_void_call := match(
+        rhs,
+        .FnCall(_, rhs_callee, _, _, _) => match(
+          static_dispatch_callee_return_type(rhs_callee, context.base),
+          .Some(sd_ret) => (sd_ret == `void`),
+          .None => false
+        ),
+        .Atom(_, _) => false
+      );
       rhs_code := match(
         context.base.get_expr_info(rhs),
         .Some(rei) => match(
@@ -471,7 +490,7 @@ generate_initialization_assignment :: (fn(expr : AstExpr, indent : String, conte
               // the missing half. Resolve through SomeT first, so a type
               // parameter that resolves to unit takes the same path.
               // See issues/fixed/binding-a-unit-returning-call-emits-invalid-c.md.
-              rhs_is_unit := is_unit_type(resolve_some_type_to_concrete(effective_type));
+              rhs_is_unit := (rhs_is_void_call || is_unit_type(resolve_some_type_to_concrete(effective_type)));
               if(rhs_is_unit, {
                 // No value to hold, so no declaration — but the code must
                 // still RUN. Most unit calls are already emitted as a
@@ -524,7 +543,7 @@ generate_initialization_assignment :: (fn(expr : AstExpr, indent : String, conte
       // `s2 compile main.yo` UAF; see issues/fixed/yo-self-dyn-throw-double-drop.md).
       rhs_is_deref := (ast_expr_is_fn_call_of(rhs, BF_DOT, Option(usize).Some(usize(2))) && match(rhs, .FnCall(_, _, dargs, _, _) => match(dargs.get(usize(1)), .Some(pe) => ast_expr_is_atom_of(pe, "*"), .None => false), .Atom(_, _) => false));
       rhs_has_dup := match(context.base.get_expr_info(rhs), .Some(r2) => match(r2.deferred_dup_expressions, .Some(d2) => (d2.len() > usize(0)), .None => false), .None => false);
-      if(!is_unit_type(lhs_type), {
+      if(!is_unit_type(lhs_type) && !rhs_is_void_call, {
         // get_variable_type_string (not get_type_string + manual name append)
         // so the scalar binding's C name is REGISTERED in declared_c_var_names
         // — _keep_pending_drop (return.yo) rejects a drop whose target was

--- a/src/codegen/exprs/other_fn_call.yo
+++ b/src/codegen/exprs/other_fn_call.yo
@@ -20,7 +20,7 @@
 { EvalValue, is_func_val, is_unknown_val, is_struct_val, is_enum_val } :: import("../../value.yo");
 { get_type_trait_methods_by_name, type_id_or_empty } :: import("../../evaluator/values/type_trait_methods.yo");
 { get_func_type, is_control_fn, is_effect_record_member, is_io_async_sm_closure } :: import("../../function_value.yo");
-{ should_skip_function_codegen, _async_override_return_type, awaited_future_c_type_override } :: import("../functions/declarations.yo");
+{ should_skip_function_codegen, _async_override_return_type, awaited_future_c_type_override, emitted_return_type_string } :: import("../functions/declarations.yo");
 { TypeValue, FuncMeta } :: import("../../types/definitions.yo");
 { is_reference_struct_type, is_atomic_reference_struct_type, is_reference_enum_type, is_function_type, is_unit_type, is_array_type, is_dyn_type, is_struct_type, is_enum_type, is_union_type, is_fn_trait_type, is_some_type } :: import("../../types/guards.yo");
 { type_is_control_bound } :: import("../../types/utils.yo");
@@ -2211,6 +2211,19 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
     .None => String.from("")
   );
   cc_mapped := if(cc_id.len() > usize(0), context.base.impl_closure_call_map.get(cc_id), Option(ImplClosureCallInfo).None);
+  // The C return-type spelling the CALLEE's prototype was emitted with. A cc_
+  // hit is a STATIC dispatch to a known closure impl fn, so the callee's own
+  // signature is the ground truth for whether this call has a value — and the
+  // two views disagree exactly when the callee resolved a `SomeT` result the
+  // call site did not. At `T = unit` the prototype says `void` while
+  // `result_type` is still the unresolved generic, whose spelling is the
+  // erasure `void*`: the guard below declared `void* t = <void call>`.
+  // See issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md.
+  cc_callee_ret := match(
+    cc_mapped,
+    .Some(ccm) => emitted_return_type_string(ccm.closure_fid.clone(), context.base),
+    .None => Option(String).None
+  );
   (out : String) = match(
     cc_mapped,
     .Some(mp) => {
@@ -2359,6 +2372,9 @@ generate_other_function_call :: (fn(expr : AstExpr, indent : String, context : F
     // ctl-handler-void-signature-vs-sret-cast.md) and its branch below must
     // still declare the temp the escape-path drops reference.
     ou_result_is_void := cond(
+      // The callee's own emitted signature wins over the call site's view of
+      // its result whenever this is a static dispatch (see `cc_callee_ret`).
+      match(cc_callee_ret, .Some(ccr) => (ccr == `void`), .None => false) => true,
       is_unit_type(result_type) => true,
       ctl_generic_ret => false,
       is_some_type(result_type) => {

--- a/src/codegen/functions/declarations.yo
+++ b/src/codegen/functions/declarations.yo
@@ -15,6 +15,7 @@
 { lookup_some_resolved_concrete, expr_info_effect_analysis, expr_info_async_state_machine_struct_name, lookup_method_callee_value } :: import("../../expr_info.yo");
 { EvalValue } :: import("../../value.yo");
 { get_func_type, is_effect_record_member, is_closure_fn, is_io_async_sm_closure, is_fn_unemittable, fn_has_specializations } :: import("../../function_value.yo");
+{ resolve_some_type_to_concrete } :: import("../exprs/closures.yo");
 { CodeGenContext, get_type_string, get_storage_type_string, sanitize_for_c_identifier, get_runtime_struct_fields, RuntimeStructField, is_function_value_with_only_builtin_yo_inline_function_call, find_returned_async_block, type_key } :: import("../utils/index.yo");
 /// One evidence parameter threaded into a function that uses effect-record
 /// evidence passing. Mirrors the `EvidenceParameter` interface.
@@ -701,15 +702,15 @@ awaited_future_c_type_override :: (
     .None => Option(String).None
   )
 });
-/// Emit a single function's forward declaration with the right linkage. Mirrors
-/// `generateFunctionDeclaration`. `is_exported` is precomputed by the caller via
-/// the SAME predicate the body emitter (generate_function) uses, so the
-/// declaration's linkage matches the definition's.
-generate_function_declaration :: (fn(function_type : TypeValue, c_function_name : String, is_extern : bool, is_exported : bool, body : Option(AstExpr), is_closure : bool, context : CodeGenContext) -> unit)({
+/// The `override_return_type` a function's prototype is emitted with:
+/// `Impl(Future(T))` → the returned async block's SM struct (see
+/// `_async_override_return_type`); otherwise the BODY's concrete type for a
+/// SomeType / SomeType-containing signature. `.None` means the signature's own
+/// result spelling stands.
+_return_type_override :: (
+  fn(function_type : TypeValue, body : Option(AstExpr), context : CodeGenContext) -> Option(String)
+)({
   ret := _func_result_type(function_type);
-  // Override return type: Impl(Future(T)) → the returned async block's SM struct
-  // (see `_async_override_return_type`); otherwise the body's concrete type for
-  // SomeType / SomeType-containing signatures.
   (override : Option(String)) = Option(String).None;
   if(type_implements_future(ret), {
     override = _async_override_return_type(function_type, body, context);
@@ -741,6 +742,99 @@ generate_function_declaration :: (fn(function_type : TypeValue, c_function_name 
       .None => ()
     );
   });
+  override
+});
+/// The C return-type spelling `func_id`'s PROTOTYPE was emitted with — the same
+/// `override ?? signature` choice `generate_function_declaration` makes, read
+/// off the same three inputs (the registered func type, the entry's body, the
+/// effect-record-member body suppression).
+///
+/// A call site that binds a call's result to a temp must ask THIS rather than
+/// the call expression's own type whenever it emits a STATIC dispatch to a
+/// known callee: the two views disagree the moment the callee resolved a
+/// `SomeT` result the site did not. At `T = unit` the prototype says `void`
+/// while the site still spells the erasure `void*`, and the temp came out
+/// `void* t = <void-returning call>` — see
+/// issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md.
+///
+/// `.None` for a func_id with no registered entry or no Func type.
+emitted_return_type_string :: (
+  fn(func_id : String, context : CodeGenContext) -> Option(String)
+)(
+  match(
+    context.get_function_entry(func_id.clone()),
+    .Some(entry) => {
+      ft := get_func_type(func_id.clone());
+      cond(
+        !is_function_type(ft) => Option(String).None,
+        true => {
+          body := if(is_effect_record_member(func_id.clone()), Option(AstExpr).None, _func_value_body(entry.value));
+          Option(String).Some(
+            match(
+              _return_type_override(ft, body, context),
+              .Some(s) => s,
+              .None => match(
+                ft,
+                .Func({ result : r, meta : __erm }) => {
+                  base := get_type_string(r, context);
+                  if(__erm.*.result_is_ref, {
+                    base.push_str("*");
+                  });
+                  base
+                },
+                _ => String.new()
+              )
+            )
+          )
+        }
+      )
+    },
+    .None => Option(String).None
+  )
+);
+/// The C return-type spelling the CALLEE of `func_expr` was emitted with, when
+/// that callee resolves to a registered closure impl fn — the `cc_` STATIC
+/// dispatch `other_fn_call` emits as `closure_<fid>(&<capture>, args...)`.
+/// `.None` when the callee is not one of those.
+///
+/// This is the honest answer to "does this call have a value?" for a static
+/// dispatch. The call EXPRESSION's own type is the CALLER's view, and it still
+/// carries the unresolved generic whenever the callee specialised that generic
+/// away: at `T = unit` the expression spells the erasure `void*` while the
+/// callee's prototype says `void`. Three emitters asked the expression and all
+/// three were wrong the same way — the call-site temp, the binding's spill
+/// temp, and the binding itself
+/// (issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md).
+static_dispatch_callee_return_type :: (
+  fn(func_expr : AstExpr, context : CodeGenContext) -> Option(String)
+)(
+  match(
+    context.get_expr_info(func_expr),
+    .Some(cei) => {
+      sd_id := match(
+        resolve_some_type_to_concrete(cei.ty),
+        .Struct({ id : i }) => i,
+        .SomeT({ id : i }) => i,
+        _ => String.from("")
+      );
+      cond(
+        (sd_id.len() == usize(0)) => Option(String).None,
+        true => match(
+          context.impl_closure_call_map.get(sd_id),
+          .Some(sd_mp) => emitted_return_type_string(sd_mp.closure_fid.clone(), context),
+          .None => Option(String).None
+        )
+      )
+    },
+    .None => Option(String).None
+  )
+);
+/// Emit a single function's forward declaration with the right linkage. Mirrors
+/// `generateFunctionDeclaration`. `is_exported` is precomputed by the caller via
+/// the SAME predicate the body emitter (generate_function) uses, so the
+/// declaration's linkage matches the definition's.
+generate_function_declaration :: (fn(function_type : TypeValue, c_function_name : String, is_extern : bool, is_exported : bool, body : Option(AstExpr), is_closure : bool, context : CodeGenContext) -> unit)({
+  override := _return_type_override(function_type, body, context);
   prototype := generate_function_prototype(function_type, c_function_name.clone(), context, override, is_closure);
   // Three arms, matching generate_function's linkage EXACTLY (see the comment
   // there): extern, exported (no prefix), otherwise `static inline`. The dead
@@ -904,4 +998,4 @@ generate_function_declarations :: (fn(context : CodeGenContext) -> unit)({
   generate_closure_vtable_declarations(context);
   em.emit_declaration_line("");
 });
-export(EvidenceParameter, collect_evidence_from_record, get_evidence_parameters, generate_function_prototype, generate_function_declaration, generate_object_constructor_declarations, generate_closure_constructor_declarations, generate_capture_dispose_function_declarations, generate_closure_vtable_declarations, generate_function_declarations, should_skip_function_codegen, _async_override_return_type, awaited_future_c_type_override);
+export(EvidenceParameter, collect_evidence_from_record, get_evidence_parameters, generate_function_prototype, generate_function_declaration, generate_object_constructor_declarations, generate_closure_constructor_declarations, generate_capture_dispose_function_declarations, generate_closure_vtable_declarations, generate_function_declarations, should_skip_function_codegen, _async_override_return_type, awaited_future_c_type_override, emitted_return_type_string, static_dispatch_callee_return_type);

--- a/tests/closure_param_forwarding.test.yo
+++ b/tests/closure_param_forwarding.test.yo
@@ -100,3 +100,31 @@ test("Test two distinct closures through the same forwarding chain", {
   assert(r1 == i32(11), "first closure captures a=1: 1 + 10");
   assert(r2 == i32(2010), "second closure captures b=2000: 2000 + 10");
 });
+test("Test a captured generic callback at T = unit", {
+  // The ZST instantiation of a forwarded `Impl(Fn(...) -> T)`. The inner
+  // closure CAPTURES `cb` and calls it, so the call is a static dispatch
+  // through impl_closure_call_map — and at `T = unit` the callee's prototype
+  // returns `void` while the call expression's own type is still the
+  // unresolved `T`, whose C spelling is the erasure `void*`. Three emitters
+  // read the expression instead of the callee and emitted
+  // `void* t = <void call>;` (the call-site temp) and then `void* t = ;` (the
+  // binding's spill), for a program `yo check` accepts.
+  // See issues/fixed/closure-call-binds-a-void-result-to-a-void-pointer-temp.md.
+  hits := ArrayList(i32).new();
+  call_unit4 :: (fn(f : Impl(Fn(n : i32) -> unit)) -> unit)({
+    f(i32(7));
+  });
+  run4 :: (fn(generic(T : Type), cb : Impl(Fn(n : i32) -> T)) -> unit)({
+    call_unit4((k : i32) => {
+      _v := cb(k);
+      ()
+    });
+  });
+  run4((n : i32) => {
+    hits.push(n);
+  });
+  // The call must still RUN: the fix turns the binding into a statement, and a
+  // statement that was dropped instead of emitted would leave this empty.
+  assert(hits.len() == usize(1), "the captured unit callback ran exactly once");
+  assert(match(hits.get(usize(0)), .Some(v) => v, .None => i32(0)) == i32(7), "it ran with the forwarded argument");
+});


### PR DESCRIPTION
## The bug

A call whose callee resolves through `impl_closure_call_map` is emitted as a
STATIC dispatch — `closure_<fid>(&<capture>, args…)` — to a function whose
prototype codegen has already written. Three emitters decided whether that call
has a **value** by reading the call expression's own type instead, and all three
were wrong the same way.

The call expression's type is the CALLER's view, and it still carries the
unresolved generic whenever the callee specialised that generic away. At
`T = unit` the callee's prototype says `void` while the expression spells the
erasure `void*`:

```c
static inline void closure_yo_id_10905(void* closure_context, int32_t k);
…
void* _file____priv_temp_16750 = closure_yo_id_10905(&(((__yo_t8*)closure_context)->cb), k);
```

`error: initializing 'void *' with an expression of incompatible type 'void'`,
for a program `yo check` accepts.

Every other instantiation is fine — at `T = i32` the call site's own resolution
kicks in and both sides say `int32_t`. It is exactly the ZST that falls between
the two channels: `other_fn_call.yo` deliberately does not take `ei.ty` when it
is unit (a unit expression type also means "value discarded", so it is not
evidence about the callee), and `resolve_some_type_to_concrete` has nothing to
walk to, because the registry that would hold a `generic(T : Type)` binder's
resolution is deliberately not durable (`unregister_some_resolved_concrete`).

Fixing only the call site moves the error one level up, to `init_assignment.yo`'s
binding spill — which already carries the guard for this shape (#`issues/fixed/binding-a-unit-returning-call-emits-invalid-c.md`) and misses it for the same
reason, then emits `void* t = ;`.

## The fix

All three ask the callee. `declarations.yo` grows two helpers:

- `emitted_return_type_string(func_id, context)` reproduces the prototype's
  `override ?? signature` choice from the same three inputs — the registered func
  type, the entry's body, the effect-record-member body suppression.
  `generate_function_declaration` now goes through the same extracted
  `_return_type_override`, so the two cannot drift.
- `static_dispatch_callee_return_type(func_expr, context)` resolves a call's
  callee through the closure map and answers with the above.

**This cannot regress a working program**: the helper answers `Some("void")` only
where the old code emitted `<erasure> t = <void-returning call>` — C that never
compiled.

## Measured

| | result |
| --- | --- |
| `issues/repros/closure-call-void-result.yo` before | 1 C error |
| after call-site fix only | 1 C error, one level up (`void* t = ;`) |
| after | **compiles, runs, prints `ok`** |
| full D18b repro before | 2 C errors |
| after | **1** — and the unit argument now renders as the dead byte `0` the callee's signature expects |

`yo check ./src` 270/270.

## Tests

Red-first: `tests/closure_param_forwarding.test.yo`, "Test a captured generic
callback at T = unit" fails on develop's compiler with exactly
`initializing 'void *' with an expression of incompatible type 'void'`, and
passes here. It asserts more than "it compiles" — the callback must still have
RUN exactly once with the forwarded argument, because the fix turns a
declaration into a statement and a statement dropped rather than emitted would
be a silent miscompile.

## What this unblocks, and what it does not

This is the first of the three walls `plans/STD_API_STABILIZATION.md` records
against **D18b** (`Thread(T).spawn` carrying its result, `join() -> T`). The
plan entry is corrected: the `void*` half was never `parallelism.yo`. Still
open, both filed:

- `issues/generic-channel-send-specialisation-is-called-but-never-emitted.md` —
  `Channel(unit).send` is called and never emitted; its mangled name appears
  exactly once in the whole translation unit.
- `_capture_judgement_type` resolving a captured closure to its capture STRUCT
  and rejecting it as not `Send`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)