### PR TITLE
codegen: two externs with one signature each get a prototype (and -O2 stops swallowing undeclared calls)

### DIFF
--- a/issues/fixed/two-externs-of-one-signature-emit-one-prototype.md
+++ b/issues/fixed/two-externs-of-one-signature-emit-one-prototype.md
@@ -1,0 +1,91 @@
+# Two externs with the same signature emit only ONE prototype
+
+**Status:** FIXED (2026-09-12)
+**Area:** codegen — extern function collection / declaration emission
+**Surfaced by:** a build fixture that declares two independent static-library
+artifacts `alpha` and `beta` and calls both from one program — so the program
+declares two `extern("Yo", … : (fn(n : i32) -> i32))` symbols of ONE type.
+
+## Symptom
+
+```
+error: call to undeclared function 'alpha'; ISO C99 and later do not support
+       implicit function declarations [-Wimplicit-function-declaration]
+```
+
+at `-O0`, and — worse — a *silent pass* at `--optimize 2`, where the emitted C
+compiled and linked with only a warning.
+
+## Minimal reproducer
+
+```rust
+pragma(Pragma.AllowUnsafe);
+{ println } :: import("std/fmt");
+extern("c", toupper : (fn(c : i32) -> i32));
+extern("c", tolower : (fn(c : i32) -> i32));
+main :: (fn() -> unit)({
+  println((unsafe(toupper(i32(97))) + unsafe(tolower(i32(66)))).to_string());
+});
+export(main);
+```
+
+`yo compile … --emit-c --skip-c-compiler` emits exactly one prototype:
+
+```c
+extern int32_t tolower(int32_t c);
+```
+
+`toupper` is called with no declaration at all.
+
+## Root cause
+
+`_register_extern_fn_callee` (`src/codegen/functions/collection.yo`) registered
+every extern callee into `CodeGenContext.extern_functions`, a
+`HashMap(String, CodegenExternFnEntry)`, **keyed by `type_key(cei_ty)`**:
+
+```yo
+context.register_extern_function(type_key(cei_ty), cei_ty, c_name, get_c_include_for_extern(c_name.clone()));
+```
+
+`toupper` and `tolower` have the *same type* — `(fn(i32) -> i32)` — so they
+share a type key and the second registration overwrote the first. The map holds
+symbols, and a type does not identify a symbol.
+
+Both downstream consumers iterate `.values()` only —
+`generate_function_declarations` (`src/codegen/functions/declarations.yo`, which
+emits the prototypes) and the `c_include` collector
+(`src/codegen/c/collection.yo`) — so nothing ever looked the entry up *by* that
+key. The collision therefore had no purpose and one pure effect: dropping
+prototypes, and dropping the `c_include` of whichever extern lost the race.
+
+This is another instance of the pattern in
+`issues/fixed/ts-registry-lookups-mis-port.md`: TS read the entry off the
+function *value*, and the Yo port replaced that with a global table keyed by
+type key.
+
+## Fix
+
+Key the registry by the C symbol name:
+
+```yo
+context.register_extern_function(c_name.clone(), cei_ty, c_name, get_c_include_for_extern(c_name.clone()));
+```
+
+A symbol name identifies the function. Two declarations of the same symbol still
+collapse to one entry, which is exactly right.
+
+## Why -O2 hid it
+
+`src/main.yo`'s optimized arm passed `-Wno-everything` and then re-enabled a
+short list of warnings, including a bare `-Wimplicit-function-declaration` —
+which *downgraded* clang's default error back to a warning. A call with no
+prototype truncates its return value to `int` and default-promotes its
+arguments; it is never benign. That flag is now
+`-Werror=implicit-function-declaration`, matching what the `-O0` arm already
+gets from clang's defaults.
+
+## Regression test
+
+`tests/extern_unsafe_wrap.test.yo` — "two externs with the same signature both
+get a prototype". Verified red before the fix (the batch's C compile fails with
+`call to undeclared library function 'toupper'`) and green after.

--- a/src/codegen/functions/collection.yo
+++ b/src/codegen/functions/collection.yo
@@ -288,7 +288,15 @@ _register_extern_fn_callee :: (
           // evaluator's side-table (the port of TS reading `type.cInclude`
           // off the extern function type). None for plain `extern("c", ...)`
           // declarations.
-          context.register_extern_function(type_key(cei_ty), cei_ty, c_name, get_c_include_for_extern(c_name.clone()));
+          //
+          // Keyed by the C NAME, not by `type_key`: two externs of the same
+          // SIGNATURE — `extern("Yo", alpha : (fn(n : i32) -> i32))` and the
+          // same for `beta` — share a type key, so the second overwrote the
+          // first and only ONE prototype was emitted. The other was then
+          // called with no declaration, which C99 and later reject
+          // (issues/fixed/two-externs-of-one-signature-emit-one-prototype.md).
+          // A symbol name identifies the function; a type does not.
+          context.register_extern_function(c_name.clone(), cei_ty, c_name, get_c_include_for_extern(c_name.clone()));
         });
       },
       .None => ()

