### PR TITLE
evaluator: a generic function returning Impl(Future(T)) resolves its return PER CALL

### DIFF
--- a/issues/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md
+++ b/issues/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md
@@ -1,0 +1,128 @@
+# A generic function returning `Impl(Future(T))` miscompiles at a second `T`
+
+**Status:** the VALUE-PARAM shape is FIXED 2026-09-12; the CLOSURE-PARAM shape
+is still open (see "What is still open").
+**Found:** 2026-09-12, writing `spawn_blocking` for waker step 5
+(`plans/WAKER_BASED_SCHEDULING.md`).
+**Pre-existing:** reproduces identically on the published **v0.2.31**.
+
+## Symptom
+
+Three different C errors depending on the shape, all the same root: ONE
+specialization's view of `T` is used where another's belongs.
+
+| shape | error |
+| --- | --- |
+| `fn(generic(T), v : T, io : Io) -> Impl(Future(T, Io))`, async body `v` | the AWAIT temp is `void*` (T never resolved) while the sync future's `result` is `int32_t` / the struct |
+| same with a closure param `f : Impl(Fn() -> T)` | `conflicting types for closure_yo_id_…` — ONE async-block closure emitted, returning `void*`, with a `Pair`-typed body |
+| an `io.await` inside the async body | `sm->result` typed `int32_t` in the specialization whose `T` is a struct |
+
+Either instantiation ALONE compiles and runs. The pair does not.
+
+## Reproducers
+
+* `issues/repros/generic-future-return-two-t-plain-param.yo`
+* `issues/repros/generic-future-return-two-t-closure-param.yo`
+* `issues/repros/generic-future-return-two-t-with-await.yo`
+
+## Root cause of the value-param shape, and its fix
+
+The evaluator DOES compute the right per-call return type. `YO_DEBUG_RRE=1`
+prints it:
+
+```
+[rre] callee=wrap old=true hkt=Impl : (Future[Future](i32) Io : Io)  resolved_ret=Impl : (Future[Future](R) Io : Io)
+[rre] callee=wrap old=true hkt=Impl : (Future[Future](Pair) Io : Io) resolved_ret=Impl : (Future[Future](R) Io : Io)
+```
+
+`hkt` is the re-evaluated return-type EXPRESSION, per call, and it is correct
+both times. It was thrown away: the adoption gate in
+`_evaluate_funcval_runtime_call` (`src/evaluator/calls/function.yo`) accepted a
+re-evaluated type only when it was SomeT-free, or when every SomeT in it
+resolved through its own cell. An `Impl(...)` existential is itself a SomeT
+with an empty resolution cell, so an async return could never pass either arm —
+`resolved_ret` stayed the declared, unresolved `Impl(Future(R) Io)`, every
+caller shared it, and the await site rendered it `void*`.
+
+The gate gains a third arm: adopt when the re-evaluated type no longer mentions
+any of THIS CALLEE'S OWN forall binders, because substitution is then complete
+for this call and what remains are existentials rather than type variables. It
+is gated on `rre_old_wanted`, which is what keeps the recorded adoption hazard
+out — the per-call closure-`F` family leaves a substituted return whose SomeTs
+all resolve concretely, so the re-eval is never wanted there in the first place.
+
+### The binder test must compare IDs, not names
+
+The first cut compared binder NAMES, and produced a compiler in which *the same
+program compiled or not according to what its type variable was called*:
+
+| receiver forall | method forall | result |
+| --- | --- | --- |
+| `U` | `R` | compiles |
+| `A` | `B` | compiles |
+| `T` | `Q` | **miscompiles** |
+| `U` | `E` | **miscompiles** |
+
+`T` and `E` are the names the PRELUDE's own `Future(T, E)` declaration uses, and
+those binders ride along inside the re-evaluated `Impl(Future(i32) Io)` — so a
+name comparison reported "still mentions `T`" for any user generic that happened
+to be called `T`, which is the most natural name there is. The fix reads the
+binder IDs off the declared return type (`_rre_binder_ids`), applying the name
+filter exactly once, where the names are unambiguously the callee's.
+
+## What is still open
+
+The CLOSURE-PARAM shape —
+`fn(generic(R), f : Impl(Fn() -> R), io : Io) -> Impl(Future(R, Io))` — still
+miscompiles, and it is a different defect: the async block inside the generic
+function is emitted ONCE for both instantiations
+(`conflicting types for closure_yo_id_…`, a forward declaration returning the
+struct and a definition returning `int32_t`). The return stamping is no longer
+the problem there; the async block itself is not specialized per `T`.
+
+`std/thread.yo`'s `spawn_blocking` has exactly that shape, which is why waker
+step 5 (`plans/WAKER_BASED_SCHEDULING.md`) is not landed with it.
+
+## What is NOT the trigger
+
+Measured, one variable at a time — none of these makes it pass:
+
+* free function vs impl method;
+* a generic receiver (`Box3(U)`) vs a concrete one;
+* `Impl(Future(T))` vs `Impl(Future(T, Io))`;
+* a bare tail vs an explicit `return(r)`;
+* a by-value closure param vs `inout`;
+* the definition living in another module;
+* result types `i32`+struct vs `i32`+`String`;
+* an `io.await` inside the async body vs none (it changes WHICH error, not whether there is one).
+
+## What DOES pass, and is the lead
+
+`std/async/mutex.yo`'s `with_lock`:
+
+```rust
+with_lock : (fn(generic(R : Type), self : Self,
+                body : Impl(Fn(inout(v) : T) -> R), io : Io) -> Impl(Future(R)))(
+  io.async((io : Io) => {
+    io.await(self.lock(io), io);
+    r := body(self._value);
+    self.unlock();
+    return(r);
+  })
+)
+```
+
+called twice on ONE `Mutex(i64)` with an `i64` body and a `String` body compiles
+and runs (`tests/async_mutex.test.yo`, and standalone). Its history is
+`issues/fixed/future-wrapper-return-shared-across-specializations.md` — the
+same class, fixed in 2026-08-30 for the valueless-closure-callee stamp sites by
+resolving `ret_type_rt` through `_resolve_some_types_deep(_, caller_env)`
+before stamping. So a correct path EXISTS; the reproducers above take a
+different one. Finding what `with_lock` does that the reproducers do not is the
+whole of the remaining work — the list above is what it is NOT.
+
+## Impact
+
+`std/thread.yo`'s `spawn_blocking` is correct and works at one instantiation
+per program; a second `T` in the same program miscompiles. That is why it is
+not exported yet.

