### PR TITLE
ci: how to get the tests/internal shard map without waiting for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1660,6 +1660,29 @@ jobs:
           # macro/reflection files (each compiles the whole evaluator,
           # ~6.5 GB peak) go one per shard; the rest stripe round-robin over
           # the sorted glob order.
+          #
+          # A shard number alone does not say WHICH file failed, and the job
+          # log is unavailable until the whole run completes — so when four
+          # shards went red at once on 2026-09-13 the map had to be
+          # reconstructed by hand before any of it could be read. Print it
+          # instead (`shard N files:` below already does, once the job runs);
+          # to get it WITHOUT waiting for CI, run the same selection locally:
+          #
+          #   heavies="tests/internal/ast_reflection.test.yo tests/internal/macro_expansion.test.yo tests/internal/macro_helpers.test.yo tests/internal/quote_macro_eval.test.yo"
+          #   for shard in 0 1 2 3; do
+          #     echo "== shard $shard =="
+          #     echo "$heavies" | tr ' ' '\n' | sed -n "$((shard + 1))p"
+          #     i=0
+          #     for f in tests/internal/*.test.yo; do
+          #       case " $heavies " in *" $f "*) continue ;; esac
+          #       [ $((i % 4)) -eq "$shard" ] && echo "$f"
+          #       i=$((i + 1))
+          #     done
+          #   done
+          #
+          # Do NOT hardcode the resulting map: it is round-robin over the
+          # sorted glob, so adding ONE file to tests/internal/ reshuffles
+          # every shard after it.
           heavies="tests/internal/ast_reflection.test.yo tests/internal/macro_expansion.test.yo tests/internal/macro_helpers.test.yo tests/internal/quote_macro_eval.test.yo"
           shard=${{ matrix.shard }}
           files=$(echo "$heavies" | tr ' ' '\n' | sed -n "$((shard + 1))p")


### PR DESCRIPTION
Comment only — `actionlint` clean, no behaviour change.

When four differential shards went red at once today, the shard *number* was all the failure list gave, and a job log is unavailable until the whole run completes (well over an hour for this workflow). The map had to be reconstructed by hand from the selection logic before any of the four failures could be named — and naming them was the whole job, since each was a different file.

The recipe now sits next to the selection it mirrors: the same loop, runnable locally, printing which files each shard owns. Verified by running it against the live selection rather than transcribed from it.

Deliberately **not** a hardcoded table. The stripe is round-robin over the sorted glob, so adding one file to `tests/internal/` reshuffles every shard after it — a table would be wrong at the next test added, and worse than none, because it would be believed.

Suggested by the session that hit the same wall from the other side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)