### PR TITLE
plans: the std campaign's terminal state, and the waker plan's real status

### DIFF
--- a/plans/STD_API_STABILIZATION.md
+++ b/plans/STD_API_STABILIZATION.md
@@ -19,6 +19,105 @@ every file:line, are in the per-group notes this plan was distilled from (see
 
 ---
 
+## 0. Where this stands — 2026-09-12
+
+Written after the v0.2.31 release, by walking every row of this document
+against the code rather than against the previous status note. **Every item
+below is either DONE, blocked on a named language feature with its own plan
+doc, or one of two remaining engineering items.** §5's three maintainer
+decisions are all made and implemented — nothing is waiting on anyone.
+
+### Done, and no longer to be re-read as open
+
+- **Phases 1 and 2** (§3's seventeen P0 rows) — every row carries a
+  FIXED/LANDED marker.
+- **The breaking window** (§2's D9–D18) — shipped in v0.2.28. The one
+  exception, **D18b** (`Thread(T).join() -> T`), is below.
+- **Phase 4** (§4's additive work), module group by module group:
+  collections, `imm`, encoding, I/O, net, the `## Stability` markers, and the
+  documentation sweep. `yo doc ./std --format json` went 1554 → 1161
+  undocumented of 3368.
+- **The waker campaign** (`plans/WAKER_BASED_SCHEDULING.md`) is complete
+  through step 4 except for the shape note there. Steps 1, 3a and 3b landed in
+  v0.2.31; **step 2 landed once v0.2.31 became the seed** — `yield` has no
+  timer under it any more, and a LIFO defect in the shared yield list fell out
+  of doing it. This document's concurrency row said "STILL OPEN: waker-based
+  async channel/async mutex" until 2026-09-12; that was stale — #576 and #586
+  had already rewritten both over `Waker`/`Park`.
+
+### §5's three maintainer decisions — ALL DECIDED AND IMPLEMENTED
+
+Nothing is waiting on anyone here. Re-checked against the code 2026-09-12:
+
+1. **`imm/Vec`: flat COW, documented as such — no RRB.** The header now carries
+   the complexity table and says why the trade was kept; `imm.List` is the
+   answer for cheap prepend on a shared value, `ArrayList` for mutation. An RRB
+   implementation would fit behind the same API if a workload ever needs shared
+   mutation to be sublinear.
+2. **`MemoryOrder.Consume`: REMOVED.** No production compiler implements it
+   (clang and gcc strengthen it to `acquire`; C++ discouraged it in P0371R1),
+   so a variant that costs `acquire` while promising dependency ordering is a
+   correctness trap. Zero uses in `std/` or `src/` before removal. Doing it
+   surfaced a real bug in the same file: `load` accepted a STORE-only order and
+   `store` a LOAD-only one, passed straight through to C11 — both forbidden by
+   §7.17.7.1–2, and invisible because the order arrives as a RUNTIME value.
+   All 33 sites panic now, as Rust does.
+3. **`HashMap.with_random_keys()`: NOT shipped; `with_keys` documents the
+   recipe.** Probed rather than assumed: importing `std/crypto/random` into
+   `std/collections/hash_map.yo` takes `yo check ./std` from 173/173 to 166/173,
+   because a core collection cannot carry that import closure. `new()` stays
+   deterministically keyed — the bootstrap fixpoint gate needs byte-identical
+   emitted C.
+
+### Blocked on a language feature, each with a plan doc
+
+| blocked row | doc |
+| --- | --- |
+| private `ctrl`/`data`/`size` fields; `_raw_lock`/`_raw_unlock`/`_raw_handle_ptr` off the public surface; `imm/*` internals | `plans/backlog/MEMBER_VISIBILITY.md` |
+| `rand.thread_rng` | `plans/backlog/THREAD_LOCAL_STORAGE.md` |
+| the ten byte conversions; `usize`/`isize` byte conversions; `Array(T,N)` `Default` | `plans/backlog/VALUE_SUBSTITUTION_IN_TYPE_POSITIONS.md` |
+| `ErrorChain`/`root_cause` | a compiler DEFECT, not a missing feature — #521, `issues/self-trait-in-a-return-type-loses-the-trait-on-an-erased-receiver.md` |
+| `JsonValue` integer arms | deliberately deferred to a breaking window (§4, encoding) |
+
+### The two engineering items that are genuinely open
+
+**1. D18b — `Thread(T).spawn` carrying its result, `join() -> T`.** Three
+walls, all now separately diagnosed, and **none of them is the spawn lowering**
+that `issues/thread-spawn-callback-returning-a-zst-emits-void-star-from-void.md`
+blamed:
+
+- *fixed* — a static-dispatch call read the CALL EXPRESSION's type instead of
+  the callee's prototype, so a `void`-returning closure call was bound to a
+  `void*` temp (#598).
+- *open* —
+  `issues/generic-channel-send-specialisation-is-called-but-never-emitted.md`.
+  One specialisation, two mangled names. Measured: the argument's type is the
+  enclosing generic's own binder, unresolved in the per-object cell, the global
+  registry AND the caller's env — so the resolution does not exist yet rather
+  than being looked up in the wrong place. Three candidate fixes were built and
+  are recorded there as dead ends.
+- *open* — `_capture_judgement_type` resolves a captured closure to its capture
+  STRUCT and then rejects it as not `Send`. A security-relevant checker; needs
+  an over-rejection canary per exempt shape before it is touched.
+
+**2. Waker step 5 — cross-thread wake and `spawn_blocking`.**
+`__yo_waker_wake` is already atomic on the future's own fields, but
+`__yo_async_enqueue_continuation` writes a THREAD-LOCAL ready queue, so a wake
+from a worker thread has nowhere safe to put the continuation and no way to
+rouse a loop parked in `__yo_io_wait`. That needs a cross-thread wake queue plus
+a loop wakeup channel (eventfd / pipe / kqueue `EVFILT_USER`), and
+`spawn_blocking` needs it before it is expressible at all
+(`std/net/dns.yo` names it as the reason `lookup_host` blocks).
+
+### One more, outside this document's scope but tracked with it
+
+`issues/a-bodyless-http-response-is-not-read-until-the-deadline.md` — a lost
+read wake-up that now reproduces identically on kqueue and io_uring, which is
+what makes it interesting: a defect in neither backend. Its checkpoints are on
+the `std-http-client-pool` branch (#556).
+
+---
+
 ## 1. Headline
 
 The library is broad — Option/Result are Rust-complete, hashing is real

--- a/plans/WAKER_BASED_SCHEDULING.md
+++ b/plans/WAKER_BASED_SCHEDULING.md
@@ -1,7 +1,7 @@
 # Waker-based scheduling
 
-**Status:** IN PROGRESS — steps 1, 3a and 3b landed 2026-09-11, step 2 is
-seed-gated, steps 4-5 are open. Written 2026-09-10. This is the largest
+**Status:** IN PROGRESS — steps 1, 2, 3a and 3b are LANDED, step 4 is landed
+except for a shape note, step 5 is the only one genuinely open. Written 2026-09-10. This is the largest
 remaining item in `plans/STD_API_STABILIZATION.md`'s concurrency group, and four
 std modules' `## Stability` markers name it as the thing that will change under
 them.
@@ -9,11 +9,11 @@ them.
 | step | state |
 | --- | --- |
 | 1. `Waker` + `park` in the runtime | **LANDED** (#561) — `std/async/waker.yo`, `__yo_async_park_start` / `__yo_waker_new` / `__yo_waker_wake` / `__yo_waker_release` in `codegen/async/runtime_core.yo`, plus the live-waker count the loop needs to know a parked task is still wakeable |
-| 2. `yield` over `park` | **SEED-GATED.** `yield_now` is the fast form and is landed; `yield` itself cannot point at it until the seed ships `__yo_async_yield_start`, because `yield` is on the compiler's own import path (through `std/fs/watch`) and the seed emits a runtime without that symbol, so the compiler fails to LINK. Moves in the release after the one that ships this runtime |
+| 2. `yield` over `park` | **LANDED 2026-09-12**, once v0.2.31 became the seed — that is the first published seed emitting `__yo_async_yield_start`, and `yield` could not point at it before, being on the compiler's own import path (through `std/fs/watch`). 400 turns: 603 ms before, 0 ms after. Doing it surfaced a defect in the shared yield list, fixed in the same PR: `__yo_async_drain_yields` walked a head-inserted list head-first, so the LAST task to yield woke FIRST. A fairness yield must be FIFO; the 1 ms timer had been supplying the ordering the list was not, which is why `yield_now` shipped LIFO unnoticed |
 | 3a. `Mutex` over a waiter queue | **LANDED** (#576) — `std/async/mutex.yo` holds an `ArrayList(Waker)`, `unlock` wakes the FRONT waiter, and `waiter_count()` is the oracle the FIFO test reads |
 | 3b. `Channel` over the same queue | **LANDED** (#586) — `send`/`recv` park on a waiter queue instead of re-checking on a 1 ms timer tick. It was blocked for a day by a compiler defect that the rewrite surfaced: the trace collector tried to monomorphize a GENERIC `ArrayList(T)` instance that only this shape put in the codegen type registry, and failed inside `array_list.yo`'s `Trace` body — a file the rewrite never touched (`issues/fixed/a-generic-instance-in-the-type-registry-breaks-trace-monomorphization.md`) |
 | 4. The combinators (`race`/`any`/`timeout`) | **PARTLY LANDED.** `timeout`'s retention is CLOSED: `abort()` now cancels the operation the task is suspended in, so the deadline timer is deregistered the moment the task wins instead of staying armed for the rest of the limit (`issues/fixed/timeout-deadline-timer-future-leak.md`). What remains is the polling SHAPE — `race`/`any` still re-check `is_finished()` around `__yo_async_poll_step()`; parking them on a wake needs a completion-notification list on `JoinHandle`, which is step 5's machinery |
-| 5. Cross-thread wake + `spawn_blocking` | open |
+| 5. Cross-thread wake + `spawn_blocking` | **OPEN — the only one.** `__yo_waker_wake` is already atomic on the future's own fields, but `__yo_async_enqueue_continuation` writes a THREAD-LOCAL ready queue, so a wake from a worker thread has nowhere safe to put the continuation and no way to rouse a loop parked in `__yo_io_wait`. Needs a cross-thread wake queue plus a loop wakeup channel (eventfd / pipe / kqueue `EVFILT_USER`) |
 
 **Two codegen bugs fell out of this campaign, both fixed.**
 
@@ -40,7 +40,7 @@ peer polls a clock:
 
 | site | what it does |
 | --- | --- |
-| `std/async/index.yo:62` (`yield`) | `io.await(IO_timer.sleep(u64(1)), io)` |
+| ~~`std/async/index.yo:62` (`yield`)~~ | ~~`io.await(IO_timer.sleep(u64(1)), io)`~~ — FIXED, step 2 |
 | `std/async/mutex.yo:62` (contended `lock`) | same 1 ms park, re-check |
 | `std/async/channel.yo` (blocked `send`/`recv`) | same |
 | `std/async/index.yo:97,129,192` (`race`, `any`, `timeout`) | `__yo_async_poll_step()` in a spin, re-checking each pass |


### PR DESCRIPTION
Docs only. Both plans had drifted from the code; I walked every row against the
tree rather than against the previous status note.

**`STD_API_STABILIZATION.md` gains a §0** that classifies everything left into
exactly three kinds, so the terminal state is readable without going through
2300 lines:

- **Done** — phases 1, 2 and 4, the breaking window, the docs sweep, and the
  waker campaign through step 4.
- **Maintainer decisions** (§5's three) — `imm/Vec` RRB-vs-COW,
  `MemoryOrder.Consume`, `HashMap.with_random_keys()`.
- **Blocked on a named language feature**, each with its plan doc — member
  visibility, thread-local storage, value substitution in type positions, plus
  `ErrorChain` (a compiler defect, #521) and `JsonValue`'s integer arms
  (deliberately deferred to a breaking window).
- **Genuinely open engineering: two.** D18b's second and third walls, and
  waker step 5.

**One row was actively stale**: the concurrency group still read "STILL OPEN:
waker-based async channel/async mutex" when #576 and #586 had already rewritten
both over `Waker`/`Park`.

**`WAKER_BASED_SCHEDULING.md`**: the header said steps 4–5 were open and step 2
was seed-gated. Step 2 landed the moment v0.2.31 became the seed (#608), so
step 5 is the only open one — and its row now says precisely what is missing:
`__yo_waker_wake` is already atomic on the future's own fields, but
`__yo_async_enqueue_continuation` writes a THREAD-LOCAL ready queue, so a
cross-thread wake has nowhere safe to put the continuation and no way to rouse
a loop parked in `__yo_io_wait`. It needs a cross-thread wake queue plus a loop
wakeup channel (eventfd / pipe / kqueue `EVFILT_USER`), and `spawn_blocking` is
not expressible until it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)