### PR TITLE
async runtime: a wake can cross a thread — waker step 5's machinery

### DIFF
--- a/issues/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md
+++ b/issues/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md
@@ -74,11 +74,32 @@ filter exactly once, where the names are unambiguously the callee's.
 
 The CLOSURE-PARAM shape —
 `fn(generic(R), f : Impl(Fn() -> R), io : Io) -> Impl(Future(R, Io))` — still
-miscompiles, and it is a different defect: the async block inside the generic
-function is emitted ONCE for both instantiations
-(`conflicting types for closure_yo_id_…`, a forward declaration returning the
-struct and a definition returning `int32_t`). The return stamping is no longer
-the problem there; the async block itself is not specialized per `T`.
+miscompiles, and it is a different defect. Measured in the emitted C, sharpened
+once the return stamping above stopped being the problem:
+
+* BOTH async-block generations exist (`closure_…000000`, `closure_…000001`),
+  and so do both `_sync_fut_t` structs. Nothing is missing.
+* The two forward declarations DISAGREE with each other correctly:
+  `…000000` is declared returning the struct, `…000001` returning `int32_t`.
+* **Both DEFINITIONS return `int32_t`.** So `…000000`'s definition contradicts
+  its own forward declaration, which is the `conflicting types for
+  closure_yo_id_…` the C compiler reports, and the struct specialization's
+  state machine calls a body that computes the wrong type.
+
+That is a prototype-vs-definition split for ONE fid, and the interesting part
+is that `generate_function` and `generate_function_declaration`
+(`src/codegen/functions/`) build both strings from the SAME helper —
+`generate_function_prototype(get_func_type(fid), …, async_override, …)`. So
+something those two passes read differs between them. `async_override` is the
+suspect: `_async_override_return_type` consults the BODY node's ExprInfo, and
+the two generations share one body AST node, so anything recorded there is
+last-writer. That is a hypothesis, not a measurement — what is measured is the
+three bullets above.
+
+The lead from the working side stands: an IMPL METHOD with a closure param
+compiles at two `R`s (`std/async/mutex.yo`'s `with_lock`, and a stripped
+20-line copy of it). A FREE FUNCTION with the same closure param does not. That
+pair is the A/B to bisect next.
 
 `std/thread.yo`'s `spawn_blocking` has exactly that shape, which is why waker
 step 5 (`plans/WAKER_BASED_SCHEDULING.md`) is not landed with it.

--- a/issues/impl-fn-param-captured-by-an-async-block-is-not-in-the-capture-struct.md
+++ b/issues/impl-fn-param-captured-by-an-async-block-is-not-in-the-capture-struct.md
@@ -1,0 +1,80 @@
+# An `Impl(Fn)` parameter captured by an `io.async` block is not in its capture struct
+
+**Status:** open
+**Found:** 2026-09-12, writing `spawn_blocking` for waker step 5
+(`plans/WAKER_BASED_SCHEDULING.md`).
+**Reproducer:** `issues/repros/impl-fn-param-captured-by-an-async-block.yo`
+
+## Symptom
+
+```
+error: use of undeclared identifier 'cb'
+```
+
+in a state-machine resume function, from a capture-struct initializer the
+resume function emits for a closure built INSIDE the async block:
+
+```c
+__yo_t_N __capture_closure_… = (__yo_t_N){
+  .cb = cb,                                          // ← undeclared here
+  .sink = (…)__yo_incr_rc_atomic(sm->var_chan_…),    // ← every OTHER capture
+  .w    = (…)__yo_incr_rc_atomic(sm->var_w_…),       //    is read from the SM
+  .owner = owner
+};
+```
+
+## Shape
+
+The enclosing function takes an `Impl(Fn)` parameter and returns an `io.async`
+block that builds a closure over it:
+
+```rust
+relay :: (
+  fn(generic(T : Type), cb : Impl(Fn() -> T, Send), io : Io,
+     where(T <: (Send, Acyclic))) -> Impl(Future(T, Io))
+)(
+  io.async((io : Io) => {
+    chan := Channel(T).new(usize(1));
+    sink := chan;
+    run_it(() => { sink.send(cb()); () });     // ← captures `cb`
+    match(chan.try_recv(), .Ok(v) => v, .Err(_) => __yo_panic("no value"))
+  })
+);
+```
+
+`chan`/`sink` are ordinary locals of the async body and are emitted correctly
+through `sm->var_…`. `cb` is the one capture that is a PARAMETER of the
+enclosing function, and the one that renders as a bare identifier.
+
+## Where it goes wrong
+
+`_generate_sm_atom` (`src/codegen/exprs/atom.yo`) maps a name to its
+state-machine slot and returns `.None` when the name is in neither the
+analysis's captured variables nor the async block's `__capture` struct; the
+caller (`src/codegen/exprs/closures.yo`, the capture-struct field initializer)
+then falls back to `get_variable_name_for_codegen`, which yields the bare
+source name.
+
+The outer half of that map is built in `_build_combined_sm_variables`
+(`src/codegen/async/state_machine.yo`) from the async closure's CAPTURE STRUCT
+field labels — so the question is why `cb` is not a field of it. The likely
+answer is that an `Impl(Fn)` parameter is bound VALUELESS by the specialization
+binder (the finding behind
+`issues/fixed/generic-channel-send-specialisation-is-called-but-never-emitted.md`),
+and `enrich_captured_variables` (`src/evaluator/utils/closure.yo`) drops a
+capture with no runtime value as compile-time-only. That is a hypothesis and
+not measured — the measured facts are the two above.
+
+A near neighbour that behaves DIFFERENTLY, and so is a useful contrast while
+fixing this: calling `cb()` directly in the async body (no inner closure)
+produces a different failure, `conflicting types for closure_yo_id_…`, rather
+than an undeclared name.
+
+## Impact
+
+`std/thread.yo`'s `spawn_blocking` is written EAGERLY — the worker thread is
+started in the function body, and the returned `io.async` block only awaits the
+park — which is both the better semantics (Rust's `spawn_blocking` starts the
+work immediately rather than on first poll) and outside the shape above. Any
+API that wants to call a closure PARAMETER from inside its own async block hits
+this.

--- a/issues/repros/cross-thread-wake-resumes-on-the-owning-loop.yo
+++ b/issues/repros/cross-thread-wake-resumes-on-the-owning-loop.yo
@@ -1,0 +1,32 @@
+{ println } :: import("std/fmt");
+{ Park } :: import("std/async/waker");
+{ Thread, get_thread_id } :: import("std/thread");
+{ AtomicI32, AtomicUsize, MemoryOrder } :: import("std/sync/atomic");
+{ Duration } :: import("std/time/duration");
+{ sleep_blocking } :: import("std/time/sleep");
+main :: (fn(io : Io) -> unit)({
+  p := Park.new();
+  w := p.waker();
+  stamped := AtomicI32(i32(0));
+  resumed_on := AtomicUsize.new(usize(0));
+  main_tid := get_thread_id();
+  h := io.spawn(
+    io.async((io : Io) => {
+      io.await(p.wait(io), io);
+      resumed_on.store(get_thread_id(), MemoryOrder.Release);
+      _a := stamped.fetch_add(i32(100), MemoryOrder.AcqRel);
+      i32(0)
+    }),
+    io
+  );
+  t := Thread(unit).spawn((tio : Io) => {
+    sleep_blocking(Duration.from_millis(i64(50)));
+    _b := stamped.fetch_add(i32(7), MemoryOrder.AcqRel);
+    w.wake();
+    ()
+  });
+  _r := h.await(io);
+  println(`stamped=${stamped.load(MemoryOrder.Acquire)} same_thread=${resumed_on.load(MemoryOrder.Acquire) == main_tid}`);
+  t.join();
+});
+export(main);

--- a/issues/repros/impl-fn-param-captured-by-an-async-block.yo
+++ b/issues/repros/impl-fn-param-captured-by-an-async-block.yo
@@ -1,0 +1,40 @@
+{ println } :: import("std/fmt");
+{ Channel } :: import("std/sync/channel");
+// The defect: an `Impl(Fn)` PARAMETER of the enclosing function, captured by a
+// closure that is built INSIDE an `io.async` block. The state machine emits a
+// bare `cb` for the capture-struct field where it must read the SM's own slot:
+//
+//   __yo_t_N __capture_closure_… = (__yo_t_N){ .cb = cb, … };
+//                                              ^^^^^^^^ undeclared in the
+//                                                       resume function
+//
+// Every OTHER capture in the same struct is rendered correctly through
+// `sm->var_…`, so this is the `Impl(Fn)` param specifically.
+run_it :: (fn(f : Impl(Fn() -> unit, Send)) -> unit)(f());
+relay :: (
+  fn(
+    generic(T : Type),
+    cb : Impl(Fn() -> T, Send),
+    io : Io,
+    where(T <: (Send, Acyclic))
+  ) -> Impl(Future(T, Io))
+)(
+  io.async(
+    (io : Io) => {
+      chan := Channel(T).new(usize(1));
+      sink := chan;
+      run_it(
+        () => {
+          sink.send(cb());
+          ()
+        }
+      );
+      match(chan.try_recv(), .Ok(v) => v, .Err(_) => __yo_panic("no value"))
+    }
+  )
+);
+main :: (fn(io : Io) -> unit)({
+  n := io.await(relay(() => i32(42), io), io);
+  println(`n=${n}`);
+});
+export(main);

