### PR TITLE
ci: say what the concurrency change actually buys, and what it does not

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,16 @@ on:
 # per-sha group would instead run every intermediate commit in parallel — and
 # would break PR cancellation, since `github.sha` on a `pull_request` event is
 # the per-push merge commit and therefore differs run to run.
+#
+# What this does NOT buy, measured 2026-09-12 right after it landed: a develop
+# run that has not STARTED yet is still superseded. `cancel-in-progress`
+# governs runs that are in progress; GitHub keeps only ONE pending run per
+# group, so a merge storm cancels the queued ones regardless. That is the
+# behaviour we want (the survivor is the newest tip) but it means "develop runs
+# are never cancelled" is too strong a reading — what holds is that a develop
+# battery, ONCE RUNNING, finishes. If nothing on develop is finishing at all,
+# suspect runner starvation first (a backlog of runs on already-merged PR
+# branches will sit in front of it — cancel those) rather than this block.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Comment only — no behaviour change, `actionlint` clean.

#630's comment reads as "a develop run is never cancelled". The first merge storm after it landed showed that is too strong: `cancel-in-progress` governs runs that are **in progress**, and GitHub keeps only ONE **pending** run per concurrency group — so a queued develop run is still superseded by the next merge. The survivor is the newest tip, which is the commit worth scoring, so the behaviour is right and only the description was wrong.

Also records the failure mode that actually blocked develop that day, because it looked like this block's fault and wasn't: a backlog of runs on branches whose PRs had already merged was holding every runner, and develop's battery only started once those were cancelled. Worth having written down next to the concurrency block, since that is where the next person will look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)