### PR TITLE
chore: exercise the CI matrix on develop's tip

### DIFF
--- a/src/token.yo
+++ b/src/token.yo
@@ -1,3 +1,4 @@
+//! (CI matrix exercise: no semantic change.)
 //! Token types for the Yo lexer.
 { rune, String } :: import("std/string");
 { ToString } :: import("std/fmt");


### PR DESCRIPTION
Draft, not for merge. #608 (std/async cancellation) and #610 landed via docs-classified pushes whose runs SKIPPED the test matrix, so the current develop tip has never run the Windows legs. PR #614 fails `plain arm awaits once, looping arm polls to completion` (`a 1ms deadline beats the 5ms work`) on BOTH Windows legs 3×, with an emitted-C diff attributable entirely to #608's cancellation machinery and zero hunks from #614's diff. This comment-only PR forces the full matrix on develop's tip: if its Windows legs fail the same test, the regression is pre-existing on develop and #614 is unblocked. See issues/windows-1ms-deadline-race-loses-since-cancellation-landing.md.