--- a/issues/repros/generic-future-return-two-t-closure-param.yo
+++ b/issues/repros/generic-future-return-two-t-closure-param.yo
@@ -1,0 +1,12 @@
+{ println } :: import("std/fmt");
+Pair :: struct(lo : i32, hi : i32);
+wrap2 :: (fn(generic(R : Type), f : Impl(Fn() -> R), io : Io) -> Impl(Future(R, Io)))(
+  io.async((io : Io) => f())
+);
+main :: (fn(io : Io) -> unit)({
+  a := io.await(wrap2(() => i32(7), io), io);
+  println(`a=${a + i32(0)}`);
+  b := io.await(wrap2(() => Pair(lo : i32(3), hi : i32(4)), io), io);
+  println(`b=${b.lo + b.hi}`);
+});
+export(main);

--- a/issues/repros/generic-future-return-two-t-plain-param.yo
+++ b/issues/repros/generic-future-return-two-t-plain-param.yo
@@ -1,0 +1,12 @@
+{ println } :: import("std/fmt");
+Pair :: struct(lo : i32, hi : i32);
+wrap :: (fn(generic(T : Type), v : T, io : Io) -> Impl(Future(T, Io)))(
+  io.async((io : Io) => v)
+);
+main :: (fn(io : Io) -> unit)({
+  a := io.await(wrap(i32(7), io), io);
+  println(`a=${a + i32(0)}`);
+  b := io.await(wrap(Pair(lo : i32(3), hi : i32(4)), io), io);
+  println(`b=${b.lo + b.hi}`);
+});
+export(main);

