### PR TITLE
fix: the build-test-suite-flags golden pinned itself to macOS

### DIFF
--- a/tests/cli-cases/build-test-suite-flags/expected_stdout
+++ b/tests/cli-cases/build-test-suite-flags/expected_stdout
@@ -1,6 +1,6 @@
 ✓ first passes
 ✗ second fails on purpose
-Test failed with exit code 6
+Test failed with exit code
 deliberate failure — the suite bails here
 Bailing out early due to test failure
 1 passed

--- a/tests/cli-cases/build-test-suite-flags/opts
+++ b/tests/cli-cases/build-test-suite-flags/opts
@@ -24,4 +24,14 @@ timeout=300
 # Only the runner's own lines are compared: the child compile emits the host's
 # ASan probe verdict, openssl paths and clang warnings with generated-C line
 # numbers, none of which are this case's subject.
-stdout_keep_match=(✓|✗) [a-z ]+|Test failed with exit code [0-9]+|deliberate failure — the suite bails here|Bailing out early due to test failure|[0-9]+ (passed|failed|total)
+#
+# The exit CODE is matched but not captured, deliberately. A failing `assert`
+# aborts, and the number the runner prints for an abort is platform-specific:
+# macOS reports the raw signal (6, SIGABRT) and Linux the shell encoding
+# (128 + 6 = 134). Recording either one pins the case to the host that recorded
+# it — this golden was recorded on macOS and could never pass on Linux, which
+# is how it reached develop red. `stdout_keep_match` keeps only the matched
+# SUBSTRING, so dropping `[0-9]+` from the pattern keeps the line and drops the
+# number. The subject of this case is `bail` and `verbose`, not how an abort is
+# encoded.
+stdout_keep_match=(✓|✗) [a-z ]+|Test failed with exit code|deliberate failure — the suite bails here|Bailing out early due to test failure|[0-9]+ (passed|failed|total)


### PR DESCRIPTION
This is the whole of develop's red tier-1 gate — the only GOLDEN-DIFF in a scorecard of 129.

```
stdout diff (golden < / run >):
  < Test failed with exit code 6
  > Test failed with exit code 134
```

A failing `assert` aborts, and the number the runner prints for an abort is platform-specific: macOS reports the raw signal (6, SIGABRT), Linux the shell convention (128 + 6 = 134). The golden was recorded on macOS, so this case could **never** pass on Linux — it isn't a regression in behaviour, it's a golden that pinned itself to the host that recorded it.

Fix: match the line without capturing the number. `stdout_keep_match` keeps only the matched *substring*, so dropping `[0-9]+` from that alternation keeps `Test failed with exit code` and drops whatever follows. The case's subject is `bail` (the third test's name absent, total 2 not 3) and `verbose` (the assert's own message surviving); neither has anything to do with how an abort is encoded, so nothing is weakened by not pinning it. The rationale is recorded in `opts` next to the existing keep-match comment, so the next person to record this golden doesn't put the number back.

Verified with a stage-1 binary built from develop's tip: `PASS 1  GOLDEN-DIFF 0  NO-GOLDEN 0  SKIP 0`.

With this and #637, all six of develop's failures are accounted for: four shards (#637), tier-1 (here), and `test (windows-11-arm)`, which is separate and still being looked at — `test (windows-latest)` passed, so it is arm-specific rather than a general Windows break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)