### PR TITLE
verifier: V5 task 3 slice 1 — ghost_fn calls are gated to ghost context

### DIFF
--- a/src/evaluator/builtins/contracts.yo
+++ b/src/evaluator/builtins/contracts.yo
@@ -44,6 +44,7 @@
 { file_has_pragma } :: import("../memory_safety.yo");
 { ArrayList } :: import("std/collections/array_list");
 { HashMap } :: import("std/collections/hash_map");
+{ HashSet } :: import("std/collections/hash_set");
 { format_error_message } :: import("../../error.yo");
 { Exception } :: import("std/error");
 { evaluate_expression_raw } :: import("../exprs/expr.yo");
@@ -201,8 +202,22 @@ _evaluate_transparent_unary :: (
   );
   expr
 });
-/// `ghost_fn(f)` — marks a function value ghost-only. Phase 0: transparent
-/// pass-through. Mirrors `evaluateGhostFn`.
+/// V5 task 3: the ghost-fn registry. `ghost_fn(...)` registers the wrapped
+/// function's func_id here; function.yo's call arm rejects calls to these
+/// from non-ghost context (a ghost_fn has no runtime semantics).
+(g_ghost_fn_ids : HashSet(String)) = HashSet(String).new();
+register_ghost_fn :: (fn(func_id : String) -> unit)({
+  g_ghost_fn_ids.insert(func_id);
+  ()
+});
+is_ghost_fn :: (fn(func_id : String) -> bool)(
+  g_ghost_fn_ids.contains(func_id)
+);
+/// `ghost_fn(f)` — marks a function value ghost-only. V5 task 3: the
+/// wrapped function is REGISTERED as ghost (calls from non-ghost context
+/// are a compile error — function.yo's FuncVal arm checks the registry);
+/// the marker itself stays a transparent pass-through. Mirrors
+/// `evaluateGhostFn`.
 evaluate_ghost_fn :: (fn(expr : AstExpr, env : Environment, ctx : EvalContext, exn : Exception) -> AstExpr)({
   if(!ast_expr_is_fn_call_of(expr, BF_GHOST_FN, .Some(usize(1))), {
     exn.throw(
@@ -220,6 +235,38 @@ evaluate_ghost_fn :: (fn(expr : AstExpr, env : Environment, ctx : EvalContext, e
   ctx.is_ghost_context = true;
   out := _evaluate_transparent_unary(expr, env, ctx, exn);
   ctx.is_ghost_context = prev_ghost;
+  // Register the wrapped function as ghost: its func_id goes into the
+  // ghost-fn registry so every later CALL from non-ghost context errors.
+  args := match(
+    expr,
+    .FnCall(_, _, a, _, _) => a,
+    .Atom(_, _) => ArrayList(AstExpr).new()
+  );
+  match(
+    args.get(usize(0)),
+    .Some(inner) => {
+      match(
+        expr_info_table_get(ctx.expr_info_table, ast_expr_id(inner)),
+        .Some(ii) => {
+          match(
+            ii.value,
+            .Some(gv) => {
+              match(
+                gv,
+                .FuncVal(gfvd, _) => {
+                  register_ghost_fn(gfvd.*.func_id.clone());
+                },
+                _ => ()
+              );
+            },
+            .None => ()
+          );
+        },
+        .None => ()
+      );
+    },
+    .None => ()
+  );
   out
 });
 /// Ghost-only constructs (V5 §6: forall/exists/==>) have NO
@@ -1240,5 +1287,7 @@ export(
   take_verify_tasks,
   record_verify_task_def_eval_failure,
   verify_task_def_eval_failure,
+  register_ghost_fn,
+  is_ghost_fn,
   strip_proved_ensures_asserts
 );

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -138,6 +138,7 @@ MACRO_DISPATCH_ENABLED :: true;
 { TypeField, get_struct_fields } :: import("../types/field.yo");
 { try_to_call_function_with_arguments, resolve_param_types_from_expected, validate_where_constraints_for_call, reapply_where_clause_exprs_for_call, create_specialized_function_inline, _type_has_array_len_var, _trial_eval_ret_type_expr } :: import("./helper.yo");
 { get_func_type, register_func_type, is_control_fn } :: import("../../function_value.yo");
+{ is_ghost_fn } :: import("../builtins/contracts.yo");
 { function_may_mutate_rc_storage } :: import("../effects/mutation_summary.yo");
 { create_unknown_val, create_unknown_val_with_name, is_runtime_only_unknown_val, value_to_string } :: import("../../value.yo");
 /// Named call-result unknown: promotes a Type-universe result to
@@ -4028,6 +4029,19 @@ Fix: wrap the call:
         cap_tys := __fvm7.*.cap_tys;
         func_id_fv := __fvm7.*.func_id;
         fv_env_key := __fvm7.*.env_key;
+        // V5 task 3: a `ghost_fn(...)` definition is callable ONLY from
+        // ghost context (contract clauses, ghost bindings, ghost_fn bodies,
+        // and the verifier's predicate pass) — it has no runtime semantics.
+        if(is_ghost_fn(func_id_fv.clone()) && !ctx.is_ghost_context, {
+          exn.throw(
+            dyn(
+              format_error_message(
+                ast_expr_token(expr),
+                String.from("a ghost_fn is callable only from ghost context (contract clauses, ghost(...) bindings, ghost_fn bodies) — it has no runtime semantics")
+              )
+            )
+          );
+        });
         n_p := param_names.len();
         n_ev := evidence_names.len();
         (n_a : usize) = args.len();

--- a/tests/spec/contracts_phase0.test.yo
+++ b/tests/spec/contracts_phase0.test.yo
@@ -81,12 +81,15 @@ test("ghost binding evaluates as a no-op", {
   assert((a + b) == i32(5), "a + b == 5 regardless of ghost");
 });
 
-test("ghost_fn declaration is parseable and callable in Phase 0", {
+test("ghost_fn is parseable, and V5 gates calls from non-ghost code", {
   is_positive :: ghost_fn((fn(x : i32) -> bool)(x > i32(0)));
-  // Phase 0 is transparent — the ghost function is still callable.
-  // Later phases will forbid calls from non-ghost code.
-  assert(is_positive(i32(5)), "5 is positive");
-  assert(!is_positive(i32(-5)), "-5 is not positive");
+  // V5 task 3: a ghost_fn is callable ONLY from ghost context (contract
+  // clauses, ghost bindings, ghost_fn bodies) — Phase 0's transparency is
+  // retired; ordinary calls are a compile error.
+  comptime_expect_error({
+    probe := is_positive(i32(5));
+    probe;
+  }, "ghost_fn is callable only from ghost context");
 });
 
 test("old() is a transparent pass-through in Phase 0", {


### PR DESCRIPTION
## Summary

First slice of V5 task 3 (`FORMAL_VERIFICATION.md`): `ghost_fn` stops being transparent at the CALL site.

- `evaluate_ghost_fn` registers the wrapped function's func_id in a ghost-fn registry (`HashSet` side table in contracts.yo).
- function.yo's FuncVal call arm rejects calls to registered ids **from non-ghost context** with a precise error naming the rule — the Phase-0 transparency that `tests/spec/contracts_phase0.test.yo` itself anticipated ("Later phases will forbid calls from non-ghost code") is retired; that test now asserts the gate via `comptime_expect_error`.
- Inside ghost context (contract clauses, `ghost(...)` bindings, `ghost_fn` bodies, the verifier's predicate pass) calls evaluate exactly as before.

Validated locally with the standalone driver (this tree's evaluator): an ordinary-code call fails the load with the gate message at the call site; a `requires(within(x, 0))` fixture loads clean through the ghost-context bracket.

Remaining task 3 (next slice, same branch if green in time): `ghost(x := e)` binding semantics + ghost-escape errors + codegen erasure.