--- a/issues/repros/spawn-blocking-tests.yo
+++ b/issues/repros/spawn-blocking-tests.yo
@@ -1,0 +1,91 @@
+//! NOT a live test file — `spawn_blocking` is written but not exported yet
+//! (std/thread.yo says why). This is the test file to move back to
+//! `tests/spawn_blocking.test.yo` the day the closure-param half of
+//! issues/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md
+//! is fixed. It is kept here rather than deleted because it is the acceptance
+//! criterion `plans/WAKER_BASED_SCHEDULING.md` asks for, written and argued:
+//! the third test asserts by ORDERING, not by timing, and its blocking callee
+//! is bounded so a stalled loop fails with a zero reading instead of hanging.
+//! `std/thread`'s `spawn_blocking` — run a BLOCKING call on its own OS thread
+//! and await its result without stalling the event loop.
+//!
+//! This is the adopter of the cross-thread wake
+//! (`plans/WAKER_BASED_SCHEDULING.md` step 5): the worker finishes on a thread
+//! that does not own the awaiting task, so it posts the resumption to that
+//! task's loop and nudges it out of its I/O wait. Before the wake queue there
+//! was nowhere safe to put the continuation and no way to rouse the loop.
+//!
+//! The oracle is ORDERING, not timing: the blocking callee reports how much a
+//! sibling async task managed to do while it was blocked. A stalled loop makes
+//! that number zero, which fails — it does not hang, because the callee is
+//! bounded.
+{ assert } :: import("std/assert");
+{ spawn_blocking } :: import("std/thread");
+{ AtomicI32, MemoryOrder } :: import("std/sync/atomic");
+{ Duration } :: import("std/time/duration");
+{ sleep_blocking } :: import("std/time/sleep");
+{ yield } :: import("std/async");
+test("spawn_blocking returns the worker's value", {
+  n := io.await(spawn_blocking(() => (i32(20) + i32(22)), io), io);
+  assert(n == i32(42), "the blocking callee's value came back");
+});
+_Pair :: struct(lo : i32, hi : i32);
+test("spawn_blocking carries a non-scalar result", {
+  // A VALUE struct of Send fields. `String` is a non-atomic `ref` struct and
+  // so is deliberately not Send — it may not cross a thread, and the bound on
+  // `spawn_blocking` rejects it at compile time.
+  pr := io.await(spawn_blocking(() => _Pair(lo : i32(3), hi : i32(4)), io), io);
+  assert((pr.lo + pr.hi) == i32(7), "a value struct crossed back from the worker thread");
+});
+test("a sibling task keeps running while spawn_blocking blocks", {
+  progress := AtomicI32(i32(0));
+  // The sibling: an ordinary async task doing 40 turns of the loop.
+  sib := io.spawn(
+    io.async((io : Io) => {
+      (i : i32) = i32(0);
+      while(runtime(i < i32(40)), {
+        io.await(yield(io), io);
+        progress.fetch_add(i32(1), MemoryOrder.AcqRel);
+        i = (i + i32(1));
+      });
+      i32(0)
+    }),
+    io
+  );
+  // The blocking callee: a genuinely blocking sleep on its own thread, waiting
+  // for the sibling to make progress. BOUNDED, so a stalled loop fails with a
+  // zero reading instead of hanging the suite.
+  observed := io.await(
+    spawn_blocking(() => {
+      (spins : i32) = i32(0);
+      while(runtime((progress.load(MemoryOrder.Acquire) < i32(5)) && (spins < i32(200))), {
+        sleep_blocking(Duration.from_millis(i64(5)));
+        spins = (spins + i32(1));
+      });
+      progress.load(MemoryOrder.Acquire)
+    }, io),
+    io
+  );
+  assert(observed >= i32(5), "the event loop kept turning while the worker thread blocked");
+  _r := io.await(sib, io);
+  assert(progress.load(MemoryOrder.Acquire) == i32(40), "the sibling ran to completion");
+});
+test("two spawn_blocking calls in flight at once", {
+  a := io.spawn(
+    spawn_blocking(() => {
+      sleep_blocking(Duration.from_millis(i64(20)));
+      i32(1)
+    }, io),
+    io
+  );
+  b := io.spawn(
+    spawn_blocking(() => {
+      sleep_blocking(Duration.from_millis(i64(20)));
+      i32(2)
+    }, io),
+    io
+  );
+  ra := io.await(a, io);
+  rb := io.await(b, io);
+  assert((ra + rb) == i32(3), "both workers delivered");
+});

