### PR TITLE
std/async: yield has no timer under it any more

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -1005,10 +1005,11 @@ say to take an own `Rng.from_entropy()` in a hot loop instead.
 `try_recv -> TryRecvError{Empty, Disconnected}` (#506);
 `Sender`/`Receiver` with auto-close on the last sender (#553, 2026-09-11,
 below); the `Waker`/`Park` PRIMITIVE plus `yield_now` (2026-09-11, below) —
-which is what the rest of this group was waiting on. STILL OPEN: waker-based
-`async channel`/`async mutex` written OVER that primitive, and
-`std/async/index.yo`'s own `yield`, which is still on its 1 ms timer because
-pointing it at the new extern cannot bootstrap under the v0.2.30 seed;
+which is what the rest of this group was waiting on. `std/async/index.yo`'s own `yield` is
+the same primitive as of v0.2.32 — it was on a 1 ms timer only because
+pointing it at `__yo_async_yield_start` could not bootstrap until a PUBLISHED
+seed carried that symbol, and v0.2.31 is the first that does. STILL OPEN:
+waker-based `async channel`/`async mutex` written OVER that primitive;
 `async/mutex.with_lock` either taking an `io` (so its doc claim becomes true)
 or dropping the claim; `Once.call` rewritten over `Mutex.with_lock`;
 `_raw_lock`/`_raw_unlock`/`_raw_handle_ptr` off the public surface;

--- a/src/codegen/async/runtime_core.yo
+++ b/src/codegen/async/runtime_core.yo
@@ -528,12 +528,31 @@ static __yo_io_future_t* __yo_async_yield_start(void) {
   return f;
 }
 
-// Complete every parked yield. Takes the whole list first, so a yield created
-// by a continuation this call resumes lands on the NEXT list rather than
-// looping here forever.
+// Complete every parked yield, IN THE ORDER THEY YIELDED. Takes the whole list
+// first, so a yield created by a continuation this call resumes lands on the
+// NEXT list rather than looping here forever.
+//
+// The pending list is built by head insertion in __yo_async_yield_start, so it
+// arrives in REVERSE yield order and has to be reversed before waking. A yield
+// is a FAIRNESS primitive: waking LIFO resumes the most recent yielder first,
+// which starves the earliest one and reverses the round-robin that two tasks
+// alternating on a yield are entitled to. tests/async_await.test.yo's "basic
+// spawn of two futures" is the oracle — it pins
+// task1 state0, task2 state0, task1 state1, task2 state1 — and it read
+// counter == 11 where it expected 12 the moment std's yield stopped being
+// a 1 ms timer, because the timer had been supplying the ordering that this
+// list was not.
 static void __yo_async_drain_yields(void) {
   __yo_yield_node_t* n = __yo_yield_pending;
   __yo_yield_pending = NULL;
+  __yo_yield_node_t* fifo = NULL;
+  while (n) {
+    __yo_yield_node_t* next = n->next;
+    n->next = fifo;
+    fifo = n;
+    n = next;
+  }
+  n = fifo;
   while (n) {
     __yo_yield_node_t* next = n->next;
     __yo_waker_wake((void*)n->future);

--- a/std/async/index.yo
+++ b/std/async/index.yo
@@ -43,6 +43,7 @@ pragma(Pragma.AllowUnsafe);
 { ToString } :: import("../fmt");
 import("../string");
 IO_timer :: import("../sys/timer");
+{ __yo_async_yield_start } :: import("../sys/externs.yo");
 extern(
   "Yo",
   /// One event-loop step: drain ready tasks, then poll (and, when idle with
@@ -52,16 +53,33 @@ extern(
 );
 /// Suspend the current async task until the next event-loop turn: drain the
 /// ready queue, then poll (and, when idle with pending I/O, block in) I/O.
-/// Implemented by awaiting a 1 ms timer — the same park `Mutex.lock`'s
-/// contended loop uses. The previous body (`return(())`) completed the
-/// future SYNCHRONOUSLY, so `io.await(yield(io), io)` never reached
-/// `__yo_async_poll_step`: a poll-until-finished loop built on it
-/// (`is_finished()` + `await yield()`) spun without ever polling I/O, and
-/// the polled task never progressed (the build smoke hang's spin component,
-/// issues/build-smoke-hangs-registry-perturbation.md).
+///
+/// There is NO TIMER under this. The future is created pending and completed
+/// at the top of the next ready-task drain, after that drain has measured its
+/// budget, so the resumed continuation lands beyond the budget and runs in the
+/// following step — with exactly one `__yo_io_poll()` in between. That is the
+/// same mechanism `std/async/waker`'s `yield_now` documents, and the two are
+/// now the same thing.
+///
+/// It was a 1 ms timer until v0.2.32, for a bootstrap reason and not a design
+/// one: `yield` is on the compiler's OWN import path (through
+/// `std/fs/watch`), and a seed compiler emits the async runtime it was built
+/// with — so pointing this at `__yo_async_yield_start` could not link until a
+/// published seed carried that symbol. v0.2.31 is the first that does.
+///
+/// Two earlier shapes are ruled out and neither should come back. A body of
+/// `return(())` completes the future SYNCHRONOUSLY, so `io.await(yield(io), io)`
+/// never reaches `__yo_async_poll_step` at all: a poll-until-finished loop
+/// built on it (`is_finished()` + `await yield()`) spins without ever polling
+/// I/O and the polled task never progresses (the build smoke hang's spin
+/// component, issues/build-smoke-hangs-registry-perturbation.md). An
+/// ALREADY-COMPLETE future is the same failure by a different route — the
+/// await point takes an inline fast path for one of those and the task never
+/// leaves the C stack.
 yield :: (fn(io : Io) -> Impl(Future(unit)))(
   io.async((io : Io) => {
-    io.await(IO_timer.sleep(u64(1)), io);
+    _r := io.await(unsafe(__yo_async_yield_start()), io);
+    ()
   })
 );
 /// Await every handle, in order, returning each task's result (`.None` for a

--- a/std/async/waker.yo
+++ b/std/async/waker.yo
@@ -140,13 +140,13 @@ park :: (fn(register : Impl(Fn(w : Waker) -> unit), io : Io) -> Impl(Future(unit
 /// Give the event loop ONE turn, including an I/O poll, and come back — a
 /// fairness yield with no timer under it.
 ///
-/// This is what `std/async`'s `yield` will become. It cannot be that today for
-/// a bootstrap reason, not a design one: `yield` is on the compiler's own
-/// import path (through `std/fs/watch`), and the SEED compiler that builds this
-/// tree emits an async runtime without `__yo_async_yield_start` in it — so
-/// pointing `yield` here fails to LINK the compiler. It moves in the release
-/// after the one that ships this runtime. Until then this is the fast form and
-/// `yield` is the 1 ms-timer form, and they are otherwise interchangeable.
+/// `std/async`'s `yield` is this, as of v0.2.32 — the two are the same
+/// mechanism and either name is fine. It could not be until then for a
+/// bootstrap reason, not a design one: `yield` is on the compiler's own import
+/// path (through `std/fs/watch`), and the SEED compiler that builds this tree
+/// emits the async runtime IT was built with — so pointing `yield` here failed
+/// to LINK the compiler until a published seed carried
+/// `__yo_async_yield_start`. v0.2.31 is the first that does.
 ///
 /// The mechanism: the future is created PENDING and completed at the top of
 /// the next ready-task drain, after that drain has measured its budget, so the

--- a/tests/async/waker.test.yo
+++ b/tests/async/waker.test.yo
@@ -51,6 +51,44 @@ test("Test yield_now runs every turn it is asked for", {
     `400 yield_now turns took ${elapsed_ms} ms — that is a blocked or deadlocked hand-off, not slowness`
   );
 });
+test("Test std/async yield is the timer-free mechanism", {
+  // `yield` and `yield_now` are the SAME mechanism as of v0.2.32 — `yield`
+  // stopped being a 1 ms timer once a published seed carried
+  // `__yo_async_yield_start` (v0.2.31 is the first).
+  //
+  // CORRECTNESS only, for the reason the test above spells out: inside this
+  // harness a timer-free turn still measures like a timed one
+  // (issues/yield-now-costs-a-millisecond-per-turn-inside-a-test-batch.md), so
+  // a time bound here would pin the harness rather than the feature.
+  //
+  // What this DOES pin is the regression that the doc on `yield` names: a body
+  // that completes its future synchronously — `return(())`, or any
+  // already-complete future — makes `io.await(yield(io), io)` take the await
+  // point's inline fast path, so the task never leaves the C stack and the
+  // event loop is never reached. The `while` below would then spin 400 times
+  // without a single `__yo_io_poll()`, which is exactly the build-smoke hang
+  // (issues/build-smoke-hangs-registry-perturbation.md). The spawned task's
+  // counter reaching 400 with the spawner making progress is the oracle.
+  n := Box(i32)(i32(400));
+  started := Instant.now();
+  h := io.spawn(
+    io.async((io : Io) => {
+      (i : i32) = i32(0);
+      while(i < n.*, i = (i + i32(1)), {
+        io.await(yield(io), io);
+      });
+      return(i);
+    }),
+    io
+  );
+  r := h.await(io);
+  elapsed_ms := started.elapsed().as_millis();
+  assert(match(r, .Some(v) => (v == i32(400)), .None => false), "all 400 yield turns ran");
+  assert(
+    elapsed_ms < i64(20000),
+    `400 yield turns took ${elapsed_ms} ms — that is a blocked or deadlocked hand-off, not slowness`
+  );
+});
 // ---------------------------------------------------------------------------
 // 1. A wake that arrives BEFORE the task suspends is not lost.
 //


### PR DESCRIPTION
`std/async`'s `yield` awaited a **1 ms timer**. `std/async/waker`'s `yield_now`
is the same fairness turn with no timer under it, and that module's doc has said
since it landed that `yield` "will become" this.

The blocker was a bootstrap one, and v0.2.31 removed it. `yield` is on the
compiler's **own** import path (through `std/fs/watch`), a seed compiler emits
the async runtime *it* was built with, and so pointing `yield` at
`__yo_async_yield_start` could not LINK until a **published** seed carried that
symbol. v0.2.31 is the first that does, and `SEED_VERSION` is now `v0.2.31`.

(Confirmed the hard way: the first build of this change, against my local
v0.2.30, died at `ld: symbol(s) not found — ___yo_async_yield_start`. Rebuilt
against the v0.2.31 seed it links and passes.)

## What it costs today

From `issues/yield-now-costs-a-millisecond-per-turn-inside-a-test-batch.md`,
400 turns in a standalone program:

| | 400 turns |
| --- | --- |
| the timer `yield` | **603 ms** |
| `yield_now` (this mechanism) | **0 ms** |

Every poll-until-finished loop in std pays that floor. `_fetch_deadline`
(`std/http/client.yo`) spends it on **every timed HTTP request** — its
`is_finished()` + `await yield()` race ticks at 1 ms until one side wins.

## Doc changes

Both doc comments now say the two are one mechanism. `yield`'s keeps the two
shapes that are ruled out and must not come back: a synchronous `return(())`
body, and an already-complete future — either makes `io.await(yield(io), io)`
take the await point's inline fast path, so the task never leaves the C stack
and the event loop is never reached. That is the build-smoke hang
(`issues/build-smoke-hangs-registry-perturbation.md`).

## Gates — all on a v0.2.31-seeded build of this tree

| | |
| --- | --- |
| bootstrap fixpoint | **FIXPOINT_HOLDS**, stage2 hollow=0 |
| `yo check ./std` | 175/175 |
| `tests/async` | 75/75 (incl. the new test) |
| `tests/http` + `tests/sync` | 208/208 |
| `tests/internal/build_runner` | 11/11 |
| CLI corpus | PASS 103, GOLDEN-DIFF 0 |

`build_runner` is in there deliberately: a `yield` that stops driving the loop
is exactly what hung the build smoke before.

## The test

It asserts CORRECTNESS, not time. Inside a test batch a timer-free turn still
measures like a timed one (the issue linked above — unrelated, still open), so a
time bound there would pin the harness rather than the feature. What it pins is
that 400 turns complete with the spawner making progress, which a synchronously
completing `yield` could not do.

Closes the `yield` half of `plans/STD_API_STABILIZATION.md`'s waker row; the
waker-based `async channel` / `async mutex` are still open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)