### PR TITLE
async runtime (windows): IOCP audit — overlapped connect/sendto/recvfrom, socket-fd close registry, fs-watch rearm

### DIFF
--- a/issues/fixed/windows-blocking-connect-parks-the-event-loop.md
+++ b/issues/fixed/windows-blocking-connect-parks-the-event-loop.md
@@ -1,0 +1,111 @@
+# Windows: `io` connect runs a BLOCKING `connect()` on the event-loop thread
+
+**Status: FIXED (2026-09-12).** `__yo_async_connect_start`
+(`src/codegen/async/runtime_io_windows.yo`) called the plain blocking
+`connect()` and returned an already-complete future. The socket is
+blocking (`WSASocketW(..., WSA_FLAG_OVERLAPPED)` — overlapped, not
+non-blocking), so the call parks the WHOLE single-threaded event loop
+inside the kernel for the duration of the TCP handshake: milliseconds on
+loopback, but the full SYN-retransmit window — measured **21.3 s** —
+against a black-holed address, with every concurrent task (timers, other
+sockets, the accept path) frozen behind it.
+
+This is the same class as the D6 accept hang
+(`issues/fixed/d6-schannel-hangs-the-windows-test-legs-for-four-hours.md`,
+fixed by the overlapped AcceptEx port in be3b42aa6): connect was simply
+never given the same treatment. On Linux the same operation goes through
+`io_uring_prep_connect` and never parks the loop, so this is a Windows
+divergence, not a cross-platform stance.
+
+Found 2026-09-12 by the Windows async-I/O runtime audit
+(`audit/windows-async-io`). **Severity:** HIGH — any connect to a slow,
+filtered or unreachable address freezes all concurrency; `Tcp.net.connect`
+to a peered-but-slow endpoint stalls unrelated timers.
+
+## Reproducer
+
+```rust
+// tmp/connect_blocks.yo — 192.0.2.1 is TEST-NET-1 (RFC 5737): never
+// delivered, so the connect stays pending for the whole retry window.
+pragma(Pragma.AllowUnsafe);
+{ IpAddr, SocketAddr } :: import("std/net/addr");
+{ TcpStream } :: import("std/net/tcp");
+{ Exception, IoExn } :: import("std/error");
+{ sleep } :: import("std/sys/timer");
+{ Instant } :: import("std/time/instant");
+{ println } :: import("std/fmt");
+
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  addr := SocketAddr.new(IpAddr.V4(u8(192), u8(0), u8(2), u8(1)), u16(81));
+  started := Instant.now();
+  io.spawn(
+    io.async((io : Io) => {
+      task_exn := Exception(
+        throw : (err -> { unwind(()); })
+      );
+      stream := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : task_exn));
+      io.await(stream.close(io), IoExn(io : io, exn : task_exn));
+      return(());
+    }),
+    io
+  );
+  io.spawn(
+    io.async((io : Io) => {
+      io.await(sleep(u64(300)), io);
+      return(());
+    }),
+    io
+  );
+  sleep_task.await(io); // sleeps the 300 ms task
+  elapsed_ms := started.elapsed().as_millis();
+  cond(
+    (elapsed_ms >= i64(900)) => {
+      println(`BLOCKING CONFIRMED: the 300 ms sleep took ${elapsed_ms} ms`);
+    },
+    true => {
+      println(`OK: the 300 ms sleep took ${elapsed_ms} ms`);
+    }
+  );
+});
+export(main);
+```
+
+Before the fix: `BLOCKING CONFIRMED: the 300 ms sleep took 21341 ms`.
+After: `OK: the 300 ms sleep took 316 ms`. (The `sleep_task.await(io)`
+line is spelled as a statement in the real repro; the harness exits
+without the still-pending connect — `__yo_async_run_until_complete`
+breaks when the main future completes even with I/O outstanding.)
+
+## Fix
+
+`__yo_async_connect_start` now issues the overlapped **ConnectEx**
+extension — the connect-side twin of the landed AcceptEx work:
+
+- `LPFN_CONNECTEX` fetched via `WSAIoctl(SIO_GET_EXTENSION_FUNCTION_POINTER)`,
+  thread-local cached like the AcceptEx pointers.
+- Gated to `AF_INET`/`AF_INET6` **stream** sockets, decided from the
+  socket's own family (`getsockname`) and type (`getsockopt(SO_TYPE)`)
+  BEFORE consulting the cached pointer — the same thread-local-caching
+  trap the accept path documents for AF_UNIX.
+- The socket is bound to the family wildcard first (ConnectEx requires a
+  bound socket; an already-bound one just gets WSAEINVAL here).
+- `is_connect` on the overlapped struct; `__yo_win_process_completion`
+  sets `SO_UPDATE_CONNECT_CONTEXT` on success (without it getpeername/
+  shutdown on the socket fail), and the synchronous-completion case
+  (loopback: ConnectEx returns TRUE, no IOCP packet under
+  FILE_SKIP_COMPLETION_PORT_ON_SUCCESS) finishes inline.
+- Everything else — AF_UNIX (no ConnectEx exists there), datagram sockets
+  (UDP `connect()` is a local, immediate filter install), or the extension
+  being unavailable — keeps the plain `connect()`.
+
+Abort semantics are unchanged: an aborted task suspended in a pending
+ConnectEx leaves the operation registered until it completes naturally —
+the documented fallback for every overlapped op whose future has no
+`cancel_fn` (only timers do, `runtime_core.yo`).
+
+Regression test: `tests/net/tcp.test.yo` "connecting to a non-routable
+address does not park the event loop" (the repro's timing assert; on a
+network that refuses TEST-NET immediately the connect resolves fast and
+the assert passes, just less discriminatingly). The loopback connect/echo
+battery in the same file covers ConnectEx's synchronous completion and
+error mapping.

--- a/issues/fixed/windows-blocking-connect-parks-the-event-loop.md
+++ b/issues/fixed/windows-blocking-connect-parks-the-event-loop.md
@@ -84,9 +84,10 @@ extension — the connect-side twin of the landed AcceptEx work:
 - `LPFN_CONNECTEX` fetched via `WSAIoctl(SIO_GET_EXTENSION_FUNCTION_POINTER)`,
   thread-local cached like the AcceptEx pointers.
 - Gated to `AF_INET`/`AF_INET6` **stream** sockets, decided from the
-  socket's own family (`getsockname`) and type (`getsockopt(SO_TYPE)`)
-  BEFORE consulting the cached pointer — the same thread-local-caching
-  trap the accept path documents for AF_UNIX.
+  socket's own family and type BEFORE consulting the cached pointer — the
+  same thread-local-caching trap the accept path documents for AF_UNIX.
+  Both come from one `getsockopt(SOL_SOCKET, SO_PROTOCOL_INFOW)`; see
+  "The family probe cannot be `getsockname`" below for why.
 - The socket is bound to the family wildcard first (ConnectEx requires a
   bound socket; an already-bound one just gets WSAEINVAL here).
 - `is_connect` on the overlapped struct; `__yo_win_process_completion`
@@ -109,3 +110,65 @@ network that refuses TEST-NET immediately the connect resolves fast and
 the assert passes, just less discriminatingly). The loopback connect/echo
 battery in the same file covers ConnectEx's synchronous completion and
 error mapping.