--- a/plans/WAKER_BASED_SCHEDULING.md
+++ b/plans/WAKER_BASED_SCHEDULING.md
@@ -13,7 +13,71 @@ them.
 | 3a. `Mutex` over a waiter queue | **LANDED** (#576) — `std/async/mutex.yo` holds an `ArrayList(Waker)`, `unlock` wakes the FRONT waiter, and `waiter_count()` is the oracle the FIFO test reads |
 | 3b. `Channel` over the same queue | **LANDED** (#586) — `send`/`recv` park on a waiter queue instead of re-checking on a 1 ms timer tick. It was blocked for a day by a compiler defect that the rewrite surfaced: the trace collector tried to monomorphize a GENERIC `ArrayList(T)` instance that only this shape put in the codegen type registry, and failed inside `array_list.yo`'s `Trace` body — a file the rewrite never touched (`issues/fixed/a-generic-instance-in-the-type-registry-breaks-trace-monomorphization.md`) |
 | 4. The combinators (`race`/`any`/`timeout`) | **PARTLY LANDED.** `timeout`'s retention is CLOSED: `abort()` now cancels the operation the task is suspended in, so the deadline timer is deregistered the moment the task wins instead of staying armed for the rest of the limit (`issues/fixed/timeout-deadline-timer-future-leak.md`). What remains is the polling SHAPE — `race`/`any` still re-check `is_finished()` around `__yo_async_poll_step()`; parking them on a wake needs a completion-notification list on `JoinHandle`, which is step 5's machinery |
-| 5. Cross-thread wake + `spawn_blocking` | **OPEN — the only one.** `__yo_waker_wake` is already atomic on the future's own fields, but `__yo_async_enqueue_continuation` writes a THREAD-LOCAL ready queue, so a wake from a worker thread has nowhere safe to put the continuation and no way to rouse a loop parked in `__yo_io_wait`. Needs a cross-thread wake queue plus a loop wakeup channel (eventfd / pipe / kqueue `EVFILT_USER`) |
+| 5. Cross-thread wake + `spawn_blocking` | **RUNTIME WRITTEN AND WORKING; `spawn_blocking` BLOCKED on a compiler defect.** Details below |
+
+## Step 5, as it stands 2026-09-12
+
+**The runtime is written and measured working.** Each event loop owns one
+explicitly locked inbox plus a wakeup channel into its own I/O backend; a wake
+raised on a foreign thread pushes the waker TOKEN onto the owner's inbox and
+nudges that channel, and the owner drains it on its own thread at the top of
+every tick. So exactly one new piece of shared state exists, it is locked, and
+every runtime variable stays single-threaded — which is the resolution this
+document proposed, implemented as proposed.
+
+* `src/codegen/async/runtime_core.yo` — `__yo_loop_t`, the inbox, the drain,
+  `blocking_inflight` brackets, and a waker TOKEN (rather than the park future)
+  as the thing that travels, so **no reference count ever crosses a thread**.
+* wakeup channels: `EVFILT_USER` on the loop's own kqueue (macOS), an eventfd
+  with a re-armed `POLL_ADD` (Linux io_uring), `PostQueuedCompletionStatus`
+  (Windows IOCP), a no-op on wasm.
+* `std/async/waker.yo` — `Waker` is `atomic(ref(...))` and therefore `Send`,
+  which is what lets a token be handed to a worker thread at all.
+* `std/thread.yo` — `spawn_blocking`, eager (Rust's semantics: the work starts
+  at the call, not on first poll).
+
+End to end, `io.await(spawn_blocking(() => 20 + 22, io), io)` returns 42 with
+the wake crossing the thread boundary, and `tests/cross_thread_wake.test.yo`
+gates the machinery on its own, without generics.
+
+**That test's oracle is the THREAD IDENTITY, not the value**, and it took an
+emitted-C A/B to find out why it has to be. Disable the cross-thread post,
+re-clang, re-run: the value arrives either way — the old path enqueued the
+continuation on the WAKER's thread-local queue, and that thread's own loop ran
+it at exit, producing the right answer on the wrong thread. Only
+`resumed_on == main_tid` flips. A test that checked the value would have passed
+over the bug the whole step exists for.
+
+It also has to await the park from inside a SPAWNED task. A blocking
+`io.await` in `main` is a poll loop over the future's state word, which a
+foreign CAS satisfies directly: no continuation is ever registered, so there is
+nothing for the inbox to carry and the test is vacuous. That is this document's
+own first recorded risk, met in practice. **The blocker is a second instantiation:**
+`spawn_blocking` is
+`fn(generic(T), own(cb) : Impl(Fn() -> T, Send), io) -> Impl(Future(T, Io))`,
+and the closure-param form of that shape miscompiles at a second `T` — the async
+block inside the generic function is emitted ONCE for both. The value-param form
+of the same family is fixed
+(`issues/fixed/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md`);
+the closure-param form is still open in that same document, with three
+reproducers and a table of nine variables that are NOT the trigger. Shipping
+`spawn_blocking` before it is fixed would ship an API that silently miscompiles
+the second time a program uses it.
+
+Two traps recorded from doing it, both of which cost a full build-and-bisect
+cycle:
+
+* `__yo_async_drain_yields` called `__yo_waker_wake(n->future)`. Once that
+  primitive took a TOKEN, the `void*` signature meant C said nothing and every
+  `yield` hung on a garbage `owner` pointer. Emitted-C A/B (patch the `.c`,
+  re-clang, re-run) isolated it in seconds where a rebuild took twelve minutes.
+* A closure captured BY another closure — which the relaying wrapper creates —
+  was never released, because the drop walk is blind to a bare `Impl(Fn)` SomeT.
+  Fixing that in the SHARED drop generator double-released every closure slot
+  whose captures a synthesized capture-dispose already frees: a
+  heap-use-after-free that macOS ran green and Linux ASan caught. It belongs in
+  the spawn wrapper alone
+  (`issues/a-closure-typed-slot-never-releases-its-captures.md`).
 
 **Two codegen bugs fell out of this campaign, both fixed.**
 

--- a/src/codegen/async/runtime_core.yo
+++ b/src/codegen/async/runtime_core.yo
@@ -73,13 +73,136 @@ static int __yo_io_wait(void);
 // declared, not merely declared: a static object has no forward-declaration
 // spelling in C.
 // See plans/WAKER_BASED_SCHEDULING.md.
-static ${thread_local} size_t __yo_async_live_wakers = 0;
+// ---------------------------------------------------------------------------
+// The per-loop control block — the ONE piece of shared state in this runtime
+// ---------------------------------------------------------------------------
+// Everything else here is thread-local and touched only by the loop that owns
+// it, which is the whole model: no mutexes, no atomics, no shared scheduler
+// state. A cross-thread wake cannot join that model directly —
+// __yo_async_enqueue_continuation writes an unsynchronized queue, and a thread
+// parked in __yo_io_wait has no way to notice a foreign push at all.
+//
+// The resolution keeps the invariant rather than weakening it. Each loop owns
+// ONE explicitly locked inbox plus a wakeup channel into its own I/O backend.
+// A wake raised on a foreign thread pushes the TOKEN onto the owner's inbox
+// and nudges that channel; the owner drains the inbox ON ITS OWN THREAD at the
+// top of every tick and does the state change and the enqueue there. So
+// exactly one new piece of shared state exists, it is locked, and every
+// runtime variable stays single-threaded.
+// See plans/WAKER_BASED_SCHEDULING.md step 5.
+//
+// Nothing that crosses a thread boundary touches a REFERENCE COUNT. The park
+// future's refcount is non-atomic like every other runtime object's, so the
+// token — not the future — is what travels, the owner allocates and frees it,
+// and a release raised on a foreign thread is deferred through the same inbox.
+typedef struct __yo_waker_token_t {
+  __yo_io_future_t* future;
+  struct __yo_loop_t* owner;
+  // Inbox link. Written only under the owner's lock.
+  struct __yo_waker_token_t* xnext;
+  // 0 idle, 1 queued on the owner's inbox. The CAS is what makes a repeated
+  // foreign wake idempotent without holding the lock to find out.
+  _Atomic int queued;
+  // Set by a foreign __yo_waker_release: the owner drops the token's reference
+  // and frees the token when it drains the inbox.
+  _Atomic int release_pending;
+} __yo_waker_token_t;
+
+typedef struct __yo_loop_t {
+  __YO_THREAD_SYNC_TYPE lock;
+  __yo_waker_token_t* xwake_head;
+  __yo_waker_token_t* xwake_tail;
+  // A lock-free "is the inbox worth locking for" read, for the hot predicate
+  // the loop drivers call on every tick.
+  _Atomic size_t xwake_count;
+  // Waker tokens alive for tasks parked on THIS loop. Atomic because a token
+  // is released wherever its last holder happens to be.
+  _Atomic size_t live_wakers;
+  // Blocking calls this loop is waiting on, running on other threads. While
+  // this is non-zero the loop keeps waiting with no I/O outstanding and never
+  // reports a wake deadlock: the wake is coming from outside its world.
+  _Atomic size_t blocking_inflight;
+  // Backend wakeup channel, filled in by __yo_io_init.
+  int notify_ready;
+  int notify_fd;
+  void* notify_handle;
+} __yo_loop_t;
+
+static ${thread_local} __yo_loop_t __yo_this_loop;
+static ${thread_local} bool __yo_this_loop_ready = false;
+
+// Nudge a loop out of a blocking backend wait. Defined by the platform I/O
+// runtime, which owns the channel; a no-op where the target cannot have a
+// second thread at all (wasm).
+static void __yo_io_notify(__yo_loop_t* loop);
+
+static __yo_loop_t* __yo_loop_self(void) {
+  if (!__yo_this_loop_ready) {
+    __yo_this_loop_ready = true;
+    __yo_mutex_init(&__yo_this_loop.lock);
+    __yo_this_loop.xwake_head = NULL;
+    __yo_this_loop.xwake_tail = NULL;
+    atomic_init(&__yo_this_loop.xwake_count, 0);
+    atomic_init(&__yo_this_loop.live_wakers, 0);
+    atomic_init(&__yo_this_loop.blocking_inflight, 0);
+    __yo_this_loop.notify_ready = 0;
+    __yo_this_loop.notify_fd = -1;
+    __yo_this_loop.notify_handle = NULL;
+  }
+  return &__yo_this_loop;
+}
+
+// How many waker tokens are alive for THIS loop.
+static size_t __yo_async_live_wakers(void) {
+  return atomic_load(&__yo_loop_self()->live_wakers);
+}
+
+// Is a foreign wake waiting to be drained?
+static bool __yo_async_has_xwake(void) {
+  return atomic_load(&__yo_loop_self()->xwake_count) > 0;
+}
+
+// Is this loop waiting on a blocking call running on another thread?
+static bool __yo_async_has_blocking_inflight(void) {
+  return atomic_load(&__yo_loop_self()->blocking_inflight) > 0;
+}
+
+// Could a wake still arrive from OUTSIDE this loop?
+//
+// The wake-deadlock report below reasons "in a single-threaded loop nothing
+// can fire it", which is exactly right and stops being right the moment the
+// process spawns a thread: that thread may be holding a waker token for a task
+// parked here. So with any thread in the process, a live waker is a reason to
+// WAIT rather than to conclude. A wake that never comes then hangs, which is
+// honest — the runtime cannot tell that apart from one that is merely slow,
+// and the same is true of every blocking join.
+static bool __yo_async_foreign_wake_possible(void) {
+  return (atomic_load(&__yo_threads_ever_spawned) > 0) && (__yo_async_live_wakers() > 0);
+}
+
+// spawn_blocking brackets: the loop must not conclude "nothing can happen"
+// while a worker thread is still going to wake it.
+static void __yo_async_blocking_begin(void) {
+  atomic_fetch_add(&__yo_loop_self()->blocking_inflight, 1);
+}
+static void __yo_async_blocking_end(void* loop_p) {
+  __yo_loop_t* loop = (__yo_loop_t*)loop_p;
+  if (!loop) {
+    return;
+  }
+  atomic_fetch_sub(&loop->blocking_inflight, 1);
+  __yo_io_notify(loop);
+}
+static void* __yo_async_loop_self_ptr(void) {
+  return (void*)__yo_loop_self();
+}
 typedef struct __yo_yield_node_t {
   __yo_io_future_t* future;
   struct __yo_yield_node_t* next;
 } __yo_yield_node_t;
 static ${thread_local} __yo_yield_node_t* __yo_yield_pending = NULL;
 static void __yo_async_drain_yields(void);
+static void __yo_async_drain_xwakes(void);
 static bool __yo_async_has_pending_yield(void);
 static bool __yo_async_has_pending_work(void);
 static void __yo_async_report_wake_deadlock(void);
@@ -153,6 +276,10 @@ static int __yo_async_strict_nesting(void) {
 // Returns the number of tasks resumed, so the caller knows whether anything a
 // blocking waiter watches may have changed in this step.
 static int __yo_async_run_ready_tasks(void) {
+  // BEFORE the budget snapshot: a foreign wake has already paid for a thread
+  // hop, so it runs in THIS step rather than the next one. (A yield is the
+  // opposite case and is drained after — see below.)
+  __yo_async_drain_xwakes();
   int budget = (int)__yo_thread_async_queue.count;
   // AFTER the snapshot, deliberately: a completed yield enqueues its
   // continuation past the budget, so it resumes in the NEXT step — with one
@@ -215,7 +342,9 @@ static void __yo_async_poll_step(void) {
     // (issues/fixed/event-loop-blocks-after-completing-the-awaited-future.md).
     // Same rule as __yo_async_wait_all's !tasks_processed.
     if (ran == 0 && !__yo_thread_async_queue.head && !__yo_async_has_pending_yield()
-        && __yo_has_pending_io()) {
+        && !__yo_async_has_xwake()
+        && ((__yo_has_pending_io() || __yo_async_has_blocking_inflight())
+            || __yo_async_foreign_wake_possible())) {
       __yo_io_wait();
     }
   }
@@ -232,10 +361,14 @@ static bool __yo_async_poll_step_live(void) {
   if (__yo_async_has_pending_yield()) {
     return true;
   }
+  if (__yo_async_has_xwake() || __yo_async_has_blocking_inflight()
+      || __yo_async_foreign_wake_possible()) {
+    return true;
+  }
   if (__yo_has_pending_io()) {
     return true;
   }
-  if (__yo_async_live_wakers > 0) {
+  if (__yo_async_live_wakers() > 0) {
     __yo_async_report_wake_deadlock();
   }
   return false;
@@ -253,6 +386,7 @@ static void __yo_async_run_until_complete(void* future_ptr) {
   int __future_state = future->state;
   while (__future_state != -1 && __future_state != -2) {
     int tasks_run = 0;
+    __yo_async_drain_xwakes();
     __yo_async_drain_yields();
     while (tasks_run < 100) {
       __yo_continuation_t* cont = __yo_thread_async_queue.head;
@@ -278,7 +412,9 @@ static void __yo_async_run_until_complete(void* future_ptr) {
       break;
     }
     if (tasks_run == 0 && !__yo_thread_async_queue.head
-        && !__yo_async_has_pending_yield() && __yo_has_pending_io()) {
+        && !__yo_async_has_pending_yield() && !__yo_async_has_xwake()
+        && ((__yo_has_pending_io() || __yo_async_has_blocking_inflight())
+            || __yo_async_foreign_wake_possible())) {
       __yo_io_wait();
       __future_state = future->state;
       continue;
@@ -317,6 +453,7 @@ static void __yo_async_wait_all(void) {
   __yo_io_init();
   while (true) {
     bool tasks_processed = false;
+    __yo_async_drain_xwakes();
     __yo_async_drain_yields();
     while (__yo_thread_async_queue.head) {
       __yo_continuation_t* cont = __yo_thread_async_queue.head;
@@ -331,13 +468,16 @@ static void __yo_async_wait_all(void) {
     }
     __yo_io_poll();
     if (!tasks_processed && !__yo_thread_async_queue.head
-        && !__yo_async_has_pending_yield() && __yo_has_pending_io()) {
+        && !__yo_async_has_pending_yield() && !__yo_async_has_xwake()
+        && ((__yo_has_pending_io() || __yo_async_has_blocking_inflight())
+            || __yo_async_foreign_wake_possible())) {
       __yo_io_wait();
       continue;
     }
     if (!__yo_thread_async_queue.head && !__yo_async_has_pending_yield()
-        && !__yo_has_pending_io()) {
-      if (__yo_async_live_wakers > 0) {
+        && !__yo_async_has_xwake() && !__yo_async_has_blocking_inflight()
+        && !__yo_async_foreign_wake_possible() && !__yo_has_pending_io()) {
+      if (__yo_async_live_wakers() > 0) {
         __yo_async_report_wake_deadlock();
       }
       break;
@@ -452,19 +592,21 @@ static void* __yo_waker_new(void* f) {
   if (!f) {
     return NULL;
   }
+  __yo_waker_token_t* t = (__yo_waker_token_t*)__yo_rc_alloc(sizeof(__yo_waker_token_t));
   __yo_incr_rc(f);
-  __yo_async_live_wakers++;
-  return f;
+  t->future = (__yo_io_future_t*)f;
+  t->owner = __yo_loop_self();
+  t->xnext = NULL;
+  atomic_init(&t->queued, 0);
+  atomic_init(&t->release_pending, 0);
+  atomic_fetch_add(&t->owner->live_wakers, 1);
+  return (void*)t;
 }
 
-// Make the parked task runnable. Idempotent: a second wake, or a wake of a
-// future that reached a terminal state some other way, is a no-op — which is
-// what lets a waiter list wake everyone without tracking who already ran.
-static void __yo_waker_wake(void* p) {
-  if (!p) {
-    return;
-  }
-  __yo_io_future_t* f = (__yo_io_future_t*)p;
+// Complete a park future and enqueue whoever is suspended on it. ONLY ever
+// called on the loop that owns the future, so every field it touches — the
+// ready queue included — is single-threaded exactly as before.
+static void __yo_waker_wake_local(__yo_io_future_t* f) {
   int expected = 0;
   if (!atomic_compare_exchange_strong(&f->state, &expected, -1)) {
     return;
@@ -477,12 +619,87 @@ static void __yo_waker_wake(void* p) {
   }
 }
 
+// Hand a token to its owner loop and nudge that loop awake. The push is the
+// only shared write, and the CAS above it makes a repeated wake free.
+static void __yo_waker_post(__yo_waker_token_t* t) {
+  __yo_loop_t* owner = t->owner;
+  int expected = 0;
+  if (!atomic_compare_exchange_strong(&t->queued, &expected, 1)) {
+    // Already on the inbox: the owner will see the state this wake just set.
+    __yo_io_notify(owner);
+    return;
+  }
+  __yo_mutex_lock(&owner->lock);
+  t->xnext = NULL;
+  if (owner->xwake_tail) {
+    owner->xwake_tail->xnext = t;
+  } else {
+    owner->xwake_head = t;
+  }
+  owner->xwake_tail = t;
+  atomic_fetch_add(&owner->xwake_count, 1);
+  __yo_mutex_unlock(&owner->lock);
+  __yo_io_notify(owner);
+}
+
+// Drain the inbox onto this loop's own ready queue. Takes the whole list under
+// the lock and then works outside it, so a wake raised while this runs lands
+// on the next list instead of blocking the waker.
+static void __yo_async_drain_xwakes(void) {
+  __yo_loop_t* loop = __yo_loop_self();
+  if (atomic_load(&loop->xwake_count) == 0) {
+    return;
+  }
+  __yo_mutex_lock(&loop->lock);
+  __yo_waker_token_t* t = loop->xwake_head;
+  loop->xwake_head = NULL;
+  loop->xwake_tail = NULL;
+  atomic_store(&loop->xwake_count, 0);
+  __yo_mutex_unlock(&loop->lock);
+  while (t) {
+    __yo_waker_token_t* next = t->xnext;
+    t->xnext = NULL;
+    atomic_store(&t->queued, 0);
+    if (t->future) {
+      __yo_waker_wake_local(t->future);
+    }
+    // A release raised on a foreign thread is deferred to here so the park
+    // future's non-atomic refcount is only ever touched by its own loop.
+    if (atomic_load(&t->release_pending)) {
+      if (t->future) {
+        __yo_decr_rc((void*)t->future);
+        t->future = NULL;
+      }
+      __yo_free(t);
+    }
+    t = next;
+  }
+}
+
+// Make the parked task runnable. Idempotent: a second wake, or a wake of a
+// future that reached a terminal state some other way, is a no-op — which is
+// what lets a waiter list wake everyone without tracking who already ran.
+static void __yo_waker_wake(void* p) {
+  if (!p) {
+    return;
+  }
+  __yo_waker_token_t* t = (__yo_waker_token_t*)p;
+  if (t->owner != __yo_loop_self()) {
+    __yo_waker_post(t);
+    return;
+  }
+  if (t->future) {
+    __yo_waker_wake_local(t->future);
+  }
+}
+
 // Non-blocking read: has this park future been woken?
 static bool __yo_waker_is_woken(void* p) {
   if (!p) {
     return true;
   }
-  return atomic_load(&((__yo_io_future_t*)p)->state) != 0;
+  __yo_io_future_t* f = ((__yo_waker_token_t*)p)->future;
+  return !f || atomic_load(&f->state) != 0;
 }
 
 // Drop a waker token.
@@ -490,10 +707,30 @@ static void __yo_waker_release(void* p) {
   if (!p) {
     return;
   }
-  if (__yo_async_live_wakers > 0) {
-    __yo_async_live_wakers--;
+  __yo_waker_token_t* t = (__yo_waker_token_t*)p;
+  __yo_loop_t* owner = t->owner;
+  size_t lw = atomic_load(&owner->live_wakers);
+  if (lw > 0) {
+    atomic_fetch_sub(&owner->live_wakers, 1);
   }
-  __yo_decr_rc(p);
+  if (owner != __yo_loop_self()) {
+    // The park future's refcount belongs to the owner loop, so the drop is
+    // deferred to it rather than taken here. The owner frees the token too.
+    atomic_store(&t->release_pending, 1);
+    __yo_waker_post(t);
+    return;
+  }
+  if (atomic_load(&t->queued)) {
+    // Still on this loop's own inbox (a foreign wake landed before the local
+    // release): mark it and let the drain do both.
+    atomic_store(&t->release_pending, 1);
+    return;
+  }
+  if (t->future) {
+    __yo_decr_rc((void*)t->future);
+    t->future = NULL;
+  }
+  __yo_free(t);
 }
 
 // ============================================================================
@@ -555,7 +792,10 @@ static void __yo_async_drain_yields(void) {
   n = fifo;
   while (n) {
     __yo_yield_node_t* next = n->next;
-    __yo_waker_wake((void*)n->future);
+    // The FUTURE-level completion, not __yo_waker_wake: that one takes a
+    // waker TOKEN now (it has to know which loop owns the park), and a yield
+    // has no token — it is its own loop's business by construction.
+    __yo_waker_wake_local(n->future);
     __yo_decr_rc((void*)n->future);
     __yo_free(n);
     n = next;
@@ -573,8 +813,9 @@ static bool __yo_async_has_pending_yield(void) {
 // decide there is nothing left to wait for and return with the parked task's
 // future unresolved.
 static bool __yo_async_has_pending_work(void) {
-  return __yo_has_pending_io() || __yo_async_live_wakers > 0
-    || __yo_async_has_pending_yield();
+  return __yo_has_pending_io() || __yo_async_live_wakers() > 0
+    || __yo_async_has_pending_yield() || __yo_async_has_xwake()
+    || __yo_async_has_blocking_inflight();
 }
 
 // Nothing runnable, no I/O outstanding, and yet a waker is alive: in a
@@ -583,11 +824,18 @@ static bool __yo_async_has_pending_work(void) {
 // with the future unresolved or spinning at 100% CPU. A lost wake is
 // otherwise invisible — it shows up as a hang, and on one platform only.
 static void __yo_async_report_wake_deadlock(void) {
+  // A blocking call running on another thread WILL wake this loop, so the
+  // premise of the report ("nothing can fire it") does not hold while one is
+  // outstanding.
+  if (__yo_async_has_blocking_inflight() || __yo_async_has_xwake()
+      || __yo_async_foreign_wake_possible()) {
+    return;
+  }
   fprintf(stderr,
     "panic: every async task is parked on a waker that nothing can fire "
     "(%zu waker token(s) alive, no runnable task, no pending I/O). A wake was "
     "lost, or two tasks are each waiting for the other.\\n",
-    __yo_async_live_wakers);
+    __yo_async_live_wakers());
   fflush(stderr);
 }
 

--- a/src/codegen/async/runtime_io_linux.yo
+++ b/src/codegen/async/runtime_io_linux.yo
@@ -534,9 +534,20 @@ generate_async_runtime_io_linux :: (fn(emitter : Emitter) -> unit)({
 #include <arpa/inet.h>
 #include <sys/un.h>
 
+#include <sys/eventfd.h>
+#include <poll.h>
+
 static _Thread_local struct io_uring __yo_io_ring;
 // __yo_io_initialized is defined in runtime-core
 static _Thread_local size_t __yo_pending_io_count = 0;
+// Cross-thread wakeup channel (plans/WAKER_BASED_SCHEDULING.md step 5): an
+// eventfd this loop keeps a POLL_ADD armed on, so a foreign thread can end an
+// io_uring_wait_cqe that would otherwise block forever. Its SQE carries a
+// SENTINEL user_data rather than a future, and takes no pending-I/O slot: it
+// is not work the loop is waiting for, it is how the loop is reachable.
+#define __YO_IO_NOTIFY_UD ((void*)(uintptr_t)1)
+static _Thread_local int __yo_notify_efd = -1;
+static inline void __yo_io_arm_notify(void);
 // Ring size matches the fixed io_uring queue depth we initialize below.
 #define __YO_IO_RING_ENTRIES 1024
 // Number of SQEs queued in userspace but not yet submitted to the kernel.
@@ -583,12 +594,27 @@ static void __yo_io_init(void) {
     exit(1);
   }
   __yo_io_initialized = true;
+  __yo_notify_efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  if (__yo_notify_efd >= 0) {
+    __yo_loop_t* loop = __yo_loop_self();
+    loop->notify_fd = __yo_notify_efd;
+    loop->notify_ready = 1;
+    __yo_io_arm_notify();
+  }
   ASYNC_DEBUG("[Io] io_uring initialized with %d entries (flags=0x%x)\\n", __YO_IO_RING_ENTRIES, params.flags);
 }
 
 // Cleanup io_uring
 static void __yo_io_cleanup(void) {
   if (!__yo_io_initialized) return;
+  // Clear the loop's pointer BEFORE closing the eventfd, so a foreign wake
+  // racing the shutdown cannot write to a descriptor this function is about to
+  // close (and which the kernel may have handed to something else by then).
+  {
+    __yo_loop_t* loop = __yo_loop_self();
+    loop->notify_ready = 0;
+    loop->notify_fd = -1;
+  }
   // If async main returns while some SQEs are still only queued in userspace,
   // cancel them here instead of silently dropping the event-loop ref we took in
   // __yo_io_ring_submit.
@@ -603,6 +629,10 @@ static void __yo_io_cleanup(void) {
     __yo_decr_rc((void*)future);
   }
   io_uring_queue_exit(&__yo_io_ring);
+  if (__yo_notify_efd >= 0) {
+    close(__yo_notify_efd);
+    __yo_notify_efd = -1;
+  }
   __yo_io_initialized = false;
   ASYNC_DEBUG("[Io] io_uring cleaned up\\n");
 }
@@ -642,6 +672,33 @@ static inline bool __yo_io_ring_submit_cancel(__yo_io_future_t* target) {
   return true;
 }
 
+// Re-arm the wakeup channel's POLL_ADD. One-shot per completion, so every
+// drain of the eventfd arms the next one.
+static inline void __yo_io_arm_notify(void) {
+  if (__yo_notify_efd < 0) return;
+  if (__yo_sq_unsubmitted >= __YO_IO_RING_ENTRIES) return;
+  struct io_uring_sqe* sqe = io_uring_get_sqe(&__yo_io_ring);
+  if (!sqe) return;
+  io_uring_prep_poll_add(sqe, __yo_notify_efd, POLLIN);
+  io_uring_sqe_set_data(sqe, __YO_IO_NOTIFY_UD);
+  __yo_sq_deferred_futures[(__yo_sq_deferred_head + __yo_sq_unsubmitted) % __YO_IO_RING_ENTRIES] = NULL;
+  __yo_sq_unsubmitted++;
+}
+
+// Nudge a loop out of io_uring_wait_cqe. Safe from any thread: an eventfd
+// write is atomic and the descriptor is the only thing touched.
+static void __yo_io_notify(__yo_loop_t* loop) {
+  if (!loop || !loop->notify_ready || loop->notify_fd < 0) {
+    return;
+  }
+  uint64_t one = 1;
+  ssize_t w;
+  do {
+    w = write(loop->notify_fd, &one, sizeof(one));
+  } while (w < 0 && errno == EINTR);
+  (void)w;
+}
+
 // Flush any queued SQEs to the kernel if non-empty. Returns the liburing result.
 // On failure (ret < 0), the SQEs remain in the SQ ring so __yo_sq_unsubmitted
 // is left unchanged -- the next submit attempt (via poll/wait) will retry them.
@@ -667,6 +724,17 @@ static inline int __yo_io_flush_sq(void) {
 // The future pointer is stored directly in the SQE user data
 static void __yo_io_process_cqe(struct io_uring_cqe* cqe) {
   __yo_io_future_t* future = (__yo_io_future_t*)io_uring_cqe_get_data(cqe);
+  if ((void*)future == __YO_IO_NOTIFY_UD) {
+    // The wakeup channel fired. It carries no operation — draining the
+    // eventfd and re-arming is all there is to do; the foreign wake itself is
+    // picked up by __yo_async_drain_xwakes at the top of the next tick.
+    uint64_t v;
+    while (__yo_notify_efd >= 0 && read(__yo_notify_efd, &v, sizeof(v)) == (ssize_t)sizeof(v)) {
+    }
+    io_uring_cqe_seen(&__yo_io_ring, cqe);
+    __yo_io_arm_notify();
+    return;
+  }
   if (!future) {
     // Completion of a cancellation SQE (__yo_io_ring_submit_cancel): it owns
     // no future and no pending-I/O slot. The cancelled operation reports
@@ -753,6 +821,9 @@ static int __yo_io_wait(void) {
     return __yo_poll_and_fs_event_tick();
   }
 
+  // With no I/O outstanding but a blocking call running on another thread, the
+  // wait below is a wait on the wakeup channel alone — which is what the loop
+  // should be doing rather than spinning.
   struct io_uring_cqe* cqe;
   // Combined submit + wait in a single syscall -- this is the main batching win:
   // all deferred SQEs are submitted alongside the blocking wait for a CQE.
@@ -1522,6 +1593,12 @@ static inline void __yo_io_init(void) {
 }
 
 static inline void __yo_io_cleanup(void) {}
+
+// No ring to interrupt: without liburing this target has no blocking I/O wait
+// to be woken out of.
+static void __yo_io_notify(__yo_loop_t* loop) {
+  (void)loop;
+}
 
 static inline bool __yo_has_pending_io(void) {
   return __yo_active_watch_count > 0;

--- a/src/codegen/async/runtime_io_macos.yo
+++ b/src/codegen/async/runtime_io_macos.yo
@@ -604,6 +604,10 @@ generate_async_runtime_io_macos :: (fn(emitter : Emitter) -> unit)({
 #include <errno.h>
 
 // kqueue file descriptor for async I/O (per-thread — each thread has its own event loop)
+// Identifier of this loop's EVFILT_USER wakeup channel. Any value works as
+// long as no real fd/ident collides with it under EVFILT_USER, which has its
+// own ident namespace.
+#define __YO_KQ_NOTIFY_IDENT ((uintptr_t)1)
 static _Thread_local int __yo_io_kq = -1;
 // __yo_io_initialized is defined in runtime-core
 static _Thread_local size_t __yo_pending_io_count = 0;  // per-thread event loop counter
@@ -694,12 +698,45 @@ static void __yo_io_init(void) {
     abort();
   }
   __yo_io_initialized = true;
+  // Cross-thread wakeup channel (plans/WAKER_BASED_SCHEDULING.md step 5): a
+  // user event on this loop's own kqueue. kevent() is the documented way to
+  // interrupt a kevent() wait from another thread, and unlike a self-pipe it
+  // costs no file descriptor and no read() on the wake path.
+  {
+    __yo_loop_t* loop = __yo_loop_self();
+    struct kevent uev;
+    EV_SET(&uev, __YO_KQ_NOTIFY_IDENT, EVFILT_USER, EV_ADD | EV_CLEAR, 0, 0, NULL);
+    if (kevent(__yo_io_kq, &uev, 1, NULL, 0, NULL) == 0) {
+      loop->notify_handle = (void*)(intptr_t)__yo_io_kq;
+      loop->notify_ready = 1;
+    }
+  }
   ASYNC_DEBUG("[Io] kqueue initialized: kq=%d\\n", __yo_io_kq);
+}
+
+// Nudge a loop out of its kevent() wait. Safe from any thread: the kqueue
+// descriptor is the only thing touched, and kevent() is thread-safe.
+static void __yo_io_notify(__yo_loop_t* loop) {
+  if (!loop || !loop->notify_ready) {
+    return;
+  }
+  int kq = (int)(intptr_t)loop->notify_handle;
+  struct kevent uev;
+  EV_SET(&uev, __YO_KQ_NOTIFY_IDENT, EVFILT_USER, 0, NOTE_TRIGGER, 0, NULL);
+  kevent(kq, &uev, 1, NULL, 0, NULL);
 }
 
 // Cleanup kqueue
 static void __yo_io_cleanup(void) {
   if (!__yo_io_initialized) return;
+  // The wakeup channel goes with the kqueue it lives on. Clear the loop's
+  // pointer FIRST so a foreign wake racing the shutdown does not call
+  // kevent() on a descriptor this function is about to close.
+  {
+    __yo_loop_t* loop = __yo_loop_self();
+    loop->notify_ready = 0;
+    loop->notify_handle = NULL;
+  }
   // If async main returns while registrations are still only queued in the
   // deferred changelist, cancel them explicitly instead of dropping them on
   // close(kqueue).
@@ -742,6 +779,11 @@ static void __yo_io_wake_continuation(__yo_io_future_t* future) {
 
 // Process a single completed kqueue event
 static void __yo_io_process_event(struct kevent* ev) {
+  // The cross-thread wakeup channel. It carries no operation — its only job
+  // is to end the kevent() wait so the loop reaches __yo_async_drain_xwakes.
+  if (ev->filter == EVFILT_USER) {
+    return;
+  }
   // Timer events use a different context struct
   if (ev->filter == EVFILT_TIMER) {
     typedef struct { __yo_io_future_t* future; } __yo_timer_ctx_t;
@@ -905,13 +947,17 @@ static int __yo_io_wait(void) {
     nanosleep(&ts, NULL);
     return __yo_poll_and_fs_event_tick();
   }
-  if (__yo_pending_io_count == 0) {
+  if (__yo_pending_io_count == 0 && !__yo_async_has_blocking_inflight()
+      && !__yo_async_foreign_wake_possible()) {
     // Defensive: if we have deferred changes but nothing pending, flush
     // them so they do not sit indefinitely (rare -- registration bumps
     // __yo_pending_io_count, so this should normally be a no-op).
     if (__yo_kq_n_changes > 0) __yo_kq_flush_changes();
     return 0;
   }
+  // With no I/O outstanding but a blocking call running on another thread, the
+  // kevent() below is a wait on the EVFILT_USER wakeup channel alone — which
+  // is exactly what the loop should be doing rather than spinning.
 
   struct kevent events[64];
   struct timespec timeout = {0, 100 * 1000 * 1000};  // 100ms timeout

--- a/src/codegen/async/runtime_io_wasm.yo
+++ b/src/codegen/async/runtime_io_wasm.yo
@@ -467,6 +467,13 @@ static void __yo_io_init(void) {
   __yo_io_initialized = true;
 }
 
+// Cross-thread wakeup channel: there is no second thread on this target, so
+// there is nothing to wake. The symbol exists because the async core calls it
+// unconditionally (plans/WAKER_BASED_SCHEDULING.md step 5).
+static void __yo_io_notify(__yo_loop_t* loop) {
+  (void)loop;
+}
+
 // Cleanup pending timers
 static void __yo_io_cleanup(void) {
   while (__yo_wasm_timer_head) {

--- a/src/codegen/async/runtime_io_windows.yo
+++ b/src/codegen/async/runtime_io_windows.yo
@@ -2105,12 +2105,37 @@ static void __yo_io_init(void) {
     ASYNC_DEBUG("[Io] WSAStartup failed: %d\\n", wsa_result);
   }
 
+  // Cross-thread wakeup channel (plans/WAKER_BASED_SCHEDULING.md step 5): a
+  // posted completion packet with a NULL OVERLAPPED. The wait loop already
+  // skips those, so it costs nothing but the wake it delivers.
+  if (__yo_io_iocp) {
+    __yo_loop_t* loop = __yo_loop_self();
+    loop->notify_handle = (void*)__yo_io_iocp;
+    loop->notify_ready = 1;
+  }
   __yo_io_initialized = true;
   ASYNC_DEBUG("[Io] Windows async runtime initialized\\n");
 }
 
+// Nudge a loop out of GetQueuedCompletionStatusEx. Safe from any thread — an
+// IOCP handle is explicitly shareable and PostQueuedCompletionStatus is its
+// documented cross-thread signal.
+static void __yo_io_notify(__yo_loop_t* loop) {
+  if (!loop || !loop->notify_ready) {
+    return;
+  }
+  PostQueuedCompletionStatus((HANDLE)loop->notify_handle, 0, 0, NULL);
+}
+
 static void __yo_io_cleanup(void) {
   if (!__yo_io_initialized) return;
+  // Clear the loop's pointer BEFORE closing the port, so a foreign wake racing
+  // the shutdown cannot post to a handle this function is about to close.
+  {
+    __yo_loop_t* loop = __yo_loop_self();
+    loop->notify_ready = 0;
+    loop->notify_handle = NULL;
+  }
   if (__yo_io_iocp) {
     CloseHandle(__yo_io_iocp);
     __yo_io_iocp = NULL;
@@ -2344,7 +2369,11 @@ static int __yo_io_wait(void) {
     Sleep(10);
     return __yo_poll_and_fs_event_tick();
   }
-  if (__yo_pending_io_count == 0) return 0;
+  // With no I/O outstanding but a blocking call running on another thread, the
+  // wait below is a wait on the wakeup channel alone — which is what the loop
+  // should be doing rather than spinning.
+  if (__yo_pending_io_count == 0 && !__yo_async_has_blocking_inflight()
+      && !__yo_async_foreign_wake_possible()) return 0;
 
   DWORD timeout_ms = __yo_win_timer_next_timeout(__yo_win_now_ms());
   if (__yo_active_watch_count > 0 && (timeout_ms == INFINITE || timeout_ms > 50)) {

--- a/src/codegen/parallelism/runtime.yo
+++ b/src/codegen/parallelism/runtime.yo
@@ -140,6 +140,9 @@ typedef struct __yo_thread_entry_args_t {
 // The codegen will handle extracting the closure function pointer and data
 static __yo_thread_t __yo_thread_spawn(__yo_thread_fn fn, void* closure) {
   PARALLELISM_DEBUG("[THREAD] Spawning new thread\\n");
+  // Tell every event loop in the process that a wake can now come from
+  // outside it (see __yo_threads_ever_spawned).
+  atomic_fetch_add(&__yo_threads_ever_spawned, 1);
 
   __yo_thread_t thread;
 
@@ -443,7 +446,10 @@ static void __yo_worker_spawn(__yo_thread_fn fn, void* closure) {`
   );
   emitter.emit_string_line(init_mutex_call);
   emitter.emit_string_line(
-    `  __YO_THREAD_SYNC_LOCK(&__yo_worker_pool_mutex);
+    `  // A pool worker can wake a loop on another thread just as a dedicated
+  // thread can (see __yo_threads_ever_spawned).
+  atomic_fetch_add(&__yo_threads_ever_spawned, 1);
+  __YO_THREAD_SYNC_LOCK(&__yo_worker_pool_mutex);
 
   // Initialize pool on first spawn if not already done
   if (!__yo_worker_pool_initialized) {

--- a/src/codegen/types/generation.yo
+++ b/src/codegen/types/generation.yo
@@ -709,6 +709,16 @@ static __YO_THREAD_SYNC_TYPE __yo_mutex_create(void);
 static __YO_COND_TYPE __yo_cond_create(void);
 
 #include <stdatomic.h>
+// How many OS threads this process has EVER spawned.
+//
+// The async loop reads it to decide whether a live waker could be fired from
+// outside its own world. The wake-deadlock report's premise is "in a
+// single-threaded loop nothing can fire it" — true, and the moment a second
+// thread exists it stops being true, so the loop must wait rather than report.
+// Defined here, beside the threading primitives, because the async core and
+// the parallelism runtime are emitted independently and either can be present
+// without the other.
+static _Atomic size_t __yo_threads_ever_spawned = 0;
 static inline int __yo_atomic_load_int(_Atomic int* obj, memory_order order) {
   return atomic_load_explicit(obj, order);
 }

--- a/std/async/waker.yo
+++ b/std/async/waker.yo
@@ -63,10 +63,18 @@ pragma(Pragma.AllowUnsafe);
 /// the token cannot outlive its target — a non-owning pointer here would be
 /// the use-after-free `Watcher`'s event-loop callback once had
 /// (`issues/fixed/a-dropped-watcher-leaves-the-event-loop-calling-freed-memory.md`).
-Waker :: ref(
-  struct(
-    /// The park future, with one reference held on this token's behalf.
-    _p : *u8
+/// ATOMIC, and therefore `Send`: a waker exists to be handed to whoever will
+/// signal, and since step 5 of the waker campaign that includes a worker
+/// thread (`spawn_blocking`). A cross-thread `wake()` does not touch the park
+/// future — it hands this token to the future's own loop and nudges it — so
+/// the only refcount that crosses a thread boundary is this token's own, which
+/// is what `atomic` makes safe.
+Waker :: atomic(
+  ref(
+    struct(
+      /// The waker token, holding one reference to the park it resumes.
+      _p : *u8
+    )
   )
 );
 impl(

--- a/std/sys/externs.yo
+++ b/std/sys/externs.yo
@@ -167,6 +167,14 @@ extern(
   __yo_waker_wake : (fn(waker : *u8) -> unit),
   __yo_waker_is_woken : (fn(waker : *u8) -> bool),
   __yo_waker_release : (fn(waker : *u8) -> unit),
+  // spawn_blocking brackets. Between them the loop keeps waiting with no I/O
+  // outstanding and never reports a wake deadlock: the wake is coming from a
+  // worker thread, which is outside everything the loop can see.
+  // `__yo_async_loop_self_ptr` identifies the loop to end the bracket on,
+  // because `end` runs on the WORKER thread.
+  __yo_async_loop_self_ptr : (fn() -> *u8),
+  __yo_async_blocking_begin : (fn() -> unit),
+  __yo_async_blocking_end : (fn(loop : *u8) -> unit),
   // ========================================================================
   // File Extra Operations (async only: sleep remains async)
   // ========================================================================
@@ -380,6 +388,9 @@ export(
   __yo_waker_wake,
   __yo_waker_is_woken,
   __yo_waker_release,
+  __yo_async_loop_self_ptr,
+  __yo_async_blocking_begin,
+  __yo_async_blocking_end,
   // File extra operations (statfs accessors only - statfs itself is now sync)
   __yo_statfs_buf_size,
   __yo_statfs_type,

--- a/std/thread.yo
+++ b/std/thread.yo
@@ -35,6 +35,12 @@ pragma(Pragma.AllowUnsafe);
 { AtomicBool, AtomicUsize, MemoryOrder } :: import("./sync/atomic");
 { Channel } :: import("./sync/channel");
 { assert } :: import("./assert");
+{ Park } :: import("./async/waker.yo");
+{
+  __yo_async_loop_self_ptr,
+  __yo_async_blocking_begin,
+  __yo_async_blocking_end
+} :: import("./sys/externs.yo");
 extern(
   "Yo",
   __yo_thread_get_hardware_threads : (fn() -> usize),
@@ -333,6 +339,97 @@ spawn :: (fn(pool : ThreadPool, cb : Impl(Fn(io : Io) -> unit, Send)) -> unit)({
   pool._used.store(true, MemoryOrder.Release);
   __yo_worker_spawn(cb);
   _unlock_after_submission(pool, took);
+});
+/// Run a BLOCKING call on its own OS thread and await the result, without
+/// stalling the event loop.
+///
+/// This is Rust's `tokio::task::spawn_blocking`, and it is the reason the
+/// runtime has a cross-thread wake at all
+/// (`plans/WAKER_BASED_SCHEDULING.md` step 5): the worker finishes on a
+/// thread that does not own the awaiting task, so it cannot touch that task's
+/// ready queue. It hands a `Waker` back instead, which posts the resumption to
+/// the owning loop's inbox and nudges that loop out of its I/O wait.
+///
+/// ```rust
+/// { spawn_blocking } :: import "std/thread";
+///
+/// // A synchronous, blocking call — a C library, a getaddrinfo, a big read.
+/// n := io.await(spawn_blocking(() => expensive_sync_work(), io), io);
+/// ```
+///
+/// A sibling task keeps running the whole time: the loop is free between the
+/// suspension and the wake, which is the property `tests/spawn_blocking.test.yo`
+/// asserts by ORDERING rather than by timing.
+///
+/// The thread is not joined. It has already delivered its value and its wake
+/// by the time the awaiting task resumes, so joining would only block the loop
+/// on the thread's own teardown; the handle is dropped, which detaches it.
+///
+/// A blocking call that never returns keeps the process alive — the same
+/// contract a detached `Thread` has, and the same one Rust's blocking pool
+/// has.
+/// The worker's value, off the hand-off channel. A plain generic function
+/// rather than a `match` written inline in the async block below: the block is
+/// specialized per `T`, and an inline match there recorded ONE result type for
+/// every specialization — the first `T` won and every other one miscompiled
+/// (issues/an-async-blocks-tail-match-records-one-result-type-for-every-specialization.md).
+_take_blocking_result :: (
+  fn(generic(T : Type), chan : Channel(T), where(T <: (Send, Acyclic))) -> T
+)(
+  match(
+    chan.try_recv(),
+    .Ok(v) => v,
+    .Err(_) => __yo_panic("spawn_blocking: the worker thread produced no value (it unwound)")
+  )
+);
+/// NOT EXPORTED YET. It works — end to end, with the wake crossing the thread
+/// boundary — but only for ONE `T` per program: the closure-param form of
+/// `fn(generic(T), … Impl(Fn() -> T) …) -> Impl(Future(T))` emits its async
+/// block ONCE for every instantiation
+/// (issues/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md).
+/// Exporting it before that is fixed would ship an API that silently
+/// miscompiles the second time a program uses it.
+spawn_blocking :: (
+  fn(
+    generic(T : Type),
+    own(cb) : Impl(Fn() -> T, Send),
+    io : Io,
+    where(T <: (Send, Acyclic))
+  ) -> Impl(Future(T, Io))
+)({
+  // EAGER: the worker starts here, in the function body, and the returned
+  // future only waits for it. That is Rust's semantics — `spawn_blocking`
+  // begins the work immediately rather than on first poll — and it keeps the
+  // callback out of the async block, which matters for a second reason:
+  // an `Impl(Fn)` PARAMETER captured by an `io.async` block is missing from
+  // that block's capture struct and emits a bare identifier into the state
+  // machine (issues/impl-fn-param-captured-by-an-async-block-is-not-in-the-capture-struct.md).
+  p := Park.new();
+  w := p.waker();
+  chan := Channel(T).new(usize(1));
+  sink := chan;
+  // The loop to un-bracket. `blocking_end` runs on the WORKER thread, where
+  // "this loop" is a different loop entirely.
+  owner := unsafe(__yo_async_loop_self_ptr());
+  unsafe(__yo_async_blocking_begin());
+  worker := Thread(unit).spawn((tio : Io) => {
+    sink.send(cb());
+    // Wake BEFORE ending the bracket. The wake is what keeps the loop alive
+    // across the hand-off; ending the bracket first leaves a window in which
+    // the loop sees no runnable task, no I/O and no inbox entry, and is
+    // entitled to conclude it has nothing left to do.
+    w.wake();
+    unsafe(__yo_async_blocking_end(owner));
+    ()
+  });
+  // Not joined: by the time the awaiting task resumes the worker has already
+  // delivered its value and its wake, so joining would only block the loop on
+  // the thread's own teardown. Dropping the handle detaches it.
+  _detached := worker;
+  io.async((io : Io) => {
+    io.await(p.wait(io), io);
+    _take_blocking_result(chan)
+  })
 });
 /// Get the number of hardware threads (CPU cores) available.
 get_hardware_threads :: __yo_thread_get_hardware_threads;

--- a/tests/cross_thread_wake.test.yo
+++ b/tests/cross_thread_wake.test.yo
@@ -1,0 +1,134 @@
+//! A `Waker` fired from ANOTHER OS thread resumes the parked task ON ITS OWN
+//! LOOP.
+//!
+//! Step 5 of `plans/WAKER_BASED_SCHEDULING.md`. Before it, a wake raised off
+//! the loop's own thread had nowhere safe to put the continuation —
+//! `__yo_async_enqueue_continuation` writes a THREAD-LOCAL queue — so it went
+//! onto the WAKER's queue and the suspended task was resumed by the worker
+//! thread, running the loop's state on a thread that does not own it. Each
+//! loop now owns one explicitly locked inbox plus a wakeup channel into its
+//! own I/O backend; the token — never the future, and never a reference count
+//! — is what crosses.
+//!
+//! **The oracle is the thread identity, not the value.** Measured with an
+//! emitted-C A/B (disable the cross-thread post, re-clang, re-run): the value
+//! arrives either way, and `same_thread` flips from true to false. A test that
+//! only checked the value would have passed over the bug it exists for.
+//!
+//! **And the park must be awaited from inside a SPAWNED task.** A blocking
+//! `io.await` in `main` is a poll loop over the future's state word, which a
+//! foreign CAS satisfies directly — no continuation, nothing for the inbox to
+//! carry. That is the risk this document's §"Risks" names first.
+//!
+//! `Waker` is `atomic(ref(...))` and therefore `Send`, which is what lets it be
+//! captured by a `Thread(unit).spawn` closure at all. `Park` is not, and should
+//! not be: it belongs to the loop that created it.
+{ assert } :: import("std/assert");
+{ Park } :: import("std/async/waker");
+{ Thread, get_thread_id } :: import("std/thread");
+{ AtomicI32, AtomicUsize, MemoryOrder } :: import("std/sync/atomic");
+{ Duration } :: import("std/time/duration");
+{ sleep_blocking } :: import("std/time/sleep");
+test("a waker fired from another OS thread resumes its task on the owning loop", {
+  p := Park.new();
+  w := p.waker();
+  stamped := AtomicI32(i32(0));
+  resumed_on := AtomicUsize.new(usize(0));
+  main_tid := get_thread_id();
+  h := io.spawn(
+    io.async((io : Io) => {
+      io.await(p.wait(io), io);
+      resumed_on.store(get_thread_id(), MemoryOrder.Release);
+      _a := stamped.fetch_add(i32(100), MemoryOrder.AcqRel);
+      i32(0)
+    }),
+    io
+  );
+  t := Thread(unit).spawn((tio : Io) => {
+    // Genuinely blocking, on its own thread: the loop has no I/O and no
+    // runnable task for these 50 ms, so it must wait rather than conclude
+    // it has nothing left to do.
+    sleep_blocking(Duration.from_millis(i64(50)));
+    _b := stamped.fetch_add(i32(7), MemoryOrder.AcqRel);
+    w.wake();
+    ()
+  });
+  _r := h.await(io);
+  assert(stamped.load(MemoryOrder.Acquire) == i32(107), "the worker ran and the task resumed");
+  assert(
+    resumed_on.load(MemoryOrder.Acquire) == main_tid,
+    "the task resumed on the loop that owns it, not on the thread that woke it"
+  );
+  t.join();
+});
+test("two parks woken from two different threads", {
+  p1 := Park.new();
+  p2 := Park.new();
+  w1 := p1.waker();
+  w2 := p2.waker();
+  order := AtomicI32(i32(0));
+  main_tid := get_thread_id();
+  both_on_main := AtomicI32(i32(0));
+  h1 := io.spawn(
+    io.async((io : Io) => {
+      io.await(p1.wait(io), io);
+      if(get_thread_id() == main_tid, {
+        _x := both_on_main.fetch_add(i32(1), MemoryOrder.AcqRel);
+      });
+      _a := order.fetch_add(i32(1), MemoryOrder.AcqRel);
+      i32(0)
+    }),
+    io
+  );
+  h2 := io.spawn(
+    io.async((io : Io) => {
+      io.await(p2.wait(io), io);
+      if(get_thread_id() == main_tid, {
+        _y := both_on_main.fetch_add(i32(1), MemoryOrder.AcqRel);
+      });
+      _b := order.fetch_add(i32(10), MemoryOrder.AcqRel);
+      i32(0)
+    }),
+    io
+  );
+  t1 := Thread(unit).spawn((tio : Io) => {
+    sleep_blocking(Duration.from_millis(i64(20)));
+    w1.wake();
+    ()
+  });
+  t2 := Thread(unit).spawn((tio : Io) => {
+    sleep_blocking(Duration.from_millis(i64(40)));
+    w2.wake();
+    ()
+  });
+  _r1 := h1.await(io);
+  _r2 := h2.await(io);
+  assert(order.load(MemoryOrder.Acquire) == i32(11), "both wakes arrived");
+  assert(both_on_main.load(MemoryOrder.Acquire) == i32(2), "both tasks resumed on the owning loop");
+  t1.join();
+  t2.join();
+});
+test("a wake that arrives BEFORE the task suspends is not lost", {
+  // The classic ordering trap from the other side. `wake` completes the park
+  // future, and an await point reads the future's state before registering a
+  // continuation, so an already-woken park resumes inline instead of
+  // suspending forever.
+  p := Park.new();
+  w := p.waker();
+  t := Thread(unit).spawn((tio : Io) => {
+    w.wake();
+    ()
+  });
+  t.join();
+  ran := AtomicI32(i32(0));
+  h := io.spawn(
+    io.async((io : Io) => {
+      io.await(p.wait(io), io);
+      _a := ran.fetch_add(i32(1), MemoryOrder.AcqRel);
+      i32(0)
+    }),
+    io
+  );
+  _r := h.await(io);
+  assert(ran.load(MemoryOrder.Acquire) == i32(1), "the early wake was observed rather than lost");
+});


### PR DESCRIPTION
Step 5 of `plans/WAKER_BASED_SCHEDULING.md`, and the last open item in
`plans/STD_API_STABILIZATION.md` §0.

Each event loop owns ONE explicitly locked inbox plus a wakeup channel into its
own I/O backend. A wake raised on a foreign thread pushes the waker TOKEN onto
the owner's inbox and nudges that channel; the owner drains it on its own
thread at the top of every tick and does the state change and the enqueue
there. Exactly one new piece of shared state exists, it is locked, and every
runtime variable stays single-threaded — the resolution the plan proposed,
implemented as proposed rather than by sprinkling atomics over the scheduler.

**Nothing that crosses a thread boundary touches a reference count.** The park
future's refcount is non-atomic like every other runtime object's, so the TOKEN
travels instead of the future, the owner allocates and frees it, and a release
raised on a foreign thread is deferred through the same inbox.

Wakeup channels, one per backend:

| backend | channel |
| --- | --- |
| macOS kqueue | `EVFILT_USER` on the loop's own kqueue |
| Linux io_uring | an eventfd with a re-armed `POLL_ADD` carrying a sentinel `user_data` and no pending-I/O slot |
| Windows IOCP | `PostQueuedCompletionStatus` with a NULL OVERLAPPED, which the wait loop already skips |
| wasm | a no-op — the target cannot have a second thread |

`Waker` becomes `atomic(ref(...))` and is therefore `Send`, which is what lets
a token be handed to a worker thread at all. `Park` is not, and should not be.

### The test, and why its oracle is the thread identity

`tests/cross_thread_wake.test.yo` gates the machinery without generics. Two
things about it are load-bearing, and I found both the hard way:

- **It asserts `resumed_on == main_tid`, not the value.** An emitted-C A/B
  (disable the cross-thread post, re-clang, re-run) shows the value arrives
  *either way* — the old path enqueued the continuation on the waker's own
  thread-local queue and that thread's loop ran it at exit, producing the right
  answer on the wrong thread. Only the thread identity flips.
- **The park is awaited from inside a SPAWNED task.** A blocking `io.await` in
  `main` is a poll loop over the future's state word, which a foreign CAS
  satisfies directly: no continuation is registered, so there is nothing for
  the inbox to carry and the test is vacuous. That is the plan's own first
  recorded risk, met in practice.

### `spawn_blocking` is written and NOT exported

It works end to end — eager, as Rust's is — but it is
`fn(generic(T), own(cb) : Impl(Fn() -> T, Send), io) -> Impl(Future(T, Io))`,
and the closure-param form of that shape still emits its async block once for
every instantiation. It would work for one `T` per program and silently
miscompile the second, so it stays unexported with the reason in its doc
comment, and its tests are parked beside the reproducers rather than deleted.
The blocker is measured in
`issues/a-generic-function-returning-impl-future-t-miscompiles-at-a-second-t.md`.

### Gates (local, on this tree)

- `yo test ./tests --exclude tests/internal --exclude tests/cli-cases` —
  **4164 passed, 0 failed**
- `scripts/bootstrap/gates_fast.sh` — **T1_DONE failures=0**: both repros, the
  23-file battery with hollow=0, the CLI golden corpus (PASS 103, GOLDEN-DIFF 0,
  NO-GOLDEN 0), fmt check + idempotence, embedded-Yo sites
- `fixpoint_only.sh` — **FIXPOINT_HOLDS**, stage2 hollow=0
- `yo check ./src` 270/270, `yo check ./std` 175/175

🤖 Generated with [Claude Code](https://claude.com/claude-code)