### PR TITLE
revert: strip the YO_DEBUG_ENVRES probe that #651 carried onto develop

### DIFF
--- a/src/evaluator/types/function.yo
+++ b/src/evaluator/types/function.yo
@@ -13,8 +13,6 @@
 pragma(Pragma.AllowUnsafe);
 { String } :: import("std/string");
 import("std/fmt");
-{ eprintln } :: import("std/fmt");
-_(env : rsdenv_dbg) :: import("std/env");
 {
   AstExpr,
   ast_expr_token,
@@ -4666,9 +4664,6 @@ _resolve_some_types_deep :: (
             // Skip registering IoExn — it's a compound effect that
             // would overwrite single-effect Io and poison subsequent
             // io.async calls that only need Io.
-            if(rsdenv_dbg.get(`YO_DEBUG_ENVRES`).is_some(), {
-              eprintln(`[envres] name=${match(nst, .SomeT(_, _en, _, _, _, _, _, _, _, _, _) => _en, _ => String.from("?"))} id=${match(nst, .SomeT(_eid, _, _, _, _, _, _, _, _, _, _) => _eid, _ => String.from("?"))} -> ${type_to_string(nres)} from_env=${nres_from_env.to_string()} env_mod=${env.module_path} frames=${env.frames.len().to_string()}`);
-            });
             if(nres_from_env, {
               _is_ioexn := match(
                 nres,


### PR DESCRIPTION
**#651 was titled and reviewed as documentation-only. It was not.** It also carried the temporary `[envres]` instrumentation from the measurement it describes — an `eprintln`, a `std/env` import alias, and a debug branch inside `_resolve_some_types_deep`, one of the hottest paths in the evaluator.

My mistake, and a mechanical one worth naming so it doesn't recur: `git checkout -B <branch> origin/develop` **carries uncommitted changes to tracked files forward**, so the probe rode along into a `git add -A`. AGENTS.md says to review `git diff` before considering work done; I didn't, and the PR's own diffstat (`src/evaluator/types/function.yo | 5 +++++`) would have said so in one line.

`src/evaluator/types/function.yo` is now **byte-identical to `941fe3ed2`**, the last tip before #651 — verified by `git diff 941fe3ed2 -- <file>` returning empty, rather than by re-reading the hunks.

Nothing was released or seeded from the affected range: develop's battery for `941fe3ed2` was still queued when #651 landed, and the v0.2.32 cut is deliberately sequenced behind a green battery. That sequencing is the reason a debug branch in the evaluator did not become the trust-chain root — which is a decent argument for the sequencing independent of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)