### PR TITLE
tests/async: a 4 ms timer margin is not an ordering on Windows

### DIFF
--- a/issues/fixed/a-4ms-timer-margin-is-not-an-ordering-on-windows.md
+++ b/issues/fixed/a-4ms-timer-margin-is-not-an-ordering-on-windows.md
@@ -1,0 +1,58 @@
+# A 4 ms timer margin is not an ordering on Windows
+
+**Status:** FIXED 2026-09-12.
+**Found:** 2026-09-12 by yo-d1, on `p1/yo-toml-manifest` — both Windows legs of
+one run failing identically, which is what ruled out timing noise.
+
+## Symptom
+
+```
+✗ plain arm awaits once, looping arm polls to completion
+  Test failed with exit code 22
+  a 1ms deadline beats the 5ms work (at .../std/assert.yo:39:17)
+```
+
+on `test (windows-latest)` AND `test (windows-11-arm)`, in
+`tests/async/while_await_in_match_arm.test.yo`. macOS and every Linux leg pass.
+
+## What the test asserted
+
+```rust
+work   := 5 ms sleep, then i32(7)
+race(Some(1 ms)) spawns work and a 1 ms deadline, polls both with `yield`,
+and reports 200 when the DEADLINE won, 100/101 when the WORK won.
+assert(c == i32(200), "a 1ms deadline beats the 5ms work");
+```
+
+That is a 4 ms margin. Windows' default timer resolution is **15.6 ms**
+(the multimedia timer period is not raised, deliberately — raising it globally
+costs power, and neither Rust nor tokio does it). Both sleeps therefore come
+due within one tick, `__yo_win_timer_process_due` fires every timer whose
+deadline has passed in a single call, and both handles finish in the SAME loop
+turn. The loop's report then reads `h.is_finished()` first and answers 100.
+
+So the assertion is not one the platform can support at that margin. It is not
+a statement about the runtime at all below ~16 ms.
+
+## Why it surfaced when it did
+
+It had been passing because `yield` was a 1 ms timer: that timer woke the loop
+often enough, and early enough, that a turn frequently landed between the two
+completions. #608 removed the timer (step 2 of
+`plans/WAKER_BASED_SCHEDULING.md`), the extra wakeups went with it, and the
+latent assumption showed. The regression is real — the test genuinely went from
+green to red — but the defect was in the test's premise, not in the yield.
+
+Two things hid it from #608's own CI run: that run passed windows-latest (the
+ordering is a race, and it went the other way), and every develop run since
+took the docs-only fast path, which SKIPS the Windows legs. "develop is green"
+can mean "develop skipped 15 jobs" — worth remembering.
+
+## Fix
+
+Every margin in the file is now at least 25x the coarsest resolution we run on:
+the work sleeps 200 ms and the deadline that must lose is 5 s. The order the
+two complete in is then a property of the runtime rather than of the host's
+clock, which is what the test is about. The test's real subject — a
+while-with-await inside one match arm whose sibling arm also awaits — is
+untouched.

--- a/tests/async/while_await_in_match_arm.test.yo
+++ b/tests/async/while_await_in_match_arm.test.yo
@@ -10,9 +10,22 @@
 { Duration } :: import("std/time/duration");
 { sleep } :: import("std/time/sleep");
 { yield } :: import("std/async");
