### PR TITLE
build: default Manifest.workspace_members — #646's field took manifest.test.yo out

### DIFF
--- a/src/manifest.yo
+++ b/src/manifest.yo
@@ -178,7 +178,16 @@ Manifest :: ref(
     /// each relative to `dir`. Empty when this manifest declares no workspace.
     /// `workspace_members` (the function) expands them; the raw patterns are
     /// kept so a diagnostic can name what the author wrote.
-    workspace_members : ArrayList(String)
+    ///
+    /// DEFAULTED to empty, which is what the field's own doc line above already
+    /// says the empty value MEANS, and what `expand_workspace_members` and
+    /// `run_build` both test for. Added without a default in #646, which left
+    /// `tests/internal/manifest.test.yo` constructing a Manifest the type no
+    /// longer accepts — the SECOND time in one day that a new field with no
+    /// default took an internal test file out (see #637 for the first three).
+    /// A default fixes every construction site at once instead of one per
+    /// field addition.
+    (workspace_members : ArrayList(String)) ?= ArrayList(String).new()
   )
 );
 impl(


### PR DESCRIPTION
develop's shard 3 went red, and it is **not** #649 — I reproduced all 19 of shard 3's files locally to find out which, because a shard number alone doesn't say.

`Manifest` gained `workspace_members : ArrayList(String)` in #646 (workspaces) with **no default**, and `tests/internal/manifest.test.yo` still constructs a `Manifest` without it. A member-count mismatch is a hard eval error, so the whole file is out:

```
error: Type member "workspace_members" is not provided and has no default value or assigned value.
```

**This is the second time today the same pattern took an internal test file out** — #637 fixed three sites from #626 this morning. The reason is structural, not careless: `check ./src`, `check ./std`, the CLI corpus and the fixpoint are what gets run per slice, and **none of them compiles `tests/internal/`**. A new field on a type in `src/` is invisible to all four and visible in minutes to the one gate that isn't run.

**Defaulted rather than edited at the call site**, because empty *is* the documented meaning:
- the field's own doc line says "Empty when this manifest declares no workspace";
- `expand_workspace_members` returns early on empty;
- `run_build` branches on `workspace_members.len() == usize(0)`.

One default covers every construction site, present and future. Editing the single test site would just queue the same break for the next field — which is precisely what happened between #626 and #646.

## Verification (develop-tip stage-1 binary)

```
tests/internal/manifest.test.yo      19/19   <- does not compile without this
tests/internal/build_runner.test.yo  12/12
tests/internal/lock_file.test.yo     17/17
tests/internal/init.test.yo          25/25
check ./src                          275/275
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)