### PR TITLE
AGENTS: the cancel rule has a docs-only trap — I walked into it writing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,12 +329,25 @@ yo version clean      # Remove all cached versions
   gh run cancel <id>   # for each run whose branch is not in that list
   ```
 
-  **KEEP**: every open PR's runs, and the NEWEST `develop` run. **CANCEL**: runs
-  on branches with no open PR (i.e. merged or abandoned), and older `develop`
-  runs once a newer tip has queued. When in doubt about someone else's branch,
-  leave it — the cost of one extra run is small next to cancelling work a
-  teammate is waiting on. Cancellation is asynchronous, so a job may still read
-  `in_progress` for a minute afterwards; re-list rather than cancelling twice.
+  **KEEP**: every open PR's runs, and the newest `develop` run that is actually
+  RUNNING THE BATTERY. **CANCEL**: runs on branches with no open PR (i.e. merged
+  or abandoned), and older `develop` runs superseded by a newer tip that runs the
+  battery.
+
+  **The trap, walked into within minutes of writing this rule:** a docs-only tip
+  takes the fast path and SKIPS 15 of 18 jobs, then reports `success`. If you
+  cancel the older `develop` run because a newer tip queued, and that newer tip
+  is docs-only, you have destroyed the only real verification of the code and
+  replaced it with a green tick that compiled nothing. Check before cancelling —
+  `gh run view <newer-id> --json jobs --jq '[.jobs[]|select(.conclusion=="skipped")]|length'`
+  returning 15 means it is the fast path, so KEEP the older run. If it is already
+  cancelled, `gh run rerun <older-id>` gets it back: a docs-only tip is
+  code-identical to its parent, so the parent's battery is the valid verdict.
+
+  When in doubt about someone else's branch, leave it — the cost of one extra
+  run is small next to cancelling work a teammate is waiting on. Cancellation is
+  asynchronous, so a job may still read `in_progress` for a minute afterwards;
+  re-list rather than cancelling twice.
 - **Always run `yo fmt <file.yo>` on every `.yo` file you create or modify, before committing.** Use `yo fmt --check` to verify. Do not commit unformatted `.yo` files. (There is no pre-commit hook any more — `.husky/` went with the node toolchain, so this is on you.)
 - Always check if there is need to create/update existing instructions & rules & skill files, design/plan docs after implementing a change.
 - **Whenever you learn something new about Yo syntax, semantics, or common pitfalls — especially from trial and error — immediately update the relevant skill files** (`.github/skills/yo-syntax/syntax-cheatsheet.md`, `.github/skills/yo-core-patterns/core-patterns-cheatsheet.md`, etc.) **and instruction files** (`.github/instructions/yo-syntax.instructions.md`, `.github/instructions/yo-design.instructions.md`). This keeps the institutional knowledge accurate for future sessions.


### PR DESCRIPTION
#653 said "cancel older `develop` runs once a newer tip has queued". **Minutes later I did exactly that and destroyed the only real verification of develop's code.**

A docs-only tip takes the fast path: **15 of 18 jobs skipped, then `success`**. Measured on develop at `90fc1c172` (an AGENTS.md-only merge) — `green=3 skipped=15`. So "a newer tip queued" is not sufficient grounds to cancel the older run, because the newer one may verify nothing. I cancelled the battery on `bec3bd8fc` — the actual verdict for the code a v0.2.32 cut would be made from — and replaced it with a green tick that compiled nothing.

The rule now says to **check before cancelling**:

```bash
gh run view <newer-id> --json jobs --jq '[.jobs[]|select(.conclusion=="skipped")]|length'
```

15 means it's the fast path, so keep the older run. And it records the recovery — `gh run rerun <older-id>` — which is valid precisely because a docs-only tip is code-identical to its parent, so the parent's battery is the right verdict. (Already done: `34726014056` is re-running.)

Kept as a **named trap** rather than smoothed into the prose, because the failure mode is silent — the fast path reports SUCCESS, so nothing about the cancelled state looks wrong afterwards. That's the same shape as the merge-storm cancellations this session started with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)