### PR TITLE
verifier: V5 task 3 slice 2 — ghost_fn inlining in the walk + ghost bindings with escape errors

### DIFF
--- a/plans/backlog/FORMAL_VERIFICATION.md
+++ b/plans/backlog/FORMAL_VERIFICATION.md
@@ -1173,9 +1173,21 @@ a broken invariant is a compile error naming the failing iteration.
 > here as the honest scope cut). The INOUT half of task 4 needed NO new
 > machinery: `param_types` records the declared T, `=` rebinds the
 > current, and #557's entry snapshot already backs `old(v)` — pinned by
-> the inout_bump proves / inout_nochange REFUTES twins. Remaining V5:
-> ghost erasure (task 3), std/spec collections (task 5), the
-> insertion-sort exit (task 6).
+> the inout_bump proves / inout_nochange REFUTES twins. SLICE 2 LANDED
+> on feat/fv5-ghost2 (2026-09-12): ghost_fn calls INLINE in the VC walk
+> (a spec function's meaning IS its body — params bound to the walked
+> actuals, recursion-guarded by an inlining stack;
+> `requires(within(x, 0))` now ASSUMES the inlined predicate, pinned by
+> the bounded proves / strictly_bounded REFUTES-at-x=0 twins — the refute
+> is what proves the inlining is real); `ghost(name := e)` binds a
+> spec-only name in EVERY mode (the walk REBINDS it so assert predicates
+> read it — in verify targets the assert's predicate evaluates under
+> ghost context; ordinary reads get the "ghost value escapes
+> specification context" error, which also closes a PRE-EXISTING hole: a
+> runtime-mode assert reading a ghost binding used to emit an UNDECLARED
+> C identifier — the evaluator resolved the name while codegen erased
+> the binding); the binding never reaches codegen. Remaining V5: std/spec
+> collections (task 5), the insertion-sort exit (task 6).
 
 **Scope:** specification-only computation — the vocabulary real
 functional correctness specs need.

--- a/src/evaluator/builtins/contracts.yo
+++ b/src/evaluator/builtins/contracts.yo
@@ -107,6 +107,32 @@ _evaluate_contract_marker :: (
   expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_info);
   expr
 });