+// 200 ms, not the 5 ms this was written with. The deadline case below asserts
+// that a 1 ms deadline BEATS the work, and a 4 ms margin is not an ordering any
+// platform guarantees: Windows' default timer resolution is 15.6 ms, so a 1 ms
+// and a 5 ms sleep come due in the SAME tick and `__yo_win_timer_process_due`
+// fires both — the loop then sees the work finished and reports 100 where the
+// test wants 200. It passed for as long as the 1 ms timer under `yield` kept
+// waking the loop often enough to catch the deadline alone; #608 removed that
+// timer and the latent assumption surfaced, on both Windows legs at once
+// (issues/fixed/a-4ms-timer-margin-is-not-an-ordering-on-windows.md).
+//
+// Every margin here is now at least 25x the coarsest resolution we run on, so
+// the ORDER these two complete in is a property of the runtime rather than of
+// the host's clock — which is what the test is actually about.
 work :: (fn(io : Io) -> Impl(Future(i32, IoExn)))(
   io.async(e => {
-    e.io.await(sleep(Duration.from_millis(i64(5)), e.io), e.io);
+    e.io.await(sleep(Duration.from_millis(i64(200)), e.io), e.io);
     i32(7)
   })
 );
@@ -77,10 +90,10 @@ test("plain arm awaits once, looping arm polls to completion", {
   e := IoExn(io : io, exn : exn);
   a := io.await(race(Option(Duration).None, io), e);
   assert(a == i32(7), "plain arm returns the awaited value");
-  b := io.await(race(Option(Duration).Some(Duration.from_millis(i64(500))), io), e);
-  assert(b == i32(101), "work (5ms) finishes before the 500ms deadline, after at least one yield");
+  b := io.await(race(Option(Duration).Some(Duration.from_millis(i64(5000))), io), e);
+  assert(b == i32(101), "work (200ms) finishes before the 5s deadline, after at least one yield");
   c := io.await(race(Option(Duration).Some(Duration.from_millis(i64(1))), io), e);
-  assert(c == i32(200), "a 1ms deadline beats the 5ms work");
+  assert(c == i32(200), "a 1ms deadline beats the 200ms work");
 });
 test("looping arm listed first", {
   exn := Exception(
@@ -94,6 +107,6 @@ test("looping arm listed first", {
   e := IoExn(io : io, exn : exn);
   a := io.await(race_rev(Option(Duration).None, io), e);
   assert(a == i32(7), "plain arm (second) returns the awaited value");
-  b := io.await(race_rev(Option(Duration).Some(Duration.from_millis(i64(500))), io), e);
+  b := io.await(race_rev(Option(Duration).Some(Duration.from_millis(i64(5000))), io), e);
   assert(b == i32(100), "looping arm (first) completes");
 });


### PR DESCRIPTION
Both Windows legs of every run since #608 fail `while_await_in_match_arm.test.yo`
on the same assert — found by yo-d1, whose stack cannot go green until it is
resolved.

The failing assert (in the log, not just the exit code) is **"a 1ms deadline
beats the 5ms work"**. Windows' default timer resolution is 15.6 ms, so a 1 ms
and a 5 ms sleep come due in the SAME tick; `__yo_win_timer_process_due` fires
every due timer in one call, both handles finish in one loop turn, and the
report reads `h.is_finished()` first and answers 100 where the test wants 200.
Below ~16 ms that assertion is not about the runtime at all.

#608 (timer-free `yield`) is the correct bisect and the wrong culprit: the 1 ms
timer under `yield` had been waking the loop often enough to land a turn
between the two completions. Removing it surfaced a premise that was never
sound.

**Fix** — every margin in the file is now at least 25x the coarsest clock we
run on: the work sleeps 200 ms, the deadline that must lose is 5 s. The ORDER
the two complete in is then a property of the runtime rather than of the host's
clock, which is what the test is about. The test's real subject — a
while-with-await inside one match arm whose sibling arm also awaits — is
untouched, and so are both of its assertions' shapes.

Verified locally against the v0.2.31 compiler with the tree's std: 2 passed.

Write-up: `issues/fixed/a-4ms-timer-margin-is-not-an-ordering-on-windows.md`.

One thing worth carrying forward from yo-d1's analysis: nothing on develop had
exercised the Windows legs since #608 landed, because every run since took the
docs-only fast path, which skips 15 jobs. "develop is green" can mean "develop
skipped the legs that would have caught this".

🤖 Generated with [Claude Code](https://claude.com/claude-code)