--- a/src/main.yo
+++ b/src/main.yo
@@ -2980,6 +2980,13 @@ run_compile :: (
   // silently return an empty list with `check`, `build` and the whole suite
   // green. See issues/ftt-stub-in-live-closure-falls-off-non-void-function.md.
   //
+  // A call with NO prototype is in the same family and is never benign: the
+  // return value is truncated to `int` and the arguments go through default
+  // promotion, so it is an ERROR here rather than the warning `-Wno-everything`
+  // would otherwise leave behind. That warning is what hid a dropped extern
+  // prototype at -O2 while -O0 rejected it outright
+  // (issues/fixed/two-externs-of-one-signature-emit-one-prototype.md).
+  //
   // The -O0 arm below needs no such re-enabling — `-Wall` and clang's
   // defaults already include all three.
   cond(
@@ -2987,7 +2994,7 @@ run_compile :: (
       cmd.arg(String.from("-Wno-everything"));
       cmd.arg(String.from("-Wincompatible-pointer-types"));
       cmd.arg(String.from("-Wint-conversion"));
-      cmd.arg(String.from("-Wimplicit-function-declaration"));
+      cmd.arg(String.from("-Werror=implicit-function-declaration"));
       cmd.arg(String.from("-Werror=return-type"));
       cmd.arg(`-O${optimize}`);
     },

--- a/tests/extern_unsafe_wrap.test.yo
+++ b/tests/extern_unsafe_wrap.test.yo
@@ -27,3 +27,18 @@ test("call-site wrap: direct extern call works inside unsafe(...)", {
   n := unsafe(strlen(cstr));
   assert(n == usize(6), "wrapped strlen returns the expected length");
 });
+// ── Two externs, one signature. The codegen registry that collects extern
+//    symbols for prototype emission was keyed by the TYPE KEY, so `toupper`
+//    and `tolower` — identical `(fn(i32) -> i32)` types — collided and only
+//    the second one's prototype was emitted. The first was then called with
+//    no declaration at all, which clang rejects at -O0
+//    ("call to undeclared library function 'toupper'") and silently accepted
+//    at -O2 (issues/fixed/two-externs-of-one-signature-emit-one-prototype.md).
+extern("c", toupper : (fn(c : i32) -> i32));
+extern("c", tolower : (fn(c : i32) -> i32));
+test("two externs with the same signature both get a prototype", {
+  upper := unsafe(toupper(i32(97)));
+  lower := unsafe(tolower(i32(66)));
+  assert(upper == i32(65), "toupper('a') is 'A'");
+  assert(lower == i32(98), "tolower('B') is 'b'");
+});


### PR DESCRIPTION
Split out of #620 so it can land ahead of that stack — yo-0b hit the same class twice today at `-O2` from the other side.

## The bug

`_register_extern_fn_callee` registered every extern callee into
`CodeGenContext.extern_functions` **keyed by `type_key`**. Two symbols of the
same TYPE therefore collided and the second overwrote the first:

```rust
pragma(Pragma.AllowUnsafe);
{ println } :: import("std/fmt");
extern("c", toupper : (fn(c : i32) -> i32));
extern("c", tolower : (fn(c : i32) -> i32));
main :: (fn() -> unit)({
  println((unsafe(toupper(i32(97))) + unsafe(tolower(i32(66)))).to_string());
});
export(main);
```

emits exactly one prototype — `extern int32_t tolower(int32_t c);` — and calls
`toupper` with no declaration at all.

Nothing ever looked an entry up by that key: both consumers
(`generate_function_declarations` and the `c_include` collector) iterate
`.values()`. So the collision had one pure effect — dropping prototypes, and
dropping the losing extern's `c_include` with them. It is keyed by the **C
symbol name** now. A name identifies a function; a type does not.

This is the third instance of the shape in
`issues/fixed/ts-registry-lookups-mis-port.md`: TS read the entry off the
function VALUE, and the Yo port replaced it with a global table keyed by type.

## The part that matters beyond this bug

`--optimize 2` was hiding the whole class. `run_compile` passes
`-Wno-everything` and then re-enables a short list of warnings by name,
including a bare `-Wimplicit-function-declaration` — which **downgrades clang's
default error back to a warning**. So any undeclared call in emitted C has been
linking silently at the optimization level everything real is built at; a call
with no prototype truncates its return to `int` and default-promotes its
arguments, and is never benign.

That flag is now `-Werror=implicit-function-declaration`, matching what the
`-O0` arm already gets from clang's defaults — the same reasoning the
neighbouring `-Werror=return-type` was added under.

## Gate

`tests/extern_unsafe_wrap.test.yo` gains "two externs with the same signature
both get a prototype", verified **red first**: before the fix the batch's C
compile fails with `call to undeclared library function 'toupper'`.

Locally: `check ./src` + `check ./std` clean, `compile src/main.yo
--skip-c-compiler` clean (0 transpile failures), the full CLI corpus at 121
PASS, and stage2/stage3 **FIXPOINT_HOLDS** — all taken on the branch this was
split from.

`issues/fixed/two-externs-of-one-signature-emit-one-prototype.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)