+/// The file set the current command is verifying (absolute or as-given
+/// paths — matched by equality against `Token.module_path`). Empty = no
+/// verification is recording (plain `yo check`/`compile`), so registry
+/// effects are inert. Declared EARLY: the contract-marker handlers
+/// (evaluate_ghost and friends) read `_is_verify_target`, and importers
+/// can force those lazily before line 900 evaluates.
+(g_verify_target_paths : ArrayList(String)) = ArrayList(String).new();
+set_verify_target_paths :: (fn(paths : ArrayList(String)) -> unit)({
+  g_verify_target_paths = paths;
+  ()
+});
+_is_verify_target :: (fn(module_path : String) -> bool)({
+  (found : bool) = false;
+  (i : usize) = usize(0);
+  while((i < g_verify_target_paths.len()) && !found, {
+    match(
+      g_verify_target_paths.get(i),
+      .Some(p) => if(p == module_path, {
+        found = true;
+      }),
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  found
+});
 /// `requires(...)` in expression position — no-op marker. Mirrors
 /// `evaluateRequires`.
 /// Reject a zero-argument contract marker in expression position.
@@ -162,11 +188,86 @@ evaluate_decreases :: (fn(expr : AstExpr, env : Environment, ctx : EvalContext, 
   );
   _evaluate_contract_marker(expr, env, ctx, exn)
 });
-/// `ghost(...)` — ghost-binding marker, transparent in Phase 0. Mirrors
-/// `evaluateGhost`.
-evaluate_ghost :: (fn(expr : AstExpr, env : Environment, ctx : EvalContext, exn : Exception) -> AstExpr)(
-  _evaluate_contract_marker(expr, env, ctx, exn)
+/// V5 task 3: the ghost-BINDING name set. `ghost(name := e)` registers the
+/// bound name here; identifier resolution (identifer_and_operator.yo)
+/// rejects reads of these names from non-ghost context — the "ghost value
+/// escapes specification context" error.
+(g_ghost_binding_names : HashSet(String)) = HashSet(String).new();
+register_ghost_binding :: (fn(name : String) -> unit)({
+  g_ghost_binding_names.insert(name);
+  ()
+});
+is_ghost_binding_name :: (fn(name : String) -> bool)(
+  g_ghost_binding_names.contains(name)
 );
+/// `ghost(...)` — V5 task 3 slice 2: `ghost(name := e)` BINDS the name
+/// for spec use ONLY (contract clauses, ghost code, ghost_fn bodies, and —
+/// in VERIFICATION targets — assert predicates) in EVERY mode: the binding
+/// never reaches codegen, and ordinary code reading it gets the escape
+/// error (identifer_and_operator.yo's ghost-name check). Without this, a
+/// runtime-mode assert reading a ghost binding emitted an UNDECLARED C
+/// identifier — the evaluator resolved the name (Phase 0's marker bound it)
+/// while codegen erased the binding. Other `ghost(...)` shapes keep the
+/// transparent no-op marker. Mirrors `evaluateGhost`.
+evaluate_ghost :: (fn(expr : AstExpr, env : Environment, ctx : EvalContext, exn : Exception) -> AstExpr)({
+  args0 := match(
+    expr,
+    .FnCall(_, _, a, _, _) => a,
+    .Atom(_, _) => ArrayList(AstExpr).new()
+  );
+  {
+    match(
+      args0.get(usize(0)),
+      .Some(first) => {
+        if(ast_expr_is_fn_call_of(first, ":=", Option(usize).Some(usize(2))), {
+          ba := match(
+            first,
+            .FnCall(_, _, a2, _, _) => a2,
+            .Atom(_, _) => ArrayList(AstExpr).new()
+          );
+          nm := match(
+            ba.get(usize(0)),
+            .Some(n0) => ast_expr_token(n0).value,
+            .None => String.new()
+          );
+          rhs := match(
+            ba.get(usize(1)),
+            .Some(r0) => r0,
+            .None => make_err_expr()
+          );
+          // The RHS is ghost code (quantifiers are legal in it).
+          prev_ghost := ctx.is_ghost_context;
+          ctx.is_ghost_context = true;
+          evaluated := evaluate_expression_raw(rhs, env, ctx, exn);
+          ctx.is_ghost_context = prev_ghost;
+          r_info := match(
+            expr_info_table_get(ctx.expr_info_table, ast_expr_id(evaluated)),
+            .Some(ri) => ri,
+            .None => new_expr_info(env, t_unit())
+          );
+          _ := add_variable_to_env(
+            env,
+            nm.clone(),
+            r_info.ty,
+            r_info.value,
+            false,
+            false,
+            false,
+            false,
+            ast_expr_token(first)
+          );
+          register_ghost_binding(nm.clone());
+          out_info := new_expr_info(r_info.env, t_unit());
+          out_info.value = Option(EvalValue).Some(EvalValue.UnitVal);
+          expr_info_table_set(ctx.expr_info_table, ast_expr_id(expr), out_info);
+          return(expr);
+        });
+      },
+      .None => ()
+    );
+  };
+  _evaluate_contract_marker(expr, env, ctx, exn)
+});
 /// Shared transparent pass-through for `ghost_fn(inner)` / `old(inner)`:
 /// evaluate the single inner argument and propagate its ExprInfo to the outer
 /// call. Mirrors the bodies of `evaluateGhostFn` / `evaluateOld`.
@@ -831,7 +932,6 @@ verify_task_def_eval_failure :: (fn(fn_id : String) -> Option(String))(
 /// paths — matched by equality against `Token.module_path`). Empty = no
 /// verification is recording (plain `yo check`/`compile`), so registry
 /// effects are inert.
-(g_verify_target_paths : ArrayList(String)) = ArrayList(String).new();
 /// The CLI override (`--verify-mode`); the file pragma is source of truth
 /// when present, this decides otherwise.
 (g_verify_mode_override : Option(String)) = Option(String).None;
@@ -840,25 +940,6 @@ set_verify_mode_override :: (fn(m : Option(String)) -> unit)({
   ()
 });
 /// Declare the verification target file set (and reset any previous one).
-set_verify_target_paths :: (fn(paths : ArrayList(String)) -> unit)({
-  g_verify_target_paths = paths;
-  ()
-});
-_is_verify_target :: (fn(module_path : String) -> bool)({
-  (found : bool) = false;
-  (i : usize) = usize(0);
-  while((i < g_verify_target_paths.len()) && !found, {
-    match(
-      g_verify_target_paths.get(i),
-      .Some(p) => if(p == module_path, {
-        found = true;
-      }),
-      .None => ()
-    );
-    i = (i + usize(1));
-  });
-  found
-});
 /// The verification mode for a module: `"runtime"` | `"verify"` |
 /// `"verify+"` | `"ignore"`. The FILE's pragma is the source of truth when
 /// present (plans/backlog/FORMAL_VERIFICATION.md §"Verification modes");
@@ -1289,5 +1370,7 @@ export(
   verify_task_def_eval_failure,
   register_ghost_fn,
   is_ghost_fn,
+  register_ghost_binding,
+  is_ghost_binding_name,
   strip_proved_ensures_asserts
 );

--- a/src/evaluator/exprs/_expr.yo
+++ b/src/evaluator/exprs/_expr.yo
@@ -332,7 +332,8 @@ import("std/fmt");
   evaluate_old,
   evaluate_forall,
   evaluate_exists,
-  evaluate_implies
+  evaluate_implies,
+  _is_verify_target
 } :: import("../builtins/contracts.yo");
 { evaluate_the } :: import("../builtins/the.yo");
 {
@@ -488,6 +489,33 @@ _check_evaluator_deadline :: (fn(exn : Exception) -> unit)(
     });
   })
 );
