### PR TITLE
codegen: the RRE adoption arm takes an existential, not a type that CONTAINS one

### DIFF
--- a/src/evaluator/calls/function.yo
+++ b/src/evaluator/calls/function.yo
@@ -2262,7 +2262,21 @@ _evaluate_funcval_runtime_call :: (
           // (`IterFilter(Self, F)`) leaves a substituted return whose SomeTs
           // ALL resolve concretely, so `rre_old_wanted` is false there and the
           // re-eval is never even wanted.
-          .Some(hkt_ty) => if(((get_all_some_types(hkt_ty).len() == usize(0)) || (rre_old_wanted && (type_somes_all_resolve_concrete(hkt_ty) || !(_rre_mentions_binder(hkt_ty, rre_binder_ids))))) && !(is_unit_type(hkt_ty)), {
+          // ...and the arm is restricted to a hkt_ty that IS a SomeT, which is
+          // what the justification above actually describes: an async return
+          // `Impl(Future(i32) Io)` is ONE SomeT, an existential wrapper. A type
+          // that merely CONTAINS one — `Box( : (Fn(i32) -> i32))` — is the
+          // hazard the era_suspect note two paragraphs up already records
+          // ("adopting that Box(wrapper) clobbered the per-call capture
+          // identity"), and it reaches C as a second struct for a type that
+          // already has one: the function then takes its signature from
+          // `Box( : (Fn…))` and its body's constructor from
+          // `Box(<capture struct>)`, which is "incompatible pointer types
+          // returning ..." — a warning on every platform and a hard ERROR on
+          // the one CI leg running clang 22. Bisected to THIS line (#619; its
+          // parent #611 emits 3 Box structs and no warning, it emits 5 and 2).
+          // issues/a-box-over-an-impl-fn-is-emitted-as-two-c-structs.md
+          .Some(hkt_ty) => if(((get_all_some_types(hkt_ty).len() == usize(0)) || (rre_old_wanted && (type_somes_all_resolve_concrete(hkt_ty) || (is_some_type(hkt_ty) && !(_rre_mentions_binder(hkt_ty, rre_binder_ids)))))) && !(is_unit_type(hkt_ty)), {
             resolved_ret = hkt_ty;
           }),
           .None => ()


### PR DESCRIPTION
develop's last red gate, and it is mine.

`test (windows-11-arm)` is the only leg installing clang 22, where `-Wincompatible-pointer-types` is a default **error**. Every other platform compiled this as a warning and ran the result — which is exactly why it survived unnoticed.

The emitted C had **two structs for one Yo type**:

```c
struct __yo_t_5151165989142611580_struct { // Box( : (Fn(i32) -> i32))
struct __yo_t_12134693802553570606_struct { // Box(<struct:capture_…>)
```

Identical layout, identical payload — and a function took its signature from the first and its body's `__yo_new_…` from the second.

## Bisected to #619

| commit | warnings | `Box` structs |
| --- | --- | --- |
| `#603`, `#611`, `#612` | 0 | 3 |
| **`#619`** | **2** | **5** |

`#619` (mine, earlier today) widened the RRE adoption gate with a third arm: adopt the re-evaluated return once it no longer mentions any of the callee's own forall binders. The justification I wrote for it says *"whatever SomeTs remain are existential wrappers rather than type variables — that is exactly what an async return IS, `Impl(Future(i32) Io)` is one SomeT."* **The condition did not say that.** It also accepted a type that merely *contains* a SomeT, so `Box( : (Fn(i32) -> i32))` replaced the already-correct per-call `Box(<capture struct>)`.

The era_suspect arm three paragraphs above refuses precisely this, with the reason spelled out — *"adopting that `Box(wrapper)` clobbered the per-call capture identity and leaked raw type_keys into dyn wrapper C names"*. The new arm just lacked the same protection. It now requires `is_some_type(hkt_ty)`, which is what the comment always claimed.

## Two earlier attributions were wrong

Both are recorded in the issue rather than quietly dropped: **#598** (excluded — `#603` postdates it and is clean) and **#603** itself (it *is* the type-naming change, and it is clean). The first A/B spanned **48 commits** and I read it as naming one; the tell was the type-naming scheme differing between the two emissions, which I had already looked at without interrogating.

## Verification (stage-1 binary built from this tree)

```
the defect                   2 warnings -> 0,  5 Box structs -> 3  (the pre-#619 count)
generic_future_return_two_t  4/4    <- what the arm exists for
closure_param_forwarding     4/4    <- incl. #598's T = unit guard
closure 14/14 · async_mutex 4/4 · async_await 210/210
tier-1 battery               T1_DONE failures=0
                             corpus 156 PASS / 0 GOLDEN-DIFF
                             check ./std 175/175
                             CLI cases 131 PASS / 0 GOLDEN-DIFF
                             embedded-Yo 7 sites / 0 failures
bootstrap fixpoint           FIXPOINT_HOLDS, stage2 hollow=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)