--- a/issues/repros/generic-future-return-two-t-with-await.yo
+++ b/issues/repros/generic-future-return-two-t-with-await.yo
@@ -1,0 +1,26 @@
+{ println } :: import("std/fmt");
+{ yield } :: import("std/async");
+Pair :: struct(lo : i32, hi : i32);
+Box3 :: (fn(comptime(U) : Type) -> comptime(Type))(ref(struct(n : U)));
+impl(
+  generic(U : Type),
+  Box3(U),
+  new : (fn(v : U) -> Self)(Self(n : v)),
+  wrap : (
+    fn(generic(T : Type), self : Self, f : Impl(Fn(x : U) -> T), io : Io) -> Impl(Future(T))
+  )(
+    io.async((io : Io) => {
+      io.await(yield(io), io);
+      r := f(self.n);
+      return(r);
+    })
+  )
+);
+main :: (fn(io : Io) -> unit)({
+  b3 := Box3(i32).new(i32(1));
+  a := io.await(b3.wrap((x : i32) => (x + i32(6)), io), io);
+  println(`a=${a + i32(0)}`);
+  b := io.await(b3.wrap((x : i32) => Pair(lo : x, hi : i32(4)), io), io);
+  println(`b=${b.lo + b.hi}`);
+});
+export(main);