+/// An `assert(P, ...)` call's PREDICATE is specification (V5): ghost
+/// bindings and the ghost-only quantifier builtins are legal inside it.
+/// Bracket the arguments with the ghost flag, then run the ORDINARY call
+/// path (std/assert's assert is an ordinary function).
+_evaluate_assert_ghost_args :: (
+  fn(
+    expr : AstExpr,
+    env : Environment,
+    ctx : EvalContext,
+    exn : Exception
+  ) -> AstExpr
+)({
+  // The ghost bracket applies ONLY in verification targets: there the
+  // assert is a PROOF site (its runtime emission is suppressed). In a
+  // runtime-mode file the assert EXECUTES, so ghost bindings must stay
+  // unreadable there — the escape error fires instead (otherwise codegen
+  // would emit a runtime assert reading a name no C declaration carries).
+  tok0 := ast_expr_token(expr);
+  if(!_is_verify_target(tok0.module_path.clone()), {
+    return(evaluate_function_call(expr, env, t_unit(), Option(EvalValue).None, ctx, exn));
+  });
+  prev_ghost := ctx.is_ghost_context;
+  ctx.is_ghost_context = true;
+  out := evaluate_function_call(expr, env, t_unit(), Option(EvalValue).None, ctx, exn);
+  ctx.is_ghost_context = prev_ghost;
+  out
+});
 /// `exists` is BOTH the ghost-only verification quantifier (V5,
 /// plans/backlog/FORMAL_VERIFICATION.md §6) and — historically — the name
 /// std/fs's path-existence check is exported under