+
+## The family probe cannot be `getsockname` (fixed 2026-09-13)
+
+The first cut of this fix read the family from `getsockname()` and fell
+back to `AF_INET` when that call failed:
+
+```c
+int family = AF_INET;
+if (getsockname(s, (struct sockaddr*)&local_name, &local_name_len) == 0) {
+  family = local_name.ss_family;
+}
+```
+
+`getsockname()` fails with `WSAEINVAL` on a socket that has not been bound,
+and an **unbound client socket is exactly what this code path exists for** —
+the bullet two lines down even says so ("the socket is bound to the family
+wildcard first"). So the probe took its `AF_INET` fallback for every fresh
+client socket, whatever its real family, and the gate it was supposed to
+implement never ran:
+
+- **AF_UNIX** connects were routed into the ConnectEx arm. The socket was
+  then "wildcard-bound" with a `sockaddr_in` (rejected — the return value
+  is deliberately ignored), and `ConnectEx` on the still-unbound socket
+  answered `WSAEINVAL`. Every Unix-domain connect failed.
+- **AF_INET6** clients would have failed identically: bound with a
+  `sockaddr_in`, then `WSAEINVAL`. The suite has no IPv6 *client* connect,
+  so nothing caught it — `tests/net/tcp.test.yo`'s only v6 case is a
+  `bind` test.
+
+Measured: run `34724452396` at `0fc80fd78` failed
+`tests/net/unix.test.yo` -> "bind, connect, accept, echo round-trip" on
+**both** Windows legs (`windows-latest` job 103642084964, `windows-11-arm`
+job 103642084960), while develop's job 103609844499 at `cbbff5208` logged
+the same test passing. Two architectures, deterministic, with
+`std/assert.yo:39` "unexpected exception" — the `io.await` on
+`UnixStream.connect` throwing.
+
+The fix reads the provider's own answer instead, which is valid before
+bind and returns family and type together:
+
+```c
+WSAPROTOCOL_INFOW proto_info;
+int proto_info_len = (int)sizeof(proto_info);
+int family = 0;
+int sock_type = 0;
+if (getsockopt(s, SOL_SOCKET, SO_PROTOCOL_INFOW, (char*)&proto_info, &proto_info_len) == 0) {
+  family = proto_info.iAddressFamily;
+  sock_type = proto_info.iSocketType;
+}
+bool connectex_family = (family == AF_INET || family == AF_INET6) && sock_type == SOCK_STREAM;
+```
+
+If even `SO_PROTOCOL_INFOW` fails, `family` stays `0` and the plain
+`connect()` runs — the pre-overlapped behaviour, never a wrong-family
+ConnectEx.
+
+**The general rule** (it applies to the accept path's identical-looking
+probe, which is safe only because a *listener* is always bound by the time
+`accept` is reachable): a socket-property probe used to GATE a code path
+must not have a failure fallback that silently satisfies the gate. Either
+read a property that is valid in the state the path targets, or fail
+CLOSED — fall back to the conservative arm, as this fix now does.

--- a/issues/fixed/windows-file-close-leaks-fd-until-wsa-is-started.md
+++ b/issues/fixed/windows-file-close-leaks-fd-until-wsa-is-started.md
@@ -1,0 +1,116 @@
+# Windows: `__yo_file_close` leaks the CRT fd in any program that never started Winsock
+
+**Status: FIXED (2026-09-12).** Both close paths (`__yo_file_close`, the
+sync `File.close_sync`, and `__yo_async_close_start`) used a
+"closesocket-first" probe to decide whether an fd was a socket:
+
+```c
+SOCKET s = (SOCKET)(uintptr_t)(uint32_t)fd;
+int cs = closesocket(s);
+if (cs != 0) {
+  DWORD wsa_err = WSAGetLastError();
+  if (wsa_err == WSAENOTSOCK) {
+    _close(fd);
+  }
+}
+```
+
+Two failure modes, one of them reproduced:
+
+1. **WSA never started → every close leaks.** `closesocket` requires a prior
+   `WSAStartup`. Only `__yo_io_init` (the async runtime) and `__yo_wsa_init`
+   (sync socket helpers) call it — a program that uses neither (sync file
+   I/O only) gets `WSANOTINITIALISED` (10093) from `closesocket`, which is
+   NOT `WSAENOTSOCK`, so the `_close(fd)` fallback never runs. Every
+   open/close round leaks one CRT fd until the UCRT fd table (default 8192)
+   fills and every further open fails `EMFILE`. Reproduced on
+   Windows 10.0.26200: 9000 open/close rounds, 812 failures, first
+   `errno=24` (EMFILE) at round 8188.
+2. **Numeric collision can close the WRONG object.** A SOCKET HANDLE VALUE
+   travels as an `i32` "fd" through this runtime, and CRT fds are small
+   integers — the spaces can collide (CRT fd 420 vs socket handle
+   0x1A4). `closesocket(file_fd)` with a colliding value would close the
+   socket silently and skip `_close`, leaking the file handle too. Not
+   reproduced (needs a specific allocation pattern); the probe order made
+   it possible by construction.
+
+Found 2026-09-12 by the Windows async-I/O runtime audit (PR branch
+`audit/windows-async-io`). **Severity:** HIGH for long-running sync
+programs — a file-processing loop exhausts the fd table after ~8192
+open/close rounds and every subsequent open fails.
+
+## Why the test suite never saw it
+
+Every test binary drives an async harness, whose event loop runs
+`__yo_io_init` → `WSAStartup` before any test body. The leak only
+manifests in standalone SYNC programs — exactly the shape `File` +
+`Dispose` (`std/fs/file.yo`) invites. The standalone reproducer therefore
+lives here rather than in `tests/`:
+
+```rust
+// tmp/close_leak.yo — sync-only program: no async main, no socket call.
+pragma(Pragma.AllowUnsafe);
+{ open_sync, close_sync } :: import("std/sys/file");
+{ O_WRONLY, O_CREAT, O_TRUNC } :: import("std/sys/constants");
+{ String } :: import("std/string");
+{ println } :: import("std/fmt");
+
+main :: (fn() -> unit)({
+  path := String.from("./tmp/close_leak_target.txt");
+  p := path.to_cstr().ptr().unwrap();
+  mode := i32(438); // 0666
+  fd0 := open_sync(p, (O_CREAT | (O_WRONLY | O_TRUNC)), mode);
+  cond(
+    (fd0 < i32(0)) => { println(`initial open failed: ${fd0}`); return(()); },
+    true => close_sync(fd0)
+  );
+  (fails : i32) = i32(0);
+  (first_errno : i32) = i32(0);
+  (i : i32) = i32(0);
+  while(i < i32(9000), i = (i + i32(1)), {
+    fd := open_sync(p, O_WRONLY, mode);
+    cond(
+      (fd < i32(0)) => {
+        cond(
+          (fails == i32(0)) => { (first_errno = fd); () },
+          true => ()
+        );
+        (fails = (fails + i32(1)));
+      },
+      true => close_sync(fd)
+    );
+  });
+  cond(
+    (fails > i32(0)) => {
+      println(`LEAK CONFIRMED: ${fails} of 9000 open rounds failed, first errno=${i32(0) - first_errno}`);
+    },
+    true => println(`OK: all 9000 open/close rounds succeeded`)
+  );
+});
+export(main);
+```
+
+Before the fix: `LEAK CONFIRMED: 812 of 9000 open rounds failed, first
+errno=24`. After: `OK: all 9000 open/close rounds succeeded`.
+
+## Fix
+
+`src/codegen/async/runtime_io_windows.yo` now keeps a socket-fd registry
+(`__yo_win_sock_fds` + mark/is/unmark, the same shape as the O_APPEND fd
+table). Every socket the runtime creates is registered —
+`__yo_async_socket_start`, both accept paths (`__yo_win_finish_accept`,
+the AF_UNIX fallback `accept()`), and `__yo_sync_socketpair` — and both
+close functions consult the registry instead of probing Winsock:
+
+- `__yo_file_close`: registered → `__yo_wsa_init()` + `closesocket` +
+  unregister; otherwise plain `_close(fd)`. A file close now touches
+  Winsock never.
+- `__yo_async_close_start`: same split (`__yo_io_init` at the top already
+  guarantees Winsock for the socket arm).
+
+This removes the `WSANOTINITIALISED` leak and the collision hazard by
+construction: the runtime KNOWS which fds are sockets instead of asking
+the kernel and misreading the answer. The registry's correctness is
+exercised by the whole `tests/net` battery (every `TcpStream`/
+`UdpSocket` close goes through it — a misroute there fails dozens of
+tests); the sync-program leak itself is the standalone repro above.

--- a/issues/fixed/windows-fs-event-dir-part-unbounded-wcscpy.md
+++ b/issues/fixed/windows-fs-event-dir-part-unbounded-wcscpy.md
@@ -1,0 +1,33 @@
+# Windows: single-file `fs.watch` copies the watched path into `dir_part[MAX_PATH]` unbounded
+
+**Status: FIXED (2026-09-12).** The non-directory branch of
+`__yo_fs_event_start`
+(`src/codegen/async/runtime_io_windows.yo`) prepared the parent directory
+for `FindFirstChangeNotificationW` with:
+
+```c
+wchar_t dir_part[MAX_PATH];
+wcscpy(dir_part, wpath);        // wpath is caller-supplied UTF-8→UTF-16
+```
+
+`wpath` is the fully converted watch path — a path longer than 260 UTF-16
+units smashes the stack. Every sibling call site in the file bounds its
+copies (`GetFinalPathNameByHandleW` results are length-checked, `__yo_win_utf8_to_wide`
+heap-allocates); this one was missed. Found 2026-09-12 by inspection in
+the Windows async-I/O runtime audit (`audit/windows-async-io`); not
+reproduced — a >260-char single-file watch path is legal on Windows 10+
+(`MAX_PATH` is not the kernel limit), and constructing one deliberately
+in a test is brittle across CI configurations.
+
+## Fix
+
+```c
+wchar_t dir_part[MAX_PATH];
+wcsncpy(dir_part, wpath, MAX_PATH - 1);
+dir_part[MAX_PATH - 1] = L'\0';
+```
+
+The truncation falls back to watching the truncated prefix — the same
+degraded-but-safe outcome the surrounding `MAX_PATH` buffers already
+imply. A structural fix (dynamic `wcslen`-sized buffers throughout the
+fs-event path) belongs with any long-path work, not this patch.

--- a/issues/fixed/windows-fs-watch-rearm-drops-recursive-flag.md
+++ b/issues/fixed/windows-fs-watch-rearm-drops-recursive-flag.md
@@ -1,0 +1,51 @@
+# Windows: `fs.watch` re-arm drops the recursive flag after the first delivered batch
+
+**Status: FIXED (2026-09-12).** `__yo_fs_event_start`
+(`src/codegen/async/runtime_io_windows.yo`) arms the initial
+`ReadDirectoryChangesW` with `WatchSubtree = (flags & FS_EVENT_RECURSIVE)`,
+but the re-arm in `__yo_poll_and_fs_event_tick` hard-coded `FALSE`:
+
+```c
+ReadDirectoryChangesW(fse->dir_handle,
+  fse->notify_buf, sizeof(fse->notify_buf),
+  FALSE,                     // <-- the caller's recursive choice, dropped
+  FILE_NOTIFY_CHANGE_FILE_NAME | ... );
+```
+
+A recursive watch (`WatchOptions(recursive : true)`) therefore asked for
+less than the caller requested from its second batch on.
+
+Found 2026-09-12 by the Windows async-I/O runtime audit. **Severity: LOW
+as it ships — masked.** A raw-C probe against Windows 10.0.26200 shows
+the kernel keeps the FIRST arm's scope on the handle: a handle armed
+`TRUE` at start still reports `sub\child.txt` events after a `FALSE`
+re-arm (and, control probe: a FRESH handle armed `FALSE` reports nothing
+for subdirectory changes, so the flag itself works). The narrowed re-arm
+is thus not user-visible on current desktop Windows — but it is
+semantically wrong, depends on undocumented handle state, and a kernel
+that honors per-request scope (Server variants, future builds) would
+silently stop recursive watches after their first delivered batch.
+
+The same probe run observed the re-used OVERLAPPED/buffer delivering
+one-batch-stale and duplicate records on this machine (both under
+consistent and shrunken re-arm scope) — the duplication is consistent
+with post-creation scanner touches (Defender/indexer) rather than the
+re-arm itself, and `Watcher` already exposes each raw record as its own
+`FsEvent`, so no claim is made against the delivery path here. If
+duplicates ever become a reported problem, the structural fix is to
+associate the directory handle with the IOCP and consume completions as
+packets (the AcceptEx/read/write machinery) instead of polling
+`GetOverlappedResult`.
+
+## Fix
+
+`__yo_fs_event_t` gains `watch_subtree`; `__yo_fs_event_start` records
+the caller's choice and the tick re-arms with
+`fse->watch_subtree ? TRUE : FALSE`.
+
+Regression test: `tests/fs/watch.test.yo` "a recursive watch keeps
+reporting subdirectory changes after the first batch" — round 1 touches
+a root entry (forcing the delivered batch that triggers the re-arm),
+round 2 touches only a subdirectory entry. Windows/macOS assert the
+subdirectory event; Linux inotify is single-directory (recursive is
+documented best-effort), so only the root round is asserted there.

--- a/issues/fixed/windows-udp-recvfrom-blocks-the-event-loop.md
+++ b/issues/fixed/windows-udp-recvfrom-blocks-the-event-loop.md
@@ -1,0 +1,106 @@
+# Windows: UDP `sendto`/`recvfrom` run blocking calls on the event-loop thread
+
+**Status: FIXED (2026-09-12).** `__yo_async_sendto_start` and
+`__yo_async_recvfrom_start`
+(`src/codegen/async/runtime_io_windows.yo`) called the plain blocking
+`sendto`/`recvfrom` and returned already-complete futures. On a quiet
+socket `recvfrom` blocks until a datagram arrives — a UDP server task
+awaiting `UdpSocket.recv_from` with no traffic parked the ENTIRE event
+loop inside the kernel, freezing every timer, socket and fs watch. Same
+bug class as the D6 accept hang and the blocking connect (both fixed);
+`send`/`recv` on the same runtime were already overlapped
+(`WSASend`/`WSARecv`), so the datagram pair was the remaining gap.
+
+Found 2026-09-12 by the Windows async-I/O runtime audit
+(`audit/windows-async-io`). **Severity:** HIGH for any concurrent UDP
+workload — one quiet `recv_from` freezes the process; a UDP server is
+unusable alongside anything else on the loop.
+
+Note the Linux backend has the same shape ("io_uring doesn't have direct
+sendto, use synchronous", `runtime_io_linux.yo`) — but there the sockets
+are still blocking too, so the freeze is cross-platform for the DATAGRAM
+ops today. Fixing Windows does not regress parity (it improves it); the
+Linux side would want `IORING_OP_SENDTO/RECVFROM` or non-blocking +
+multishot recv, tracked in the audit summary issue
+(`issues/windows-async-io-runtime-audit.md`).
+
+## Reproducer
+
+```rust
+// tmp/udp_overlapped.yo — a quiet recv_from must park the TASK, not the
+// loop: the 200 ms sleep is issued while the recv is pending and must
+// still complete on time.
+pragma(Pragma.AllowUnsafe);
+{ assert } :: import("std/assert");
+{ SocketAddr } :: import("std/net/addr");
+{ UdpSocket } :: import("std/net/udp");
+{ sleep } :: import("std/sys/timer");
+{ Instant } :: import("std/time/instant");
+{ ArrayList } :: import("std/collections/array_list");
+{ GlobalAllocator } :: import("std/allocator");
+{ malloc, free } :: GlobalAllocator;
+{ println } :: import("std/fmt");
+{ Exception, IoExn } :: import("std/error");
+
+main :: (fn(io : Io, exn : Exception) -> unit)({
+  server := io.await(UdpSocket.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+  client := io.await(UdpSocket.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+
+  recv_task := io.spawn(
+    io.async((io : Io) => {
+      task_exn := Exception(throw : (err -> { unwind(()); }));
+      recv_buf := (*u8)(malloc(usize(64)).unwrap());
+      got := io.await(server.recv_from(recv_buf, usize(64), io), IoExn(io : io, exn : task_exn));
+      (n, from) := got;
+      assert((n == usize(5)), "expected 5 bytes");
+      assert(from.ip.is_loopback(), "sender address decoded");
+      free(.Some((*void)(recv_buf)));
+      return(());
+    }),
+    io
+  );
+
+  started := Instant.now();
+  io.await(sleep(u64(200)), io);
+  (sleep_ms : i64) = started.elapsed().as_millis();
+
+  data := ArrayList(u8).new();  // "ping!"
+  data.push(u8(112)); data.push(u8(105)); data.push(u8(110));
+  data.push(u8(103)); data.push(u8(33));
+  sent := io.await(client.send_to(data, server.local_addr(), io), IoExn(io : io, exn : exn));
+  assert((sent == usize(5)), "send_to sent 5 bytes");
+
+  recv_task.await(io);
+  assert((sleep_ms < i64(500)), "sleep was delayed by a pending recv_from");
+  io.await(client.close(io), IoExn(io : io, exn : exn));
+  io.await(server.close(io), IoExn(io : io, exn : exn));
+});
+export(main);
+```
+
+Before the fix the program DEADLOCKS (the loop is inside `recvfrom`, the
+200 ms sleep never runs, the datagram is never sent). After:
+`concurrent sleep took 200 ms`, datagram + decoded sender address
+delivered.
+
+## Fix
+
+Both ops mirror the landed `WSASend`/`WSARecv` shape exactly — associate
+the socket with the port, an overlapped struct, sync-completion /
+`WSA_IO_PENDING` / error arms. One datagram-specific wrinkle:
+`WSARecvFrom` writes the source-address LENGTH at completion time, so it
+cannot point at a caller stack local that dies with the start call — the
+length rides in the overlapped struct (`from_len`) and the completion
+path (`__yo_win_process_completion`) copies it back through the caller's
+`out_fromlen` pointer. `WSASendTo`'s destination address is consumed at
+call time and needs nothing.
+
+The caller's `src_addr`/`addrlen`/buffer outlive the call the same way
+`recv`'s buffer always has: they are owned by the suspended task's state
+machine, which the await machinery keeps alive until the operation
+completes (`std/net/udp.yo` allocates them in the task and awaits).
+
+Regression test: `tests/net/udp.test.yo` "a quiet recv_from parks the
+task, not the event loop" (the repro's assertions); the existing
+send_to/recv_from round-trip tests in the same file cover the data path
+and address decode.

--- a/issues/linux-udp-datagram-ops-are-synchronous-and-park-the-loop.md
+++ b/issues/linux-udp-datagram-ops-are-synchronous-and-park-the-loop.md
@@ -1,0 +1,59 @@
+# Linux `sendto`/`recvfrom` are synchronous and park the whole event loop
+
+**Status:** OPEN. **Found:** 2026-09-13, by the one RED in a 269-file hollow
+sweep on PR #638.
+**Platform:** Linux (io_uring backend) only. Windows is overlapped as of #638;
+macOS was already task-parked.
+
+## The defect
+
+`src/codegen/async/runtime_io_linux.yo`:
+
+```c
+// io_uring doesn't have direct sendto, use synchronous
+ssize_t result = sendto(sockfd, buf, len, flags, ...);
+...
+// io_uring doesn't have direct recvfrom, use synchronous
+ssize_t result = recvfrom(sockfd, buf, len, flags, ...);
+```
+
+Both run on the LOOP THREAD. A `recv_from` on a quiet socket therefore blocks
+every other task in the program until a datagram arrives — the same defect
+`issues/fixed/windows-udp-recvfrom-blocks-the-event-loop.md` fixed on Windows,
+and the sibling of the D6 accept hang.
+
+The comment is also out of date: modern io_uring has `IORING_OP_SENDTO` and
+`IORING_OP_RECVFROM` (Linux 5.19+).
+
+## How it surfaced
+
+`tests/net/udp.test.yo`'s "a quiet recv_from parks the task, not the event
+loop" — added by #638 to pin the Windows fix — spawns a task that awaits
+`recv_from`, then sleeps 200 ms on the main task and asserts the sleep was not
+stretched. On Linux the spawned `recv_from` parks the loop, so the sleep never
+runs, the datagram is never sent, and the test DEADLOCKS until the harness
+kills it:
+
+```
+=== hollow sweep scorecard ===
+    268 GREEN
+      1 RED
+  tests/net/udp.test.yo	RED
+```
+
+That test is SKIPPED on Linux for now, with the reason at the skip. It is
+already the regression test this fix needs: delete the skip and it must pass.
+
+## Why no suite caught it before
+
+Nothing awaited a datagram that had not arrived yet. Every other UDP test sends
+before it receives, so the synchronous call returns immediately and the parking
+is invisible. It takes a QUIET socket plus a concurrent task to see it, which
+is exactly the shape #638's test introduced.
+
+## Fix
+
+Convert both to io_uring submissions in the shape the landed `send`/`recv`
+already use (`IORING_OP_SENDTO` / `IORING_OP_RECVFROM`), with the source-address
+length riding in the completion like the Windows `WSARecvFrom` fix does. Then
+remove the Linux skip from the test above.

--- a/issues/windows-async-io-runtime-audit.md
+++ b/issues/windows-async-io-runtime-audit.md
@@ -1,0 +1,72 @@
+# Windows async I/O runtime audit — findings register
+
+**Status: OPEN (audit 2026-09-12, branch `audit/windows-async-io`).** A
+full read of `src/codegen/async/runtime_io_windows.yo` (both emitted
+sections) against `runtime_io_linux.yo`, `runtime_io_macos.yo`,
+`runtime_core.yo` and the std call sites, with every suspected bug
+reproduced (or explicitly dispositioned) before fixing. Five defects were
+fixed in the same branch; this register records them and everything
+inspected and deliberately NOT changed, so the next audit starts from
+evidence rather than re-derivation.
+
+## Fixed in this audit
+
+| # | Issue | Severity | Disposition |
+| --- | --- | --- | --- |
+| 1 | [Sync file close leaks the CRT fd until Winsock is started](fixed/windows-file-close-leaks-fd-until-wsa-is-started.md) | HIGH (reproduced: EMFILE after ~8192 open/close rounds in a socket-free program) | socket-fd registry replaces the closesocket probe |
+| 2 | [Blocking `connect()` parks the event loop](fixed/windows-blocking-connect-parks-the-event-loop.md) | HIGH (reproduced: a 300 ms sleep took 21.3 s while a TEST-NET connect was in flight) | overlapped ConnectEx for INET/INET6 stream sockets |
+| 3 | [UDP `recvfrom`/`sendto` run blocking calls on the loop thread](fixed/windows-udp-recvfrom-blocks-the-event-loop.md) | HIGH (reproduced: quiet `recv_from` deadlocks the whole loop) | overlapped WSARecvFrom/WSASendTo, mirroring recv/send |
+| 4 | [fs.watch re-arm drops the recursive flag](fixed/windows-fs-watch-rearm-drops-recursive-flag.md) | LOW (masked by the kernel keeping the first arm's handle scope; probed) | re-arm replays the caller's choice |
+| 5 | [Unbounded `wcscpy` into `dir_part[MAX_PATH]` in the single-file watch path](fixed/windows-fs-event-dir-part-unbounded-wcscpy.md) | LOW (by inspection; >260-char watch path smashes the stack) | bounded copy |
+
+## Inspected and deliberately NOT changed (with reasons)
+
+- **`__yo_async_waitpid_start` blocks in `WaitForSingleObject(INFINITE)`.**
+  A long-running child parks the loop, and two awaited children serialize.
+  Cross-platform as designed: the Linux backend calls plain blocking
+  `waitpid(2)` (`runtime_io_common.yo`), so this is the shared stance, not
+  a Windows divergence. A real fix wants RegisterWaitForSingleObject
+  (Windows) / pidfd or waitid (Linux) — a cross-platform design decision,
+  not a Windows patch. Command.output avoids the worst interaction today
+  because parked pipe reads only retry from the tick, and the tick is not
+  reached while waitpid blocks — worth revisiting TOGETHER with the fix.
+- **Linux `sendto`/`recvfrom` are synchronous** (the io_uring backend
+  comments "no direct sendto"). Modern io_uring has
+  `IORING_OP_SENDTO/RECVFROM`; with Windows now overlapped, Linux is the
+  divergent side. The blocking-recvfrom freeze reproduces there the same
+  way it did on Windows before fix #3.
+- **`__yo_io_cleanup` frees the timer list but not**: parked pipe reads
+  (`__yo_win_pipe_reads`), dir states (`__yo_dir_state_head`), the
+  overlapped free list, fs-event handles, or the socket-fd registry —
+  process-exit leaks only, invisible unless `--debug-heap` is the oracle;
+  none of those allocations are RC-tracked so they are not reported
+  either.
+- **`__yo_wsa_initialized` is not reset by `__yo_io_cleanup`** (which does
+  call `WSACleanup`): a sync socket helper that runs after an async
+  runtime teardown would use Winsock without a startup. Reachable only in
+  a program that tears the loop down and then does sync socket I/O — no
+  std path does; noted for whoever next touches teardown.
+- **`__yo_async_getdents_start` maps every `FindFirstFileW` failure to
+  "no entries" (EOF)**, including access-denied. Error-masking, not
+  loop-blocking; same on the scandir path.
+- **The QPC deadline clock** (landed the same day as this audit, #627)
+  was re-read and left alone.
+- **`__yo_win_overlapped_t` mixing**: socket ops `__yo_rc_alloc` their
+  overlapped structs but return them via `__yo_win_free_overlapped`'s
+  free list (never `__yo_free`d). Consistent one-way recycling — the
+  free list hands the block to a later file op which re-zeroes it; no
+  double-free is possible. Not pretty, not wrong.
+- **The RDCW consume/re-arm pattern** (poll `GetOverlappedResult`, re-use
+  OVERLAPPED + buffer) can deliver stale/duplicate records on machines
+  where a post-creation scanner (Defender, indexer) touches freshly
+  written files — observed in raw-C probes on this host under BOTH the
+  old and the new re-arm scope, i.e. not caused by fix #4 and not
+  reliably attributable to the runtime. The structural hardening (IOCP-
+  associate the directory handle and consume completions as packets, like
+  every other op) is the right follow-up if duplicates are ever reported
+  by a real user.
+- **`tests/net/unix.test.yo` "bind, connect, accept, echo round-trip"
+  fails on THIS host (exit 22) under the unmodified CI-equivalent seed
+  binary** — pre-existing, environmental (AF_UNIX), unchanged by this
+  audit's patches; recorded so the next Windows session doesn't chase it
+  as a new regression.

--- a/issues/windows-async-io-runtime-audit.md
+++ b/issues/windows-async-io-runtime-audit.md
@@ -65,8 +65,23 @@ evidence rather than re-derivation.
   associate the directory handle and consume completions as packets, like
   every other op) is the right follow-up if duplicates are ever reported
   by a real user.
-- **`tests/net/unix.test.yo` "bind, connect, accept, echo round-trip"
+- ~~**`tests/net/unix.test.yo` "bind, connect, accept, echo round-trip"
   fails on THIS host (exit 22) under the unmodified CI-equivalent seed
   binary** — pre-existing, environmental (AF_UNIX), unchanged by this
-  audit's patches; recorded so the next Windows session doesn't chase it
-  as a new regression.
+  audit's patches~~ — **RETRACTED 2026-09-13: it was this audit's own
+  regression.** CI disagrees with the local reading: run `34724452396`
+  at `0fc80fd78` failed that test on BOTH Windows legs
+  (`windows-latest` 103642084964, `windows-11-arm` 103642084960) while
+  develop's job 103609844499 at `cbbff5208` logged it passing. Cause:
+  fix #2's ConnectEx family gate read the family from `getsockname()`,
+  which fails `WSAEINVAL` on the unbound client socket the path is FOR,
+  so the `AF_INET` fallback routed AF_UNIX (and would have routed
+  AF_INET6) into ConnectEx. Fixed by `getsockopt(SO_PROTOCOL_INFOW)`,
+  failing closed; regression test
+  `tests/net/tcp.test.yo` "IPv6 loopback connect round-trip". Detail in
+  `issues/fixed/windows-blocking-connect-parks-the-event-loop.md`.
+
+  The lesson for the next audit: a local "it fails on the seed binary
+  too" reading is not a disposition when the same test passes on
+  develop's CI legs. Check develop's own job log for the test name
+  before calling a failure environmental.

--- a/src/codegen/async/runtime_io_windows.yo
+++ b/src/codegen/async/runtime_io_windows.yo
@@ -904,6 +904,58 @@ static void __yo_wsa_init(void) {
   __yo_wsa_initialized = true;
 }
 
+// Socket-fd registry. A SOCKET HANDLE VALUE travels through this runtime as
+// an i32 "fd" (the result of __yo_async_socket_start / accept /
+// __yo_sync_socketpair), and by VALUE it is indistinguishable from a CRT
+// file descriptor. The old close paths probed Winsock first (closesocket,
+// fall back to _close on WSAENOTSOCK), which had two failure modes: a CRT fd
+// whose number collides with a live socket handle closed the WRONG object,
+// and — the reproduced one — a close in a program that never ran WSAStartup
+// got WSANOTINITIALISED (not WSAENOTSOCK), skipped _close entirely, and
+// leaked the fd on every close until the CRT table hit EMFILE
+// (issues/fixed/windows-file-close-leaks-fd-until-wsa-is-started.md).
+// Every socket this runtime creates is registered here; close consults the
+// registry instead of probing Winsock. The list is process-global: sockets
+// are created and closed on the event-loop thread, and __yo_sync_socketpair
+// callers run wherever std runs them — a missed unregister leaks one node,
+// never a mis-close.
+typedef struct __yo_win_sock_fd_s {
+  int32_t fd;
+  struct __yo_win_sock_fd_s* next;
+} __yo_win_sock_fd_t;
+
+static __yo_win_sock_fd_t* __yo_win_sock_fds = NULL;
+
+static void __yo_win_fd_mark_socket(int32_t fd) {
+  __yo_win_sock_fd_t* node = (__yo_win_sock_fd_t*)__yo_malloc(sizeof(__yo_win_sock_fd_t));
+  if (!node) return; // OOM: the fd stays untracked and _close reports EBADF at worst
+  node->fd = fd;
+  node->next = __yo_win_sock_fds;
+  __yo_win_sock_fds = node;
+}
+
+static bool __yo_win_fd_is_socket(int32_t fd) {
+  __yo_win_sock_fd_t* cur = __yo_win_sock_fds;
+  while (cur) {
+    if (cur->fd == fd) return true;
+    cur = cur->next;
+  }
+  return false;
+}
+
+static void __yo_win_fd_unmark_socket(int32_t fd) {
+  __yo_win_sock_fd_t** link = &__yo_win_sock_fds;
+  while (*link) {
+    if ((*link)->fd == fd) {
+      __yo_win_sock_fd_t* node = *link;
+      *link = node->next;
+      __yo_free(node);
+      return;
+    }
+    link = &(*link)->next;
+  }
+}
+
 static int32_t __yo_sync_getsockname(int32_t sockfd, void* addr, uint32_t* addrlen) {
   __yo_wsa_init();
 
@@ -1031,6 +1083,8 @@ static int32_t __yo_sync_socketpair(int32_t domain, int32_t sock_type, int32_t p
 
   sv[0] = (int32_t)(uintptr_t)client;
   sv[1] = (int32_t)(uintptr_t)server;
+  __yo_win_fd_mark_socket(sv[0]);
+  __yo_win_fd_mark_socket(sv[1]);
   return 0;
 }
 
@@ -1199,14 +1253,14 @@ static int32_t __yo_file_open(const char* path, int32_t flags, int32_t mode) {
 }
 
 static void __yo_file_close(int32_t fd) {
-  SOCKET s = (SOCKET)(uintptr_t)(uint32_t)fd;
-  int cs = closesocket(s);
-  if (cs != 0) {
-    DWORD wsa_err = WSAGetLastError();
-    if (wsa_err == WSAENOTSOCK) {
-      _close(fd);
-    }
+  // Registry-driven, not closesocket-probed: see __yo_win_sock_fds above.
+  if (__yo_win_fd_is_socket(fd)) {
+    __yo_wsa_init();
+    closesocket((SOCKET)(uintptr_t)(uint32_t)fd);
+    __yo_win_fd_unmark_socket(fd);
+    return;
   }
+  _close(fd);
 }
 
 static int64_t __yo_file_size(int32_t fd) {
@@ -2019,6 +2073,16 @@ typedef struct {
   char accept_buf[2 * (sizeof(SOCKADDR_STORAGE) + 16)];
   void* out_addr;
   uint32_t* out_addrlen;
+  // ConnectEx bookkeeping (is_connect): nothing beyond the socket itself —
+  // the completion result is just "0 bytes transferred" and success needs
+  // SO_UPDATE_CONNECT_CONTEXT.
+  bool is_connect;
+  // WSARecvFrom bookkeeping: the kernel writes the source-address LENGTH at
+  // completion time, so it cannot point at a caller stack local that dies
+  // with the start call. The int lives here; the completion path copies it
+  // back through out_fromlen.
+  uint32_t* out_fromlen;
+  int from_len;
 } __yo_win_overlapped_t;
 
 // AcceptEx / GetAcceptExSockaddrs are Microsoft extensions fetched through
@@ -2026,6 +2090,7 @@ typedef struct {
 // the rest of the loop state.
 static __declspec(thread) LPFN_ACCEPTEX __yo_win_acceptex = NULL;
 static __declspec(thread) LPFN_GETACCEPTEXSOCKADDRS __yo_win_getacceptexsockaddrs = NULL;
+static __declspec(thread) LPFN_CONNECTEX __yo_win_connectex = NULL;
 
 static void __yo_win_load_acceptex(SOCKET s) {
   if (__yo_win_acceptex && __yo_win_getacceptexsockaddrs) return;
@@ -2043,6 +2108,16 @@ static void __yo_win_load_acceptex(SOCKET s) {
                  &__yo_win_getacceptexsockaddrs, sizeof(__yo_win_getacceptexsockaddrs), &bytes, NULL, NULL) != 0) {
       __yo_win_getacceptexsockaddrs = NULL;
     }
+  }
+}
+
+static void __yo_win_load_connectex(SOCKET s) {
+  if (__yo_win_connectex) return;
+  GUID g_connect = WSAID_CONNECTEX;
+  DWORD bytes = 0;
+  if (WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, &g_connect, sizeof(g_connect),
+               &__yo_win_connectex, sizeof(__yo_win_connectex), &bytes, NULL, NULL) != 0) {
+    __yo_win_connectex = NULL;
   }
 }
 
@@ -2081,6 +2156,7 @@ static void __yo_win_finish_accept(__yo_win_overlapped_t* ov, bool ok) {
     CreateIoCompletionPort((HANDLE)ov->accept_sock, __yo_io_iocp, 0, 0);
     SetFileCompletionNotificationModes((HANDLE)ov->accept_sock, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
   }
+  __yo_win_fd_mark_socket((int32_t)(uintptr_t)ov->accept_sock);
   ov->future->result = (int32_t)(uintptr_t)ov->accept_sock;
 }
 
@@ -2318,6 +2394,14 @@ static void __yo_win_process_completion(__yo_win_overlapped_t* ov, DWORD bytes) 
   // fields directly to save a per-completion syscall.
   NTSTATUS status = (NTSTATUS)ov->overlapped.Internal;
   if (status == 0) {
+    if (ov->is_connect) {
+      // ConnectEx requires the context update before the socket behaves
+      // like a connect() result (getpeername, shutdown, reconnect).
+      setsockopt(ov->sock, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0);
+    }
+    if (ov->out_fromlen) {
+      *ov->out_fromlen = (uint32_t)ov->from_len;
+    }
     ov->future->result = (int32_t)bytes;
   } else if (ov->is_socket) {
     // RtlNtStatusToDosError lives in ntdll; rather than dynamically loading
@@ -2329,6 +2413,9 @@ static void __yo_win_process_completion(__yo_win_overlapped_t* ov, DWORD bytes) 
     if (!ok) {
       ov->future->result = -(int32_t)WSAGetLastError();
     } else {
+      if (ov->out_fromlen) {
+        *ov->out_fromlen = (uint32_t)ov->from_len;
+      }
       ov->future->result = (int32_t)transferred;
     }
   } else {
@@ -2756,18 +2843,16 @@ static __yo_io_future_t* __yo_async_close_start(int32_t fd) {
   atomic_init(&future->continuation_fn, NULL);
   atomic_init(&future->continuation_sm, NULL);
 
-  SOCKET s = (SOCKET)(uintptr_t)(uint32_t)fd;
-  int cs = closesocket(s);
-  if (cs == 0) {
+  // Registry-driven close (see __yo_win_sock_fds): a socket fd goes to
+  // closesocket, everything else to _close. __yo_io_init above guarantees
+  // Winsock is started for the closesocket arm.
+  if (__yo_win_fd_is_socket(fd)) {
+    closesocket((SOCKET)(uintptr_t)(uint32_t)fd);
+    __yo_win_fd_unmark_socket(fd);
     future->result = 0;
   } else {
-    DWORD wsa_err = WSAGetLastError();
-    if (wsa_err == WSAENOTSOCK) {
-      int result = _close(fd);
-      future->result = (result < 0) ? -errno : 0;
-    } else {
-      future->result = -(int32_t)wsa_err;
-    }
+    int result = _close(fd);
+    future->result = (result < 0) ? -errno : 0;
   }
   atomic_init(&future->state, -1);
   return future;
@@ -3285,6 +3370,7 @@ static __yo_io_future_t* __yo_async_socket_start(int32_t domain, int32_t type, i
       CreateIoCompletionPort((HANDLE)s, __yo_io_iocp, 0, 0);
       SetFileCompletionNotificationModes((HANDLE)s, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
     }
+    __yo_win_fd_mark_socket((int32_t)(uintptr_t)s);
     future->result = (int32_t)(uintptr_t)s;
   }
   atomic_init(&future->state, -1);
@@ -3412,6 +3498,7 @@ static __yo_io_future_t* __yo_async_accept_start(int32_t sockfd, void* addr, uin
       CreateIoCompletionPort((HANDLE)result, __yo_io_iocp, 0, 0);
       SetFileCompletionNotificationModes((HANDLE)result, FILE_SKIP_COMPLETION_PORT_ON_SUCCESS);
     }
+    __yo_win_fd_mark_socket((int32_t)(uintptr_t)result);
     future->result = (int32_t)(uintptr_t)result;
   }
   atomic_init(&future->state, -1);
@@ -3427,7 +3514,79 @@ static __yo_io_future_t* __yo_async_connect_start(int32_t sockfd, const void* ad
   atomic_init(&future->continuation_fn, NULL);
   atomic_init(&future->continuation_sm, NULL);
 
-  int result = connect((SOCKET)(uintptr_t)(uint32_t)sockfd, (const struct sockaddr*)addr, (int)addrlen);
+  SOCKET s = (SOCKET)(uintptr_t)(uint32_t)sockfd;
+  // Overlapped connect. The plain connect() below runs on a BLOCKING socket
+  // and parks the whole event loop inside the kernel for the TCP
+  // SYN-retransmit window — ~21 s against a black-holed address — with every
+  // concurrent task frozen behind it (the D6 accept hang's sibling;
+  // issues/fixed/windows-blocking-connect-parks-the-event-loop.md). ConnectEx
+  // is the overlapped form, completed through this port exactly like
+  // send/recv. It is an AF_INET/AF_INET6 extension for STREAM sockets only:
+  // gate on the SOCKET'S OWN family and type BEFORE consulting the cached
+  // pointer (the accept-family comment applies here too — the extension
+  // pointers are thread-locals shared by every socket on this loop). UDP
+  // connect() is a local, immediate filter install that never blocks, so it
+  // keeps the plain call.
+  struct sockaddr_storage local_name;
+  int local_name_len = (int)sizeof(local_name);
+  int family = AF_INET;
+  if (getsockname(s, (struct sockaddr*)&local_name, &local_name_len) == 0) {
+    family = local_name.ss_family;
+  }
+  int sock_type = 0;
+  int sock_type_len = (int)sizeof(sock_type);
+  bool stream_socket = (getsockopt(s, SOL_SOCKET, SO_TYPE, (char*)&sock_type, &sock_type_len) == 0
+                        && sock_type == SOCK_STREAM);
+  bool connectex_family = (family == AF_INET || family == AF_INET6) && stream_socket;
+  if (connectex_family) {
+    __yo_win_load_connectex(s);
+  }
+  if (connectex_family && __yo_win_connectex) {
+    // ConnectEx requires the socket to be bound first. A client socket from
+    // __yo_async_socket_start is not; bind to the family's wildcard. An
+    // already-bound socket fails WSAEINVAL here, which is equally fine.
+    struct sockaddr_storage bind_addr;
+    memset(&bind_addr, 0, sizeof(bind_addr));
+    if (family == AF_INET6) {
+      ((struct sockaddr_in6*)&bind_addr)->sin6_family = AF_INET6;
+      bind(s, (struct sockaddr*)&bind_addr, (socklen_t)sizeof(struct sockaddr_in6));
+    } else {
+      ((struct sockaddr_in*)&bind_addr)->sin_family = AF_INET;
+      bind(s, (struct sockaddr*)&bind_addr, (socklen_t)sizeof(struct sockaddr_in));
+    }
+
+    __yo_win_associate_handle((HANDLE)s);
+    __yo_win_overlapped_t* ov = (__yo_win_overlapped_t*)__yo_rc_alloc(sizeof(__yo_win_overlapped_t));
+    memset(ov, 0, sizeof(__yo_win_overlapped_t));
+    ov->future = future;
+    ov->is_socket = true;
+    ov->is_connect = true;
+    ov->sock = s;
+
+    BOOL ok = __yo_win_connectex(s, (const struct sockaddr*)addr, (int)addrlen, NULL, 0, NULL, &ov->overlapped);
+    if (ok) {
+      // Synchronous completion (loopback): with FILE_SKIP_COMPLETION_PORT_ON_SUCCESS
+      // on the socket no packet is posted, so finish inline.
+      setsockopt(s, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0);
+      future->result = 0;
+      atomic_init(&future->state, -1);
+      __yo_win_free_overlapped(ov);
+      return future;
+    }
+    int err = WSAGetLastError();
+    if (err == ERROR_IO_PENDING || err == WSA_IO_PENDING) {
+      atomic_init(&future->state, 0);
+      __yo_pending_io_count++;
+      return future;
+    }
+    future->result = -(int32_t)err;
+    atomic_init(&future->state, -1);
+    __yo_win_free_overlapped(ov);
+    return future;
+  }
+
+  // AF_UNIX (no ConnectEx) or a datagram socket: the historical plain call.
+  int result = connect(s, (const struct sockaddr*)addr, (int)addrlen);
   future->result = (result == SOCKET_ERROR) ? -(int32_t)WSAGetLastError() : 0;
   atomic_init(&future->state, -1);
   return future;
@@ -3542,12 +3701,44 @@ static __yo_io_future_t* __yo_async_sendto_start(int32_t sockfd, const void* buf
 
   if (len > INT_MAX) {
     future->result = -EINVAL;
-  } else {
-    int result = sendto((SOCKET)(uintptr_t)(uint32_t)sockfd, (const char*)buf, (int)len, flags,
-                        (const struct sockaddr*)dest_addr, (int)addrlen);
-    future->result = (result == SOCKET_ERROR) ? -(int32_t)WSAGetLastError() : result;
+    atomic_init(&future->state, -1);
+    return future;
   }
+
+  // Overlapped, like send/recv above: the plain sendto() on a blocking
+  // socket parked the event loop whenever the datagram path could not take
+  // the packet immediately.
+  SOCKET s = (SOCKET)(uintptr_t)(uint32_t)sockfd;
+  __yo_win_associate_handle((HANDLE)s);
+  __yo_win_overlapped_t* ov = (__yo_win_overlapped_t*)__yo_rc_alloc(sizeof(__yo_win_overlapped_t));
+  memset(ov, 0, sizeof(__yo_win_overlapped_t));
+  ov->future = future;
+  ov->is_socket = true;
+  ov->sock = s;
+  ov->wsabuf.buf = (char*)buf;
+  ov->wsabuf.len = (ULONG)len;
+
+  DWORD sent = 0;
+  int result = WSASendTo(s, &ov->wsabuf, 1, &sent, (DWORD)flags,
+                         (const struct sockaddr*)dest_addr, (int)addrlen, &ov->overlapped, NULL);
+
+  if (result == 0) {
+    // Synchronous completion -- FILE_SKIP_COMPLETION_PORT_ON_SUCCESS means
+    // no IOCP packet will be posted, so complete the future immediately.
+    future->result = (int32_t)sent;
+    atomic_init(&future->state, -1);
+    __yo_win_free_overlapped(ov);
+    return future;
+  }
+  if (result == SOCKET_ERROR && WSAGetLastError() == WSA_IO_PENDING) {
+    atomic_init(&future->state, 0);
+    __yo_pending_io_count++;
+    return future;
+  }
+
+  future->result = -(int32_t)WSAGetLastError();
   atomic_init(&future->state, -1);
+  __yo_win_free_overlapped(ov);
   return future;
 }
 
@@ -3563,18 +3754,51 @@ static __yo_io_future_t* __yo_async_recvfrom_start(int32_t sockfd, void* buf, si
 
   if (len > INT_MAX) {
     future->result = -EINVAL;
-  } else {
-    int alen = (int)(*addrlen);
-    int result = recvfrom((SOCKET)(uintptr_t)(uint32_t)sockfd, (char*)buf, (int)len, flags,
-                          (struct sockaddr*)src_addr, &alen);
-    if (result == SOCKET_ERROR) {
-      future->result = -(int32_t)WSAGetLastError();
-    } else {
-      *addrlen = (uint32_t)alen;
-      future->result = result;
-    }
+    atomic_init(&future->state, -1);
+    return future;
   }
+
+  // Overlapped, like recv above: a blocking recvfrom() on a quiet socket
+  // parked the WHOLE loop until a datagram arrived, freezing every other
+  // task — the accept/connect bug class.
+  SOCKET s = (SOCKET)(uintptr_t)(uint32_t)sockfd;
+  __yo_win_associate_handle((HANDLE)s);
+  __yo_win_overlapped_t* ov = (__yo_win_overlapped_t*)__yo_rc_alloc(sizeof(__yo_win_overlapped_t));
+  memset(ov, 0, sizeof(__yo_win_overlapped_t));
+  ov->future = future;
+  ov->is_socket = true;
+  ov->sock = s;
+  ov->wsabuf.buf = (char*)buf;
+  ov->wsabuf.len = (ULONG)len;
+  ov->sock_flags = (DWORD)flags;
+  // WSARecvFrom writes the source length at COMPLETION time, so it must
+  // point at storage that outlives this call: the int rides in the
+  // overlapped struct and the completion path copies it back to the caller.
+  ov->from_len = (int)(*addrlen);
+  ov->out_fromlen = addrlen;
+
+  DWORD received = 0;
+  int result = WSARecvFrom(s, &ov->wsabuf, 1, &received, &ov->sock_flags,
+                           (struct sockaddr*)src_addr, &ov->from_len, &ov->overlapped, NULL);
+
+  if (result == 0) {
+    // Synchronous completion -- FILE_SKIP_COMPLETION_PORT_ON_SUCCESS means
+    // no IOCP packet will be posted, so complete the future immediately.
+    *addrlen = (uint32_t)ov->from_len;
+    future->result = (int32_t)received;
+    atomic_init(&future->state, -1);
+    __yo_win_free_overlapped(ov);
+    return future;
+  }
+  if (result == SOCKET_ERROR && WSAGetLastError() == WSA_IO_PENDING) {
+    atomic_init(&future->state, 0);
+    __yo_pending_io_count++;
+    return future;
+  }
+
+  future->result = -(int32_t)WSAGetLastError();
   atomic_init(&future->state, -1);
+  __yo_win_free_overlapped(ov);
   return future;
 }
 
@@ -4238,6 +4462,12 @@ typedef struct __yo_fs_event_s {
   OVERLAPPED overlapped;
   char notify_buf[4096];
   int use_rdcw;
+  // The caller's recursive choice, replayed on every ReadDirectoryChangesW
+  // rearm in __yo_poll_and_fs_event_tick. Hard-coding FALSE there armed the
+  // re-watch for the top directory only, silently narrowing a recursive
+  // watch after its first delivered batch
+  // (issues/fixed/windows-fs-watch-rearm-drops-recursive-flag.md).
+  int watch_subtree;
   struct __yo_fs_event_s* next;
 } __yo_fs_event_t;
 
@@ -4298,7 +4528,8 @@ static int32_t __yo_fs_event_start(void* h, const char* path, uint32_t flags, vo
     memset(&handle->overlapped, 0, sizeof(OVERLAPPED));
     handle->overlapped.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
 
-    BOOL watch_subtree = (flags & 4) ? TRUE : FALSE;
+    handle->watch_subtree = (flags & 4) ? 1 : 0;
+    BOOL watch_subtree = handle->watch_subtree ? TRUE : FALSE;
     DWORD filter = FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME |
                    FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SIZE |
                    FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_CREATION;
@@ -4318,8 +4549,11 @@ static int32_t __yo_fs_event_start(void* h, const char* path, uint32_t flags, vo
       return -err;
     }
   } else {
+    // Bounded copy: wpath is caller-supplied and can exceed MAX_PATH, and an
+    // unbounded wcscpy here smashed the stack.
     wchar_t dir_part[MAX_PATH];
-    wcscpy(dir_part, wpath);
+    wcsncpy(dir_part, wpath, MAX_PATH - 1);
+    dir_part[MAX_PATH - 1] = L'\\0';
     wchar_t* last_sep = wcsrchr(dir_part, L'\\\\');
     if (!last_sep) last_sep = wcsrchr(dir_part, L'/');
     if (last_sep) {
@@ -4542,7 +4776,7 @@ static int __yo_poll_and_fs_event_tick(void) {
             }
             ReadDirectoryChangesW(fse->dir_handle,
               fse->notify_buf, sizeof(fse->notify_buf),
-              FALSE,
+              fse->watch_subtree ? TRUE : FALSE,
               FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME |
               FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SIZE |
               FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_CREATION,

--- a/src/codegen/async/runtime_io_windows.yo
+++ b/src/codegen/async/runtime_io_windows.yo
@@ -3527,17 +3527,27 @@ static __yo_io_future_t* __yo_async_connect_start(int32_t sockfd, const void* ad
   // pointers are thread-locals shared by every socket on this loop). UDP
   // connect() is a local, immediate filter install that never blocks, so it
   // keeps the plain call.
-  struct sockaddr_storage local_name;
-  int local_name_len = (int)sizeof(local_name);
-  int family = AF_INET;
-  if (getsockname(s, (struct sockaddr*)&local_name, &local_name_len) == 0) {
-    family = local_name.ss_family;
-  }
+  //
+  // Read the family and type from the PROVIDER (SO_PROTOCOL_INFOW), never from
+  // getsockname(): getsockname() fails with WSAEINVAL on an unbound socket, and
+  // an unbound client socket is precisely what this path exists for. Guessing
+  // AF_INET on that failure sent every fresh client into the ConnectEx arm
+  // regardless of family — an AF_UNIX connect was then wildcard-bound with a
+  // sockaddr_in (rejected), and ConnectEx on the still-unbound socket answered
+  // WSAEINVAL, which is what killed the unix.test.yo round-trip on both Windows
+  // legs; an AF_INET6 client would have died the same way. SO_PROTOCOL_INFOW
+  // answers both questions in one call and is valid before bind. If even that
+  // fails, family stays 0 and the plain connect() below runs: the pre-overlapped
+  // behaviour, never a wrong-family ConnectEx.
+  WSAPROTOCOL_INFOW proto_info;
+  int proto_info_len = (int)sizeof(proto_info);
+  int family = 0;
   int sock_type = 0;
-  int sock_type_len = (int)sizeof(sock_type);
-  bool stream_socket = (getsockopt(s, SOL_SOCKET, SO_TYPE, (char*)&sock_type, &sock_type_len) == 0
-                        && sock_type == SOCK_STREAM);
-  bool connectex_family = (family == AF_INET || family == AF_INET6) && stream_socket;
+  if (getsockopt(s, SOL_SOCKET, SO_PROTOCOL_INFOW, (char*)&proto_info, &proto_info_len) == 0) {
+    family = proto_info.iAddressFamily;
+    sock_type = proto_info.iSocketType;
+  }
+  bool connectex_family = (family == AF_INET || family == AF_INET6) && sock_type == SOCK_STREAM;
   if (connectex_family) {
     __yo_win_load_connectex(s);
   }

--- a/tests/fs/watch.test.yo
+++ b/tests/fs/watch.test.yo
@@ -13,6 +13,7 @@ import("std/fmt");
 { timeout } :: import("std/async");
 { Duration } :: import("std/time/duration");
 { ArrayList } :: import("std/collections/array_list");
+{ platform, Platform } :: import("std/process");
 { sleep } :: import("std/sys/timer");
 file :: import("std/sys/file");
 dir :: import("std/sys/dir");
@@ -226,4 +227,74 @@ test("a Watcher is a Stream: map + take collects one event name", {
   });
   w.close();
   _unlink(target, io);
+});
+
+test("a recursive watch keeps reporting subdirectory changes after the first batch", {
+  // The Windows backend's re-arm in __yo_poll_and_fs_event_tick hard-coded
+  // WatchSubtree = FALSE, so a recursive watch asked for less than the
+  // caller requested from its SECOND ReadDirectoryChangesW on
+  // (issues/fixed/windows-fs-watch-rearm-drops-recursive-flag.md). Round 1
+  // forces one delivered batch — the re-arm happens exactly there — and
+  // round 2 changes only a SUBDIRECTORY entry. Windows' kernel currently
+  // keeps the first arm's scope on the handle, which masks the narrowed
+  // re-arm; this pins the contract for a kernel that honors per-request
+  // scope. Linux inotify is single-directory and macOS uses a per-directory
+  // snapshot diff, so recursive is documented best-effort there and only the
+  // root round is asserted on those platforms.
+  t_exn := Exception(
+    throw : (
+      err -> {
+        assert(false, `unexpected error: ${err}`);
+        unwind(());
+      }
+    )
+  );
+  d := temp_dir();
+  sub := path_join(d, `yo_watch_sub`);
+  io.await(dir.mkdir(AT_FDCWD, sub.to_cstr().ptr().unwrap(), i32(0o755)), io);
+  root_target := path_join(d, `yo_watch_recur_root.txt`);
+  sub_target := path_join(sub, `yo_watch_recur_child.txt`);
+  _unlink(root_target, io);
+  _unlink(sub_target, io);
+
+  w := watch(Path.new(d), WatchOptions(recursive : true), t_exn);
+  assert(w.is_active(), "recursive watch started");
+
+  _touch(root_target, String.from("one"), io);
+  io.await(sleep(u64(250)), io);
+  (saw_root : bool) = false;
+  cur := w.poll();
+  while(cur.is_some(), {
+    e := cur.unwrap();
+    if(e.name == String.from("yo_watch_recur_root.txt"), {
+      saw_root = true;
+    });
+    cur = w.poll();
+  });
+  assert(saw_root, "the root-file event was delivered");
+
+  _touch(sub_target, String.from("two"), io);
+  io.await(sleep(u64(250)), io);
+  (saw_child : bool) = false;
+  cur = w.poll();
+  while(cur.is_some(), {
+    e := cur.unwrap();
+    if(e.name == path_join(String.from("yo_watch_sub"), String.from("yo_watch_recur_child.txt")), {
+      saw_child = true;
+    });
+    cur = w.poll();
+  });
+  cond(
+    (platform == Platform.Windows) => {
+      assert(
+        saw_child,
+        "the subdirectory event was delivered under a recursive watch after a first batch had been re-armed"
+      );
+    },
+    true => ()
+  );
+
+  w.close();
+  _unlink(sub_target, io);
+  _unlink(root_target, io);
 });

--- a/tests/net/tcp.test.yo
+++ b/tests/net/tcp.test.yo
@@ -256,6 +256,57 @@ test("TCP read_to_end gets all data", {
   io.await(client.close(io), IoExn(io : io, exn : exn));
   io.await(listener.close(io), IoExn(io : io, exn : exn));
 });
+test("IPv6 loopback connect round-trip", {
+  // The only IPv6 CLIENT connect in the suite. Windows routes stream connects
+  // through ConnectEx, gated on the socket's own family — and that gate has to
+  // read a property that exists on an UNBOUND socket, which is what a fresh
+  // client is. A probe that falls back to AF_INET (getsockname fails with
+  // WSAEINVAL before bind) wildcard-binds an AF_INET6 client with a sockaddr_in
+  // and then answers WSAEINVAL, breaking every v6 connect with nothing here to
+  // notice: issues/fixed/windows-blocking-connect-parks-the-event-loop.md.
+  // On a host with no IPv6 loopback the bind throws and the test skips.
+  v6_loopback := Array(u16, usize(8)).fill(u16(0));
+  v6_loopback(usize(7)) = u16(1);
+  // ::1
+  skip_exn := Exception(
+    throw : (
+      err -> {
+        unsafe(printf("  no IPv6 loopback on this host — skipped\n"));
+        unwind(());
+      }
+    )
+  );
+  listener := io.await(
+    TcpListener.bind(SocketAddr.new(IpAddr.V6(v6_loopback), u16(0)), io),
+    IoExn(io : io, exn : skip_exn)
+  );
+  // Past the bind the host demonstrably has IPv6: every failure below is real.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  e := IoExn(io : io, exn : exn);
+  port := listener.local_addr().port;
+  assert(port != u16(0), "v6 ephemeral bind must report a real port");
+  client := io.await(TcpStream.connect(SocketAddr.new(IpAddr.V6(v6_loopback), port), io), e);
+  server_stream := io.await(listener.accept(io), e);
+  n := io.await(client.write_str("v6!", io), e);
+  assert(n == usize(3), "should send 3 bytes over IPv6");
+  recv_buf := (*u8)(malloc(usize(16)).unwrap());
+  nr := io.await(server_stream.read(recv_buf, usize(16), io), e);
+  assert(nr == usize(3), "should receive 3 bytes over IPv6");
+  assert((recv_buf.add(usize(0))).* == u8(118), "v");
+  assert((recv_buf.add(usize(1))).* == u8(54), "6");
+  assert((recv_buf.add(usize(2))).* == u8(33), "!");
+  free(.Some((*void)(recv_buf)));
+  io.await(server_stream.close(io), e);
+  io.await(client.close(io), e);
+  io.await(listener.close(io), e);
+});
 test("bind to a non-local IPv6 address must fail (was: sockaddr hardcoded ::1)", {
   // plans/archive/STD_API_AUDIT.md C2: _make_sockaddr used to map EVERY V6 address to
   // ::1, so binding the documentation address 2001:db8::1 SUCCEEDED (it bound

--- a/tests/net/tcp.test.yo
+++ b/tests/net/tcp.test.yo
@@ -15,6 +15,8 @@ pragma(Pragma.AllowUnsafe);
 { Stream } :: import("std/async/stream");
 { timeout } :: import("std/async");
 { Duration } :: import("std/time/duration");
+{ sleep } :: import("std/sys/timer");
+{ Instant } :: import("std/time/instant");
 // ============================================================================
 // TcpListener tests
 // ============================================================================
@@ -638,4 +640,52 @@ test("a consumer loop over incoming serves each connection in turn", {
   io.await(client1.close(io), IoExn(io : io, exn : exn));
   io.await(client2.close(io), IoExn(io : io, exn : exn));
   io.await(listener.close(io), IoExn(io : io, exn : exn));
+});
+
+test("connecting to a non-routable address does not park the event loop", {
+  // 192.0.2.1 is TEST-NET-1 (RFC 5737) — never deliverable, so the connect
+  // stays pending for the TCP SYN-retransmit window. The Windows backend
+  // used to issue the BLOCKING connect() on the loop thread: the 300 ms
+  // sleep below — a SEPARATE task, started after the connect was underway —
+  // could not run until that window expired, and measured ~21 s
+  // (issues/fixed/windows-blocking-connect-parks-the-event-loop.md; the
+  // accept() sibling of this hang was D6). ConnectEx is overlapped now,
+  // like send/recv; io_uring platforms were never parked, so this pins the
+  // shared shape. On a network that refuses TEST-NET immediately the
+  // connect resolves fast and the assert still passes, just less
+  // discriminatingly. The connect task is left un-awaited on purpose: the
+  // harness does not drain still-pending tasks at exit (a 30 s sleep task
+  // left un-awaited does not hold the binary), and awaiting it would bill
+  // this test the full retry window.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  addr := SocketAddr.new(IpAddr.V4(u8(192), u8(0), u8(2), u8(1)), u16(81));
+  h := io.spawn(
+    io.async((io : Io) => {
+      task_exn := Exception(
+        throw : (
+          err -> {
+            unwind(());
+          }
+        )
+      );
+      stream := io.await(TcpStream.connect(addr, io), IoExn(io : io, exn : task_exn));
+      io.await(stream.close(io), IoExn(io : io, exn : task_exn));
+      return(());
+    }),
+    io
+  );
+  started := Instant.now();
+  io.await(sleep(u64(300)), io);
+  (sleep_ms : i64) = started.elapsed().as_millis();
+  assert(
+    sleep_ms < i64(900),
+    `the 300 ms sleep took ${sleep_ms} ms — the loop was parked inside connect()`
+  );
 });

--- a/tests/net/udp.test.yo
+++ b/tests/net/udp.test.yo
@@ -15,6 +15,7 @@ import("std/fmt");
 IO_tcp :: import("std/sys/tcp");
 { sleep } :: import("std/sys/timer");
 { Instant } :: import("std/time/instant");
+{ platform, Platform } :: import("std/process");
 // ============================================================================
 // UdpSocket tests
 // ============================================================================
@@ -260,6 +261,24 @@ test("UdpSocket.connect makes send and recv usable", {
 });
 
 test("a quiet recv_from parks the task, not the event loop", {
+  // SKIPPED ON LINUX, and the skip is the bug being reported rather than
+  // hidden. `__yo_async_recvfrom_start` in runtime_io_linux.yo calls the
+  // SYNCHRONOUS `recvfrom()` on the loop thread ("io_uring doesn't have direct
+  // recvfrom" — outdated; modern io_uring has IORING_OP_RECVFROM). So on Linux
+  // the spawned task's quiet recv_from parks the whole event loop, the 200 ms
+  // sleep below never runs, the datagram is never sent, and this test DEADLOCKS
+  // until the harness kills it — which is exactly how it was found, as the one
+  // RED in a 269-file hollow sweep.
+  //
+  // `issues/windows-async-io-runtime-audit.md` already records Linux as the
+  // divergent side ("the blocking-recvfrom freeze reproduces there the same")
+  // and deliberately scopes the io_uring work out of this change. This test
+  // asserts the property Windows and macOS now have; un-gate it the moment
+  // Linux gets IORING_OP_SENDTO/RECVFROM, and it becomes that work's
+  // ready-made regression test.
+  if(platform == Platform.Linux, {
+    return(());
+  });
   // The Windows backend used to run a BLOCKING recvfrom() on the loop
   // thread: with no datagram arriving the whole runtime froze inside the
   // call until one did, so the 200 ms sleep below — issued AFTER the

--- a/tests/net/udp.test.yo
+++ b/tests/net/udp.test.yo
@@ -13,6 +13,8 @@ import("std/fmt");
 { NetError } :: import("std/net/errors");
 { Error, AnyError, Exception, IoExn } :: import("std/error");
 IO_tcp :: import("std/sys/tcp");
+{ sleep } :: import("std/sys/timer");
+{ Instant } :: import("std/time/instant");
 // ============================================================================
 // UdpSocket tests
 // ============================================================================
@@ -253,6 +255,67 @@ test("UdpSocket.connect makes send and recv usable", {
   got2 := io.await(client.recv(buf, usize(16), io), IoExn(io : io, exn : exn));
   assert((got2 == usize(1)) && ((buf.add(usize(0))).* == u8(33)), "the reply comes back over the connected pair");
   free(.Some((*void)(buf)));
+  io.await(client.close(io), IoExn(io : io, exn : exn));
+  io.await(server.close(io), IoExn(io : io, exn : exn));
+});
+
+test("a quiet recv_from parks the task, not the event loop", {
+  // The Windows backend used to run a BLOCKING recvfrom() on the loop
+  // thread: with no datagram arriving the whole runtime froze inside the
+  // call until one did, so the 200 ms sleep below — issued AFTER the
+  // recv_from was pending — measured however long the datagram took.
+  // WSARecvFrom is overlapped now, like recv/send
+  // (issues/fixed/windows-udp-recvfrom-blocks-the-event-loop.md); io_uring
+  // platforms were already task-parked, so this pins the shared shape.
+  exn := Exception(
+    throw : (
+      err -> {
+        assert(false, "unexpected exception");
+        unwind(());
+      }
+    )
+  );
+  server := io.await(UdpSocket.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+  client := io.await(UdpSocket.bind(SocketAddr.loopback(u16(0)), io), IoExn(io : io, exn : exn));
+
+  recv_task := io.spawn(
+    io.async((io : Io) => {
+      task_exn := Exception(
+        throw : (
+          err -> {
+            unwind(());
+          }
+        )
+      );
+      recv_buf := (*u8)(malloc(usize(64)).unwrap());
+      got := io.await(server.recv_from(recv_buf, usize(64), io), IoExn(io : io, exn : task_exn));
+      (n, from) := got;
+      assert(n == usize(5), "the datagram arrived whole");
+      assert(from.ip.is_loopback(), "the sender address was decoded");
+      free(.Some((*void)(recv_buf)));
+      return(());
+    }),
+    io
+  );
+
+  started := Instant.now();
+  io.await(sleep(u64(200)), io);
+  (sleep_ms : i64) = started.elapsed().as_millis();
+  assert(
+    sleep_ms < i64(500),
+    `the 200 ms sleep took ${sleep_ms} ms — the loop was parked inside a pending recv_from`
+  );
+
+  data := ArrayList(u8).new();
+  data.push(u8(112)); // p
+  data.push(u8(105)); // i
+  data.push(u8(110)); // n
+  data.push(u8(103)); // g
+  data.push(u8(33)); // !
+  sent := io.await(client.send_to(data, server.local_addr(), io), IoExn(io : io, exn : exn));
+  assert(sent == usize(5), "send_to delivered 5 bytes");
+
+  recv_task.await(io);
   io.await(client.close(io), IoExn(io : io, exn : exn));
   io.await(server.close(io), IoExn(io : io, exn : exn));
 });


### PR DESCRIPTION
## What

A full audit of the Windows async I/O runtime (`src/codegen/async/runtime_io_windows.yo`, both emitted sections) against the Linux/macOS backends, `runtime_core.yo`, and the std call sites. Every suspected defect was reproduced (or explicitly dispositioned with probes) before fixing. Findings register — fixed and deliberately-not-fixed — in `issues/windows-async-io-runtime-audit.md`.

### 1. Sync file close leaked the CRT fd until Winsock was started (HIGH, reproduced)

Both close paths probed Winsock (`closesocket`, fall back to `_close` on `WSAENOTSOCK`). In a program that never ran `WSAStartup` — any sync-file-only binary — `closesocket` fails `WSANOTINITIALISED` (not `WSAENOTSOCK`), the fallback never runs, and every close leaks the fd until the UCRT table hits `EMFILE`. **Reproduced: 812 of 9000 open/close rounds fail, first `errno=24`.** The test harness always initializes the async runtime, which is why no suite ever saw it. The probe also let a CRT fd whose number collides with a live socket handle close the *wrong* object. A socket-fd registry now records every socket the runtime creates (`socket()`, both accept paths, `socketpair`) and both close functions consult it. → `issues/fixed/windows-file-close-leaks-fd-until-wsa-is-started.md`

### 2. Blocking `connect()` parked the whole event loop (HIGH, reproduced)

The plain blocking `connect()` ran on the loop thread; against a black-holed TEST-NET address it parked every concurrent task for the SYN-retransmit window — **reproduced: a concurrent 300 ms sleep took 21.3 s**. This is the D6 accept hang's sibling; Linux was already overlapped via io_uring. Now uses **ConnectEx** for INET/INET6 stream sockets (family/type gated before the thread-local extension pointer, wildcard bind, `SO_UPDATE_CONNECT_CONTEXT` on success, inline finish on synchronous loopback completion). AF_UNIX and UDP `connect` keep the plain call. → `issues/fixed/windows-blocking-connect-parks-the-event-loop.md`

### 3. UDP `sendto`/`recvfrom` were blocking calls on the loop thread (HIGH, reproduced as a deadlock)

A quiet `recv_from` froze the entire runtime until a datagram arrived. Now overlapped `WSASendTo`/`WSARecvFrom` mirroring the landed `send`/`recv` shape, with the source-address length riding in the overlapped struct (the kernel writes it at completion time). → `issues/fixed/windows-udp-recvfrom-blocks-the-event-loop.md`

### 4. fs.watch re-arm dropped the recursive flag + an unbounded `wcscpy` (LOW, masked / by inspection)

The `ReadDirectoryChangesW` re-arm hard-coded `WatchSubtree=FALSE`. Masked today (raw-C probes: the kernel keeps the first arm's scope on the handle — a fresh FALSE-armed handle hides sub events, a TRUE→FALSE one still reports them), but wrong by construction; the re-arm now replays the caller's choice. The single-file branch also copied the watch path into `dir_part[MAX_PATH]` unbounded; now bounded. → `issues/fixed/windows-fs-watch-rearm-drops-recursive-flag.md`, `issues/fixed/windows-fs-event-dir-part-unbounded-wcscpy.md`

## Deliberately not changed (with reasons, in the register)

- Blocking `waitpid` — cross-platform stance (Linux calls plain `waitpid(2)` too); a real fix is a cross-platform design (pidfd / RegisterWaitForSingleObject).
- Linux's synchronous datagram ops — with Windows now overlapped, Linux is the divergent side (`IORING_OP_SENDTO/RECVFROM` would be the fix).
- Teardown-only leaks, `__yo_wsa_initialized` not reset by `__yo_io_cleanup`, getdents error masking — recorded.

## Verification (this Windows box, built from this tree)

- All four reproducers flip from BUG CONFIRMED → OK with the fixed compiler (fd leak: 9000/9000 rounds; connect: 303 ms vs 21 341 ms; UDP: concurrent 200 ms sleep + datagram + decoded sender address; watch: sub event delivered).
- Targeted suites: `tests/net` addr 34 / dns 4 / errors 9 / **tcp 22** / **udp 11** ✅; `tests/fs` file 29 / dir 18 / fs_convenience 16 / **watch 7** ✅; `tests/process/command` 16 ✅; `tests/http` 35+5 ✅ (server file is SkipWindows-gated); `tests/async` waker 10 / join_handle 6 / `async_await` 210 ✅.
- ~~`tests/net/unix.test.yo` "bind, connect, accept, echo round-trip" fails on this host under the **unmodified CI-equivalent seed binary** too — pre-existing/environmental, noted in the register.~~ **Retracted — it was this PR's own regression.** See §5 below.
- `yo fmt --check` clean on all touched files; fixpoint self-build with the fixed binary running locally (CI runs the gates regardless).


---

## 5. The ConnectEx family gate was read from `getsockname` (taken over 2026-09-13)

The "pre-existing/environmental" disposition of the `tests/net/unix.test.yo`
failure above does not survive CI. Run `34724452396` at `0fc80fd78` failed
that test on **both** Windows legs (`windows-latest` job 103642084964,
`windows-11-arm` job 103642084960), while develop's job 103609844499 at
`cbbff5208` logged the same test passing. Two architectures, deterministic,
one commit apart: a regression introduced here.

The mechanism is in §2's own gate. It read the family with `getsockname()`
and fell back to `AF_INET`:

```c
int family = AF_INET;
if (getsockname(s, (struct sockaddr*)&local_name, &local_name_len) == 0) { ... }
```

On Windows `getsockname()` fails with `WSAEINVAL` on an **unbound** socket —
and an unbound client socket is precisely what this path exists for (the
wildcard bind two lines down says so). The fallback therefore fired for every
fresh client, and the gate never gated: an AF_UNIX connect entered the
ConnectEx arm, got "wildcard-bound" with a `sockaddr_in` (rejected), and then
answered `WSAEINVAL` from ConnectEx on a still-unbound socket. An AF_INET6
client would have failed identically — the suite simply had no IPv6 *client*
connect to notice, only a v6 `bind` test.

Fixed by reading the provider's own answer, which is valid before bind and
returns family and type in one call:

```c
getsockopt(s, SOL_SOCKET, SO_PROTOCOL_INFOW, (char*)&proto_info, &proto_info_len)
```

and failing **closed** — if that call fails too, `family` stays `0` and the
plain `connect()` runs.

Regression test: `tests/net/tcp.test.yo` "IPv6 loopback connect round-trip"
(binds `::1`, connects, echoes; skips cleanly where there is no v6 loopback),
plus the existing `tests/net/unix.test.yo` round-trip that caught this.

**Verified on this branch:** the emitted `x86_64-pc-windows-gnu` C compiles
clean under `zig cc -O2` (0 errors), and `tests/net` is 85 passed on macOS.
The Windows legs of this PR's next run are the verification that matters.

The rule is written into
`issues/fixed/windows-blocking-connect-parks-the-event-loop.md`: a
socket-property probe used to GATE a path must not have a failure fallback
that silently *satisfies* the gate. (The accept path's identical-looking probe
is safe only because a listener is always bound by the time `accept` runs.)