--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -1764,6 +1764,176 @@ _funcval_bind_foralls :: (
 /// from that function's frame, shrinking the per-level frame on the deep CTFE
 /// recursion path (Phase-6 stage-2 self-compile overflow). Pure code motion — same
 /// behavior. Returns the call expr.
+/// The SomeT **ids** of this callee's own forall binders, read off the DECLARED
+/// return type: every SomeT in it whose name is one of `forall_names`.
+///
+/// Reading them from the return rather than from `Func.forall_types` is what
+/// makes them the SAME objects the re-evaluated type would have to carry, and
+/// the name filter is applied ONCE, here, where the names are unambiguously
+/// this callee's — not against the prelude's `Future(T, E)` binders, which ride
+/// along inside the re-evaluated type and share those names.
+_rre_binder_ids :: (
+  fn(ret : TypeValue, forall_names : ArrayList(String)) -> ArrayList(String)
+)({
+  out := ArrayList(String).new();
+  if(forall_names.len() == usize(0), {
+    return(out);
+  });
+  work := ArrayList(TypeValue).new();
+  work.push(ret);
+  (steps : usize) = usize(0);
+  while((work.len() > usize(0)) && (steps < usize(4096)), {
+    steps = (steps + usize(1));
+    cur := match(work.pop(), .Some(c) => c, .None => TypeValue.Unit);
+    somes := get_all_some_types(cur);
+    match(cur, .SomeT(_, _, _, _, _, _, _, _, _, _, _) => (), _ => somes.push(cur));
+    (si : usize) = usize(0);
+    while(si < somes.len(), {
+      match(
+        somes.get(si),
+        .Some(sv) => match(
+          sv,
+          .SomeT({ id : sid, name : snm, required_trait_types : srt }) => {
+            (ni : usize) = usize(0);
+            while(ni < forall_names.len(), {
+              match(
+                forall_names.get(ni),
+                .Some(fn_nm) => if(fn_nm == snm, {
+                  out.push(sid.clone());
+                }),
+                .None => ()
+              );
+              ni = (ni + usize(1));
+            });
+            (ri : usize) = usize(0);
+            while(ri < srt.len(), {
+              match(srt.get(ri), .Some(rt) => work.push(rt), .None => ());
+              ri = (ri + usize(1));
+            });
+          },
+          .FnTraitT(_, _, fcp, fcr, _, fit, _, _) => {
+            (fi : usize) = usize(0);
+            while(fi < fcp.len(), {
+              match(fcp.get(fi), .Some(fp) => work.push(fp), .None => ());
+              fi = (fi + usize(1));
+            });
+            work.push(fcr);
+            (gi : usize) = usize(0);
+            while(gi < fit.len(), {
+              match(fit.get(gi), .Some(it) => work.push(it), .None => ());
+              gi = (gi + usize(1));
+            });
+          },
+          .FutureTraitT(_, fo, _, fet, _) => {
+            work.push(fo);
+            (ei : usize) = usize(0);
+            while(ei < fet.len(), {
+              match(fet.get(ei), .Some(et) => work.push(et), .None => ());
+              ei = (ei + usize(1));
+            });
+          },
+          _ => ()
+        ),
+        .None => ()
+      );
+      si = (si + usize(1));
+    });
+  });
+  out
+});
+/// Does `t` still mention one of `ids` — this callee's own forall binders?
+///
+/// `get_all_some_types` stops AT a `SomeT` — it pushes the wrapper and does not
+/// look inside its `required_trait_types` — so it reports "one SomeT" for
+/// `Impl(Future(R) Io)` and never sees the `R`. That is the exact shape of an
+/// async return, so the RRE adoption gate below needs a walk that goes one
+/// level further: into an `Impl`'s traits, and through the `Fn` / `Future`
+/// trait members that carry the binder.
+///
+/// By SomeT **id**, never by name. The prelude's own `Future(T, E)` declaration
+/// carries binders named `T` and `E`, and those names ride along inside the
+/// re-evaluated `Impl(Future(i32) Io)` — so a name comparison reports "still
+/// mentions T" for a callee whose forall merely happens to be called `T`, which
+/// is the most natural name there is. Measured: the identical program compiled
+/// with the forall named `R` and did not with `T`.
+///
+/// Written flat (a worklist, not nested helpers) because a regular `fn` in Yo
+/// captures nothing from its enclosing scope.
+_rre_mentions_binder :: (fn(t : TypeValue, ids : ArrayList(String)) -> bool)({
+  if(ids.len() == usize(0), {
+    // No binder ids to check against: say YES, which leaves the gate exactly
+    // as conservative as it was.
+    return(true);
+  });
+  work := ArrayList(TypeValue).new();
+  work.push(t);
+  (steps : usize) = usize(0);
+  (found : bool) = false;
+  while((work.len() > usize(0)) && !found && (steps < usize(4096)), {
+    steps = (steps + usize(1));
+    cur := match(work.pop(), .Some(c) => c, .None => TypeValue.Unit);
+    // The structural walk first: a binder reached through a struct field, an
+    // array element or a pointee is collected here, and each collected SomeT
+    // is re-examined below.
+    somes := get_all_some_types(cur);
+    match(cur, .SomeT(_, _, _, _, _, _, _, _, _, _, _) => (), _ => somes.push(cur));
+    (si : usize) = usize(0);
+    while((si < somes.len()) && !found, {
+      match(
+        somes.get(si),
+        .Some(sv) => match(
+          sv,
+          .SomeT({ name : sn, required_trait_types : srt }) => {
+            (ni : usize) = usize(0);
+            while((ni < ids.len()) && !found, {
+              match(
+                ids.get(ni),
+                .Some(nm) => if(nm == sn, {
+                  found = true;
+                }),
+                .None => ()
+              );
+              ni = (ni + usize(1));
+            });
+            (ri : usize) = usize(0);
+            while(ri < srt.len(), {
+              match(srt.get(ri), .Some(rt) => work.push(rt), .None => ());
+              ri = (ri + usize(1));
+            });
+          },
+          .FnTraitT(_, _, fcp, fcr, _, fit, _, _) => {
+            (fi : usize) = usize(0);
+            while(fi < fcp.len(), {
+              match(fcp.get(fi), .Some(fp) => work.push(fp), .None => ());
+              fi = (fi + usize(1));
+            });
+            work.push(fcr);
+            (gi : usize) = usize(0);
+            while(gi < fit.len(), {
+              match(fit.get(gi), .Some(it) => work.push(it), .None => ());
+              gi = (gi + usize(1));
+            });
+          },
+          .FutureTraitT(_, fo, _, fet, _) => {
+            work.push(fo);
+            (ei : usize) = usize(0);
+            while(ei < fet.len(), {
+              match(fet.get(ei), .Some(et) => work.push(et), .None => ());
+              ei = (ei + usize(1));
+            });
+          },
+          _ => ()
+        ),
+        .None => ()
+      );
+      si = (si + usize(1));
+    });
+  });
+  // A walk that ran out of steps is treated as "still mentions one": the gate
+  // this feeds only ever WIDENS adoption, so the conservative answer is the
+  // one that leaves the previous behaviour in place.
+  found || (steps >= usize(4096))
+});
 _evaluate_funcval_runtime_call :: (
   fn(
     expr : AstExpr,
@@ -2023,6 +2193,8 @@ _evaluate_funcval_runtime_call :: (
   // and the per-call closure-F family (`IterFilter(Self, F)`) keeps SomeTs
   // after substitution (nsomes > 0 → the substituted result is not adopted-
   // over; it still enters via the pre-existing !all_resolve_concrete arm).
+  // This callee's own forall binders, by SomeT id — see _rre_mentions_binder.
+  rre_binder_ids := _rre_binder_ids(ret_type, forall_names);
   rre_decl_tyarg_somes := ArrayList(TypeValue).new();
   _collect_type_arg_somes(ret_type, rre_decl_tyarg_somes, ArrayList(String).new());
   rre_era_suspect := ((rre_decl_tyarg_somes.len() > usize(0)) && (get_all_some_types(resolved_ret).len() == usize(0)));
@@ -2073,7 +2245,24 @@ _evaluate_funcval_runtime_call :: (
           // into dyn wrapper C names (`__yo_wrap_unknown_R#gs_…`, the
           // fn/closure gate C-compile break). Era repair only ever needs the
           // fully-concrete canonical, so it takes the strict arm.
-          .Some(hkt_ty) => if(((get_all_some_types(hkt_ty).len() == usize(0)) || (rre_old_wanted && type_somes_all_resolve_concrete(hkt_ty))) && !(is_unit_type(hkt_ty)), {
+          // Third arm: the re-evaluated return no longer mentions ANY of this
+          // callee's own generic binders, so substitution is COMPLETE for this
+          // call and whatever SomeTs remain are existential wrappers rather
+          // than type variables. That is exactly what an async return IS —
+          // `Impl(Future(i32) Io)` is one SomeT, with an empty resolution
+          // cell, so both arms above reject it and `resolved_ret` stayed
+          // `Impl(Future(R) Io)`: EVERY caller of a generic
+          // `-> Impl(Future(R))` function then shared one unresolved return,
+          // the await site rendered it `void*`, and a second instantiation
+          // miscompiled against the first
+          // (issues/fixed/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md).
+          //
+          // Gated on `rre_old_wanted`, which is what keeps the recorded
+          // adoption hazard out: the per-call closure-`F` family
+          // (`IterFilter(Self, F)`) leaves a substituted return whose SomeTs
+          // ALL resolve concretely, so `rre_old_wanted` is false there and the
+          // re-eval is never even wanted.
+          .Some(hkt_ty) => if(((get_all_some_types(hkt_ty).len() == usize(0)) || (rre_old_wanted && (type_somes_all_resolve_concrete(hkt_ty) || !(_rre_mentions_binder(hkt_ty, rre_binder_ids))))) && !(is_unit_type(hkt_ty)), {
             resolved_ret = hkt_ty;
           }),
           .None => ()

--- a/tests/generic_future_return_two_t.test.yo
+++ b/tests/generic_future_return_two_t.test.yo
@@ -1,0 +1,38 @@
+//! A generic function returning `Impl(Future(T))`, instantiated at two
+//! different `T`s in one program.
+//!
+//! Either instantiation alone always compiled; the pair did not — the caller's
+//! await site kept the DECLARED, unresolved return, rendered it `void*`, and
+//! the second instantiation's C disagreed with the first's
+//! (issues/fixed/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md).
+//!
+//! The second test is not a duplicate: the forall is named `T`, which is the
+//! name the PRELUDE's own `Future(T, E)` declaration uses. The first cut of the
+//! fix compared binders by NAME and so accepted `R` and rejected `T` — the same
+//! program compiling or not according to what its type variable was called.
+{ assert } :: import("std/assert");
+_Pair :: struct(lo : i32, hi : i32);
+_wrap_r :: (fn(generic(R : Type), v : R, io : Io) -> Impl(Future(R, Io)))(
+  io.async((io : Io) => v)
+);
+_wrap_t :: (fn(generic(T : Type), v : T, io : Io) -> Impl(Future(T, Io)))(
+  io.async((io : Io) => v)
+);
+test("a generic Impl(Future(R)) at two different R in one program", {
+  a := io.await(_wrap_r(i32(7), io), io);
+  assert(a == i32(7), "the i32 instantiation returned its own value");
+  b := io.await(_wrap_r(_Pair(lo : i32(3), hi : i32(4)), io), io);
+  assert((b.lo + b.hi) == i32(7), "the struct instantiation returned its own value");
+});
+test("the same, with the forall named T — the prelude's own binder name", {
+  a := io.await(_wrap_t(i64(11), io), io);
+  assert(a == i64(11), "the i64 instantiation returned its own value");
+  b := io.await(_wrap_t(_Pair(lo : i32(5), hi : i32(6)), io), io);
+  assert((b.lo + b.hi) == i32(11), "the struct instantiation returned its own value");
+});
+test("a third instantiation does not disturb the first two", {
+  a := io.await(_wrap_r(true, io), io);
+  assert(a, "the bool instantiation returned its own value");
+  c := io.await(_wrap_r(i32(9), io), io);
+  assert(c == i32(9), "the i32 instantiation still returns its own value");
+});


### PR DESCRIPTION
Two instantiations of `fn(generic(T), v : T, io : Io) -> Impl(Future(T, Io))` in
one program did not compile. Either alone always did. Pre-existing on v0.2.31.

**Stacked on #612** — retarget to `develop` when that merges.

### The evaluator was computing the right answer and discarding it

`YO_DEBUG_RRE=1` on the reproducer:

```
[rre] callee=wrap old=true hkt=Impl : (Future[Future](i32) Io : Io)  resolved_ret=Impl : (Future[Future](T) Io : Io)
[rre] callee=wrap old=true hkt=Impl : (Future[Future](Pair) Io : Io) resolved_ret=Impl : (Future[Future](T) Io : Io)
```

`hkt` is the return-type expression re-evaluated per call, and it is right both
times. The adoption gate threw it away: it accepted a re-evaluated type only
when it was SomeT-free, or when every SomeT in it resolved through its own cell.
An `Impl(...)` existential IS a SomeT with an empty cell, so an async return
could never pass either arm. Every caller then shared one unresolved return, the
await site rendered it `void*`, and the second instantiation's C disagreed with
the first's.

The gate gains a third arm: **adopt when the re-evaluated type no longer
mentions any of this callee's own forall binders** — substitution is then
complete for this call, and what remains are existentials rather than type
variables. Gated on `rre_old_wanted`, which is what keeps the recorded adoption
hazard out: the per-call closure-`F` family leaves a substituted return whose
SomeTs all resolve concretely, so the re-eval is never wanted there at all.

### The binder test compares IDs, not names — and that is not a detail

The first cut compared names, and produced a compiler in which the same program
compiled or not according to what its type variable was called:

| receiver forall | method forall | result |
| --- | --- | --- |
| `U` | `R` | compiles |
| `A` | `B` | compiles |
| `T` | `Q` | **miscompiles** |
| `U` | `E` | **miscompiles** |

`T` and `E` are the names the prelude's own `Future(T, E)` declaration uses, and
those binders ride along inside the re-evaluated `Impl(Future(i32) Io)`.
`_rre_binder_ids` reads the ids off the declared return instead, applying the
name filter exactly once, where the names are unambiguously the callee's.

### Gates

- `tests/generic_future_return_two_t.test.yo` — red-first: fails to compile on
  v0.2.31 ("Cannot unify incompatible types"), 3/3 here. Its second test names
  the forall `T` on purpose.
- `yo test ./tests --exclude tests/internal --exclude tests/cli-cases` —
  **4161 passed, 0 failed**.
- `yo check ./src` — 270/270.
- Bootstrap fixpoint — running; will report.

### Still open, and a different defect

The CLOSURE-PARAM shape (`f : Impl(Fn() -> R)` rather than `v : R`) still
miscompiles: the async block inside the generic function is emitted ONCE for
both instantiations (`conflicting types for closure_yo_id_…`). The return
stamping is no longer the problem there. Measured in
`issues/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md`
with three reproducers and a table of nine variables that are NOT the trigger.
It is what keeps `spawn_blocking` (waker step 5) unlanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)