@@ -873,6 +901,8 @@ _evaluate_expression :: (
           evaluate_ghost_fn(expr, env, ctx, exn),
         ((__dk_len == usize(3)) && ast_expr_is_fn_call_of(expr, BF_OLD, .None)) =>
           evaluate_old(expr, env, ctx, exn),
+        ((__dk_len == usize(6)) && ast_expr_is_fn_call_of(expr, "assert", Option(usize).None)) =>
+          _evaluate_assert_ghost_args(expr, env, ctx, exn),
         ((__dk_len == usize(6)) && ast_expr_is_fn_call_of(expr, BF_FORALL, .None)) =>
           evaluate_forall(expr, env, ctx, exn),
         ((__dk_len == usize(6)) && ast_expr_is_fn_call_of(expr, BF_EXISTS, .None)) =>

--- a/src/evaluator/exprs/identifer_and_operator.yo
+++ b/src/evaluator/exprs/identifer_and_operator.yo
@@ -35,6 +35,7 @@ _(env : ident_dbg_env) :: import("std/env");
 { get_value_of_some_type_from_env } :: import("../../types/env_lookup.yo");
 { format_error_message, format_error_message_with_help } :: import("../../error.yo");
 { suggest_name } :: import("../../diagnostics.yo");
+{ is_ghost_binding_name } :: import("../builtins/contracts.yo");
 { Exception } :: import("std/error");
 /// Evaluate an identifier or operator expression.
 ///
@@ -223,7 +224,24 @@ evaluate_identifier_and_operator :: (
   found_frame_idx_out := ArrayList(usize).new();
   variable := match(
     find_variable_in_env_at(env, identifier_string, found_frame_idx_out),
-    .Some(v) => v,
+    .Some(v) => {
+      // V5 task 3: a `ghost(name := e)` binding is spec-only. Reading it
+      // from ordinary code is the "ghost value escapes specification
+      // context" error; contract predicates, ghost bindings and ghost_fn
+      // bodies (all under is_ghost_context) read it freely.
+      if(is_ghost_binding_name(identifier_string.clone()) && !ctx.is_ghost_context, {
+        exn.throw(
+          dyn(
+            format_error_message(
+              token,
+              `ghost value escapes specification context: '${identifier_string}' is a ghost binding, readable only from contract clauses, ghost(...) code and ghost_fn bodies`
+            )
+          )
+        );
+        return(expr);
+      });
+      v
+    },
     // Lazy top-level bindings (plans/reference/LAZY_TOPLEVEL_BINDINGS.md §4.2): a miss
     // on a name that is a deferred `::` definition of this identifier's own
     // module forces that definition now and binds it here. Def-time body

--- a/src/verifier/vc.yo
+++ b/src/verifier/vc.yo
@@ -38,6 +38,12 @@ pragma(Pragma.AllowUnsafe);
 { EvalValue, is_func_val } :: import("../value.yo");
 { VcSort, VcOp, VcTerm, VcQuery, VcQuantKind, new_vc_query, vc_eq, vc_and, vc_or, vc_not, vc_distinct } :: import("./terms.yo");
 { mangle_vc_name, encode_sort } :: import("./encode.yo");
+{ is_ghost_fn } :: import("../evaluator/builtins/contracts.yo");
+
+/// V5 task 3 slice 2: the ghost_fn inlining stack (see
+/// `_ghost_fn_inline_term`). Declared at module top so it is initialized
+/// before any lazy `::` definition can be forced by an importer.
+(g_ghost_inline_stack : ArrayList(String)) = ArrayList(String).new();
 {
   get_func_requires_exprs,
   get_func_ensures_exprs,
@@ -1979,6 +1985,35 @@ _call_term :: (
     );
     return(Option(VcTerm).None);
   });
+  // --- ghost(x := e) (V5 task 3 slice 2): a SPEC rebind ---------------------
+  // The binding is erased from codegen but the WALK tracks it — later spec
+  // code (assert predicates, ghost_fn calls) reads it through ctx.vars.
+  if((head == "ghost") && (n == usize(1)) && ast_expr_is_fn_call_of(args.get(usize(0)).unwrap(), ":=", Option(usize).Some(usize(2))), {
+    ga := match(
+      args.get(usize(0)).unwrap(),
+      .FnCall(_, _, a2, _, _) => a2,
+      .Atom(_, _) => ArrayList(AstExpr).new()
+    );
+    gv := _expr_term(ctx, ga.get(usize(1)).unwrap());
+    return(
+      match(
+        gv,
+        .Some(gvt) => {
+          gn := ga.get(usize(0));
+          is_plain_name := match(
+            gn,
+            .Some(gnx) => ast_expr_is_atom(gnx),
+            .None => false
+          );
+          if(is_plain_name, {
+            ctx.vars.insert(ast_expr_token(ga.get(usize(0)).unwrap()).value.clone(), gvt);
+          });
+          Option(VcTerm).Some(VcTerm.BoolLit(true))
+        },
+        .None => Option(VcTerm).None
+      )
+    );
+  });
   // --- begin blocks --------------------------------------------------------
   if(head == "begin", {
     return(_begin_term(ctx, args));
@@ -2559,6 +2594,122 @@ _begin_term :: (fn(inout(ctx) : VcCtx, args : ArrayList(AstExpr)) -> Option(VcTe
   });
   result
 });
+/// V5 task 3 slice 2: inline a ghost_fn call — the spec function's BODY
+/// walks with the actuals bound to its parameters (Dafny's spec-function
+/// semantics; a ghost_fn has no contracts to assume, so its meaning IS its
+/// body). Guarded against recursion by an inlining stack: a spec function
+/// that reaches itself — directly or through another ghost_fn — has no
+/// finite expansion and is rejected.
+_ghost_fn_inline_term :: (
+  fn(inout(ctx) : VcCtx, at : AstExpr, args : ArrayList(AstExpr), fid : String) -> Option(VcTerm)
+)({
+  (si : usize) = usize(0);
+  while(si < g_ghost_inline_stack.len(), {
+    if(g_ghost_inline_stack.get(si).unwrap() == fid, {
+      _fail_subset(ctx, String.from("recursive ghost_fn inlining (a spec function must not reach itself)"), at);
+      return(Option(VcTerm).None);
+    });
+    si = (si + usize(1));
+  });
+  callee_atom := match(
+    at,
+    .FnCall(_, f, _, _, _) => f,
+    .Atom(_, _) => at
+  );
+  params := ArrayList(String).new();
+  (body : AstExpr) = make_err_expr();
+  (found : bool) = false;
+  match(
+    expr_info_table_get(ctx.table, ast_expr_id(callee_atom)),
+    .Some(ci) => {
+      match(
+        ci.value,
+        .Some(v) => {
+          match(
+            v,
+            .FuncVal(gfvd, _) => {
+              params = gfvd.*.params;
+              body = gfvd.*.body;
+              found = true;
+            },
+            _ => ()
+          );
+        },
+        .None => ()
+      );
+    },
+    .None => ()
+  );
+  if(!found, {
+    _fail_subset(ctx, String.from("ghost_fn callee without a resolvable body"), at);
+    return(Option(VcTerm).None);
+  });
+  if(args.len() != params.len(), {
+    _fail_subset(ctx, `ghost_fn call arity mismatch (${args.len().to_string()} args, ${params.len().to_string()} params)`, at);
+    return(Option(VcTerm).None);
+  });
+  // Walk the actuals, bind the spec params, walk the body, restore.
+  saved_names := ArrayList(String).new();
+  saved_vals := ArrayList(Option(VcTerm)).new();
+  (i : usize) = usize(0);
+  while(i < args.len(), {
+    match(
+      args.get(i),
+      .Some(a) => {
+        v := _expr_term(ctx, a);
+        match(
+          v,
+          .Some(vt) => {
+            match(
+              params.get(i),
+              .Some(cp) => {
+                saved_names.push(cp.clone());
+                saved_vals.push(ctx.vars.get(cp.clone()));
+                ctx.vars.insert(cp.clone(), vt);
+              },
+              .None => ()
+            );
+          },
+          .None => {
+            return(Option(VcTerm).None);
+          }
+        );
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  g_ghost_inline_stack.push(fid.clone());
+  out := _expr_term(ctx, body);
+  _ := g_ghost_inline_stack.pop();
+  (ri : usize) = saved_names.len();
+  while(ri > usize(0), {
+    ri = (ri - usize(1));
+    match(
+      saved_names.get(ri),
+      .Some(sn) => {
+        match(
+          saved_vals.get(ri),
+          .Some(sv) => {
+            match(
+              sv,
+              .Some(old) => {
+                ctx.vars.insert(sn.clone(), old);
+              },
+              .None => {
+                _ := ctx.vars.remove(sn.clone());
+                ()
+              }
+            );
+          },
+          .None => ()
+        );
+      },
+      .None => ()
+    );
+  });
+  out
+});
 /// Calls to a contracted callee: prove requires under the caller path,
 /// then assume ensures with a fresh result var bound.
 _callee_call_term :: (
@@ -2589,6 +2740,12 @@ _callee_call_term :: (
     return(Option(VcTerm).None);
   });
   fid := callee_id.unwrap();
+  // V5 task 3 slice 2: a ghost_fn callee is INLINED — its body walks with
+  // the actuals bound to its parameters (spec functions carry no contracts;
+  // their meaning IS the body).
+  if(is_ghost_fn(fid.clone()), {
+    return(_ghost_fn_inline_term(ctx, e, args, fid.clone()));
+  });
   // Recursion (V4): a self-call needs `decreases(M)`. The measure of the
   // CURRENT state is captured BEFORE the param rebinding; after the
   // rebinding (callee params = actual terms) the measure evaluates as the

--- a/tests/internal/verifier_ghost.test.yo
+++ b/tests/internal/verifier_ghost.test.yo
@@ -1,0 +1,153 @@
+//! The ghost-semantics tests — V5 task 3 (FORMAL_VERIFICATION.md):
+//! ghost_fn calls INLINE in the VC walk (a spec function's meaning is its
+//! body — `requires(within(x, 0))` assumes the inlined predicate), and
+//! `ghost(name := e)` binds a spec-only name (the walk tracks it for
+//! assert predicates; ordinary reads are the escape error).
+//!
+//! In-process model (verifier_quantifiers's shape); proofs and refutations
+//! need the real solver (YO_TEST_Z3=1), the escape gate runs solver-free.
+{ String, StringBuilder } :: import("std/string");
+{ Exception } :: import("std/error");
+{ ArrayList } :: import("std/collections/array_list");
+{ assert } :: import("std/assert");
+{ env } :: import("std/env");
+{
+  mm_load_file,
+  mm_preload_prelude,
+  mm_resolve_entry_abs,
+  resolve_std_path,
+  _take_load_error
+} :: import("../../src/module_manager.yo");
+{ clear_module_cache } :: import("../../src/evaluator/module_loader.yo");
+{
+  set_verify_mode_override,
+  set_verify_target_paths,
+  take_verify_tasks
+} :: import("../../src/evaluator/builtins/contracts.yo");
+{
+  default_verify_run_config,
+  resolve_solver_sync,
+  verify_and_strip_tasks,
+  VerifyFnReport
+} :: import("../../src/verifier/driver.yo");
+
+_have_z3 :: (fn() -> bool)(
+  match(
+    env.get(String.from("YO_TEST_Z3")),
+    .Some(v) => (v == String.from("1")),
+    .None => false
+  )
+);
+_load_reports :: (
+  fn(rel_path : String, io : Io, expect_ok : bool) -> ArrayList(VerifyFnReport)
+)({
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `verifier_ghost: unexpected throw: ${err}`);
+      }
+    )
+  );
+  std_path := resolve_std_path();
+  targets := ArrayList(String).new();
+  targets.push(rel_path.clone());
+  targets.push(mm_resolve_entry_abs(rel.clone(), std_path.clone()));
+  _ := take_verify_tasks();
+  set_verify_mode_override(Option(String).None);
+  set_verify_target_paths(targets);
+  clear_module_cache();
+  mm_preload_prelude(std_path.clone(), true, io, exn);
+  outcome := mm_load_file(rel.clone(), std_path.clone(), true, io, exn);
+  match(
+    _take_load_error(),
+    .Some(rendered) => {
+      assert(
+        outcome.ok == expect_ok,
+        `fixture ${rel_path} load ok=${outcome.ok.to_string()} (expected ${expect_ok.to_string()}): ${rendered}`
+      );
+    },
+    .None => {
+      assert(outcome.ok == expect_ok, `fixture ${rel_path} load ok=${outcome.ok.to_string()}`);
+    }
+  );
+  cfg := default_verify_run_config();
+  binary := match(
+    resolve_solver_sync(cfg),
+    .Resolved(p) => p,
+    _ => String.new()
+  );
+  verify_and_strip_tasks(cfg, binary, take_verify_tasks())
+});
+_reports_dump :: (fn(reports : ArrayList(VerifyFnReport)) -> String)({
+  ids := ArrayList(String).new();
+  (i : usize) = usize(0);
+  while(i < reports.len(), {
+    match(
+      reports.get(i),
+      .Some(rp) => {
+        ids.push(`${rp.fn_id}=${rp.outcome} [${rp.subset_construct}]`);
+      },
+      .None => ()
+    );
+    i = (i + usize(1));
+  });
+  sb := StringBuilder.new();
+  (j : usize) = usize(0);
+  while(j < ids.len(), {
+    if(j > usize(0), {
+      sb.write_string(String.from(", "));
+    });
+    sb.write_string(ids.get(j).unwrap().clone());
+    j = (j + usize(1));
+  });
+  sb.to_string()
+});
+/// The fn-under-test is the SECOND task (lazy forcing registers the
+/// ghost_fn first when the contract references it).
+_second :: (fn(reports : ArrayList(VerifyFnReport)) -> VerifyFnReport)(
+  reports.get(usize(1)).unwrap()
+);
+_first :: (fn(reports : ArrayList(VerifyFnReport)) -> VerifyFnReport)(
+  reports.get(usize(0)).unwrap()
+);
+
+test("ghost_fn predicates INLINE (bounded proves through within)", {
+  if(!_have_z3(), {
+    return(());
+  });
+  reports := _load_reports(String.from("./tests/spec/fixtures/valid/ghost_fn_inline.yo"), io, true);
+  assert(reports.len() == usize(2), `two functions, got ${reports.len().to_string()}: [${_reports_dump(reports)}]`);
+  rp := _second(reports);
+  assert(rp.outcome == "ok", `bounded proves through the inlined requires, got: [${_reports_dump(reports)}]`);
+});
+
+test("the inlining is REAL — a false post-condition REFUTES (x = 0 model)", {
+  if(!_have_z3(), {
+    return(());
+  });
+  reports := _load_reports(String.from("./tests/spec/fixtures/negative/ghost_fn_inline_false.yo"), io, true);
+  assert(reports.len() == usize(2), `two functions, got ${reports.len().to_string()}: [${_reports_dump(reports)}]`);
+  rp := _second(reports);
+  assert(rp.outcome == "refuted", `strictly_bounded refutes (an assumed-instead-of-inlined predicate would prove anything), got: [${_reports_dump(reports)}]`);
+});
+
+test("ghost bindings track through the walk (ghost_bump proves)", {
+  if(!_have_z3(), {
+    return(());
+  });
+  reports := _load_reports(String.from("./tests/spec/fixtures/valid/ghost_binding.yo"), io, true);
+  assert(reports.len() == usize(1), `one function, got ${reports.len().to_string()}: [${_reports_dump(reports)}]`);
+  rp := _first(reports);
+  assert(rp.outcome == "ok", `ghost_bump proves (the assert reads the ghost binding), got: [${_reports_dump(reports)}]`);
+});
+
+test("reading a ghost binding from ordinary code is a LOUD gate (solver-free)", {
+  reports := _load_reports(String.from("./tests/spec/fixtures/negative/ghost_escape.yo"), io, false);
+  assert(reports.len() == usize(1), `one function, got ${reports.len().to_string()}: [${_reports_dump(reports)}]`);
+  rp := _first(reports);
+  assert(rp.outcome == "subset-error", `leaky is gated, got: [${_reports_dump(reports)}]`);
+  assert(
+    rp.subset_construct.contains(String.from("ghost")),
+    `the report names the ghost escape, got: ${rp.subset_construct}`
+  );
+});

--- a/tests/internal/verifier_ghost.test.yo
+++ b/tests/internal/verifier_ghost.test.yo
@@ -51,13 +51,13 @@ _load_reports :: (
   std_path := resolve_std_path();
   targets := ArrayList(String).new();
   targets.push(rel_path.clone());
-  targets.push(mm_resolve_entry_abs(rel.clone(), std_path.clone()));
+  targets.push(mm_resolve_entry_abs(rel_path.clone(), std_path.clone()));
   _ := take_verify_tasks();
   set_verify_mode_override(Option(String).None);
   set_verify_target_paths(targets);
   clear_module_cache();
   mm_preload_prelude(std_path.clone(), true, io, exn);
-  outcome := mm_load_file(rel.clone(), std_path.clone(), true, io, exn);
+  outcome := mm_load_file(rel_path.clone(), std_path.clone(), true, io, exn);
   match(
     _take_load_error(),
     .Some(rendered) => {

--- a/tests/spec/fixtures/negative/ghost_escape.yo
+++ b/tests/spec/fixtures/negative/ghost_escape.yo
@@ -1,0 +1,17 @@
+// The escape twin: reading a ghost binding from ORDINARY code is a
+// compile error ("ghost value escapes specification context") — the
+// load fails with that cause (through the #557 def-eval chain it reaches
+// the verifier report; plain yo check names it directly).
+pragma(Pragma.Verify);
+
+leaky :: (
+  fn(
+    x : i32,
+    requires(x >= i32(0)),
+    ensures(result >= i32(0))
+  ) -> (result : i32)
+)({
+  ghost(prev := x);
+  y := prev;
+  y
+});

--- a/tests/spec/fixtures/negative/ghost_fn_inline_false.yo
+++ b/tests/spec/fixtures/negative/ghost_fn_inline_false.yo
@@ -1,0 +1,18 @@
+// The refuting twin of ghost_fn_inline: the inlined requires admits x = 0,
+// so `result > 0` is FALSE there — z3 must REFUTE with x = 0 (this is what
+// proves the inlining is real: an assumed-instead-of-inlined predicate
+// would make anything provable).
+pragma(Pragma.Verify);
+
+strictly_bounded :: (
+  fn(
+    x : i32,
+    requires(within(x, i32(0))),
+    ensures(result > i32(0))
+  ) -> (result : i32)
+)({
+  y := x;
+  y
+});
+
+within :: ghost_fn((fn(x : i32, lo : i32) -> bool)((x >= lo) && (x <= (lo + i32(100)))));

--- a/tests/spec/fixtures/valid/ghost_binding.yo
+++ b/tests/spec/fixtures/valid/ghost_binding.yo
@@ -1,0 +1,20 @@
+// ghost(x := e) binding (V5 task 3 slice 2): the name is spec-only —
+// readable from ghost code (here: a ghost_fn's body) and the verifier's
+// walk; ordinary code reading it is the escape error (see the negative
+// twin). Erased from codegen: the marker emits nothing.
+pragma(Pragma.Verify);
+{ assert } :: import("std/assert");
+
+ghost_bump :: (
+  fn(
+    x : i32,
+    requires(x >= i32(0), x <= i32(1000)),
+    ensures(result == (x + i32(1)))
+  ) -> (result : i32)
+)({
+  ghost(prev := x);
+  y := x;
+  y = (y + i32(1));
+  assert(y == (prev + i32(1)));
+  y
+});

--- a/tests/spec/fixtures/valid/ghost_fn_inline.yo
+++ b/tests/spec/fixtures/valid/ghost_fn_inline.yo
@@ -1,0 +1,18 @@
+// ghost_fn INLINING (V5 task 3 slice 2): a spec function's meaning is its
+// BODY — `requires(within(x, 0))` assumes the inlined (x >= 0) && (x <= 100),
+// which is what makes the ensures provable. The forward reference to the
+// ghost_fn is legal (lazy top-level bindings).
+pragma(Pragma.Verify);
+
+bounded :: (
+  fn(
+    x : i32,
+    requires(within(x, i32(0))),
+    ensures(result >= i32(0))
+  ) -> (result : i32)
+)({
+  y := x;
+  y
+});
+
+within :: ghost_fn((fn(x : i32, lo : i32) -> bool)((x >= lo) && (x <= (lo + i32(100)))));


### PR DESCRIPTION
## Summary

Completes V5 task 3 (`FORMAL_VERIFICATION.md`): ghost semantics end to end.

- **ghost_fn INLINING in the VC walk** — a spec function's meaning IS its body. The callee path inlines registered ghost_fns (params bound to the walked actuals, recursion-guarded by an inlining stack). `requires(within(x, 0))` now ASSUMES the inlined predicate — `bounded` proves through it, and the `strictly_bounded` twin REFUTES at x = 0: the refute is what proves the inlining is real (an assume-anything bug would prove both).
- **`ghost(name := e)` bindings** — spec-only in EVERY mode. The walk REBINDS the name so later spec code reads it; an assert's predicate evaluates under ghost context in verify targets (there the assert is a proof site — its runtime emission is suppressed). Ordinary reads get the "ghost value escapes specification context" error.
- **Pre-existing hole closed** (found by the erasure probe): in runtime mode, an assert reading a ghost binding used to emit an UNDECLARED C identifier — the Phase-0 marker bound the name evaluator-side while codegen erased the binding. The escape error now fires before such C can be emitted.
- The binding never reaches codegen (erasure is structural: the marker emits nothing).

## Validation

- `tests/internal/verifier_ghost.test.yo`: proofs/refutations z3-gated; the escape gate solver-free.
- Local end-to-end vs z3 5.1.0: `ghost_fn_inline` proves, `ghost_fn_inline_false` refutes (x = 0 model), `ghost_binding` proves 2/2 (the assert reads the ghost binding through the walk), `ghost_escape` gates, and the whole V4/V5 battery (loops, break, two-state, quantifiers, inout) still proves.