### PR TITLE
fix: develop is red — three constructor sites left behind by #626

### DIFF
--- a/src/doc/model.yo
+++ b/src/doc/model.yo
@@ -210,9 +210,16 @@ DocModel :: struct(
   version : Option(String),
   /// `yo doc --logo <path>` / `build.documentation({ logo })`: an image shown
   /// in the sidebar header. `.None` = no logo.
-  logo : Option(String),
+  ///
+  /// DEFAULTED, and the default is the documented meaning: a model built
+  /// without a logo has none. Four construction sites across the doc tests
+  /// were left behind when these two fields landed without defaults, and the
+  /// PR that added them merged with its CI cancelled, so the break reached
+  /// develop — one default here is the fix for every such site, present and
+  /// future.
+  (logo : Option(String)) ?= Option(String).None,
   /// `--favicon <path>`: the site's `<link rel="icon">`. `.None` = none.
-  favicon : Option(String)
+  (favicon : Option(String)) ?= Option(String).None
 );
 export(
   DocItemKind,

--- a/tests/internal/build_runner.test.yo
+++ b/tests/internal/build_runner.test.yo
@@ -33,7 +33,6 @@ _mk_artifact :: (fn(kind : ArtifactKind, name : String, root : String) -> BuildA
     defines : ArrayList(String).new(),
     strip : false,
     static_link : false,
-    runtime_files : ArrayList(String).new(),
     linked_artifacts : ArrayList(String).new(),
     linked_system_libs : ArrayList(String).new(),
     package_dir : String.from(""),

--- a/tests/internal/pkg_config.test.yo
+++ b/tests/internal/pkg_config.test.yo
@@ -50,8 +50,7 @@ _empty_for_test :: (fn() -> PkgConfigResult)(
     include_paths : ArrayList(String).new(),
     library_paths : ArrayList(String).new(),
     link_libraries : ArrayList(String).new(),
-    defines : ArrayList(String).new(),
-    runtime_files : ArrayList(String).new()
+    defines : ArrayList(String).new()
   )
 );
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
develop's first battery to actually **finish** since the merge storm came back with four red self-hosted gates. All four internal-test shards trace to #626, which merged with 21 of its 22 checks cancelled or failed.

B13 deleted `runtime_files` all the way down — `PkgConfigResult` declared it, `BuildArtifact` carried it, `run_build` deduplicated it — because nothing ever pushed a value into it. Two test construction sites were left passing it, and a member-count mismatch is a **hard eval error that takes the whole file out**:

| shard | file | error |
| --- | --- | --- |
| 0 | `build_runner.test.yo` → `BuildArtifact` | Too many members provided. Expected 22, got 23 |
| 2 | `pkg_config.test.yo` → `PkgConfigResult` | same shape |
| 1 | `doc_render_markdown.test.yo` → `DocModel` | Type member "logo" is not provided and has no default |
| 3 | `doc_stability.test.yo` → `DocModel` | same |

**The two classes are fixed differently on purpose.** `runtime_files` is *gone*, so deleting the stale argument is the only correct edit. `DocModel`'s `logo`/`favicon` are `Option(String)` whose own doc comments say `.None` = no logo / no favicon — the default **is** the documented meaning, so one default per field fixes four sites now and every future one, instead of four edits that the next field addition would repeat. The compiler's own construction site (`doc_command.yo`) passes both explicitly and is untouched, so nothing about `yo doc` changes.

**Why four green gates missed it.** `check ./src`, `check ./std`, the CLI corpus and the fixpoint are what gets run per slice, and none of them compiles `tests/internal/` — `check` does not look at `tests/` at all. A struct field removal is invisible to all four and visible in about four minutes to the one that was skipped. Worth adding `yo test ./tests/internal/build_runner.test.yo --parallel 1` plus the doc and pkg_config files to the per-slice battery for anything that touches a type in `src/`.

Local, with a stage-1 binary built from develop's tip — each of these does not compile without this change:

```
build_runner        12/12
pkg_config          11/11
doc_render_markdown 26/26
doc_stability        7/7
```

The third site was flagged by the session that wrote #626 after I reported the first two; credit where due — I would have shipped a fix that left shard 2 red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)